### PR TITLE
Sync callback trace updates into simsopt QS diagnostics

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -141,6 +141,15 @@ avoiding an otherwise unnecessary relaxed forward replay.  If
 ``save_wout(..., state=result["_state_final"])`` is used immediately after
 ``run()``, no additional equilibrium solve is performed.
 
+SciPy can also revisit the same rejected trust-region trial point.  The
+optimizer therefore keeps a small residual-only LRU cache for relaxed trial
+callbacks.  The cache stores NumPy residual vectors, not VMEC states or JAX
+tapes, so it removes repeated forward solves without retaining large XLA
+buffers.  To audit the exact callback sequence, run the diagnostic script with
+``--trace-callbacks``; the JSON history then includes a ``callback_trace`` block
+that labels each residual/Jacobian callback as an exact-state cache hit, a
+trial-residual cache hit, a fresh trial solve, or an exact tape replay.
+
 The lowest accepted-point callback count currently comes from the custom
 ``method="gauss_newton"`` loop: it uses relaxed residuals only for line-search
 trial points and one exact Jacobian per accepted point.  The SciPy trust-region
@@ -178,7 +187,8 @@ costs.  For GPU profiling, always separate the first run from cache-warm runs:
 
    JAX_PLATFORM_NAME=gpu python tools/diagnostics/profile_exact_optimizer.py \
      --problem qa --max-mode 1 --inner-max-iter 20 \
-     --trial-max-iter 20 --solver-device default --max-nfev 1
+     --trial-max-iter 20 --solver-device default --max-nfev 1 \
+     --trace-callbacks --json-out gpu_trace.json
 
 April 2026 callback diagnostics for the full input-deck QH ``max_mode=1`` case
 show where the GPU path loses today.  Local CPU used JAX 0.9.2 on an Apple
@@ -240,6 +250,14 @@ JAX.  The bottleneck is the accepted-point tape build/replay path.  A CPU
 slower than a CPU-only process, but vmec_jax does not force CPU execution for
 GPU-enabled users.  Use explicit CPU-only workers for controlled CPU studies,
 and explicit GPU backends for GPU profiling.
+
+A follow-up QH ``max_mode=2`` GPU trace with ``max_nfev=4`` and
+``inner_max_iter=trial_max_iter=120`` showed the same bottleneck.  The warm
+run spent about ``74 s`` total: four accepted-point Jacobian callbacks consumed
+about ``49 s`` end-to-end, while three relaxed trial solves consumed about
+``24 s``.  The trace contained one exact-state residual cache hit and no
+repeated trial residuals, so the next GPU optimization lane is reducing
+accepted-point tape build/replay cost rather than adding more residual caching.
 
 Fixed-boundary GPU diagnostics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_optimization_callback_trace.py
+++ b/tests/test_optimization_callback_trace.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import numpy as np
+
+from vmec_jax.optimization import FixedBoundaryExactOptimizer
+
+
+def _bare_optimizer() -> FixedBoundaryExactOptimizer:
+    opt = FixedBoundaryExactOptimizer.__new__(FixedBoundaryExactOptimizer)
+    opt._profile = {}
+    opt._trial_residual_cache = OrderedDict()
+    opt._trial_residual_cache_max = 2
+    opt._callback_trace_enabled = True
+    opt._callback_trace = []
+    opt._callback_point_ids = {}
+    opt._callback_previous_key = None
+    return opt
+
+
+def test_trial_residual_cache_is_small_lru() -> None:
+    opt = _bare_optimizer()
+
+    p0 = np.array([0.0, 1.0])
+    p1 = np.array([1.0, 2.0])
+    p2 = np.array([2.0, 3.0])
+
+    opt._remember_trial_residual(p0, np.array([1.0, 2.0]))
+    opt._remember_trial_residual(p1, np.array([3.0, 4.0]))
+    np.testing.assert_allclose(opt._cached_trial_residual(p0), [1.0, 2.0])
+
+    opt._remember_trial_residual(p2, np.array([5.0, 6.0]))
+
+    assert opt._cached_trial_residual(p1) is None
+    np.testing.assert_allclose(opt._cached_trial_residual(p0), [1.0, 2.0])
+    np.testing.assert_allclose(opt._cached_trial_residual(p2), [5.0, 6.0])
+    assert opt._profile["trial_residual_cache_hit"]["count"] == 3
+
+
+def test_callback_trace_records_repeat_points_and_summary() -> None:
+    opt = _bare_optimizer()
+
+    p0 = np.array([0.0, 1.0])
+    p1 = np.array([0.5, 1.0])
+
+    opt._trace_callback_event("residual", p0, source="exact_state_cache", wall_time_s=0.1)
+    opt._trace_callback_event("jacobian", p0, source="exact_tape_replay", wall_time_s=0.2)
+    opt._trace_callback_event("residual", p1, source="trial_solve", wall_time_s=0.3)
+
+    dump = opt._callback_trace_dump()
+
+    assert dump["enabled"] is True
+    assert [event["point_id"] for event in dump["events"]] == [0, 0, 1]
+    assert [event["same_as_previous"] for event in dump["events"]] == [False, True, False]
+    assert dump["summary"]["residual:exact_state_cache"]["count"] == 1
+    assert dump["summary"]["jacobian:exact_tape_replay"]["wall_time_s"] == 0.2

