### PR TITLE
Merge main finite-beta controls into Simsopt diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,9 @@ The scripts save `input.initial`, `input.final`, `wout_initial.nc`,
 Redl bootstrap-current mismatch residuals are the next finite-beta extensions;
 the current examples keep the stage-one structure and current-profile support
 in place so those terms can be added without changing the user workflow.
+The QI script exposes `QI_MBOZ`, `QI_NBOZ`, `QI_NPHI`, `QI_NALPHA`, and
+`QI_N_BOUNCE` at the top; the defaults are first-run diagnostic settings, and
+should be increased for final research-quality QI refinements.
 
 ## QA/QH/QP/QI Optimization Policy Sweep
 

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -544,8 +544,16 @@ residual through ``booz_xform_jax``.
 
 All controls are top-level variables in those scripts: ``MAX_MODE``,
 ``MAX_NFEV``, ``USE_ESS``, ``USE_MODE_CONTINUATION``, and
-``SOLVER_DEVICE``.  Set ``SOLVER_DEVICE = "gpu"`` or run with
-``JAX_PLATFORM_NAME=gpu`` on a machine with a working JAX GPU install.
+``SOLVER_DEVICE``.  The scripts also expose ``INNER_MAX_ITER``,
+``INNER_FTOL``, ``TRIAL_MAX_ITER``, and ``TRIAL_FTOL`` so deck-controlled
+VMEC budgets can be kept or overridden explicitly.  Set
+``SOLVER_DEVICE = "gpu"`` or run with ``JAX_PLATFORM_NAME=gpu`` on a machine
+with a working JAX GPU install.
+
+The QI finite-beta script additionally exposes ``QI_MBOZ``, ``QI_NBOZ``,
+``QI_NPHI``, ``QI_NALPHA``, and ``QI_N_BOUNCE``.  Its defaults are intended as
+diagnostic first-run settings; increase these grid controls before treating a
+QI finite-beta refinement as a final research-quality result.
 
 The current implementation includes differentiable finite-beta global
 diagnostics and current-driven iota through ``PCURR_TYPE = "cubic_spline_ip"``.

--- a/docs/optimization_sweep_results.rst
+++ b/docs/optimization_sweep_results.rst
@@ -231,6 +231,12 @@ and QI adds the smooth Boozer-space QI residual.  The scripts save
 ``input.initial``, ``input.final``, ``wout_initial.nc``, ``wout_final.nc``, and
 ``history.json`` for each run.
 
+All finite-beta controls are plain variables at the top of the scripts.  For
+QI, ``QI_MBOZ``, ``QI_NBOZ``, ``QI_NPHI``, ``QI_NALPHA``, and
+``QI_N_BOUNCE`` control the Boozer/QI residual grid.  The default QI grid is
+small enough for first-run diagnostics; increase it for final
+research-quality QI runs.
+
 Mercier ``DMerc`` and Redl bootstrap-current mismatch are not yet enabled as
 fully differentiable residual blocks in vmec_jax.  The finite-beta scaffolding
 is structured so those terms can be added next without changing the user-facing

--- a/examples/optimization/qa_optimization_finite_beta.py
+++ b/examples/optimization/qa_optimization_finite_beta.py
@@ -18,6 +18,10 @@ CONTINUATION_NFEV = 8
 USE_ESS = True
 USE_MODE_CONTINUATION = True
 SOLVER_DEVICE = None  # set to "cpu" or "gpu" to force one backend
