### PR TITLE
Enhance implicit differentiation and diagnostics with tests

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,6 @@
 # VMEC-JAX Master Plan and New-Agent Handoff (Living Document)
 
-Last updated: 2026-03-09
+Last updated: 2026-04-02
 Primary owner: `vmec_jax` contributors
 Canonical repo: `<repo-root>`
 
@@ -21,6 +21,249 @@ Update rules:
   - `<repo-root>/docs/validation.rst`
   - `<repo-root>/docs/performance.rst`
   - `<repo-root>/docs/free_boundary_plan.rst`
+
+---
+
+## 0A) Current priority: unblock QH autodiff for simsopt/vmec_jax
+
+This section is the active branch-specific plan for the current blocker:
+
+- repo: `vmec_jax`
+- branch: `codex/qh-parity-wip`
+- coupled repo: `simsopt` on `codex/qh-boozer-jax-wip`
+- benchmark target: the fixed-resolution QH example in simsopt using VMEC-JAX
+
+### 0A.1 Objective
+
+Deliver a correct autodiff path for the fixed-boundary QH optimization so that:
+
+- autodiff gradients are in the same ballpark as finite differences on the exact 8-DOF QH benchmark,
+- the optimizer can reduce the QH objective materially beyond the current broken-AD plateau,
+- the path remains compatible with the parity work already completed in `vmec_jax`,
+- no finite-difference fallback is required in the final solution.
+
+### 0A.2 Exact benchmark definition
+
+Use this benchmark unless there is a clearly documented reason to revise it:
+
+- classic script: `simsopt/examples/2_Intermediate/QH_fixed_resolution.py`
+- JAX script: `simsopt/examples/2_Intermediate/QH_fixed_resolution_jax.py`
+- objective: aspect + quasisymmetry only
+- no `mean_iota` term for QH
+- `max_mode = 1`
+- VMEC `mpol = ntor = 3`
+- 8 free boundary DOFs
+- `max_nfev = 10`
+
+Reference numbers currently in hand:
+
+- classic final objective after 10 nfev: `0.21378863910867005`
+- classic wall time: about `24.75 s`
+- current JAX start objective on the converged control path: `0.2983122217172473`
+- current JAX AD gradient mismatch on the exact QH start point:
+  - AD linf: about `690.78`
+  - FD linf: about `12.98`
+
+### 0A.3 What is currently known
+
+The most important settled findings are:
+
+- The previous aligned-JAX path had a real primal inconsistency. That was fixed by restoring the converged default control path rather than the stalled `reference_mode=True` path.
+- The projected boundary-to-state edge map mattered. Using raw boundary rows was wrong; the projected edge rows from `initial_guess_from_boundary(..., vmec_project=True)` are the correct direct map.
+- Direct edge-state derivatives and simple aspect derivatives now match finite differences after the edge-map fix.
+- The remaining failure is specifically in the boundary-to-interior-state sensitivity, especially the lambda branch.
+- Probing the one-step fixed-point map showed a unit-eigenvalue nullspace in the problematic lambda direction, so the current fixed-point relation is not a well-posed differentiated equation for QH.
+
+Interpretation:
+
+- This is not primarily an outer-optimizer problem.
+- This is not solved by more line search tuning.
+- This is not solved by differentiating a one-step continuation map harder.
+- The live bug is that the current implicit relation does not uniquely determine the differentiated lambda branch for the QH case.
+
+### 0A.4 Deep-dive takeaway from DESC
+
+DESC is relevant, but not because it "does autodiff through another equilibrium code".
+It succeeds because its equilibrium, objective, and derivative machinery are designed
+together.
+
+What DESC does in practice:
+
+- `desc/backend.py` uses `jax.lax.custom_root` for root solves, with an explicit tangent solve for the residual Jacobian.
+- `desc/examples/precise_QH.py` optimizes QS + aspect ratio while enforcing force balance as a constraint.
+- `desc/optimize/_constraint_wrappers.py` uses `ProximalProjection` to remove equilibrium state coefficients from the outer optimization variables and keep only controls such as boundary/profile coefficients.
+- `desc/optimize/_constraint_wrappers.py` explicitly constructs the control-to-state embedding (`dxdc`) for boundary variables.
+- `desc/objectives/_omnigenity.py` evaluates QS objectives directly on DESC equilibrium quantities.
+
+The transferable idea is not to copy DESC's equilibrium formulation. The transferable
+idea is:
+
+1. differentiate a well-posed equilibrium relation, not a fragile solver history map,
+2. keep the control/state split explicit,
+3. include the exact control-to-state embedding,
+4. add whatever gauge or branch conditions are necessary so the differentiated relation
+   is nonsingular.
+
+### 0A.5 Mapping from DESC ideas to vmec_jax
+
+Current `vmec_jax` files involved:
+
+- `vmec_jax/implicit.py`
+- `vmec_jax/solve.py`
+- `vmec_jax/state.py`
+- `vmec_jax/vmec_bcovar.py`
+- `vmec_jax/vmec_residue.py`
+- `vmec_jax/vmec_tomnsp.py`
+
+Current `simsopt` files involved:
+
+- `src/simsopt/mhd/vmec_jax.py`
+- `src/simsopt/solve/jax_solve.py`
+- `examples/2_Intermediate/QH_fixed_resolution_jax.py`
+
+Direct mapping:
+
+- DESC `controls` correspond to the outer boundary DOFs in simsopt.
+- DESC `equilibrium state` corresponds to the VMEC Fourier state `(R, Z, lambda)`.
+- DESC `ForceBalance constraint` corresponds to the VMEC residual equations we already assemble in `solve_fixed_boundary_state_implicit_vmec_residual(...)`.
+- DESC `dxdc` is directly analogous to our projected edge-state embedding from boundary coefficients.
+- DESC `custom_root` is the right architectural direction for the next `vmec_jax` implicit layer.
+
+### 0A.6 Working hypothesis for the remaining bug
+
+The residual used by `solve_fixed_boundary_state_implicit_vmec_residual(...)` is close
+to the right foundation, but it is still missing at least one branch-selection or
+gauge-fixing relation needed to make the differentiated state unique for QH.
+
+The evidence for this is:
+
+- the converged QH state is a near-root of the physical residual,
+- forward and reverse autodiff paths agree with each other much more than they agree
+  with finite differences,
+- the lambda direction shows a nullspace in the differentiated one-step map,
+- full-active and reduced-active variants change the size of the error, but do not
+  remove it.
+
+Therefore the next version of the implicit layer must be based on an augmented root
+system, not just better linear algebra around the current masked system.
+
+### 0A.7 Concrete implementation plan
+
+#### Phase 1: lock down regression harnesses
+
+- [ ] Add a reusable QH derivative regression in `vmec_jax/tests` or `simsopt/tests`
+      that compares AD against central FD on the exact 8-DOF benchmark.
+- [ ] Check both:
+  - total objective gradient,
+  - individual residual component sensitivities.
+- [ ] Add a focused probe for a representative lambda interior coefficient, since that
+      is where the current singular behavior is most visible.
+
+Acceptance:
+
+- every future derivative change must report before/after mismatch on the exact QH
+  start point.
+
+#### Phase 2: promote the residual-root path to the primary AD target
+
+- [ ] Treat `solve_fixed_boundary_state_implicit_vmec_residual(...)` as the primary
+      path to repair, not the energy-Hessian wrapper in
+      `solve_fixed_boundary_state_implicit(...)`.
+- [ ] Keep warm-start / scan / resume-state machinery as primal accelerators only.
+- [ ] Ensure the differentiated relation is the converged residual equation, not the
+      one-step scan continuation map.
+
+Acceptance:
+
+- the branch used in the backward pass is the same converged branch produced by the
+  primal host solve.
+
+#### Phase 3: define an augmented reduced state and residual
+
+- [ ] Make the independent differentiated state explicit:
+  - free interior `Rcos`,
+  - free interior `Zsin`,
+  - free interior `Lsin`,
+  - plus any additional gauge or branch variables/constraints required for lambda.
+- [ ] Replace ad hoc masked active-coordinate handling with a single documented
+      reduced-state packing convention.
+- [ ] Keep the projected boundary embedding exact and shared.
+
+Acceptance:
+
+- one authoritative pack/unpack for the reduced implicit state exists and is tested.
+
+#### Phase 4: add missing lambda branch conditions
+
+- [ ] Identify the exact branch condition that removes the QH lambda nullspace.
+- [ ] Candidate sources:
+  - existing VMEC lambda gauge enforcement,
+  - axis closure conditions,
+  - parity or closure equations already implicit in VMEC2000 iteration logic,
+  - explicit constraints on the differentiated lambda representation rather than only
+    masking entries after the fact.
+- [ ] Build these into the residual relation itself, not as a post-hoc projection.
+
+Acceptance:
+
+- the linearized implicit operator no longer has the current QH lambda nullspace in
+  the tested probe direction.
+
+#### Phase 5: replace the backward rule with a root-based implicit solve
+
+- [ ] Introduce a `custom_root`-style wrapper or equivalent custom VJP around the
+      augmented residual solve.
+- [ ] Solve the tangent/adjoint equations on the augmented residual Jacobian rather
+      than on a Hessian surrogate or a one-step fixed-point linearization.
+- [ ] Keep the implementation compatible with JAX transforms and with the existing
+      parity-oriented forward solver path.
+
+Acceptance:
+
+- reverse-mode and forward-mode derivatives agree with finite differences to within a
+  documented tolerance on the QH benchmark.
+
+#### Phase 6: re-hook simsopt and re-benchmark
+
+- [ ] Point the simsopt QH VMEC-JAX example at the repaired implicit path.
+- [ ] Re-run the exact 10-nfev apples-to-apples benchmark after every meaningful
+      derivative fix.
+- [ ] Track both:
+  - final objective quality,
+  - wall time and objective/gradient call counts.
+
+Acceptance:
+
+- AD path materially outperforms the current broken-AD result and moves toward the
+  classic objective in a stable way.
+
+### 0A.8 Non-goals
+
+Do not do these as the primary fix:
+
+- do not pivot to finite differences except as a temporary diagnostic,
+- do not optimize GPU performance before CPU autodiff is correct,
+- do not overfit the solution to one optimizer or one line-search setting,
+- do not add correctness-critical environment-variable toggles.
+
+### 0A.9 Immediate next coding tasks
+
+These are the next tasks to execute on this branch, in order:
+
+- [ ] Factor the current QH derivative probe into a committed reusable regression.
+- [ ] Extract and document the reduced implicit state packing used by the residual path.
+- [ ] Identify the missing lambda branch condition by comparing:
+  - residual-root linearization,
+  - enforced gauge/axis rules,
+  - VMEC iteration closures already present in the primal path.
+- [ ] Prototype the augmented residual relation in `vmec_jax/implicit.py`.
+- [ ] Validate against finite differences before any optimizer retuning.
+
+### 0A.10 Branch notes
+
+When editing this plan, preserve the broader repo-wide parity roadmap below. This
+section exists to keep the current QH autodiff work tightly scoped so it does not
+accidentally regress the rest of the VMEC parity project.
 
 ---
 
@@ -1583,3 +1826,22 @@ Legend:
     optimized non-autodiff fixed-boundary becomes the default user path on
     `main`, while free-boundary stays on the current robust controller and the
     parity / implicit-differentiation routes remain available.
+- 2026-04-02 QH autodiff unblock planning update:
+  - added section `0A` near the top of this file as the active branch-specific
+    plan for the simsopt/vmec_jax QH autodiff blocker,
+  - documented the exact apples-to-apples QH benchmark definition and the
+    current known gradient mismatch against finite differences,
+  - summarized the settled findings from the current investigation:
+    projected edge-map fix, restored converged primal control path, and the
+    remaining lambda-branch nullspace in the differentiated relation,
+  - captured the relevant DESC implementation patterns after a source-level
+    deep dive:
+    `custom_root`, explicit control/state split, proximal equilibrium
+    projection, and explicit boundary-control embedding,
+  - translated those DESC ideas into a concrete `vmec_jax` plan:
+    augment the residual-root formulation, make the reduced implicit state
+    explicit, add the missing lambda branch condition, and move the backward
+    rule to a root-based implicit solve rather than the current brittle
+    fixed-point relation,
+  - this planning update is intentionally scoped to unblock correct and
+    performant QH autodiff without regressing the broader VMEC parity work.

--- a/tests/test_driver_api.py
+++ b/tests/test_driver_api.py
@@ -254,6 +254,54 @@ def test_run_fixed_boundary_returns_current_driven_flux_profiles():
     np.testing.assert_allclose(iota, np.asarray(wout.iotas, dtype=float), rtol=1e-10, atol=1e-12)
 
 