--- a/tools/diagnostics/profile_exact_optimizer.py
+++ b/tools/diagnostics/profile_exact_optimizer.py
@@ -81,6 +81,11 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Force relaxed trial residual solves onto the lax.scan path; exact adjoint solves remain trace-capable non-scan.",
     )
+    p.add_argument(
+        "--trace-callbacks",
+        action="store_true",
+        help="Include SciPy residual/Jacobian callback source timings in the JSON history.",
+    )
     return p.parse_args()
 
 
@@ -374,6 +379,7 @@ def main() -> int:
             target_aspect=target_aspect,
             scipy_tr_solver=tr_solver,
             scipy_lsmr_maxiter=None if args.lsmr_maxiter <= 0 else int(args.lsmr_maxiter),
+            trace_callbacks=args.trace_callbacks,
         )
     finally:
         if trace_out is not None:

--- a/vmec_jax/optimization.py
+++ b/vmec_jax/optimization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from contextlib import nullcontext
 from dataclasses import dataclass, fields, is_dataclass, replace
 import json
@@ -1181,9 +1182,9 @@ class FixedBoundaryExactOptimizer:
         self._exact_solver_kwargs = dict(_base)
         self._trial_solver_kwargs = dict(
             _base,
-            # Trial-point residuals do not need an adjoint tape.  On CPU the
-            # VMEC2000-style Python loop is still faster, while on GPU the scan
-            # loop avoids thousands of small host-dispatched kernels.
+            # Trial-point residuals do not need an adjoint tape. Keep the
+            # solver on the measured fastest path by default; the scan loop is
+            # still available through VMEC_JAX_OPT_TRIAL_SCAN for diagnostics.
             jit_forces="auto",
             use_scan=self._use_scan_for_trial_solves(),
         )
@@ -1209,7 +1210,13 @@ class FixedBoundaryExactOptimizer:
         self._scan_exact_helper_cache: dict = {}
         self._scan_exact_path = self._select_exact_path()
         self._last_jacobian_residual: np.ndarray | None = None
+        self._trial_residual_cache: OrderedDict[bytes, np.ndarray] = OrderedDict()
+        self._trial_residual_cache_max = 8
         self._profile: dict[str, dict[str, float | int]] = {}
+        self._callback_trace_enabled = False
+        self._callback_trace: list[dict] = []
+        self._callback_point_ids: dict[bytes, int] = {}
+        self._callback_previous_key: bytes | None = None
 
         # History collected during optimisation.
         self._history: list[dict] = []
@@ -1361,6 +1368,57 @@ class FixedBoundaryExactOptimizer:
             }
         return out
 