+INNER_MAX_ITER = 0  # 0 uses NITER from the input deck
+INNER_FTOL = 0.0  # 0 uses FTOL from the input deck
+TRIAL_MAX_ITER = 300
+TRIAL_FTOL = 1.0e-10
 
 
 CONFIG = FiniteBetaStage1Config(
@@ -39,6 +43,10 @@ CONFIG = FiniteBetaStage1Config(
     use_ess=USE_ESS,
     use_mode_continuation=USE_MODE_CONTINUATION,
     solver_device=SOLVER_DEVICE,
+    inner_max_iter=INNER_MAX_ITER,
+    inner_ftol=INNER_FTOL,
+    trial_max_iter=TRIAL_MAX_ITER,
+    trial_ftol=TRIAL_FTOL,
 )
 
 

--- a/examples/optimization/qh_optimization_finite_beta.py
+++ b/examples/optimization/qh_optimization_finite_beta.py
@@ -18,6 +18,10 @@ CONTINUATION_NFEV = 8
 USE_ESS = True
 USE_MODE_CONTINUATION = True
 SOLVER_DEVICE = None  # set to "cpu" or "gpu" to force one backend
+INNER_MAX_ITER = 0  # 0 uses NITER from the input deck
+INNER_FTOL = 0.0  # 0 uses FTOL from the input deck
+TRIAL_MAX_ITER = 300
+TRIAL_FTOL = 1.0e-10
 
 
 CONFIG = FiniteBetaStage1Config(
@@ -39,6 +43,10 @@ CONFIG = FiniteBetaStage1Config(
     use_ess=USE_ESS,
     use_mode_continuation=USE_MODE_CONTINUATION,
     solver_device=SOLVER_DEVICE,
+    inner_max_iter=INNER_MAX_ITER,
+    inner_ftol=INNER_FTOL,
+    trial_max_iter=TRIAL_MAX_ITER,
+    trial_ftol=TRIAL_FTOL,
 )
 
 

--- a/examples/optimization/qi_optimization_finite_beta.py
+++ b/examples/optimization/qi_optimization_finite_beta.py
@@ -18,6 +18,20 @@ CONTINUATION_NFEV = 6
 USE_ESS = True
 USE_MODE_CONTINUATION = True
 SOLVER_DEVICE = None  # set to "cpu" or "gpu" to force one backend
+INNER_MAX_ITER = 0  # 0 uses NITER from the input deck
+INNER_FTOL = 0.0  # 0 uses FTOL from the input deck
+TRIAL_MAX_ITER = 300
+TRIAL_FTOL = 1.0e-10
+
+# Boozer/QI residual resolution. These defaults are diagnostic-friendly for a
+# first run; increase them for final research-quality QI refinements.
+QI_MBOZ = 10
+QI_NBOZ = 10
+QI_NPHI = 32
+QI_NALPHA = 8
+QI_N_BOUNCE = 12
+QI_SOFTNESS = 30.0
+QI_PROFILE_WEIGHT = 0.15
 
 
 CONFIG = FiniteBetaStage1Config(
@@ -37,6 +51,17 @@ CONFIG = FiniteBetaStage1Config(
     use_ess=USE_ESS,
     use_mode_continuation=USE_MODE_CONTINUATION,
     solver_device=SOLVER_DEVICE,
+    inner_max_iter=INNER_MAX_ITER,
+    inner_ftol=INNER_FTOL,
+    trial_max_iter=TRIAL_MAX_ITER,
+    trial_ftol=TRIAL_FTOL,
+    qi_mboz=QI_MBOZ,
+    qi_nboz=QI_NBOZ,
+    qi_nphi=QI_NPHI,
+    qi_nalpha=QI_NALPHA,
+    qi_n_bounce=QI_N_BOUNCE,
+    qi_softness=QI_SOFTNESS,
+    qi_profile_weight=QI_PROFILE_WEIGHT,
 )
 
 

--- a/tests/test_finite_beta_examples.py
+++ b/tests/test_finite_beta_examples.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+
+def test_finite_beta_examples_wire_top_level_solver_controls() -> None:
+    from examples.optimization import qa_optimization_finite_beta as qa
+    from examples.optimization import qh_optimization_finite_beta as qh
+    from examples.optimization import qi_optimization_finite_beta as qi
+
+    for module in (qa, qh, qi):
+        assert module.CONFIG.inner_max_iter == module.INNER_MAX_ITER
+        assert module.CONFIG.inner_ftol == module.INNER_FTOL
+        assert module.CONFIG.trial_max_iter == module.TRIAL_MAX_ITER
+        assert module.CONFIG.trial_ftol == module.TRIAL_FTOL
+        assert module.CONFIG.solver_device == module.SOLVER_DEVICE
+
+
+def test_qi_finite_beta_example_uses_diagnostic_default_grid() -> None:
+    from examples.optimization import qi_optimization_finite_beta as qi
+
+    assert qi.CONFIG.qi_mboz == qi.QI_MBOZ == 10
+    assert qi.CONFIG.qi_nboz == qi.QI_NBOZ == 10
+    assert qi.CONFIG.qi_nphi == qi.QI_NPHI == 32
+    assert qi.CONFIG.qi_nalpha == qi.QI_NALPHA == 8
+    assert qi.CONFIG.qi_n_bounce == qi.QI_N_BOUNCE == 12


### PR DESCRIPTION
Merge latest main into simsopt-qs-diagnostics so the Simsopt integration branch includes the finite-beta example run-control knobs and their smoke test.\n\nLocal verification:\n- ../simsopt_jax/.venv/bin/python -m pytest tests/test_finite_beta_examples.py tests/test_boundary_field.py tests/test_optimization_callback_trace.py -q