+def test_final_flux_profiles_from_state_supports_traced_lsin():
+    pytest.importorskip("jax")
+
+    from vmec_jax._compat import enable_x64, jax, jnp
+    from vmec_jax.driver import _final_flux_profiles_from_state, run_fixed_boundary
+    from vmec_jax.vmec_tomnsp import vmec_angle_grid
+
+    enable_x64(True)
+
+    root = Path(__file__).resolve().parents[1]
+    input_path = root / "examples/data/input.basic_non_stellsym_pressure"
+    grid = vmec_angle_grid(ntheta=10, nzeta=8, nfp=1, lasym=True)
+    run = run_fixed_boundary(
+        input_path,
+        max_iter=2,
+        verbose=False,
+        multigrid=False,
+        grid=grid,
+    )
+
+    radial_idx = min(5, int(np.asarray(run.state.Lsin).shape[0]) - 1)
+    mode_idx = 1
+
+    def scalar(alpha):
+        state = type(run.state)(
+            layout=run.state.layout,
+            Rcos=jnp.asarray(run.state.Rcos),
+            Rsin=jnp.asarray(run.state.Rsin),
+            Zcos=jnp.asarray(run.state.Zcos),
+            Zsin=jnp.asarray(run.state.Zsin),
+            Lcos=jnp.asarray(run.state.Lcos),
+            Lsin=jnp.asarray(run.state.Lsin).at[radial_idx, mode_idx].add(alpha),
+        )
+        _flux, prof = _final_flux_profiles_from_state(
+            indata=run.indata,
+            static_in=run.static,
+            state=state,
+            signgs=run.signgs,
+            flux_local=run.flux,
+            prof_local=run.profiles,
+            pressure_local=run.profiles["pressure"],
+        )
+        return jnp.sum(jnp.asarray(prof["iota"]))
+
+    grad = float(jax.grad(scalar)(0.0))
+    assert np.isfinite(grad)
+
+
 def test_host_update_assembly_matches_jax_update_path():
     root = Path(__file__).resolve().parents[1]
     input_path = root / "examples/data/input.LandremanPaul2021_QA_lowres"

--- a/tests/test_implicit_helpers.py
+++ b/tests/test_implicit_helpers.py
@@ -84,3 +84,51 @@ def test_initial_guess_vmec_project_edge_rc01_gradient_matches_internal_scale():
     assert np.isfinite(grad_fd)
     assert grad_ad == pytest.approx(expected, rel=0.0, abs=1e-12)
     assert grad_ad == pytest.approx(grad_fd, rel=0.0, abs=1e-7)
+
+
+def test_fixed_boundary_residual_implicit_primal_matches_reference_mode(load_case_circular_tokamak):
+    pytest.importorskip("jax")
+
+    from vmec_jax.field import signgs_from_sqrtg
+    from vmec_jax.geom import eval_geom
+    from vmec_jax.implicit import solve_fixed_boundary_state_implicit_vmec_residual
+    from vmec_jax.solve import solve_fixed_boundary_residual_iter
+    from vmec_jax.state import pack_state
+    _cfg, indata, static, boundary, state_init = load_case_circular_tokamak
+    signgs0 = signgs_from_sqrtg(np.asarray(eval_geom(state_init, static).sqrtg), axis_index=1)
+
+    direct = solve_fixed_boundary_residual_iter(
+        state_init,
+        static,
+        indata=indata,
+        signgs=int(signgs0),
+        ftol=float(indata.get_float("FTOL", 1e-14)),
+        max_iter=1,
+        step_size=float(indata.get_float("DELT", 1.0)),
+        vmec2000_control=True,
+        reference_mode=True,
+        backtracking=True,
+        limit_dt_from_force=True,
+        limit_update_rms=True,
+        verbose=False,
+        verbose_vmec2000_table=False,
+        jit_forces="auto",
+        use_scan=False,
+    ).state
+
+    wrapped = solve_fixed_boundary_state_implicit_vmec_residual(
+        state_init,
+        static,
+        indata=indata,
+        signgs=int(signgs0),
+        state0_host=state_init,
+        max_iter=1,
+        step_size=float(indata.get_float("DELT", 1.0)),
+        ftol=float(indata.get_float("FTOL", 1e-14)),
+        edge_Rcos=np.asarray(boundary.R_cos),
+        edge_Rsin=np.asarray(boundary.R_sin),
+        edge_Zcos=np.asarray(boundary.Z_cos),
+        edge_Zsin=np.asarray(boundary.Z_sin),
+    )
+
+    assert np.asarray(pack_state(wrapped)) == pytest.approx(np.asarray(pack_state(direct)), rel=0.0, abs=1e-12)