+    def _callback_point_id(self, cache_key: bytes) -> int:
+        point_ids = getattr(self, "_callback_point_ids", None)
+        if point_ids is None:
+            self._callback_point_ids = {}
+            point_ids = self._callback_point_ids
+        point_id = point_ids.get(cache_key)
+        if point_id is None:
+            point_id = len(point_ids)
+            point_ids[cache_key] = point_id
+        return int(point_id)
+
+    def _trace_callback_event(
+        self,
+        kind: str,
+        params,
+        *,
+        source: str,
+        wall_time_s: float,
+    ) -> None:
+        if not getattr(self, "_callback_trace_enabled", False):
+            return
+        cache_key = self._exact_cache_key(params)
+        previous_key = getattr(self, "_callback_previous_key", None)
+        event = {
+            "index": len(self._callback_trace),
+            "kind": str(kind),
+            "source": str(source),
+            "point_id": self._callback_point_id(cache_key),
+            "same_as_previous": bool(previous_key == cache_key),
+            "wall_time_s": float(wall_time_s),
+        }
+        self._callback_trace.append(event)
+        self._callback_previous_key = cache_key
+
+    def _callback_trace_dump(self) -> dict:
+        events = list(getattr(self, "_callback_trace", []))
+        counts: dict[str, int] = {}
+        wall_time: dict[str, float] = {}
+        for event in events:
+            key = f"{event['kind']}:{event['source']}"
+            counts[key] = counts.get(key, 0) + 1
+            wall_time[key] = wall_time.get(key, 0.0) + float(event["wall_time_s"])
+        return {
+            "enabled": bool(getattr(self, "_callback_trace_enabled", False)),
+            "events": events,
+            "summary": {
+                key: {"count": counts[key], "wall_time_s": wall_time[key]}
+                for key in sorted(counts)
+            },
+        }
+
     def _exact_cache_key(self, params) -> bytes:
         return np.asarray(params, dtype=float).reshape(-1).tobytes()
 
@@ -1378,6 +1436,30 @@ class FixedBoundaryExactOptimizer:
             self._profile_add("exact_state_cache_hit", 0.0)
             return self._exact_state_cache[cache_key]
         return None
+
+    def _cached_trial_residual(self, params) -> np.ndarray | None:
+        cache_key = self._exact_cache_key(params)
+        cache = getattr(self, "_trial_residual_cache", None)
+        if cache is None or cache_key not in cache:
+            return None
+        residual = cache.pop(cache_key)
+        cache[cache_key] = residual
+        self._profile_add("trial_residual_cache_hit", 0.0)
+        return np.asarray(residual, dtype=float)
+
+    def _remember_trial_residual(self, params, residual: np.ndarray) -> None:
+        cache_key = self._exact_cache_key(params)
+        cache = getattr(self, "_trial_residual_cache", None)
+        if cache is None:
+            self._trial_residual_cache = OrderedDict()
+            cache = self._trial_residual_cache
+        cache[cache_key] = np.asarray(residual, dtype=float).copy()
+        cache.move_to_end(cache_key)
+        max_size = max(0, int(getattr(self, "_trial_residual_cache_max", 0)))
+        while max_size and len(cache) > max_size:
+            cache.popitem(last=False)
+        if max_size == 0:
+            cache.clear()
 
     def _boundary_from_params(self, params):
         from ._compat import jnp as _jnp
@@ -1635,10 +1717,14 @@ class FixedBoundaryExactOptimizer:
         """Relaxed residual for line-search trial evaluations."""
         if self._solver_device_name is not None and not self._inside_solver_device_context:
             return self._run_in_solver_device_context(self.forward_residual_fun, params)
+        cached = self._cached_trial_residual(params)
+        if cached is not None:
+            return cached
         state = self._solve_forward(params, trial=True)
         t_res = time.perf_counter()
         out = np.asarray(self._residuals_fn(state), dtype=float)
         self._profile_add("residual_eval_trial", time.perf_counter() - t_res)
+        self._remember_trial_residual(params, out)
         return out
 
     def jacobian_fun(self, params) -> np.ndarray:
@@ -2048,6 +2134,7 @@ class FixedBoundaryExactOptimizer:
         """Release JIT and exact-solve caches."""
         self._exact_cache.clear()
         self._exact_state_cache.clear()
+        self._trial_residual_cache.clear()
         self._last_jacobian_residual = None
         self._post_jacobian_clear(clear_compiled=True)
 
@@ -2179,6 +2266,7 @@ class FixedBoundaryExactOptimizer:
         target_aspect: float | None = None,
         scipy_tr_solver: str | None = "lsmr",
         scipy_lsmr_maxiter: int | None = None,