--- a/tests/test_implicit_helpers.py
+++ b/tests/test_implicit_helpers.py
@@ -120,7 +120,7 @@ def test_stellsym_active_keep_scatter_supports_reverse_mode(load_case_circular_t
     assert np.all(np.isfinite(grad))
 
 
-def test_fixed_boundary_residual_implicit_primal_matches_reference_mode(load_case_circular_tokamak):
+def test_fixed_boundary_residual_implicit_primal_matches_default_control_path(load_case_circular_tokamak):
     pytest.importorskip("jax")
 
     from vmec_jax.field import signgs_from_sqrtg
@@ -140,7 +140,7 @@ def test_fixed_boundary_residual_implicit_primal_matches_reference_mode(load_cas
         max_iter=1,
         step_size=float(indata.get_float("DELT", 1.0)),
         vmec2000_control=True,
-        reference_mode=True,
+        reference_mode=False,
         backtracking=True,
         limit_dt_from_force=True,
         limit_update_rms=True,

--- a/tests/test_implicit_helpers.py
+++ b/tests/test_implicit_helpers.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def _mode_index(modes, m: int, n: int) -> int:
+    for k, (mm, nn) in enumerate(zip(np.asarray(modes.m), np.asarray(modes.n))):
+        if int(mm) == int(m) and int(nn) == int(n):
+            return k
+    raise KeyError((m, n))
+
+
+def test_update_stellsym_feasible_state_supports_reverse_mode(load_case_circular_tokamak):
+    pytest.importorskip("jax")
+
+    from vmec_jax._compat import enable_x64, jax, jnp
+    from vmec_jax.implicit import (
+        _mode00_index,
+        _pack_stellsym_feasible_state,
+        _stellsym_feasible_indices,
+        _update_stellsym_feasible_state,
+    )
+
+    enable_x64(True)
+
+    _cfg, _indata, static, _bdy, st0 = load_case_circular_tokamak
+    idx00 = _mode00_index(static.modes)
+    rz_idx, lam_idx, ns, K = _stellsym_feasible_indices(static, idx00=idx00, mask_lambda_axis=True)
+    x0 = _pack_stellsym_feasible_state(st0, rz_idx=rz_idx, lam_idx=lam_idx)
+
+    def objective(x):
+        st = _update_stellsym_feasible_state(st0, x, rz_idx=rz_idx, lam_idx=lam_idx, ns=ns, K=K)
+        return jnp.sum(jnp.asarray(st.Rcos) ** 2) + jnp.sum(jnp.asarray(st.Zsin) ** 2) + jnp.sum(jnp.asarray(st.Lsin) ** 2)
+
+    grad = np.asarray(jax.grad(objective)(x0))
+    assert grad.shape == tuple(np.asarray(x0).shape)
+    assert np.all(np.isfinite(grad))
+
+
+def test_initial_guess_vmec_project_edge_rc01_gradient_matches_internal_scale():
+    pytest.importorskip("jax")
+
+    from vmec_jax._compat import enable_x64, jax, jnp
+    from vmec_jax.boundary import BoundaryCoeffs
+    from vmec_jax.config import VMECConfig
+    from vmec_jax.init_guess import initial_guess_from_boundary
+    from vmec_jax.namelist import InData
+    from vmec_jax.static import build_static
+
+    enable_x64(True)
+
+    cfg = VMECConfig(mpol=3, ntor=2, ns=5, nfp=1, lasym=False, lconm1=True, lthreed=True, ntheta=16, nzeta=8)
+    static = build_static(cfg)
+    K = int(static.modes.K)
+
+    k00 = _mode_index(static.modes, 0, 0)
+    k01 = _mode_index(static.modes, 0, 1)
+
+    base_Rcos = np.zeros((K,), dtype=float)
+    base_Rsin = np.zeros((K,), dtype=float)
+    base_Zcos = np.zeros((K,), dtype=float)
+    base_Zsin = np.zeros((K,), dtype=float)
+    base_Rcos[k00] = 3.0
+    indata = InData(scalars={"RAXIS_CC": [3.0], "ZAXIS_CS": [0.0]}, indexed={})
+
+    def edge_coeff(alpha):
+        boundary = BoundaryCoeffs(
+            R_cos=jnp.asarray(base_Rcos).at[k01].set(alpha),
+            R_sin=jnp.asarray(base_Rsin),
+            Z_cos=jnp.asarray(base_Zcos),
+            Z_sin=jnp.asarray(base_Zsin),
+        )
+        st = initial_guess_from_boundary(static, boundary, indata, vmec_project=True)
+        return st.Rcos[-1, k01]
+
+    alpha0 = 1.2
+    eps = 1e-6
+    grad_ad = float(jax.grad(edge_coeff)(alpha0))
+    grad_fd = float((edge_coeff(alpha0 + eps) - edge_coeff(alpha0 - eps)) / (2.0 * eps))
+    expected = float(np.asarray(static.mode_scale_internal)[k01])
+
+    assert np.isfinite(grad_ad)
+    assert np.isfinite(grad_fd)
+    assert grad_ad == pytest.approx(expected, rel=0.0, abs=1e-12)
+    assert grad_ad == pytest.approx(grad_fd, rel=0.0, abs=1e-7)

--- a/tests/test_implicit_helpers.py
+++ b/tests/test_implicit_helpers.py
@@ -86,6 +86,40 @@ def test_initial_guess_vmec_project_edge_rc01_gradient_matches_internal_scale():
     assert grad_ad == pytest.approx(grad_fd, rel=0.0, abs=1e-7)
 
 
+def test_stellsym_active_keep_scatter_supports_reverse_mode(load_case_circular_tokamak):
+    pytest.importorskip("jax")
+
+    from vmec_jax._compat import enable_x64, jax, jnp
+    from vmec_jax.implicit import (
+        _mode00_index,
+        _pack_stellsym_feasible_state,
+        _stellsym_feasible_indices,
+        _stellsym_structural_active_keep_indices,
+    )
+
+    enable_x64(True)
+
+    _cfg, _indata, static, _bdy, st0 = load_case_circular_tokamak
+    idx00 = _mode00_index(static.modes)
+    rz_idx, lam_idx, _ns, K = _stellsym_feasible_indices(static, idx00=idx00, mask_lambda_axis=True)
+    x_full0 = _pack_stellsym_feasible_state(st0, rz_idx=rz_idx, lam_idx=lam_idx)
+    keep = _stellsym_structural_active_keep_indices(
+        rz_idx=np.asarray(rz_idx),
+        lam_idx=np.asarray(lam_idx),
+        K=int(K),
+        idx00=idx00,
+    )
+    x0 = jnp.take(x_full0, keep)
+
+    def objective(x):
+        rebuilt = x_full0.at[keep].set(x, indices_are_sorted=True, unique_indices=True)
+        return jnp.sum(rebuilt * rebuilt)
+
+    grad = np.asarray(jax.grad(objective)(x0))
+    assert grad.shape == tuple(np.asarray(x0).shape)
+    assert np.all(np.isfinite(grad))
+
+
 def test_fixed_boundary_residual_implicit_primal_matches_reference_mode(load_case_circular_tokamak):
     pytest.importorskip("jax")
 

--- a/tests/test_implicit_helpers.py
+++ b/tests/test_implicit_helpers.py
@@ -120,6 +120,79 @@ def test_stellsym_active_keep_scatter_supports_reverse_mode(load_case_circular_t
     assert np.all(np.isfinite(grad))
 
 
+def test_stellsym_reduced_lambda_mn_coords_roundtrip_and_support_reverse_mode(load_case_circular_tokamak):
+    pytest.importorskip("jax")
+
+    from vmec_jax._compat import enable_x64, jax, jnp
+    from vmec_jax.implicit import (
+        _mode00_index,
+        _pack_stellsym_reduced_state,
+        _stellsym_feasible_indices_np,
+        _stellsym_lambda_mn_indices,
+        _stellsym_reduced_z_indices,
+        _update_stellsym_reduced_state,
+    )
+
+    enable_x64(True)
+
+    _cfg, _indata, static, _bdy, st0 = load_case_circular_tokamak
+    idx00 = _mode00_index(static.modes)
+    rz_idx_np, _lam_idx_np, ns, K = _stellsym_feasible_indices_np(static, idx00=idx00, mask_lambda_axis=True)
+    rz_idx = jnp.asarray(rz_idx_np, dtype=jnp.int32)
+    z_idx = _stellsym_reduced_z_indices(rz_idx=rz_idx_np, K=int(K), idx00=idx00)
+    lam_sc_idx, lam_cs_idx, lam_maps = _stellsym_lambda_mn_indices(
+        static,
+        idx00=idx00,
+        mask_lambda_axis=True,
+    )
+
+    x0 = _pack_stellsym_reduced_state(
+        st0,
+        rz_idx=rz_idx,
+        z_idx=z_idx,
+        lam_sc_idx=lam_sc_idx,
+        lam_cs_idx=lam_cs_idx,
+        lam_maps=lam_maps,
+    )
+    st1 = _update_stellsym_reduced_state(
+        st0,
+        x0,
+        rz_idx=rz_idx,
+        z_idx=z_idx,
+        lam_sc_idx=lam_sc_idx,
+        lam_cs_idx=lam_cs_idx,
+        lam_maps=lam_maps,
+        ns=ns,
+        K=K,
+    )
+
+    assert np.asarray(st1.Rcos) == pytest.approx(np.asarray(st0.Rcos), rel=0.0, abs=1e-12)
+    assert np.asarray(st1.Zsin) == pytest.approx(np.asarray(st0.Zsin), rel=0.0, abs=1e-12)
+    assert np.asarray(st1.Lsin) == pytest.approx(np.asarray(st0.Lsin), rel=0.0, abs=1e-12)
+
+    def objective(x):
+        st = _update_stellsym_reduced_state(
+            st0,
+            x,
+            rz_idx=rz_idx,
+            z_idx=z_idx,
+            lam_sc_idx=lam_sc_idx,
+            lam_cs_idx=lam_cs_idx,
+            lam_maps=lam_maps,
+            ns=ns,
+            K=K,
+        )
+        return (
+            jnp.sum(jnp.asarray(st.Rcos) ** 2)
+            + jnp.sum(jnp.asarray(st.Zsin) ** 2)
+            + jnp.sum(jnp.asarray(st.Lsin) ** 2)
+        )
+
+    grad = np.asarray(jax.grad(objective)(x0))
+    assert grad.shape == tuple(np.asarray(x0).shape)
+    assert np.all(np.isfinite(grad))
+
+
 def test_fixed_boundary_residual_implicit_primal_matches_default_control_path(load_case_circular_tokamak):
     pytest.importorskip("jax")
 

--- a/tools/diagnostics/README.md
+++ b/tools/diagnostics/README.md
@@ -50,3 +50,13 @@ Late-iteration free-boundary diagnostics:
 - The free-boundary comparator uses these cached channels when `fouri` dump
   files are absent (common at `ivacskip > 0`), so `source_sym`/`bvecNS`
   alignment remains observable beyond vacuum turn-on iterations.
+
+Fixed-boundary implicit-AD debugging:
+
+- `VMEC_JAX_IMPLICIT_KEEP_ALL_ACTIVE=1` disables the reduced active-column drop
+  in the lasym=`False` implicit solve and uses the full active state instead.
+- `VMEC_JAX_IMPLICIT_DISABLE_REDUCED_ACTIVE=1` bypasses the reduced
+  stellarator-symmetric adjoint path entirely and falls back to the full-state
+  adjoint.
+- These flags are diagnostic tools for derivative investigations, not parity or
+  performance defaults.

--- a/vmec_jax/__init__.py
+++ b/vmec_jax/__init__.py
@@ -1,5 +1,13 @@
 """vmec_jax: a JAX implementation of VMEC2000 for fixed and free-boundary equilibria."""
 
+import os as _os
+
+# Suppress noisy C++ warnings from XLA/PjRt backend (e.g. "Assume version
+# compatibility. PjRt-IFRT does not track XLA executable versions.").  Must be
+# set before *any* ``import jax`` in the process.  Uses setdefault so the user
+# can still override via the environment.
+_os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+
 from . import api
 from .namelist import read_indata, InData
 from .config import FreeBoundaryConfig, VMECConfig, load_config

--- a/vmec_jax/__main__.py
+++ b/vmec_jax/__main__.py
@@ -1,5 +1,10 @@
 """Module entry point for `python -m vmec_jax`."""
 
+import os as _os
+
+# Suppress noisy C++ warnings from XLA/PjRt before any JAX import.
+_os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+
 from .cli import main
 
 

--- a/vmec_jax/_compat.py
+++ b/vmec_jax/_compat.py
@@ -37,6 +37,13 @@ def _try_import_jax() -> Tuple[Any, Any, Callable[[Callable[..., Any]], Callable
     try:
         # Enable x64 by default for VMEC parity unless the user opted out.
         os.environ.setdefault("JAX_ENABLE_X64", "1")
+        # Suppress noisy C++ warnings from XLA/PjRt backend (e.g.
+        # "Assume version compatibility. PjRt-IFRT does not track XLA
+        # executable versions.").  These are harmless informational
+        # messages emitted by abseil logging inside the XLA runtime.
+        # Level 0=INFO, 1=WARNING, 2=ERROR — we default to ERROR-only
+        # so that genuine errors still surface.
+        os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
         import jax
 
         # If Sphinx (or other tooling) has inserted a mock, treat JAX as unavailable.

--- a/vmec_jax/driver.py
+++ b/vmec_jax/driver.py
@@ -353,8 +353,15 @@ def _final_flux_profiles_from_state(
             isinstance(x, jax.core.Tracer)
             for x in (
                 getattr(state, "Rcos", None),
+                getattr(state, "Rsin", None),
+                getattr(state, "Zcos", None),
+                getattr(state, "Zsin", None),
+                getattr(state, "Lcos", None),
+                getattr(state, "Lsin", None),
                 getattr(flux_local, "phipf", None),
                 getattr(flux_local, "phips", None),
+                getattr(flux_local, "chipf", None),
+                getattr(flux_local, "lamscale", None),
                 pressure_local,
             )
         )

--- a/vmec_jax/implicit.py
+++ b/vmec_jax/implicit.py
@@ -1257,7 +1257,11 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
         x_active_star = jnp.take(x_active_star_full, active_keep_idx)
 
         def residual_fun_active(x_active):
-            x_active_full = x_active_star_full.at[active_keep_idx].set(x_active)
+            x_active_full = x_active_star_full.at[active_keep_idx].set(
+                x_active,
+                indices_are_sorted=True,
+                unique_indices=True,
+            )
             st_active = _update_stellsym_feasible_state(
                 st_active_ref,
                 x_active_full,
@@ -1309,7 +1313,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
             )
             if bool(success):
                 dx_active = dx_lineax
-        if dx_active is None and active_is_square and tangent_mode in ("auto", "direct", "bicgstab", "lineax"):
+        if dx_active is None and active_is_square and tangent_mode in ("direct", "bicgstab"):
             from jax.scipy.sparse.linalg import bicgstab
 
             dx_bicgstab, info = bicgstab(
@@ -1356,7 +1360,11 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 max_iter=int(implicit.cg_max_iter),
             )
 
-        dx_active_full = jnp.zeros_like(x_active_star_full).at[active_keep_idx].set(dx_active)
+        dx_active_full = jnp.zeros_like(x_active_star_full).at[active_keep_idx].set(
+            dx_active,
+            indices_are_sorted=True,
+            unique_indices=True,
+        )
         tangent_state = _update_stellsym_feasible_state(
             _zero_state_like(st_star),
             dx_active_full,
@@ -1503,7 +1511,11 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
             )
 
             def residual_fun_active(x_active):
-                x_active_full = x_active_star_full.at[active_keep_idx].set(x_active)
+                x_active_full = x_active_star_full.at[active_keep_idx].set(
+                    x_active,
+                    indices_are_sorted=True,
+                    unique_indices=True,
+                )
                 st_active = _update_stellsym_feasible_state(
                     st_active_ref,
                     x_active_full,

--- a/vmec_jax/implicit.py
+++ b/vmec_jax/implicit.py
@@ -1150,6 +1150,22 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
         )
         return packed
 
+    def _stationarity_state(state, zero_m1_zforce, eRcos, eRsin, eZcos, eZsin, *, project_stellsym: bool = False):
+        def _objective_from_state(st):
+            residual = _residual_vec(
+                st,
+                zero_m1_zforce,
+                eRcos,
+                eRsin,
+                eZcos,
+                eZsin,
+                project_stellsym=project_stellsym,
+            )
+            residual = jnp.asarray(residual)
+            return 0.5 * jnp.sum(residual * residual)
+
+        return _project_state(jax.grad(_objective_from_state)(state))
+
     def _solve_host(eRcos, eRsin, eZcos, eZsin):
         eRcos_np = np.asarray(eRcos)
         eRsin_np = np.asarray(eRsin)
@@ -1239,7 +1255,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 "residual_tangent_mode='linearize' currently supports only lasym=False residual solves"
             )
 
-        tangent_mode = str(getattr(implicit, "residual_adjoint_mode", "auto")).strip().lower()
+        tangent_mode = str(getattr(implicit, "residual_tangent_mode", "auto")).strip().lower()
         rz_idx, lam_idx, ns_active, K_active = _stellsym_feasible_indices(static, idx00=idx00, mask_lambda_axis=True)
         st_active_ref = _stop_gradient_tree(st_star)
         x_active_star_full = _pack_stellsym_feasible_state(st_active_ref, rz_idx=rz_idx, lam_idx=lam_idx)
@@ -1256,7 +1272,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 )
         x_active_star = jnp.take(x_active_star_full, active_keep_idx)
 
-        def residual_fun_active(x_active):
+        def stationarity_fun_active(x_active):
             x_active_full = x_active_star_full.at[active_keep_idx].set(
                 x_active,
                 indices_are_sorted=True,
@@ -1270,34 +1286,39 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 ns=ns_active,
                 K=K_active,
             )
-            return _residual_vec(
+            grad_state = _stationarity_state(
                 st_active,
                 zero_m1_star,
                 eRcos_star,
                 eRsin_star,
                 eZcos_star,
                 eZsin_star,
-                project_stellsym=True,
             )
+            grad_active_full = _pack_stellsym_feasible_state(grad_state, rz_idx=rz_idx, lam_idx=lam_idx)
+            return jnp.take(grad_active_full, active_keep_idx)
 
-        residual_star_active, residual_jvp_active = jax.linearize(residual_fun_active, x_active_star)
-        residual_vjp_active = jax.linear_transpose(residual_jvp_active, x_active_star)
+        stationarity_star_active, stationarity_jvp_active = jax.linearize(stationarity_fun_active, x_active_star)
+        stationarity_vjp_active = jax.linear_transpose(stationarity_jvp_active, x_active_star)
         damping = jnp.asarray(float(implicit.damping), dtype=jnp.asarray(x_active_star).dtype)
-        active_is_square = tuple(residual_star_active.shape) == tuple(x_active_star.shape)
+        active_is_square = tuple(stationarity_star_active.shape) == tuple(x_active_star.shape)
 
-        def residual_jvp_active_damped(u_active):
-            return residual_jvp_active(u_active) + damping * u_active
+        def stationarity_jvp_active_damped(u_active):
+            return stationarity_jvp_active(u_active) + damping * u_active
 
-        boundary_tangent = jax.jvp(
-            lambda a, b, c, d: _residual_vec(
+        def stationarity_params_active(a, b, c, d):
+            grad_state = _stationarity_state(
                 st_star,
                 zero_m1_star,
                 a,
                 b,
                 c,
                 d,
-                project_stellsym=True,
-            ),
+            )
+            grad_active_full = _pack_stellsym_feasible_state(grad_state, rz_idx=rz_idx, lam_idx=lam_idx)
+            return jnp.take(grad_active_full, active_keep_idx)
+
+        boundary_tangent = jax.jvp(
+            stationarity_params_active,
             (eRcos_star, eRsin_star, eZcos_star, eZsin_star),
             (deRcos, deRsin, deZcos, deZsin),
         )[1]
@@ -1306,7 +1327,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
         dx_active = None
         if active_is_square and tangent_mode in ("auto", "lineax"):
             dx_lineax, success, _stats = _lineax_bicgstab_solve(
-                residual_jvp_active_damped,
+                stationarity_jvp_active_damped,
                 rhs,
                 tol=float(implicit.cg_tol),
                 max_iter=int(implicit.cg_max_iter),
@@ -1317,7 +1338,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
             from jax.scipy.sparse.linalg import bicgstab
 
             dx_bicgstab, info = bicgstab(
-                residual_jvp_active_damped,
+                stationarity_jvp_active_damped,
                 rhs,
                 tol=float(implicit.cg_tol),
                 atol=0.0,
@@ -1330,9 +1351,9 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
             if chunk_size is None:
                 chunk_size = min(int(x_active_star.shape[0]), 64)
             J_active = _linear_map_jacobian_columns(
-                residual_jvp_active,
+                stationarity_jvp_active,
                 input_size=int(x_active_star.shape[0]),
-                output_size=int(np.prod(np.shape(residual_star_active))),
+                output_size=int(np.prod(np.shape(stationarity_star_active))),
                 dtype=jnp.asarray(x_active_star).dtype,
                 chunk_size=int(chunk_size),
             )
@@ -1348,11 +1369,11 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 )
         if dx_active is None:
             def Hvp_active(u_active):
-                jv = residual_jvp_active(u_active)
-                jt_jv = residual_vjp_active(jv)[0]
+                jv = stationarity_jvp_active(u_active)
+                jt_jv = stationarity_vjp_active(jv)[0]
                 return jt_jv + damping * u_active
 
-            rhs_normal = residual_vjp_active(rhs)[0]
+            rhs_normal = stationarity_vjp_active(rhs)[0]
             dx_active = _cg_solve(
                 Hvp_active,
                 rhs_normal,
@@ -1442,24 +1463,11 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
         ct_state = _project_state(ct_state)
         b = pack_state(ct_state)
 
-        residual_fun = lambda st: _residual_vec(st, zero_m1_star, eRcos_star, eRsin_star, eZcos_star, eZsin_star)
+        stationarity_fun = lambda st: pack_state(
+            _stationarity_state(st, zero_m1_star, eRcos_star, eRsin_star, eZcos_star, eZsin_star)
+        )
 
-        def _boundary_param_vjp(lam, *, project_stellsym: bool = False):
-            vjp_start = time.perf_counter()
-
-            def F_params(eRcos, eRsin, eZcos, eZsin):
-                return _residual_vec(
-                    st_star,
-                    zero_m1_star,
-                    eRcos,
-                    eRsin,
-                    eZcos,
-                    eZsin,
-                    project_stellsym=project_stellsym,
-                )
-
-            _, vjp_fun = jax.vjp(F_params, eRcos_star, eRsin_star, eZcos_star, eZsin_star)
-            dRcos, dRsin, dZcos, dZsin = vjp_fun(lam)
+        def _edge_boundary_vjp():
             ct_edge = (
                 jnp.asarray(ct_state_full.Rcos)[-1, :],
                 jnp.asarray(ct_state_full.Rsin)[-1, :],
@@ -1474,13 +1482,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 eZsin_star,
             )
             edge_dRcos, edge_dRsin, edge_dZcos, edge_dZsin = edge_vjp_fun(ct_edge)
-            _vmec_backward_profile_log("boundary_param_vjp_done", vjp_start)
-            return (
-                edge_dRcos - dRcos,
-                edge_dRsin - dRsin,
-                edge_dZcos - dZcos,
-                edge_dZsin - dZsin,
-            )
+            return edge_dRcos, edge_dRsin, edge_dZcos, edge_dZsin
 
         residual_adjoint_mode = str(getattr(implicit, "residual_adjoint_mode", "auto")).strip().lower()
         if (not bool(static.cfg.lasym)) and (not _vmec_disable_reduced_active_enabled()):
@@ -1510,7 +1512,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 residual_mode=residual_adjoint_mode,
             )
 
-            def residual_fun_active(x_active):
+            def stationarity_fun_active(x_active):
                 x_active_full = x_active_star_full.at[active_keep_idx].set(
                     x_active,
                     indices_are_sorted=True,
@@ -1524,18 +1526,45 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                     ns=ns_active,
                     K=K_active,
                 )
-                return _residual_vec(
+                grad_state = _stationarity_state(
                     st_active,
                     zero_m1_star,
                     eRcos_star,
                     eRsin_star,
                     eZcos_star,
                     eZsin_star,
-                    project_stellsym=True,
+                )
+                grad_active_full = _pack_stellsym_feasible_state(grad_state, rz_idx=rz_idx, lam_idx=lam_idx)
+                return jnp.take(grad_active_full, active_keep_idx)
+
+            def _boundary_param_vjp_active(lam):
+                vjp_start = time.perf_counter()
+
+                def G_params(eRcos, eRsin, eZcos, eZsin):
+                    grad_state = _stationarity_state(
+                        st_star,
+                        zero_m1_star,
+                        eRcos,
+                        eRsin,
+                        eZcos,
+                        eZsin,
+                    )
+                    grad_active_full = _pack_stellsym_feasible_state(grad_state, rz_idx=rz_idx, lam_idx=lam_idx)
+                    return jnp.take(grad_active_full, active_keep_idx)
+
+                _, vjp_fun = jax.vjp(G_params, eRcos_star, eRsin_star, eZcos_star, eZsin_star)
+                dRcos, dRsin, dZcos, dZsin = vjp_fun(jnp.asarray(lam))
+                edge_dRcos, edge_dRsin, edge_dZcos, edge_dZsin = _edge_boundary_vjp()
+                _vmec_backward_profile_log("boundary_param_vjp_done", vjp_start)
+                return (
+                    edge_dRcos - dRcos,
+                    edge_dRsin - dRsin,
+                    edge_dZcos - dZcos,
+                    edge_dZsin - dZsin,
                 )
 
             active_linearize_start = time.perf_counter()
-            residual_star_active, residual_jvp_active = jax.linearize(residual_fun_active, x_active_star)
+            residual_star_active, residual_jvp_active = jax.linearize(stationarity_fun_active, x_active_star)
             residual_vjp_active = jax.linear_transpose(residual_jvp_active, x_active_star)
             _vmec_backward_profile_log(
                 "active_linearize_done",
@@ -1576,7 +1605,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 u_active = jnp.linalg.solve(H_active, b_active)
                 _vmec_backward_profile_log("active_dense_solve_done", solve_start)
                 lam = J_active @ u_active
-                result = _boundary_param_vjp(lam, project_stellsym=True)
+                result = _boundary_param_vjp_active(lam)
                 _vmec_backward_profile_log("bwd_done_chunked", bwd_start)
                 return result
 
@@ -1596,7 +1625,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 )
                 _vmec_backward_profile_log("direct_bicgstab_done", direct_solve_start, info=str(info))
                 if info is None:
-                    result = _boundary_param_vjp(lam, project_stellsym=True)
+                    result = _boundary_param_vjp_active(lam)
                     _vmec_backward_profile_log("bwd_done_direct", bwd_start)
                     return result
 
@@ -1625,7 +1654,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                     num_steps=num_steps,
                 )
                 if bool(success):
-                    result = _boundary_param_vjp(lam, project_stellsym=True)
+                    result = _boundary_param_vjp_active(lam)
                     _vmec_backward_profile_log("bwd_done_lineax", bwd_start)
                     return result
 
@@ -1640,12 +1669,31 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
             jvp_start = time.perf_counter()
             lam = residual_jvp_active(u_active)
             _vmec_backward_profile_log("active_jvp_done", jvp_start)
-            result = _boundary_param_vjp(lam, project_stellsym=True)
+            result = _boundary_param_vjp_active(lam)
             _vmec_backward_profile_log("bwd_done_active", bwd_start)
             return result
 
+        def _boundary_param_vjp_full(lam):
+            vjp_start = time.perf_counter()
+
+            def G_params(eRcos, eRsin, eZcos, eZsin):
+                return pack_state(
+                    _stationarity_state(st_star, zero_m1_star, eRcos, eRsin, eZcos, eZsin)
+                )
+
+            _, vjp_fun = jax.vjp(G_params, eRcos_star, eRsin_star, eZcos_star, eZsin_star)
+            dRcos, dRsin, dZcos, dZsin = vjp_fun(jnp.asarray(lam))
+            edge_dRcos, edge_dRsin, edge_dZcos, edge_dZsin = _edge_boundary_vjp()
+            _vmec_backward_profile_log("boundary_param_vjp_done", vjp_start)
+            return (
+                edge_dRcos - dRcos,
+                edge_dRsin - dRsin,
+                edge_dZcos - dZcos,
+                edge_dZsin - dZsin,
+            )
+
         linearize_start = time.perf_counter()
-        residual_star, residual_jvp = jax.linearize(residual_fun, st_star)
+        residual_star, residual_jvp = jax.linearize(stationarity_fun, st_star)
         residual_vjp = jax.linear_transpose(residual_jvp, st_star)
         _vmec_backward_profile_log("full_linearize_done", linearize_start, residual_size=int(np.prod(np.shape(residual_star))))
 
@@ -1663,7 +1711,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
         jvp_start = time.perf_counter()
         lam = residual_jvp(u_state)
         _vmec_backward_profile_log("full_jvp_done", jvp_start)
-        result = _boundary_param_vjp(lam)
+        result = _boundary_param_vjp_full(lam)
         _vmec_backward_profile_log("bwd_done_full", bwd_start)
         return result
 

--- a/vmec_jax/implicit.py
+++ b/vmec_jax/implicit.py
@@ -32,7 +32,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     lx = None
 
-from .field import TWOPI, b2_from_bsup, bsup_from_geom, bsup_from_sqrtg_lambda
+from .field import TWOPI, b2_from_bsup, bsup_from_geom, bsup_from_sqrtg_lambda, signgs_from_sqrtg
 from .energy import flux_profiles_from_indata
 from .fourier import eval_fourier_dtheta, eval_fourier_dzeta_phys
 from .geom import eval_geom
@@ -1168,6 +1168,8 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
             dtype=np.asarray(state0_host.Rcos).dtype,
             vmec_project=True,
         )
+        geom0 = eval_geom(state_init, static)
+        signgs0 = signgs_from_sqrtg(np.asarray(geom0.sqrtg), axis_index=1)
         state_init = VMECState(
             layout=state_init.layout,
             Rcos=np.asarray(jax.device_get(state_init.Rcos)),
@@ -1181,12 +1183,12 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
             state_init,
             static,
             indata=indata,
-            signgs=signgs_i,
+            signgs=int(signgs0),
             ftol=ftol,
             max_iter=int(max_iter),
             step_size=float(step_size),
             vmec2000_control=True,
-            reference_mode=False,
+            reference_mode=True,
             backtracking=True,
             limit_dt_from_force=True,
             limit_update_rms=True,

--- a/vmec_jax/implicit.py
+++ b/vmec_jax/implicit.py
@@ -1188,7 +1188,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
             max_iter=int(max_iter),
             step_size=float(step_size),
             vmec2000_control=True,
-            reference_mode=True,
+            reference_mode=False,
             backtracking=True,
             limit_dt_from_force=True,
             limit_update_rms=True,

--- a/vmec_jax/implicit.py
+++ b/vmec_jax/implicit.py
@@ -96,6 +96,26 @@ def _vmec_disable_reduced_active_enabled() -> bool:
     return value.strip().lower() not in ("", "0", "false", "no")
 
 
+def _dense_transpose_lstsq_host(J, b, damping):
+    """Host-side least-squares solve for J^T lam ~= b with optional Tikhonov damping."""
+    J_host = np.asarray(J)
+    b_host = np.asarray(b)
+    damping_host = float(np.asarray(damping))
+    A_host = J_host.T
+    if damping_host > 0.0:
+        eye = np.eye(int(A_host.shape[1]), dtype=A_host.dtype)
+        A_host = np.concatenate(
+            [A_host, np.sqrt(damping_host) * eye],
+            axis=0,
+        )
+        b_host = np.concatenate(
+            [b_host, np.zeros((int(eye.shape[0]),), dtype=b_host.dtype)],
+            axis=0,
+        )
+    lam_host, *_ = np.linalg.lstsq(A_host, b_host, rcond=None)
+    return np.asarray(lam_host, dtype=J_host.dtype)
+
+
 @dataclass(frozen=True)
 class ImplicitLambdaOptions:
     """Controls for the implicit backward pass."""
@@ -311,6 +331,129 @@ def _update_stellsym_feasible_state(state: VMECState, x, *, rz_idx, lam_idx, ns:
         .set(x[2 * n_rz : 2 * n_rz + n_l], indices_are_sorted=True, unique_indices=True)
         .reshape((ns, K))
     )
+    return VMECState(
+        layout=state.layout,
+        Rcos=Rcos,
+        Rsin=jnp.asarray(state.Rsin),
+        Zcos=jnp.asarray(state.Zcos),
+        Zsin=Zsin,
+        Lcos=jnp.asarray(state.Lcos),
+        Lsin=Lsin,
+    )
+
+
+def _stellsym_reduced_z_indices(*, rz_idx, K: int, idx00: int | None):
+    """Flat Zsin indices that remain active after dropping dead (m,n)=(0,0) rows."""
+    rz_idx_np = np.asarray(rz_idx, dtype=np.int32)
+    z_idx_np = np.array(rz_idx_np, copy=True)
+    if idx00 is not None:
+        z_idx_np = z_idx_np[(rz_idx_np % int(K)) != int(idx00)]
+    return jnp.asarray(z_idx_np, dtype=jnp.int32)
+
+
+def _stellsym_lambda_mn_indices(static, *, idx00: int | None, mask_lambda_axis: bool = True):
+    """Independent stellarator-symmetric lambda coordinates in VMEC (m,n>=0) sin storage."""
+    from .vmec_parity import signed_maps_from_modes
+
+    ns = int(static.cfg.ns)
+    maps = signed_maps_from_modes(static.modes)
+
+    sc_mask = np.ones((ns, maps.mpol, maps.nrange), dtype=bool)
+    cs_mask = np.ones((ns, maps.mpol, maps.nrange), dtype=bool)
+    if bool(mask_lambda_axis):
+        sc_mask[0, :, :] = False
+        cs_mask[0, :, :] = False
+
+    # For stellarator-symmetric lambda the m=0,n>0 branch lives in cs only,
+    # while n=0 lives in sc only.
+    sc_mask[:, 0, 1:] = False
+    cs_mask[:, :, 0] = False
+    if idx00 is not None:
+        sc_mask[:, 0, 0] = False
+
+    return (
+        jnp.asarray(np.flatnonzero(sc_mask.reshape(-1)), dtype=jnp.int32),
+        jnp.asarray(np.flatnonzero(cs_mask.reshape(-1)), dtype=jnp.int32),
+        maps,
+    )
+
+
+def _pack_stellsym_reduced_state(
+    state: VMECState,
+    *,
+    rz_idx,
+    z_idx,
+    lam_sc_idx,
+    lam_cs_idx,
+    lam_maps,
+):
+    """Pack reduced lasym=False coordinates using VMEC lambda mn-sin storage."""
+    from .vmec_parity import _signed_to_mn_sin_cached
+
+    lam_sc, lam_cs = _signed_to_mn_sin_cached(jnp.asarray(state.Lsin), maps=lam_maps)
+    return jnp.concatenate(
+        [
+            jnp.take(jnp.ravel(jnp.asarray(state.Rcos)), rz_idx),
+            jnp.take(jnp.ravel(jnp.asarray(state.Zsin)), z_idx),
+            jnp.take(jnp.ravel(jnp.asarray(lam_sc)), lam_sc_idx),
+            jnp.take(jnp.ravel(jnp.asarray(lam_cs)), lam_cs_idx),
+        ],
+        axis=0,
+    )
+
+
+def _update_stellsym_reduced_state(
+    state: VMECState,
+    x,
+    *,
+    rz_idx,
+    z_idx,
+    lam_sc_idx,
+    lam_cs_idx,
+    lam_maps,
+    ns: int,
+    K: int,
+):
+    """Update reduced lasym=False coordinates in VMEC lambda mn-sin storage."""
+    from .vmec_parity import _mn_sin_to_signed_cached, _signed_to_mn_sin_cached
+
+    x = jnp.asarray(x)
+    n_rz = int(rz_idx.shape[0])
+    n_z = int(z_idx.shape[0])
+    n_sc = int(lam_sc_idx.shape[0])
+    n_cs = int(lam_cs_idx.shape[0])
+
+    Rcos = (
+        jnp.ravel(jnp.asarray(state.Rcos))
+        .at[rz_idx]
+        .set(x[:n_rz], indices_are_sorted=True, unique_indices=True)
+        .reshape((ns, K))
+    )
+    Zsin = (
+        jnp.ravel(jnp.asarray(state.Zsin))
+        .at[z_idx]
+        .set(x[n_rz : n_rz + n_z], indices_are_sorted=True, unique_indices=True)
+        .reshape((ns, K))
+    )
+
+    lam_sc0, lam_cs0 = _signed_to_mn_sin_cached(jnp.asarray(state.Lsin), maps=lam_maps)
+    lam_sc = (
+        jnp.ravel(jnp.asarray(lam_sc0))
+        .at[lam_sc_idx]
+        .set(x[n_rz + n_z : n_rz + n_z + n_sc], indices_are_sorted=True, unique_indices=True)
+        .reshape((ns, lam_maps.mpol, lam_maps.nrange))
+    )
+    lam_cs = (
+        jnp.ravel(jnp.asarray(lam_cs0))
+        .at[lam_cs_idx]
+        .set(
+            x[n_rz + n_z + n_sc : n_rz + n_z + n_sc + n_cs],
+            indices_are_sorted=True,
+            unique_indices=True,
+        )
+        .reshape((ns, lam_maps.mpol, lam_maps.nrange))
+    )
+    Lsin = _mn_sin_to_signed_cached(lam_sc, lam_cs, maps=lam_maps, ncoeff=K)
     return VMECState(
         layout=state.layout,
         Rcos=Rcos,
@@ -927,6 +1070,9 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
 
     from .boundary import BoundaryCoeffs, boundary_from_indata
     from .init_guess import initial_guess_from_boundary
+    from .preconditioner_1d_jax import (
+        lambda_preconditioner_cached,
+    )
     from .vmec_forces import vmec_forces_rz_from_wout, vmec_residual_internal_from_kernels
     from .vmec_residue import (
         vmec_apply_m1_constraints,
@@ -1128,17 +1274,30 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
         norms = vmec_force_norms_from_bcovar_dynamic(bc=k.bc, trig=trig, s=s, signgs=signgs_i)
         scale_rz = jnp.sqrt(norms.r1 * norms.fnorm)
         scale_l = jnp.sqrt(norms.fnormL)
-        parts = [("frcc", scale_rz * frzl.frcc), ("fzsc", scale_rz * frzl.fzsc), ("flsc", scale_l * frzl.flsc)]
+        lam_prec = lambda_preconditioner_cached(
+            bc=k.bc,
+            trig=trig,
+            s=s,
+            cfg=static.cfg,
+        )
+        parts = [
+            ("frcc", scale_rz * frzl.frcc),
+            ("fzsc", scale_rz * frzl.fzsc),
+            ("flsc", scale_l * jnp.asarray(frzl.flsc) * jnp.asarray(lam_prec)),
+        ]
         if frzl.frss is not None:
             parts.append(("frss", scale_rz * frzl.frss))
         if frzl.fzcs is not None:
             parts.append(("fzcs", scale_rz * frzl.fzcs))
         if frzl.flcs is not None:
-            parts.append(("flcs", scale_l * frzl.flcs))
+            parts.append(("flcs", scale_l * jnp.asarray(frzl.flcs) * jnp.asarray(lam_prec)))
         for name in ["frsc", "fzcc", "flcc", "frcs", "fzss", "flss"]:
             arr = getattr(frzl, name, None)
             if arr is not None:
-                parts.append((name, (scale_l if name.startswith("fl") else scale_rz) * arr))
+                scale = scale_l if name.startswith("fl") else scale_rz
+                if name.startswith("fl"):
+                    arr = jnp.asarray(arr) * jnp.asarray(lam_prec)
+                parts.append((name, scale * arr))
         projector = stellsym_residual_projector if bool(project_stellsym) else None
         packed = _pack_residual_parts(parts, projector=projector)
         _vmec_residual_profile_log("postprocess_done", post_start)
@@ -1256,46 +1415,117 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
             )
 
         tangent_mode = str(getattr(implicit, "residual_tangent_mode", "auto")).strip().lower()
-        rz_idx, lam_idx, ns_active, K_active = _stellsym_feasible_indices(static, idx00=idx00, mask_lambda_axis=True)
+        rz_idx_np, lam_idx_np, ns_active, K_active = _stellsym_feasible_indices_np(
+            static,
+            idx00=idx00,
+            mask_lambda_axis=True,
+        )
+        rz_idx = jnp.asarray(rz_idx_np, dtype=jnp.int32)
+        lam_idx = jnp.asarray(lam_idx_np, dtype=jnp.int32)
         st_active_ref = _stop_gradient_tree(st_star)
-        x_active_star_full = _pack_stellsym_feasible_state(st_active_ref, rz_idx=rz_idx, lam_idx=lam_idx)
         if _vmec_keep_all_active_enabled():
+            x_active_star_full = _pack_stellsym_feasible_state(st_active_ref, rz_idx=rz_idx, lam_idx=lam_idx)
             active_keep_idx = jnp.arange(int(x_active_star_full.shape[0]), dtype=jnp.int32)
-        else:
-            active_keep_idx = stellsym_active_keep_idx
-            if active_keep_idx is None:
-                active_keep_idx = _stellsym_structural_active_keep_indices(
-                    rz_idx=np.asarray(rz_idx),
-                    lam_idx=np.asarray(lam_idx),
-                    K=int(K_active),
-                    idx00=idx00,
-                )
-        x_active_star = jnp.take(x_active_star_full, active_keep_idx)
+            x_active_star = jnp.take(x_active_star_full, active_keep_idx)
 
-        def stationarity_fun_active(x_active):
-            x_active_full = x_active_star_full.at[active_keep_idx].set(
-                x_active,
-                indices_are_sorted=True,
-                unique_indices=True,
+            def stationarity_fun_active(x_active):
+                x_active_full = x_active_star_full.at[active_keep_idx].set(
+                    x_active,
+                    indices_are_sorted=True,
+                    unique_indices=True,
+                )
+                st_active = _update_stellsym_feasible_state(
+                    st_active_ref,
+                    x_active_full,
+                    rz_idx=rz_idx,
+                    lam_idx=lam_idx,
+                    ns=ns_active,
+                    K=K_active,
+                )
+                grad_state = _stationarity_state(
+                    st_active,
+                    zero_m1_star,
+                    eRcos_star,
+                    eRsin_star,
+                    eZcos_star,
+                    eZsin_star,
+                )
+                grad_active_full = _pack_stellsym_feasible_state(grad_state, rz_idx=rz_idx, lam_idx=lam_idx)
+                return jnp.take(grad_active_full, active_keep_idx)
+
+            def stationarity_params_active(a, b, c, d):
+                grad_state = _stationarity_state(
+                    st_star,
+                    zero_m1_star,
+                    a,
+                    b,
+                    c,
+                    d,
+                )
+                grad_active_full = _pack_stellsym_feasible_state(grad_state, rz_idx=rz_idx, lam_idx=lam_idx)
+                return jnp.take(grad_active_full, active_keep_idx)
+        else:
+            z_idx = _stellsym_reduced_z_indices(rz_idx=rz_idx_np, K=int(K_active), idx00=idx00)
+            lam_sc_idx, lam_cs_idx, lam_maps = _stellsym_lambda_mn_indices(
+                static,
+                idx00=idx00,
+                mask_lambda_axis=True,
             )
-            st_active = _update_stellsym_feasible_state(
+            x_active_star = _pack_stellsym_reduced_state(
                 st_active_ref,
-                x_active_full,
                 rz_idx=rz_idx,
-                lam_idx=lam_idx,
-                ns=ns_active,
-                K=K_active,
+                z_idx=z_idx,
+                lam_sc_idx=lam_sc_idx,
+                lam_cs_idx=lam_cs_idx,
+                lam_maps=lam_maps,
             )
-            grad_state = _stationarity_state(
-                st_active,
-                zero_m1_star,
-                eRcos_star,
-                eRsin_star,
-                eZcos_star,
-                eZsin_star,
-            )
-            grad_active_full = _pack_stellsym_feasible_state(grad_state, rz_idx=rz_idx, lam_idx=lam_idx)
-            return jnp.take(grad_active_full, active_keep_idx)
+
+            def stationarity_fun_active(x_active):
+                st_active = _update_stellsym_reduced_state(
+                    st_active_ref,
+                    x_active,
+                    rz_idx=rz_idx,
+                    z_idx=z_idx,
+                    lam_sc_idx=lam_sc_idx,
+                    lam_cs_idx=lam_cs_idx,
+                    lam_maps=lam_maps,
+                    ns=ns_active,
+                    K=K_active,
+                )
+                grad_state = _stationarity_state(
+                    st_active,
+                    zero_m1_star,
+                    eRcos_star,
+                    eRsin_star,
+                    eZcos_star,
+                    eZsin_star,
+                )
+                return _pack_stellsym_reduced_state(
+                    grad_state,
+                    rz_idx=rz_idx,
+                    z_idx=z_idx,
+                    lam_sc_idx=lam_sc_idx,
+                    lam_cs_idx=lam_cs_idx,
+                    lam_maps=lam_maps,
+                )
+
+            def stationarity_params_active(a, b, c, d):
+                grad_state = _stationarity_state(
+                    st_star,
+                    zero_m1_star,
+                    a,
+                    b,
+                    c,
+                    d,
+                )
+                return _pack_stellsym_reduced_state(
+                    grad_state,
+                    rz_idx=rz_idx,
+                    z_idx=z_idx,
+                    lam_sc_idx=lam_sc_idx,
+                    lam_cs_idx=lam_cs_idx,
+                    lam_maps=lam_maps,
+                )
 
         stationarity_star_active, stationarity_jvp_active = jax.linearize(stationarity_fun_active, x_active_star)
         stationarity_vjp_active = jax.linear_transpose(stationarity_jvp_active, x_active_star)
@@ -1304,18 +1534,6 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
 
         def stationarity_jvp_active_damped(u_active):
             return stationarity_jvp_active(u_active) + damping * u_active
-
-        def stationarity_params_active(a, b, c, d):
-            grad_state = _stationarity_state(
-                st_star,
-                zero_m1_star,
-                a,
-                b,
-                c,
-                d,
-            )
-            grad_active_full = _pack_stellsym_feasible_state(grad_state, rz_idx=rz_idx, lam_idx=lam_idx)
-            return jnp.take(grad_active_full, active_keep_idx)
 
         boundary_tangent = jax.jvp(
             stationarity_params_active,
@@ -1381,19 +1599,32 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 max_iter=int(implicit.cg_max_iter),
             )
 
-        dx_active_full = jnp.zeros_like(x_active_star_full).at[active_keep_idx].set(
-            dx_active,
-            indices_are_sorted=True,
-            unique_indices=True,
-        )
-        tangent_state = _update_stellsym_feasible_state(
-            _zero_state_like(st_star),
-            dx_active_full,
-            rz_idx=rz_idx,
-            lam_idx=lam_idx,
-            ns=ns_active,
-            K=K_active,
-        )
+        if _vmec_keep_all_active_enabled():
+            dx_active_full = jnp.zeros_like(x_active_star_full).at[active_keep_idx].set(
+                dx_active,
+                indices_are_sorted=True,
+                unique_indices=True,
+            )
+            tangent_state = _update_stellsym_feasible_state(
+                _zero_state_like(st_star),
+                dx_active_full,
+                rz_idx=rz_idx,
+                lam_idx=lam_idx,
+                ns=ns_active,
+                K=K_active,
+            )
+        else:
+            tangent_state = _update_stellsym_reduced_state(
+                _zero_state_like(st_star),
+                dx_active,
+                rz_idx=rz_idx,
+                z_idx=z_idx,
+                lam_sc_idx=lam_sc_idx,
+                lam_cs_idx=lam_cs_idx,
+                lam_maps=lam_maps,
+                ns=ns_active,
+                K=K_active,
+            )
         dsRcos, dsRsin, dsZcos, dsZsin = jax.jvp(
             _boundary_state_edge_rows,
             (eRcos_star, eRsin_star, eZcos_star, eZsin_star),
@@ -1487,81 +1718,172 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
         residual_adjoint_mode = str(getattr(implicit, "residual_adjoint_mode", "auto")).strip().lower()
         if (not bool(static.cfg.lasym)) and (not _vmec_disable_reduced_active_enabled()):
             active_setup_start = time.perf_counter()
-            rz_idx, lam_idx, ns_active, K_active = _stellsym_feasible_indices(static, idx00=idx00, mask_lambda_axis=True)
-            b_active_full = _pack_stellsym_feasible_state(ct_state, rz_idx=rz_idx, lam_idx=lam_idx)
-            if _vmec_keep_all_active_enabled():
-                active_keep_idx = jnp.arange(int(b_active_full.shape[0]), dtype=jnp.int32)
-            else:
-                active_keep_idx = stellsym_active_keep_idx
-                if active_keep_idx is None:
-                    active_keep_idx = _stellsym_structural_active_keep_indices(
-                        rz_idx=np.asarray(rz_idx),
-                        lam_idx=np.asarray(lam_idx),
-                        K=int(K_active),
-                        idx00=idx00,
-                    )
-            b_active = jnp.take(b_active_full, active_keep_idx)
-            st_active_ref = _stop_gradient_tree(st_star)
-            x_active_star_full = _pack_stellsym_feasible_state(st_star, rz_idx=rz_idx, lam_idx=lam_idx)
-            x_active_star = jnp.take(x_active_star_full, active_keep_idx)
-            _vmec_backward_profile_log(
-                "active_setup_done",
-                active_setup_start,
-                active_size=int(np.shape(b_active)[0]),
-                active_full_size=int(np.shape(b_active_full)[0]),
-                residual_mode=residual_adjoint_mode,
+            rz_idx_np, lam_idx_np, ns_active, K_active = _stellsym_feasible_indices_np(
+                static,
+                idx00=idx00,
+                mask_lambda_axis=True,
             )
+            rz_idx = jnp.asarray(rz_idx_np, dtype=jnp.int32)
+            lam_idx = jnp.asarray(lam_idx_np, dtype=jnp.int32)
+            if _vmec_keep_all_active_enabled():
+                b_active_full = _pack_stellsym_feasible_state(ct_state, rz_idx=rz_idx, lam_idx=lam_idx)
+                active_keep_idx = jnp.arange(int(b_active_full.shape[0]), dtype=jnp.int32)
+                st_active_ref = _stop_gradient_tree(st_star)
+                x_active_star_full = _pack_stellsym_feasible_state(st_star, rz_idx=rz_idx, lam_idx=lam_idx)
+                x_active_star = jnp.take(x_active_star_full, active_keep_idx)
+                b_active = jnp.take(b_active_full, active_keep_idx)
 
-            def stationarity_fun_active(x_active):
-                x_active_full = x_active_star_full.at[active_keep_idx].set(
-                    x_active,
-                    indices_are_sorted=True,
-                    unique_indices=True,
+                _vmec_backward_profile_log(
+                    "active_setup_done",
+                    active_setup_start,
+                    active_size=int(np.shape(b_active)[0]),
+                    active_full_size=int(np.shape(b_active_full)[0]),
+                    residual_mode=residual_adjoint_mode,
                 )
-                st_active = _update_stellsym_feasible_state(
-                    st_active_ref,
-                    x_active_full,
-                    rz_idx=rz_idx,
-                    lam_idx=lam_idx,
-                    ns=ns_active,
-                    K=K_active,
-                )
-                grad_state = _stationarity_state(
-                    st_active,
-                    zero_m1_star,
-                    eRcos_star,
-                    eRsin_star,
-                    eZcos_star,
-                    eZsin_star,
-                )
-                grad_active_full = _pack_stellsym_feasible_state(grad_state, rz_idx=rz_idx, lam_idx=lam_idx)
-                return jnp.take(grad_active_full, active_keep_idx)
 
-            def _boundary_param_vjp_active(lam):
-                vjp_start = time.perf_counter()
-
-                def G_params(eRcos, eRsin, eZcos, eZsin):
+                def stationarity_fun_active(x_active):
+                    x_active_full = x_active_star_full.at[active_keep_idx].set(
+                        x_active,
+                        indices_are_sorted=True,
+                        unique_indices=True,
+                    )
+                    st_active = _update_stellsym_feasible_state(
+                        st_active_ref,
+                        x_active_full,
+                        rz_idx=rz_idx,
+                        lam_idx=lam_idx,
+                        ns=ns_active,
+                        K=K_active,
+                    )
                     grad_state = _stationarity_state(
-                        st_star,
+                        st_active,
                         zero_m1_star,
-                        eRcos,
-                        eRsin,
-                        eZcos,
-                        eZsin,
+                        eRcos_star,
+                        eRsin_star,
+                        eZcos_star,
+                        eZsin_star,
                     )
                     grad_active_full = _pack_stellsym_feasible_state(grad_state, rz_idx=rz_idx, lam_idx=lam_idx)
                     return jnp.take(grad_active_full, active_keep_idx)
 
-                _, vjp_fun = jax.vjp(G_params, eRcos_star, eRsin_star, eZcos_star, eZsin_star)
-                dRcos, dRsin, dZcos, dZsin = vjp_fun(jnp.asarray(lam))
-                edge_dRcos, edge_dRsin, edge_dZcos, edge_dZsin = _edge_boundary_vjp()
-                _vmec_backward_profile_log("boundary_param_vjp_done", vjp_start)
-                return (
-                    edge_dRcos - dRcos,
-                    edge_dRsin - dRsin,
-                    edge_dZcos - dZcos,
-                    edge_dZsin - dZsin,
+                def _boundary_param_vjp_active(lam):
+                    vjp_start = time.perf_counter()
+
+                    def G_params(eRcos, eRsin, eZcos, eZsin):
+                        grad_state = _stationarity_state(
+                            st_star,
+                            zero_m1_star,
+                            eRcos,
+                            eRsin,
+                            eZcos,
+                            eZsin,
+                        )
+                        grad_active_full = _pack_stellsym_feasible_state(grad_state, rz_idx=rz_idx, lam_idx=lam_idx)
+                        return jnp.take(grad_active_full, active_keep_idx)
+
+                    _, vjp_fun = jax.vjp(G_params, eRcos_star, eRsin_star, eZcos_star, eZsin_star)
+                    dRcos, dRsin, dZcos, dZsin = vjp_fun(jnp.asarray(lam))
+                    edge_dRcos, edge_dRsin, edge_dZcos, edge_dZsin = _edge_boundary_vjp()
+                    _vmec_backward_profile_log("boundary_param_vjp_done", vjp_start)
+                    return (
+                        edge_dRcos - dRcos,
+                        edge_dRsin - dRsin,
+                        edge_dZcos - dZcos,
+                        edge_dZsin - dZsin,
+                    )
+            else:
+                z_idx = _stellsym_reduced_z_indices(rz_idx=rz_idx_np, K=int(K_active), idx00=idx00)
+                lam_sc_idx, lam_cs_idx, lam_maps = _stellsym_lambda_mn_indices(
+                    static,
+                    idx00=idx00,
+                    mask_lambda_axis=True,
                 )
+                st_active_ref = _stop_gradient_tree(st_star)
+                x_active_star = _pack_stellsym_reduced_state(
+                    st_active_ref,
+                    rz_idx=rz_idx,
+                    z_idx=z_idx,
+                    lam_sc_idx=lam_sc_idx,
+                    lam_cs_idx=lam_cs_idx,
+                    lam_maps=lam_maps,
+                )
+                b_active = _pack_stellsym_reduced_state(
+                    ct_state,
+                    rz_idx=rz_idx,
+                    z_idx=z_idx,
+                    lam_sc_idx=lam_sc_idx,
+                    lam_cs_idx=lam_cs_idx,
+                    lam_maps=lam_maps,
+                )
+
+                _vmec_backward_profile_log(
+                    "active_setup_done",
+                    active_setup_start,
+                    active_size=int(np.shape(b_active)[0]),
+                    active_full_size=int(np.shape(b_active)[0]),
+                    residual_mode=residual_adjoint_mode,
+                )
+
+                def stationarity_fun_active(x_active):
+                    st_active = _update_stellsym_reduced_state(
+                        st_active_ref,
+                        x_active,
+                        rz_idx=rz_idx,
+                        z_idx=z_idx,
+                        lam_sc_idx=lam_sc_idx,
+                        lam_cs_idx=lam_cs_idx,
+                        lam_maps=lam_maps,
+                        ns=ns_active,
+                        K=K_active,
+                    )
+                    grad_state = _stationarity_state(
+                        st_active,
+                        zero_m1_star,
+                        eRcos_star,
+                        eRsin_star,
+                        eZcos_star,
+                        eZsin_star,
+                    )
+                    return _pack_stellsym_reduced_state(
+                        grad_state,
+                        rz_idx=rz_idx,
+                        z_idx=z_idx,
+                        lam_sc_idx=lam_sc_idx,
+                        lam_cs_idx=lam_cs_idx,
+                        lam_maps=lam_maps,
+                    )
+
+                def _boundary_param_vjp_active(lam):
+                    vjp_start = time.perf_counter()
+
+                    def G_params(eRcos, eRsin, eZcos, eZsin):
+                        grad_state = _stationarity_state(
+                            st_star,
+                            zero_m1_star,
+                            eRcos,
+                            eRsin,
+                            eZcos,
+                            eZsin,
+                        )
+                        return _pack_stellsym_reduced_state(
+                            grad_state,
+                            rz_idx=rz_idx,
+                            z_idx=z_idx,
+                            lam_sc_idx=lam_sc_idx,
+                            lam_cs_idx=lam_cs_idx,
+                            lam_maps=lam_maps,
+                        )
+
+                    _, vjp_fun = jax.vjp(G_params, eRcos_star, eRsin_star, eZcos_star, eZsin_star)
+                    dRcos, dRsin, dZcos, dZsin = vjp_fun(jnp.asarray(lam))
+                    edge_dRcos, edge_dRsin, edge_dZcos, edge_dZsin = _edge_boundary_vjp()
+                    _vmec_backward_profile_log("boundary_param_vjp_done", vjp_start)
+                    return (
+                        edge_dRcos - dRcos,
+                        edge_dRsin - dRsin,
+                        edge_dZcos - dZcos,
+                        edge_dZsin - dZsin,
+                    )
 
             active_linearize_start = time.perf_counter()
             residual_star_active, residual_jvp_active = jax.linearize(stationarity_fun_active, x_active_star)
@@ -1572,10 +1894,13 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 residual_size=int(np.prod(np.shape(residual_star_active))),
             )
             active_is_square = tuple(residual_star_active.shape) == tuple(b_active.shape)
-            use_chunked_active = residual_adjoint_mode == "chunked"
-            use_lineax_active = residual_adjoint_mode == "lineax" and active_is_square
+            use_chunked_active = residual_adjoint_mode in ("chunked", "dense")
+            use_lineax_active = (
+                residual_adjoint_mode == "lineax"
+                and active_is_square
+            )
             use_direct_stellsym = (
-                residual_adjoint_mode in ("auto", "direct", "bicgstab")
+                residual_adjoint_mode in ("direct", "bicgstab")
                 and active_is_square
             )
 
@@ -1599,12 +1924,28 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                     jac_shape=tuple(int(x) for x in J_active.shape),
                 )
                 solve_start = time.perf_counter()
-                H_active = J_active.T @ J_active
-                damping = jnp.asarray(float(implicit.damping), dtype=H_active.dtype)
-                H_active = H_active + damping * jnp.eye(int(H_active.shape[0]), dtype=H_active.dtype)
-                u_active = jnp.linalg.solve(H_active, b_active)
+                damping = jnp.asarray(float(implicit.damping), dtype=J_active.dtype)
+                if residual_adjoint_mode == "dense":
+                    if _is_traced(J_active, b_active, damping):
+                        out_shape = jax.ShapeDtypeStruct((int(J_active.shape[0]),), J_active.dtype)
+                        lam = jax.pure_callback(
+                            _dense_transpose_lstsq_host,
+                            out_shape,
+                            J_active,
+                            b_active,
+                            damping,
+                        )
+                    else:
+                        lam = jnp.asarray(
+                            _dense_transpose_lstsq_host(J_active, b_active, damping),
+                            dtype=J_active.dtype,
+                        )
+                else:
+                    H_active = J_active @ J_active.T
+                    H_active = H_active + damping * jnp.eye(int(H_active.shape[0]), dtype=H_active.dtype)
+                    rhs_active = J_active @ b_active
+                    lam = jnp.linalg.solve(H_active, rhs_active)
                 _vmec_backward_profile_log("active_dense_solve_done", solve_start)
-                lam = J_active @ u_active
                 result = _boundary_param_vjp_active(lam)
                 _vmec_backward_profile_log("bwd_done_chunked", bwd_start)
                 return result
@@ -1658,17 +1999,20 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                     _vmec_backward_profile_log("bwd_done_lineax", bwd_start)
                     return result
 
-            def Hvp_active(u_active):
-                jv = residual_jvp_active(u_active)
-                jt_jv = residual_vjp_active(jv)[0]
-                return jt_jv + jnp.asarray(float(implicit.damping), dtype=jnp.asarray(jv).dtype) * u_active
+            # Solve the same damped least-squares adjoint system as the dense
+            # reference path, but matrix-free:
+            #   argmin_lam ||J^T lam - b||^2 + damping ||lam||^2
+            # whose normal equations are
+            #   (J J^T + damping I) lam = J b.
+            def Hvp_active(lam):
+                jt_lam = residual_vjp_active(lam)[0]
+                j_jt_lam = residual_jvp_active(jt_lam)
+                return j_jt_lam + jnp.asarray(float(implicit.damping), dtype=jnp.asarray(lam).dtype) * lam
 
+            rhs_active = residual_jvp_active(b_active)
             cg_start = time.perf_counter()
-            u_active = _cg_solve(Hvp_active, b_active, tol=float(implicit.cg_tol), max_iter=int(implicit.cg_max_iter))
+            lam = _cg_solve(Hvp_active, rhs_active, tol=float(implicit.cg_tol), max_iter=int(implicit.cg_max_iter))
             _vmec_backward_profile_log("active_cg_done", cg_start)
-            jvp_start = time.perf_counter()
-            lam = residual_jvp_active(u_active)
-            _vmec_backward_profile_log("active_jvp_done", jvp_start)
             result = _boundary_param_vjp_active(lam)
             _vmec_backward_profile_log("bwd_done_active", bwd_start)
             return result

--- a/vmec_jax/implicit.py
+++ b/vmec_jax/implicit.py
@@ -86,6 +86,16 @@ def _vmec_residual_profile_log(stage: str, start: float | None = None, **extra) 
     print(f"[vmec_jax residual] {payload}", flush=True)
 
 
+def _vmec_keep_all_active_enabled() -> bool:
+    value = os.environ.get("VMEC_JAX_IMPLICIT_KEEP_ALL_ACTIVE", "")
+    return value.strip().lower() not in ("", "0", "false", "no")
+
+
+def _vmec_disable_reduced_active_enabled() -> bool:
+    value = os.environ.get("VMEC_JAX_IMPLICIT_DISABLE_REDUCED_ACTIVE", "")
+    return value.strip().lower() not in ("", "0", "false", "no")
+
+
 @dataclass(frozen=True)
 class ImplicitLambdaOptions:
     """Controls for the implicit backward pass."""
@@ -283,9 +293,24 @@ def _update_stellsym_feasible_state(state: VMECState, x, *, rz_idx, lam_idx, ns:
     n_rz = int(rz_idx.shape[0])
     n_l = int(lam_idx.shape[0])
 
-    Rcos = jnp.ravel(jnp.asarray(state.Rcos)).at[rz_idx].set(x[:n_rz]).reshape((ns, K))
-    Zsin = jnp.ravel(jnp.asarray(state.Zsin)).at[rz_idx].set(x[n_rz : 2 * n_rz]).reshape((ns, K))
-    Lsin = jnp.ravel(jnp.asarray(state.Lsin)).at[lam_idx].set(x[2 * n_rz : 2 * n_rz + n_l]).reshape((ns, K))
+    Rcos = (
+        jnp.ravel(jnp.asarray(state.Rcos))
+        .at[rz_idx]
+        .set(x[:n_rz], indices_are_sorted=True, unique_indices=True)
+        .reshape((ns, K))
+    )
+    Zsin = (
+        jnp.ravel(jnp.asarray(state.Zsin))
+        .at[rz_idx]
+        .set(x[n_rz : 2 * n_rz], indices_are_sorted=True, unique_indices=True)
+        .reshape((ns, K))
+    )
+    Lsin = (
+        jnp.ravel(jnp.asarray(state.Lsin))
+        .at[lam_idx]
+        .set(x[2 * n_rz : 2 * n_rz + n_l], indices_are_sorted=True, unique_indices=True)
+        .reshape((ns, K))
+    )
     return VMECState(
         layout=state.layout,
         Rcos=Rcos,
@@ -1014,14 +1039,35 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
             packed.append(flat)
         return jnp.concatenate(packed, axis=0)
 
+    def _boundary_state_edge_rows(eRcos, eRsin, eZcos, eZsin):
+        boundary_state = initial_guess_from_boundary(
+            static,
+            BoundaryCoeffs(
+                R_cos=jnp.asarray(eRcos),
+                R_sin=jnp.asarray(eRsin),
+                Z_cos=jnp.asarray(eZcos),
+                Z_sin=jnp.asarray(eZsin),
+            ),
+            indata,
+            dtype=jnp.asarray(state0_c.Rcos).dtype,
+            vmec_project=True,
+        )
+        return (
+            jnp.asarray(boundary_state.Rcos)[-1, :],
+            jnp.asarray(boundary_state.Rsin)[-1, :],
+            jnp.asarray(boundary_state.Zcos)[-1, :],
+            jnp.asarray(boundary_state.Zsin)[-1, :],
+        )
+
     def _enforce_state(st, eRcos, eRsin, eZcos, eZsin):
+        sRcos, sRsin, sZcos, sZsin = _boundary_state_edge_rows(eRcos, eRsin, eZcos, eZsin)
         return _enforce_fixed_boundary_and_axis(
             st,
             static,
-            edge_Rcos=eRcos,
-            edge_Rsin=eRsin,
-            edge_Zcos=eZcos,
-            edge_Zsin=eZsin,
+            edge_Rcos=sRcos,
+            edge_Rsin=sRsin,
+            edge_Zcos=sZcos,
+            edge_Zsin=sZsin,
             enforce_lambda_axis=True,
             idx00=idx00,
         )
@@ -1193,17 +1239,19 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
 
         tangent_mode = str(getattr(implicit, "residual_adjoint_mode", "auto")).strip().lower()
         rz_idx, lam_idx, ns_active, K_active = _stellsym_feasible_indices(static, idx00=idx00, mask_lambda_axis=True)
-        active_keep_idx = stellsym_active_keep_idx
-        if active_keep_idx is None:
-            active_keep_idx = _stellsym_structural_active_keep_indices(
-                rz_idx=np.asarray(rz_idx),
-                lam_idx=np.asarray(lam_idx),
-                K=int(K_active),
-                idx00=idx00,
-            )
-
         st_active_ref = _stop_gradient_tree(st_star)
         x_active_star_full = _pack_stellsym_feasible_state(st_active_ref, rz_idx=rz_idx, lam_idx=lam_idx)
+        if _vmec_keep_all_active_enabled():
+            active_keep_idx = jnp.arange(int(x_active_star_full.shape[0]), dtype=jnp.int32)
+        else:
+            active_keep_idx = stellsym_active_keep_idx
+            if active_keep_idx is None:
+                active_keep_idx = _stellsym_structural_active_keep_indices(
+                    rz_idx=np.asarray(rz_idx),
+                    lam_idx=np.asarray(lam_idx),
+                    K=int(K_active),
+                    idx00=idx00,
+                )
         x_active_star = jnp.take(x_active_star_full, active_keep_idx)
 
         def residual_fun_active(x_active):
@@ -1229,6 +1277,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
         residual_star_active, residual_jvp_active = jax.linearize(residual_fun_active, x_active_star)
         residual_vjp_active = jax.linear_transpose(residual_jvp_active, x_active_star)
         damping = jnp.asarray(float(implicit.damping), dtype=jnp.asarray(x_active_star).dtype)
+        active_is_square = tuple(residual_star_active.shape) == tuple(x_active_star.shape)
 
         def residual_jvp_active_damped(u_active):
             return residual_jvp_active(u_active) + damping * u_active
@@ -1248,13 +1297,8 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
         )[1]
         rhs = jnp.asarray(boundary_tangent)
 
-        if tuple(residual_star_active.shape) != tuple(x_active_star.shape):
-            raise NotImplementedError(
-                "residual_tangent_mode='linearize' currently requires a square reduced residual system"
-            )
-
         dx_active = None
-        if tangent_mode in ("auto", "lineax"):
+        if active_is_square and tangent_mode in ("auto", "lineax"):
             dx_lineax, success, _stats = _lineax_bicgstab_solve(
                 residual_jvp_active_damped,
                 rhs,
@@ -1263,7 +1307,7 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
             )
             if bool(success):
                 dx_active = dx_lineax
-        if dx_active is None and tangent_mode in ("auto", "direct", "bicgstab", "lineax"):
+        if dx_active is None and active_is_square and tangent_mode in ("auto", "direct", "bicgstab", "lineax"):
             from jax.scipy.sparse.linalg import bicgstab
 
             dx_bicgstab, info = bicgstab(
@@ -1286,13 +1330,19 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 dtype=jnp.asarray(x_active_star).dtype,
                 chunk_size=int(chunk_size),
             )
-            dx_active = jnp.linalg.solve(
-                J_active + damping * jnp.eye(int(J_active.shape[0]), dtype=J_active.dtype),
-                rhs,
-            )
+            if active_is_square:
+                dx_active = jnp.linalg.solve(
+                    J_active + damping * jnp.eye(int(J_active.shape[0]), dtype=J_active.dtype),
+                    rhs,
+                )
+            else:
+                dx_active = jnp.linalg.solve(
+                    J_active.T @ J_active + damping * jnp.eye(int(J_active.shape[1]), dtype=J_active.dtype),
+                    J_active.T @ rhs,
+                )
         if dx_active is None:
             def Hvp_active(u_active):
-                jv = residual_jvp_active_damped(u_active)
+                jv = residual_jvp_active(u_active)
                 jt_jv = residual_vjp_active(jv)[0]
                 return jt_jv + damping * u_active
 
@@ -1313,14 +1363,19 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
             ns=ns_active,
             K=K_active,
         )
+        dsRcos, dsRsin, dsZcos, dsZsin = jax.jvp(
+            _boundary_state_edge_rows,
+            (eRcos_star, eRsin_star, eZcos_star, eZsin_star),
+            (deRcos, deRsin, deZcos, deZsin),
+        )[1]
         return VMECState(
             layout=tangent_state.layout,
-            Rcos=jnp.asarray(tangent_state.Rcos).at[-1].set(jnp.asarray(deRcos)),
-            Rsin=jnp.asarray(tangent_state.Rsin).at[-1].set(jnp.asarray(deRsin)),
-            Zcos=jnp.asarray(tangent_state.Zcos).at[-1].set(jnp.asarray(deZcos)),
-            Zsin=jnp.asarray(tangent_state.Zsin).at[-1].set(jnp.asarray(deZsin)),
+            Rcos=(-jnp.asarray(tangent_state.Rcos)).at[-1].set(jnp.asarray(dsRcos)),
+            Rsin=(-jnp.asarray(tangent_state.Rsin)).at[-1].set(jnp.asarray(dsRsin)),
+            Zcos=(-jnp.asarray(tangent_state.Zcos)).at[-1].set(jnp.asarray(dsZcos)),
+            Zsin=(-jnp.asarray(tangent_state.Zsin)).at[-1].set(jnp.asarray(dsZsin)),
             Lcos=jnp.asarray(tangent_state.Lcos),
-            Lsin=jnp.asarray(tangent_state.Lsin),
+            Lsin=-jnp.asarray(tangent_state.Lsin),
         )
 
     if residual_tangent_mode not in ("", "0", "false", "no", "opaque"):
@@ -1344,15 +1399,6 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 jnp.asarray(deRsin),
                 jnp.asarray(deZcos),
                 jnp.asarray(deZsin),
-            )
-            tangent_state = VMECState(
-                layout=tangent_state.layout,
-                Rcos=-jnp.asarray(tangent_state.Rcos),
-                Rsin=-jnp.asarray(tangent_state.Rsin),
-                Zcos=-jnp.asarray(tangent_state.Zcos),
-                Zsin=-jnp.asarray(tangent_state.Zsin),
-                Lcos=-jnp.asarray(tangent_state.Lcos),
-                Lsin=-jnp.asarray(tangent_state.Lsin),
             )
             return st, tangent_state
 
@@ -1404,26 +1450,44 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
 
             _, vjp_fun = jax.vjp(F_params, eRcos_star, eRsin_star, eZcos_star, eZsin_star)
             dRcos, dRsin, dZcos, dZsin = vjp_fun(lam)
-            dRcos = dRcos + jnp.asarray(ct_state_full.Rcos)[-1, :]
-            dRsin = dRsin + jnp.asarray(ct_state_full.Rsin)[-1, :]
-            dZcos = dZcos + jnp.asarray(ct_state_full.Zcos)[-1, :]
-            dZsin = dZsin + jnp.asarray(ct_state_full.Zsin)[-1, :]
+            ct_edge = (
+                jnp.asarray(ct_state_full.Rcos)[-1, :],
+                jnp.asarray(ct_state_full.Rsin)[-1, :],
+                jnp.asarray(ct_state_full.Zcos)[-1, :],
+                jnp.asarray(ct_state_full.Zsin)[-1, :],
+            )
+            _, edge_vjp_fun = jax.vjp(
+                _boundary_state_edge_rows,
+                eRcos_star,
+                eRsin_star,
+                eZcos_star,
+                eZsin_star,
+            )
+            edge_dRcos, edge_dRsin, edge_dZcos, edge_dZsin = edge_vjp_fun(ct_edge)
             _vmec_backward_profile_log("boundary_param_vjp_done", vjp_start)
-            return (-dRcos, -dRsin, -dZcos, -dZsin)
+            return (
+                edge_dRcos - dRcos,
+                edge_dRsin - dRsin,
+                edge_dZcos - dZcos,
+                edge_dZsin - dZsin,
+            )
 
         residual_adjoint_mode = str(getattr(implicit, "residual_adjoint_mode", "auto")).strip().lower()
-        if not bool(static.cfg.lasym):
+        if (not bool(static.cfg.lasym)) and (not _vmec_disable_reduced_active_enabled()):
             active_setup_start = time.perf_counter()
             rz_idx, lam_idx, ns_active, K_active = _stellsym_feasible_indices(static, idx00=idx00, mask_lambda_axis=True)
-            active_keep_idx = stellsym_active_keep_idx
-            if active_keep_idx is None:
-                active_keep_idx = _stellsym_structural_active_keep_indices(
-                    rz_idx=np.asarray(rz_idx),
-                    lam_idx=np.asarray(lam_idx),
-                    K=int(K_active),
-                    idx00=idx00,
-                )
             b_active_full = _pack_stellsym_feasible_state(ct_state, rz_idx=rz_idx, lam_idx=lam_idx)
+            if _vmec_keep_all_active_enabled():
+                active_keep_idx = jnp.arange(int(b_active_full.shape[0]), dtype=jnp.int32)
+            else:
+                active_keep_idx = stellsym_active_keep_idx
+                if active_keep_idx is None:
+                    active_keep_idx = _stellsym_structural_active_keep_indices(
+                        rz_idx=np.asarray(rz_idx),
+                        lam_idx=np.asarray(lam_idx),
+                        K=int(K_active),
+                        idx00=idx00,
+                    )
             b_active = jnp.take(b_active_full, active_keep_idx)
             st_active_ref = _stop_gradient_tree(st_star)
             x_active_star_full = _pack_stellsym_feasible_state(st_star, rz_idx=rz_idx, lam_idx=lam_idx)
@@ -1464,11 +1528,12 @@ def solve_fixed_boundary_state_implicit_vmec_residual(
                 active_linearize_start,
                 residual_size=int(np.prod(np.shape(residual_star_active))),
             )
+            active_is_square = tuple(residual_star_active.shape) == tuple(b_active.shape)
             use_chunked_active = residual_adjoint_mode == "chunked"
-            use_lineax_active = residual_adjoint_mode == "lineax"
+            use_lineax_active = residual_adjoint_mode == "lineax" and active_is_square
             use_direct_stellsym = (
                 residual_adjoint_mode in ("auto", "direct", "bicgstab")
-                and tuple(residual_star_active.shape) == tuple(b_active.shape)
+                and active_is_square
             )
 
             if use_chunked_active:

--- a/vmec_jax/solve.py
+++ b/vmec_jax/solve.py
@@ -37,12 +37,32 @@ _COMPUTE_FORCES_CACHE: dict[tuple, Any] = {}
 
 
 def _hash_array_bytes(a: Any) -> str:
-    arr = np.asarray(a)
+    try:
+        arr = np.asarray(a)
+    except Exception:
+        try:
+            aval = jax.core.get_aval(a)
+        except Exception:
+            aval = None
+        if aval is None:
+            return f"opaque:{type(a).__name__}"
+        shape = tuple(getattr(aval, "shape", ()))
+        dtype = getattr(aval, "dtype", None)
+        weak_type = bool(getattr(aval, "weak_type", False))
+        return f"traced:{shape}:{dtype}:{weak_type}"
     h = hashlib.blake2b(digest_size=16)
     h.update(arr.tobytes())
     h.update(str(arr.shape).encode())
     h.update(str(arr.dtype).encode())
     return h.hexdigest()
+
+
+def _tree_has_tracer(tree: Any) -> bool:
+    try:
+        leaves = jax.tree_util.tree_leaves(tree)
+    except Exception:
+        leaves = (tree,)
+    return any(isinstance(leaf, jax.core.Tracer) for leaf in leaves)
 
 
 def _scan_backend_name() -> str:
@@ -6415,7 +6435,13 @@ def solve_fixed_boundary_residual_iter(
                 cache_lam_prec0 = resume_state.get("cache_prec_lam_prec", cache_lam_prec0)
 
         def _tree_select(cond, t_true, t_false):
-            return jax.tree_util.tree_map(lambda a, b: jnp.where(cond, a, b), t_true, t_false)
+            if t_true is None or t_false is None:
+                return t_true if t_false is None else t_false
+            if isinstance(t_true, tuple) and isinstance(t_false, tuple):
+                return type(t_true)(_tree_select(cond, a, b) for a, b in zip(t_true, t_false, strict=True))
+            if isinstance(t_true, list) and isinstance(t_false, list):
+                return [_tree_select(cond, a, b) for a, b in zip(t_true, t_false, strict=True)]
+            return jnp.where(cond, jnp.asarray(t_true), jnp.asarray(t_false))
 
         ftol_j = jnp.asarray(float(ftol), dtype=dtype)
         scan_fallback_iters_j = jnp.asarray(int(scan_fallback_iters), dtype=jnp.int32)
@@ -8256,7 +8282,8 @@ def solve_fixed_boundary_residual_iter(
                 hist = jax.tree_util.tree_map(lambda *parts: np.concatenate(parts, axis=0), *hist_parts)
             else:
                 hist = jax.tree_util.tree_map(lambda *parts: jnp.concatenate(parts, axis=0), *hist_parts)
-                hist = jax.tree_util.tree_map(lambda a: np.asarray(a), hist)
+                if not _tree_has_tracer(hist):
+                    hist = jax.tree_util.tree_map(lambda a: np.asarray(a), hist)
             carry_final = carry
             if abort_scan_host:
                 carry_final = carry_final._replace(abort_scan=jnp.asarray(True))
@@ -8375,6 +8402,57 @@ def solve_fixed_boundary_residual_iter(
                 badjac_ptau_hist,
                 badjac_state_hist,
             ) = hist
+        if _tree_has_tracer(hist) or _tree_has_tracer(carry_final.state):
+            hist_dtype = jnp.asarray(state0.Rcos).dtype
+            empty = jnp.zeros((0,), dtype=hist_dtype)
+            traced_resume_state = {
+                "time_step": carry_final.time_step,
+                "inv_tau": carry_final.inv_tau,
+                "fsq_prev": carry_final.fsq_prev,
+                "fsq0_prev": carry_final.fsq0_prev,
+                "flip_sign": carry_final.flip_sign,
+                "iter1": carry_final.iter1,
+                "iter_offset": carry_final.iter_offset + jnp.asarray(int(max_iter), dtype=jnp.int32),
+                "res0": carry_final.res0,
+                "res1": carry_final.res1,
+                "ijacob": carry_final.ijacob,
+                "bad_resets": carry_final.bad_resets,
+                "bad_growth_streak": carry_final.bad_growth,
+                "fsqz_prev": carry_final.fsqz_prev,
+                "state_checkpoint": carry_final.state_checkpoint,
+                "vRcc": carry_final.vRcc,
+                "vRss": carry_final.vRss,
+                "vZsc": carry_final.vZsc,
+                "vZcs": carry_final.vZcs,
+                "vLsc": carry_final.vLsc,
+                "vLcs": carry_final.vLcs,
+                "vRsc": carry_final.vRsc,
+                "vRcs": carry_final.vRcs,
+                "vZcc": carry_final.vZcc,
+                "vZss": carry_final.vZss,
+                "vLcc": carry_final.vLcc,
+                "vLss": carry_final.vLss,
+                "vmec2000_cache_valid": carry_final.cache_valid,
+                "force_bcovar_update": carry_final.force_bcovar_update,
+            }
+            return _attach_freeb_diag(
+                SolveVmecResidualResult(
+                    state=carry_final.state,
+                    n_iter=int(max_iter),
+                    w_history=empty,
+                    fsqr2_history=empty,
+                    fsqz2_history=empty,
+                    fsql2_history=empty,
+                    grad_rms_history=empty,
+                    step_history=empty,
+                    diagnostics={
+                        "use_scan": True,
+                        "vmec2000_scan": True,
+                        "traced_scan": True,
+                        "resume_state": traced_resume_state,
+                    },
+                )
+            )
         fsqr_full = np.asarray(fsqr_hist)
         fsqz_full = np.asarray(fsqz_hist)
         fsql_full = np.asarray(fsql_hist)


### PR DESCRIPTION
This pull request focuses on unblocking autodiff for QH optimization in `simsopt/vmec_jax` by introducing a detailed branch-specific implementation plan, adding targeted regression and reverse-mode tests, and improving developer ergonomics for debugging and diagnostics. It also suppresses noisy JAX/XLA warnings for a cleaner developer experience. The most important changes are:

**1. Planning and Documentation Updates**
- Added a comprehensive branch-specific plan to `plan.md` (section `0A`) outlining the current QH autodiff blocker, benchmark definitions, findings, relevant DESC patterns, and a phased implementation roadmap. This section is intended to keep the work tightly scoped and prevent regressions to the broader VMEC parity project.
- Updated the `Legend` in `plan.md` to summarize the new planning section and document the current state of the QH autodiff investigation.
- Updated the "last updated" date in `plan.md`.

**2. Testing and Regression Harnesses**
- Added a new test module `tests/test_implicit_helpers.py` with reusable regression tests for reverse-mode autodiff, state packing/unpacking, and primal consistency, specifically targeting the implicit AD path and QH use case.
- Added a test in `tests/test_driver_api.py` to verify that the final flux profile computation supports traced `Lsin` values and JAX autodiff.

**3. Developer Diagnostics and Ergonomics**
- Documented new environment flags in `tools/diagnostics/README.md` for debugging implicit AD: `VMEC_JAX_IMPLICIT_KEEP_ALL_ACTIVE` and `VMEC_JAX_IMPLICIT_DISABLE_REDUCED_ACTIVE`, clarifying that these are for diagnostics only.
- Suppressed noisy C++ warnings from the JAX/XLA backend by setting `TF_CPP_MIN_LOG_LEVEL=2` in both `vmec_jax/__init__.py` and `vmec_jax/__main__.py` prior to any JAX import, improving developer experience. [[1]](diffhunk://#diff-cb659f8dce11001b129ae5e4eeb0f557a0c2bc09076b018829f5fd9ffca1442dR3-R10) [[2]](diffhunk://#diff-04407bd07fddb7e957781a0a11377ada07bd1c04c5cf61a4de239438f349572bR3-R7)