+        trace_callbacks: bool | None = None,
     ) -> dict:
         """Run exact least-squares optimisation.
 
@@ -2230,6 +2318,12 @@ class FixedBoundaryExactOptimizer:
             trust-region linear solve.  This is primarily useful for the
             matrix-free path, where every LSMR iteration costs one or more
             exact ``Jv``/``J.Tv`` products.
+        trace_callbacks:
+            When true, include a lightweight SciPy callback trace in the
+            history dump.  This is intended for CPU/GPU profiling of repeated
+            trial residuals, exact-state cache hits, and accepted-point
+            Jacobian replay.  ``None`` enables tracing only when
+            ``VMEC_JAX_OPT_TRACE_CALLBACKS`` is set to a truthy value.
 
         Returns
         -------
@@ -2243,6 +2337,16 @@ class FixedBoundaryExactOptimizer:
 
         self._history = []
         self._profile = {}
+        self._trial_residual_cache.clear()
+        self._callback_trace_enabled = (
+            os.getenv("VMEC_JAX_OPT_TRACE_CALLBACKS", "").strip().lower()
+            in ("1", "true", "yes", "on")
+            if trace_callbacks is None
+            else bool(trace_callbacks)
+        )
+        self._callback_trace = []
+        self._callback_point_ids = {}
+        self._callback_previous_key = None
         self._wall_t0 = time.perf_counter()
         self._iota_fn = iota_fn  # stored so _jacobian_fun_tracked can use it
 
@@ -2491,18 +2595,49 @@ class FixedBoundaryExactOptimizer:
 
             def _residuals_y(y):
                 x = np.asarray(y, dtype=float) * scale - base_params
+                t_cb = time.perf_counter()
                 cached_state = self._cached_exact_state(x)
                 if cached_state is not None:
-                    return np.asarray(self._residuals_fn(cached_state), dtype=float)
+                    out = np.asarray(self._residuals_fn(cached_state), dtype=float)
+                    self._trace_callback_event(
+                        "residual",
+                        x,
+                        source="exact_state_cache",
+                        wall_time_s=time.perf_counter() - t_cb,
+                    )
+                    return out
+                cached_trial = self._cached_trial_residual(x)
+                if cached_trial is not None:
+                    self._trace_callback_event(
+                        "residual",
+                        x,
+                        source="trial_residual_cache",
+                        wall_time_s=time.perf_counter() - t_cb,
+                    )
+                    return cached_trial
                 # Residual-only callbacks do not need an adjoint tape. Building one
                 # for every SciPy trial point bloats memory badly on converged QA/QH
                 # runs. Keep the Jacobian exact, but evaluate residuals through the
                 # converged forward solve only.
-                return _forward_residual_exact(x)
+                out = _forward_residual_exact(x)
+                self._trace_callback_event(
+                    "residual",
+                    x,
+                    source="trial_solve",
+                    wall_time_s=time.perf_counter() - t_cb,
+                )
+                return out
 
             def _jacobian_y(y):
                 x = np.asarray(y, dtype=float) * scale - base_params
+                t_cb = time.perf_counter()
                 jac = np.asarray(self._jacobian_fun_tracked(x), dtype=float) * scale[None, :]
+                self._trace_callback_event(
+                    "jacobian",
+                    x,
+                    source="exact_tape_replay",
+                    wall_time_s=time.perf_counter() - t_cb,
+                )
                 # SciPy residual callbacks above no longer consume the exact-tape cache.
                 # Drop the retained tape immediately after the Jacobian/history entry is
                 # materialized, otherwise later converged QA iterations keep a multi-GB
@@ -2630,6 +2765,8 @@ class FixedBoundaryExactOptimizer:
             history_dump["target_iota"] = float(target_iota)
         if target_aspect is not None:
             history_dump["target_aspect"] = float(target_aspect)
+        if self._callback_trace_enabled:
+            history_dump["callback_trace"] = self._callback_trace_dump()
 
         # Private, non-serializable convenience payload for scripts that want
         # to write wout files without rerunning the VMEC solve immediately after


### PR DESCRIPTION
## Summary
- Merge latest origin/main commit 24b31b8 (optimization: trace exact callback replay) into simsopt-qs-diagnostics.
- Bring callback replay trace instrumentation, profiling-tool output, docs, and regression coverage onto the Simsopt diagnostics branch.
- Preserve branch-specific Simsopt boundary-field exact tangent APIs and the shared state-tangent replay helper from PR #9.

## Validation
- ../simsopt_jax/.venv/bin/python -m pytest tests/test_optimization_callback_trace.py tests/test_boundary_field.py tests/test_finite_beta.py tests/test_quasi_isodynamic.py tests/test_step3_profiles.py tests/test_booz_input.py tests/test_step4_field_cartesian.py tests/test_vmec_bcovar_smoke.py tests/test_qs_ess_render_smoke.py -q (18 passed, 6 skipped, 1 warning)
- ../simsopt_jax/.venv/bin/python -m pytest -q (228 passed, 103 skipped, 76 warnings)