### PR TITLE
Performance profiling and scalar-adjoint optimization improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,14 @@ between optimization workers and was faster in the exact-Jacobian GPU profile.
 Set `XLA_PYTHON_CLIENT_PREALLOCATE=true` before import if you explicitly want
 JAX's default preallocation behavior.
 
-`vmec_jax` enables JAX's persistent compilation cache by default, but its
-default cache path is scoped by machine, CPU features, Python version, and
-JAX/JAXLIB versions to avoid reusing incompatible CPU AOT executables. Set
-`VMEC_JAX_COMPILATION_CACHE=0` to disable the persistent cache or
+`vmec_jax` enables JAX's persistent compilation cache automatically for
+accelerator-selected runs. CPU cache use is explicit opt-in because XLA:CPU AOT
+cache hits can emit host-feature mismatch errors on some JAX versions. Set
+`VMEC_JAX_COMPILATION_CACHE=1` to enable the default cache for CPU runs, set
+`VMEC_JAX_COMPILATION_CACHE=0` to disable it, or set
 `VMEC_JAX_COMPILATION_CACHE_DIR=/path/to/cache` to choose a custom location.
+The default cache path is scoped by machine, CPU features, Python version, and
+JAX/JAXLIB versions.
 
 ## Showcase (single-grid)
 
@@ -149,7 +152,7 @@ All figures below use the same **single-grid** run settings: `NS_ARRAY=151`, `NI
   <img src="docs/_static/figures/readme_runtime_compare.png" width="860" />
 </p>
 
-**Cold vs warm runtime**: the *cold* bar includes XLA JIT compilation on the first call (one-time cost per process); the *warm* bar is the steady-state solve time for subsequent calls in the same process. VMEC2000 has no compilation overhead, so it is always effectively cold. `vmec_jax` enables JAX's persistent compilation cache by default under `~/.cache/vmec_jax/jax_cache/<machine-fingerprint>` so repeated cold-process runs on the same host can reuse compiled kernels without sharing CPU AOT executables across incompatible machines, Python versions, or JAX/JAXLIB versions; set `VMEC_JAX_COMPILATION_CACHE=0` to disable it or `VMEC_JAX_COMPILATION_CACHE_DIR=/path/to/cache` to choose a different location.
+**Cold vs warm runtime**: the *cold* bar includes XLA JIT compilation on the first call (one-time cost per process); the *warm* bar is the steady-state solve time for subsequent calls in the same process. VMEC2000 has no compilation overhead, so it is always effectively cold. `vmec_jax` uses JAX's persistent compilation cache automatically for accelerator-selected runs under `~/.cache/vmec_jax/jax_cache/<machine-fingerprint>`. CPU cache use is opt-in with `VMEC_JAX_COMPILATION_CACHE=1` to avoid XLA:CPU AOT host-feature mismatch warnings on some JAX versions.
 
 ## Best Stellarator-Symmetric Optimizations
 

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ Set `XLA_PYTHON_CLIENT_PREALLOCATE=true` before import if you explicitly want
 JAX's default preallocation behavior.
 
 `vmec_jax` enables JAX's persistent compilation cache by default, but its
-default cache path is machine/CPU-feature scoped to avoid reusing CPU AOT
-executables compiled on a different host. Set `VMEC_JAX_COMPILATION_CACHE=0` to
-disable the persistent cache or `VMEC_JAX_COMPILATION_CACHE_DIR=/path/to/cache`
-to choose a custom location.
+default cache path is scoped by machine, CPU features, Python version, and
+JAX/JAXLIB versions to avoid reusing incompatible CPU AOT executables. Set
+`VMEC_JAX_COMPILATION_CACHE=0` to disable the persistent cache or
+`VMEC_JAX_COMPILATION_CACHE_DIR=/path/to/cache` to choose a custom location.
 
 ## Showcase (single-grid)
 
@@ -149,7 +149,7 @@ All figures below use the same **single-grid** run settings: `NS_ARRAY=151`, `NI
   <img src="docs/_static/figures/readme_runtime_compare.png" width="860" />
 </p>
 
-**Cold vs warm runtime**: the *cold* bar includes XLA JIT compilation on the first call (one-time cost per process); the *warm* bar is the steady-state solve time for subsequent calls in the same process. VMEC2000 has no compilation overhead, so it is always effectively cold. `vmec_jax` enables JAX's persistent compilation cache by default under `~/.cache/vmec_jax/jax_cache/<machine-fingerprint>` so repeated cold-process runs on the same host can reuse compiled kernels without sharing CPU AOT executables across incompatible machines; set `VMEC_JAX_COMPILATION_CACHE=0` to disable it or `VMEC_JAX_COMPILATION_CACHE_DIR=/path/to/cache` to choose a different location.
+**Cold vs warm runtime**: the *cold* bar includes XLA JIT compilation on the first call (one-time cost per process); the *warm* bar is the steady-state solve time for subsequent calls in the same process. VMEC2000 has no compilation overhead, so it is always effectively cold. `vmec_jax` enables JAX's persistent compilation cache by default under `~/.cache/vmec_jax/jax_cache/<machine-fingerprint>` so repeated cold-process runs on the same host can reuse compiled kernels without sharing CPU AOT executables across incompatible machines, Python versions, or JAX/JAXLIB versions; set `VMEC_JAX_COMPILATION_CACHE=0` to disable it or `VMEC_JAX_COMPILATION_CACHE_DIR=/path/to/cache` to choose a different location.
 
 ## Best Stellarator-Symmetric Optimizations
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ PYTHONPATH=. python examples/optimization/render_readme_best_optimizations.py
 - Default runs select the fastest stable path for each input automatically.
 - Use `--parity` (or `performance_mode=False` in Python) to force the conservative VMEC2000 loop.
 - Use `--solver-mode accelerated` to force the optimized fixed-boundary controller.
-- For GPU benchmarking, compare both first-process and cache-warm timings; the first GPU process pays XLA compilation, while later processes reuse the persistent cache automatically.
+- For GPU benchmarking, separate raw solver throughput from public policy overhead. For example, use `tools/diagnostics/profile_fixed_boundary.py --no-auto-cli-policy --solver-mode accelerated --no-multigrid --use-scan --solver-device gpu`.
+- Compare both first-process and in-process warm timings. The first GPU process pays XLA/runtime setup; persistent cache effectiveness depends on the JAX version, backend, and machine features.
 
 Details, profiling guidance, and parity methodology:
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -21,9 +21,9 @@ Persistent XLA compilation caching is enabled by default for repeated starts.
 Compiled kernels are stored under
 ``~/.cache/vmec_jax/jax_cache/<machine-fingerprint>`` unless the user sets
 ``VMEC_JAX_COMPILATION_CACHE_DIR`` or upstream ``JAX_COMPILATION_CACHE_DIR``.
-The machine-specific suffix avoids reusing native XLA:CPU AOT executables
-compiled on a different host CPU. Set ``VMEC_JAX_COMPILATION_CACHE=0`` to
-disable the persistent cache.
+The suffix includes host CPU details plus Python/JAX/JAXLIB versions to avoid
+reusing native XLA:CPU AOT executables compiled for an incompatible runtime.
+Set ``VMEC_JAX_COMPILATION_CACHE=0`` to disable the persistent cache.
 
 VMEC2000 is a pre-compiled Fortran binary with no JIT overhead — it is always
 effectively "cold".  When benchmarking, compare ``vmec_jax`` warm runtime
@@ -1691,8 +1691,8 @@ Compilation cache
 JAX can persist compiled executables to disk. ``vmec_jax`` enables this by
 default because cold-start compilation dominates short fixed-boundary and
 optimization diagnostics, especially on GPU. By default, the cache directory is
-machine/CPU-feature scoped so shared home directories do not reuse incompatible
-CPU AOT artifacts across different hosts. Use
+machine/CPU-feature/Python/JAX scoped so shared home directories do not reuse
+incompatible CPU AOT artifacts across different hosts or runtime versions. Use
 ``VMEC_JAX_COMPILATION_CACHE_DIR=/path/to/cache`` (or the upstream
 ``JAX_COMPILATION_CACHE_DIR``) to choose the cache location, or set
 ``VMEC_JAX_COMPILATION_CACHE=0`` to disable it.
@@ -1701,8 +1701,8 @@ If XLA prints a message such as ``Loading XLA:CPU AOT result`` followed by a
 target-machine feature mismatch, it means an existing persistent-cache entry was
 compiled for another CPU. Do not suppress that message blindly: clear the old
 cache directory or rerun once with ``VMEC_JAX_COMPILATION_CACHE=0``. New default
-``vmec_jax`` cache directories avoid this by including the machine fingerprint
-in the path.
+``vmec_jax`` cache directories avoid this by including the machine, CPU feature
+signature, Python version, and JAX/JAXLIB versions in the path.
 
 CLI profiling (pre-iteration overhead)
 --------------------------------------

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -402,28 +402,28 @@ versus accepted-point optimization replay:
      - ``3.94 s``
      - replay and residual tangent projection
    * - QA ``max_mode=1`` scalar gradient, 8 DOFs
-     - ``4.79 s``
-     - ``7.72 s``
-     - residual/state cotangent and replay
+     - ``2.56 s``
+     - ``4.56 s``
+     - cached scalar cotangent and replay
    * - QA ``max_mode=3`` dense Jacobian, 48 DOFs
      - ``4.12 s``
      - ``3.80 s``
      - replay and residual tangent projection
    * - QA ``max_mode=3`` scalar gradient, 48 DOFs
-     - ``3.81 s``
-     - ``5.79 s``
-     - replay and scalar objective cotangent
+     - ``1.73 s``
+     - ``3.03 s``
+     - cached scalar cotangent and replay
 
 Those numbers are perturbed accepted-point repeats with warm compiled helper
 shapes, ``inner_max_iter`` of 40--80, and relaxed ``ftol`` appropriate for
 profiling.  They are not full production optimization timings.  The scalar
-reverse-adjoint gradient now uses a direct scalar-objective cotangent hook for
-the built-in QS residual factories rather than VJP-ing the full residual vector.
-That reduced the QA ``max_mode=1`` GPU gradient callback from about ``9.8 s`` to
-``7.7 s`` after warmup and reduced the cold+warm pair from about ``93 s`` to
-``33 s``.  Dense Jacobians remain competitive at low and moderate DOF counts;
-the scalar-adjoint path becomes more relevant for higher-mode or memory-limited
-optimizations.
+reverse-adjoint gradient now uses a cached JIT scalar-objective cotangent hook
+for the built-in QS residual factories rather than VJP-ing the full residual
+vector from Python on every callback.  That reduced the QA ``max_mode=1`` GPU
+gradient callback from about ``9.8 s`` to ``4.6 s`` after warmup, and reduced
+the QA ``max_mode=3`` GPU gradient callback from about ``5.8 s`` to ``3.0 s``.
+Dense Jacobians remain competitive at low DOF counts; the scalar-adjoint path is
+now the better candidate for higher-mode or memory-limited optimizations.
 
 After caching the fixed quasisymmetry angular quadrature grid, the same
 ``office`` QH ``max_mode=2`` accepted-point callback profile gave two perturbed

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -379,6 +379,52 @@ shortcuts were rejected as defaults: precomputed tridiagonal coefficients are
 now correctness-tested but slower on this replay graph, and stopping gradients
 through solver time-control scalars nearly doubled replay time.
 
+May 2026 follow-up profiling used Python 3.11.15, JAX 0.10.0, and
+``jax[cuda13]`` on the same ``office`` RTX A4000 host.  The GPU backend is
+working, but it is still not a clear win for these small/medium exact
+optimization callbacks.  The important split is raw fixed-boundary throughput
+versus accepted-point optimization replay:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 16 16 30
+
+   * - Callback / case
+     - CPU warm
+     - GPU warm
+     - Dominant GPU terms
+   * - Raw QH fixed-boundary, 100 iterations
+     - ``0.93 s``
+     - ``2.06 s``
+     - fixed launch/compile overhead dominates
+   * - QA ``max_mode=1`` dense Jacobian, 8 DOFs
+     - ``2.92 s``
+     - ``3.94 s``
+     - replay and residual tangent projection
+   * - QA ``max_mode=1`` scalar gradient, 8 DOFs
+     - ``4.79 s``
+     - ``7.72 s``
+     - residual/state cotangent and replay
+   * - QA ``max_mode=3`` dense Jacobian, 48 DOFs
+     - ``4.12 s``
+     - ``3.80 s``
+     - replay and residual tangent projection
+   * - QA ``max_mode=3`` scalar gradient, 48 DOFs
+     - ``3.81 s``
+     - ``5.79 s``
+     - replay and scalar objective cotangent
+
+Those numbers are perturbed accepted-point repeats with warm compiled helper
+shapes, ``inner_max_iter`` of 40--80, and relaxed ``ftol`` appropriate for
+profiling.  They are not full production optimization timings.  The scalar
+reverse-adjoint gradient now uses a direct scalar-objective cotangent hook for
+the built-in QS residual factories rather than VJP-ing the full residual vector.
+That reduced the QA ``max_mode=1`` GPU gradient callback from about ``9.8 s`` to
+``7.7 s`` after warmup and reduced the cold+warm pair from about ``93 s`` to
+``33 s``.  Dense Jacobians remain competitive at low and moderate DOF counts;
+the scalar-adjoint path becomes more relevant for higher-mode or memory-limited
+optimizations.
+
 After caching the fixed quasisymmetry angular quadrature grid, the same
 ``office`` QH ``max_mode=2`` accepted-point callback profile gave two perturbed
 GPU dense-Jacobian callbacks of about ``11.8 s`` and ``4.3 s`` with the default

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -437,6 +437,76 @@ The current practical policy is therefore:
 - do not promise first-process GPU speedups on small fixed-boundary cases until
   the scan-safe path is broadened and the GPU compile graph is reduced.
 
+Raw solver throughput vs public policy overhead
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The fixed-boundary profiler can now separate the requested raw solver path from
+the public CLI-style policy.  This matters because public defaults may add
+dynamic scan probes, staged follow-up, or finish attempts around the requested
+iteration budget.  To benchmark the raw accelerated scan path, use:
+
+.. code-block:: bash
+
+   JAX_ENABLE_X64=1 python tools/diagnostics/profile_fixed_boundary.py \
+     --input examples/data/input.nfp4_QH_warm_start \
+     --iters 20 \
+     --simple-profile \
+     --no-multigrid \
+     --no-auto-cli-policy \
+     --solver-mode accelerated \
+     --use-scan \
+     --solver-device gpu \
+     --json-out /tmp/vmec_jax_qh20_raw_gpu.json
+
+May 2026 raw-path diagnostics showed:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 16 16 16 16
+
+   * - Case
+     - Device
+     - Iterations
+     - Timing
+     - Notes
+   * - ``input.nfp4_QH_warm_start``
+     - local CPU, JAX 0.9.2
+     - 20
+     - ``4.43 s`` cold, ``0.31 s`` warm
+     - raw accelerated scan
+   * - ``input.nfp4_QH_warm_start``
+     - ``office`` GPU, JAX 0.6.2
+     - 20
+     - ``12.1 s`` cold, ``1.70 s`` warm
+     - old Python 3.10/JAX stack
+   * - ``input.nfp4_QH_warm_start``
+     - ``office`` CPU, JAX 0.6.2
+     - 100
+     - ``0.97 s`` warm
+     - same host as GPU
+   * - ``input.nfp4_QH_warm_start``
+     - ``office`` GPU, JAX 0.6.2
+     - 100
+     - ``1.77 s`` warm
+     - fixed overhead dominates
+   * - ``input.LandremanPaul2021_QA_lowres``
+     - ``office`` CPU/GPU, JAX 0.6.2
+     - 20
+     - ``1.29 s`` CPU, ``1.87 s`` GPU
+     - warmed raw path
+   * - ``input.nfp2_QI``
+     - ``office`` CPU/GPU, JAX 0.6.2
+     - 20
+     - ``0.99 s`` CPU, ``1.65 s`` GPU
+     - warmed raw path
+
+The conclusion is narrower than “GPU is slow”: raw force iterations are fast
+once warmed, but the available ``office`` stack still has high GPU fixed
+overhead and uses Python 3.10 / JAX 0.6.2.  The next GPU lane should use a
+Python 3.11+ environment with current JAX, then target the remaining
+compile/launch/replay overhead rather than changing physics tolerances or
+forcing CPU fallback.
+
 For high-mode runs, also profile the experimental reverse-adjoint scalar
 gradient callback:
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -17,13 +17,16 @@ code:
 - **Warm run**: steady-state solve time after the kernels are in memory — the
   fair comparison against VMEC2000.
 
-Persistent XLA compilation caching is enabled by default for repeated starts.
-Compiled kernels are stored under
+Persistent XLA compilation caching is enabled automatically for
+accelerator-selected runs.  CPU cache use is opt-in because XLA:CPU persistent
+cache entries are native AOT executables and can emit host-feature mismatch
+errors on some JAX versions.  Compiled kernels are stored under
 ``~/.cache/vmec_jax/jax_cache/<machine-fingerprint>`` unless the user sets
 ``VMEC_JAX_COMPILATION_CACHE_DIR`` or upstream ``JAX_COMPILATION_CACHE_DIR``.
 The suffix includes host CPU details plus Python/JAX/JAXLIB versions to avoid
 reusing native XLA:CPU AOT executables compiled for an incompatible runtime.
-Set ``VMEC_JAX_COMPILATION_CACHE=0`` to disable the persistent cache.
+Set ``VMEC_JAX_COMPILATION_CACHE=1`` to opt in for CPU runs, or
+``VMEC_JAX_COMPILATION_CACHE=0`` to disable the persistent cache.
 
 VMEC2000 is a pre-compiled Fortran binary with no JIT overhead — it is always
 effectively "cold".  When benchmarking, compare ``vmec_jax`` warm runtime
@@ -1688,11 +1691,14 @@ Control this behavior with:
 Compilation cache
 -----------------
 
-JAX can persist compiled executables to disk. ``vmec_jax`` enables this by
-default because cold-start compilation dominates short fixed-boundary and
-optimization diagnostics, especially on GPU. By default, the cache directory is
-machine/CPU-feature/Python/JAX scoped so shared home directories do not reuse
-incompatible CPU AOT artifacts across different hosts or runtime versions. Use
+JAX can persist compiled executables to disk. ``vmec_jax`` enables this
+automatically for accelerator-selected runs because cold-start compilation
+dominates short fixed-boundary and optimization diagnostics, especially on GPU.
+CPU cache use is explicit opt-in with ``VMEC_JAX_COMPILATION_CACHE=1`` because
+XLA:CPU AOT cache hits can emit host-feature mismatch errors on some JAX
+versions.  By default, the cache directory is machine/CPU-feature/Python/JAX
+scoped so shared home directories do not reuse incompatible CPU AOT artifacts
+across different hosts or runtime versions. Use
 ``VMEC_JAX_COMPILATION_CACHE_DIR=/path/to/cache`` (or the upstream
 ``JAX_COMPILATION_CACHE_DIR``) to choose the cache location, or set
 ``VMEC_JAX_COMPILATION_CACHE=0`` to disable it.
@@ -1700,9 +1706,9 @@ incompatible CPU AOT artifacts across different hosts or runtime versions. Use
 If XLA prints a message such as ``Loading XLA:CPU AOT result`` followed by a
 target-machine feature mismatch, it means an existing persistent-cache entry was
 compiled for another CPU. Do not suppress that message blindly: clear the old
-cache directory or rerun once with ``VMEC_JAX_COMPILATION_CACHE=0``. New default
-``vmec_jax`` cache directories avoid this by including the machine, CPU feature
-signature, Python version, and JAX/JAXLIB versions in the path.
+cache directory or rerun once with ``VMEC_JAX_COMPILATION_CACHE=0``. Current
+``vmec_jax`` defaults avoid enabling the CPU persistent cache unless the user
+opts in explicitly or provides a cache directory.
 
 CLI profiling (pre-iteration overhead)
 --------------------------------------

--- a/tests/test_boundary_field.py
+++ b/tests/test_boundary_field.py
@@ -162,3 +162,72 @@ def test_exact_optimizer_b_cartesian_tangent_columns_match_jacobian():
         rtol=1.0e-12,
         atol=1.0e-12,
     )
+
+
+def test_exact_optimizer_scalar_objective_cotangent_matches_dense_jacobian():
+    jax = pytest.importorskip("jax")
+
+    from vmec_jax._compat import jnp
+    from vmec_jax.boundary import boundary_from_indata
+    from vmec_jax.optimization import FixedBoundaryExactOptimizer, boundary_param_specs
+    from vmec_jax.state import unpack_state
+
+    enable_x64(True)
+
+    input_path, _wout_path = example_paths("circular_tokamak")
+    cfg, indata = load_config(str(input_path))
+    static = build_static(cfg)
+    field_static = _small_static(cfg, ntheta=5, nzeta=4)
+    boundary = boundary_from_indata(indata, static.modes)
+    specs = boundary_param_specs(
+        boundary,
+        static.modes,
+        max_mode=1,
+        min_coeff=0.0,
+        include=("rc", "zs"),
+        fix=("rc00",),
+    )[:2]
+    params = np.zeros(len(specs))
+
+    def residuals_fn(state):
+        field = b_cartesian_from_state(
+            state,
+            field_static,
+            indata=indata,
+            signgs=exact_opt._signgs,
+        )
+        return jnp.ravel(field)
+
+    def objective_value_and_cotangent_from_packed(packed_state, layout):
+        packed_state = jnp.asarray(packed_state, dtype=jnp.float64)
+
+        def objective(packed):
+            residuals = residuals_fn(unpack_state(packed, layout))
+            return 0.5 * jnp.vdot(residuals, residuals)
+
+        return jax.value_and_grad(objective)(packed_state)
+
+    residuals_fn._state_objective_value_and_cotangent_from_packed = (
+        objective_value_and_cotangent_from_packed
+    )
+
+    exact_opt = FixedBoundaryExactOptimizer(
+        static,
+        indata,
+        boundary,
+        specs,
+        residuals_fn,
+        inner_max_iter=2,
+        inner_ftol=1.0e-5,
+    )
+    cost, gradient = exact_opt.objective_and_gradient_fun(params)
+    residuals = exact_opt.residual_fun(params)
+    jacobian = exact_opt.jacobian_fun(params)
+
+    assert cost == pytest.approx(0.5 * float(np.dot(residuals, residuals)), rel=1.0e-12)
+    np.testing.assert_allclose(
+        gradient,
+        jacobian.T @ residuals,
+        rtol=1.0e-10,
+        atol=1.0e-10,
+    )

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -3,17 +3,14 @@ from pathlib import Path
 from vmec_jax._compat import _default_compilation_cache_dir
 
 
-def test_compilation_cache_is_enabled_by_default(monkeypatch):
+def test_compilation_cache_is_disabled_by_default_on_cpu(monkeypatch):
     monkeypatch.delenv("JAX_COMPILATION_CACHE_DIR", raising=False)
     monkeypatch.delenv("VMEC_JAX_COMPILATION_CACHE_DIR", raising=False)
     monkeypatch.delenv("VMEC_JAX_COMPILATION_CACHE", raising=False)
     monkeypatch.delenv("JAX_PLATFORM_NAME", raising=False)
     monkeypatch.delenv("JAX_PLATFORMS", raising=False)
 
-    cache_dir = _default_compilation_cache_dir()
-
-    assert cache_dir is not None
-    assert ".cache/vmec_jax/jax_cache/" in cache_dir
+    assert _default_compilation_cache_dir() is None
 
 
 def test_compilation_cache_dir_env_enables_cache(monkeypatch, tmp_path):

--- a/tests/test_optimization_helpers.py
+++ b/tests/test_optimization_helpers.py
@@ -16,6 +16,8 @@ from vmec_jax.optimization import (
     create_x_scale,
     gauss_newton_least_squares,
     lift_boundary_params,
+    make_qh_residuals_fn,
+    make_qs_residuals_fn,
     parse_surface_list,
     rebuild_indata_with_resolution,
     smooth_min_abs_iota_residual,
@@ -23,6 +25,7 @@ from vmec_jax.optimization import (
     surface_indices_from_static,
     truncate_indata_boundary_modes,
 )
+from vmec_jax.state import pack_state
 
 
 def test_boundary_param_specs_and_apply():
@@ -136,6 +139,78 @@ def test_smooth_min_abs_iota_residual_is_differentiable_floor():
     assert np.isfinite(float(grad_neg))
     assert float(grad_pos) < 0.0
     assert float(grad_neg) > 0.0
+
+
+def _assert_scalar_objective_hook_matches_residual_vector(residuals_fn, state):
+    residuals = np.asarray(residuals_fn(state), dtype=float)
+    packed = pack_state(state)
+    value, cotangent = residuals_fn._state_objective_value_and_cotangent_from_packed(
+        packed,
+        state.layout,
+    )
+
+    expected_value = 0.5 * float(np.dot(residuals, residuals))
+    assert float(value) == pytest.approx(expected_value, rel=1.0e-11, abs=1.0e-12)
+
+    cotangent = np.asarray(cotangent)
+    assert cotangent.shape == np.asarray(packed).shape
+    assert np.all(np.isfinite(cotangent))
+
+
+def test_qh_residual_factory_scalar_objective_hook_matches_residual_vector(
+    load_case_qh_warm_start,
+):
+    _cfg, indata, static, _boundary, state = load_case_qh_warm_start
+    residuals_fn = make_qh_residuals_fn(
+        static,
+        indata,
+        helicity_m=1,
+        helicity_n=-1,
+        target_aspect=7.0,
+        surfaces=[0.5],
+        aspect_weight=0.3,
+        qs_weight=2.0,
+    )
+
+    _assert_scalar_objective_hook_matches_residual_vector(residuals_fn, state)
+
+
+def test_qs_residual_factory_scalar_objective_hook_sanitizes_iota_cotangent(
+    load_case_qh_warm_start,
+):
+    _cfg, indata, static, _boundary, state = load_case_qh_warm_start
+    residuals_fn = make_qs_residuals_fn(
+        static,
+        indata,
+        helicity_m=1,
+        helicity_n=-1,
+        target_aspect=7.0,
+        target_iota=0.41,
+        surfaces=[0.5],
+        aspect_weight=0.3,
+        qs_weight=2.0,
+        iota_weight=4.0,
+    )
+
+    _assert_scalar_objective_hook_matches_residual_vector(residuals_fn, state)
+
+
+def test_qs_residual_factory_scalar_objective_hook_handles_iota_floor(
+    load_case_qh_warm_start,
+):
+    _cfg, indata, static, _boundary, state = load_case_qh_warm_start
+    residuals_fn = make_qs_residuals_fn(
+        static,
+        indata,
+        helicity_m=0,
+        helicity_n=1,
+        min_abs_iota=0.41,
+        surfaces=[0.5],
+        qs_weight=2.0,
+        iota_weight=4.0,
+    )
+
+    _assert_scalar_objective_hook_matches_residual_vector(residuals_fn, state)
 
 
 def test_indexed_boundary_maps_from_boundary_keep_first_duplicate_mode():

--- a/tools/diagnostics/profile_fixed_boundary.py
+++ b/tools/diagnostics/profile_fixed_boundary.py
@@ -8,8 +8,11 @@ Example:
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
+import json
 import os
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -29,21 +32,213 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--outdir", type=str, default="tmp/jax_profile", help="Profiler trace output directory")
     p.add_argument("--no-warmup", action="store_true", help="Disable warmup run")
     p.add_argument("--simple-profile", action="store_true", help="Use a timing-only profiler (no TensorBoard trace)")
+    p.add_argument("--json-out", type=str, default=None, help="Write a compact JSON timing/solver diagnostic summary.")
     p.add_argument("--jit-forces", action="store_true", help="Enable jit_forces (default)")
     p.add_argument("--no-jit-forces", action="store_true", help="Disable jit_forces")
     p.add_argument("--use-input-niter", action="store_true", help="Use NITER from input for staging")
     p.add_argument("--use-scan", action="store_true", help="Run the lax.scan iteration path")
+    p.add_argument(
+        "--solver-mode",
+        choices=("auto", "default", "parity", "accelerated"),
+        default="auto",
+        help="Solver policy passed to run_fixed_boundary (default: auto).",
+    )
     p.add_argument(
         "--solver-device",
         choices=("auto", "default", "cpu", "gpu"),
         default="auto",
         help="JAX solver device override passed to run_fixed_boundary (default: auto).",
     )
+    p.set_defaults(auto_cli_policy=True)
+    p.add_argument(
+        "--auto-cli-policy",
+        dest="auto_cli_policy",
+        action="store_true",
+        help="Allow run_fixed_boundary to apply its public CLI-style accelerated finish policy (default).",
+    )
+    p.add_argument(
+        "--no-auto-cli-policy",
+        dest="auto_cli_policy",
+        action="store_false",
+        help="Benchmark the raw requested solver path without the public CLI-style finish policy.",
+    )
+    p.set_defaults(dynamic_scan=False)
+    p.add_argument(
+        "--dynamic-scan",
+        dest="dynamic_scan",
+        action="store_true",
+        help="Allow the dynamic scan/non-scan selector probes during profiling.",
+    )
+    p.add_argument(
+        "--no-dynamic-scan",
+        dest="dynamic_scan",
+        action="store_false",
+        help="Disable dynamic scan selector probes during profiling (default).",
+    )
     p.set_defaults(multigrid=None)
     p.add_argument("--multigrid", dest="multigrid", action="store_true", help="Force multigrid staging.")
     p.add_argument("--no-multigrid", dest="multigrid", action="store_false", help="Force a direct single-grid solve.")
     p.add_argument("--dump-hlo", action="store_true", help="Dump tomnsps_rzl HLO to the output directory")
     return p.parse_args()
+
+
+@contextmanager
+def _temporary_env(updates: dict[str, str | None]):
+    previous = {key: os.environ.get(key) for key in updates}
+    try:
+        for key, value in updates.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = str(value)
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return _json_safe(value.tolist())
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _compact_diagnostics(diag: dict[str, Any]) -> dict[str, Any]:
+    keys = (
+        "solver_mode",
+        "accelerated_mode",
+        "cli_fixed_boundary_mode",
+        "cli_fixed_boundary_initial_policy",
+        "cli_accelerated_fixed_policy",
+        "cli_staged_followup_policy",
+        "cli_fixed_boundary_full_parity_fallback",
+        "cli_fixed_boundary_partial_parity_fallback",
+        "cli_fixed_boundary_staged_followup_used",
+        "cli_fixed_boundary_finish_budgets",
+        "cli_fixed_boundary_finish_modes",
+        "cli_fixed_boundary_finish_fsq",
+        "cli_fixed_boundary_finish_converged",
+        "multigrid_user_provided",
+        "multigrid_ns_stages",
+        "multigrid_niter_stages",
+        "multigrid_ftol_stages",
+        "multigrid_stage_modes",
+        "multigrid_final_stage_niter_exhausted",
+        "accelerated_single_grid_default",
+        "accelerated_scan",
+        "accelerated_stage_chunked",
+        "accelerated_stage_chunk_count",
+        "accelerated_stage_chunk_iters",
+        "accelerated_stage_early_switch",
+        "accelerated_stage_switch_reason",
+        "accelerated_stage_probe_chunk_iters",
+        "accelerated_stage_effective_mode",
+        "use_scan",
+        "vmec2000_scan",
+        "abort_scan",
+        "requested_ftol",
+        "fsq_total_target",
+        "final_fsqr",
+        "final_fsqz",
+        "final_fsql",
+        "converged",
+        "converged_strict",
+        "converged_by_total_fsq",
+        "solver_device",
+        "solver_device_auto_reroute",
+        "solver_device_requested_backend",
+    )
+    return {key: _json_safe(diag[key]) for key in keys if key in diag}
+
+
+def _summarize_run(*, args: argparse.Namespace, run: Any, wall_time: float | None, jax_module: Any) -> dict[str, Any]:
+    res = getattr(run, "result", None)
+    diag = dict(getattr(res, "diagnostics", {}) or {})
+    w_hist = np.asarray(getattr(res, "w_history", np.zeros((0,), dtype=float)), dtype=float)
+    fsqr_hist = np.asarray(getattr(res, "fsqr2_history", np.zeros((0,), dtype=float)), dtype=float)
+    fsqz_hist = np.asarray(getattr(res, "fsqz2_history", np.zeros((0,), dtype=float)), dtype=float)
+    fsql_hist = np.asarray(getattr(res, "fsql2_history", np.zeros((0,), dtype=float)), dtype=float)
+    try:
+        devices = [str(d) for d in jax_module.devices()]
+    except Exception:
+        devices = []
+    try:
+        backend = str(jax_module.default_backend())
+    except Exception:
+        backend = "unknown"
+    summary = {
+        "input": str(Path(args.input).expanduser()),
+        "requested_iters": int(args.iters),
+        "wall_time_sec": None if wall_time is None else float(wall_time),
+        "jax_version": getattr(jax_module, "__version__", "unknown"),
+        "jax_default_backend": backend,
+        "jax_devices": devices,
+        "args": {
+            "solver_mode": str(args.solver_mode),
+            "solver_device": str(args.solver_device),
+            "multigrid": args.multigrid,
+            "use_input_niter": bool(args.use_input_niter),
+            "use_scan": bool(args.use_scan),
+            "jit_forces": bool(args.jit_forces),
+            "no_jit_forces": bool(args.no_jit_forces),
+            "auto_cli_policy": bool(args.auto_cli_policy),
+            "dynamic_scan": bool(args.dynamic_scan),
+        },
+        "result": {
+            "n_iter": None if res is None else int(getattr(res, "n_iter", -1)),
+            "history_len": int(w_hist.size),
+            "final_w": None if w_hist.size == 0 else float(w_hist[-1]),
+            "final_fsqr": None if fsqr_hist.size == 0 else float(fsqr_hist[-1]),
+            "final_fsqz": None if fsqz_hist.size == 0 else float(fsqz_hist[-1]),
+            "final_fsql": None if fsql_hist.size == 0 else float(fsql_hist[-1]),
+        },
+        "diagnostics": _compact_diagnostics(diag),
+    }
+    return summary
+
+
+def _print_run_summary(summary: dict[str, Any]) -> None:
+    result = summary["result"]
+    diag = summary["diagnostics"]
+    print(
+        "[profile_fixed_boundary] "
+        f"backend={summary['jax_default_backend']} "
+        f"history_len={result['history_len']} "
+        f"n_iter={result['n_iter']} "
+        f"final_w={result['final_w']} "
+        f"converged={diag.get('converged')}",
+        flush=True,
+    )
+    policy_bits = []
+    for key in (
+        "solver_mode",
+        "cli_fixed_boundary_mode",
+        "cli_fixed_boundary_initial_policy",
+        "multigrid_ns_stages",
+        "multigrid_niter_stages",
+        "multigrid_stage_modes",
+        "use_scan",
+        "vmec2000_scan",
+        "cli_fixed_boundary_finish_budgets",
+        "cli_fixed_boundary_full_parity_fallback",
+    ):
+        if key in diag:
+            policy_bits.append(f"{key}={diag[key]}")
+    if policy_bits:
+        print("[profile_fixed_boundary] " + " ".join(policy_bits), flush=True)
 
 
 def _dump_tomnsps_hlo(input_path: str, outdir: Path) -> None:
@@ -150,79 +345,81 @@ def main() -> int:
         raise SystemExit("Specify at most one of --jit-forces or --no-jit-forces.")
     jit_forces = True if args.jit_forces else False if args.no_jit_forces else True
     solver_device = None if str(args.solver_device) == "auto" else str(args.solver_device)
+    solver_mode = None if str(args.solver_mode) == "auto" else str(args.solver_mode)
+
+    def _run_profile_once():
+        return vj.run_fixed_boundary(
+            args.input,
+            solver="vmec2000_iter",
+            solver_mode=solver_mode,
+            max_iter=int(args.iters),
+            multigrid_use_input_niter=bool(args.use_input_niter),
+            multigrid=args.multigrid,
+            verbose=False,
+            jit_forces=bool(jit_forces),
+            use_scan=bool(args.use_scan),
+            solver_device=solver_device,
+            _auto_cli_fixed_boundary_mode=bool(args.auto_cli_policy),
+        )
+
+    env_updates = {
+        # The dynamic scan selector can execute multiple warm/probe solves around
+        # the requested run.  Keep profiler defaults single-path unless explicitly
+        # requested with --dynamic-scan.
+        "VMEC_JAX_DYNAMIC_SCAN": "1" if bool(args.dynamic_scan) else "0",
+    }
 
     if bool(args.dump_hlo):
         _dump_tomnsps_hlo(str(args.input), outdir)
 
-    if not args.no_warmup:
-        warm = vj.run_fixed_boundary(
-            args.input,
-            solver="vmec2000_iter",
-            max_iter=int(args.iters),
-            multigrid_use_input_niter=bool(args.use_input_niter),
-            multigrid=args.multigrid,
-            verbose=False,
-            jit_forces=bool(jit_forces),
-            use_scan=bool(args.use_scan),
-            solver_device=solver_device,
-        )
-        try:
-            res = warm.result
+    with _temporary_env(env_updates):
+        if not args.no_warmup:
+            warm = _run_profile_once()
+            try:
+                res = warm.result
+                if res is not None and hasattr(res, "fsqr2_history"):
+                    _ = float(np.asarray(res.fsqr2_history)[-1])
+            except Exception:
+                pass
+
+        use_simple = bool(args.simple_profile)
+        if not use_simple:
+            try:
+                jax.profiler.start_trace(str(outdir))
+            except Exception as exc:
+                print(f"[profile_fixed_boundary] profiler start failed: {exc}")
+                print("[profile_fixed_boundary] falling back to timing-only profile (no trace).")
+                use_simple = True
+
+        wall_time = None
+        if use_simple:
+            import time
+
+            t0 = time.perf_counter()
+            run = _run_profile_once()
+            res = run.result
             if res is not None and hasattr(res, "fsqr2_history"):
                 _ = float(np.asarray(res.fsqr2_history)[-1])
-        except Exception:
-            pass
+            t1 = time.perf_counter()
+            wall_time = float(t1 - t0)
+            print(f"[profile_fixed_boundary] total wall time: {wall_time:.3f}s")
+        else:
+            try:
+                run = _run_profile_once()
+                res = run.result
+                if res is not None and hasattr(res, "fsqr2_history"):
+                    _ = float(np.asarray(res.fsqr2_history)[-1])
+            finally:
+                jax.profiler.stop_trace()
+            print(f"[profile_fixed_boundary] trace saved to {outdir}")
 
-    use_simple = bool(args.simple_profile)
-    if not use_simple:
-        try:
-            jax.profiler.start_trace(str(outdir))
-        except Exception as exc:
-            print(f"[profile_fixed_boundary] profiler start failed: {exc}")
-            print("[profile_fixed_boundary] falling back to timing-only profile (no trace).")
-            use_simple = True
-
-    if use_simple:
-        import time
-
-        t0 = time.perf_counter()
-        run = vj.run_fixed_boundary(
-            args.input,
-            solver="vmec2000_iter",
-            max_iter=int(args.iters),
-            multigrid_use_input_niter=bool(args.use_input_niter),
-            multigrid=args.multigrid,
-            verbose=False,
-            jit_forces=bool(jit_forces),
-            use_scan=bool(args.use_scan),
-            solver_device=solver_device,
-        )
-        res = run.result
-        if res is not None and hasattr(res, "fsqr2_history"):
-            _ = float(np.asarray(res.fsqr2_history)[-1])
-        t1 = time.perf_counter()
-        print(f"[profile_fixed_boundary] total wall time: {t1 - t0:.3f}s")
-        return 0
-
-    run = vj.run_fixed_boundary(
-        args.input,
-        solver="vmec2000_iter",
-        max_iter=int(args.iters),
-        multigrid_use_input_niter=bool(args.use_input_niter),
-        multigrid=args.multigrid,
-        verbose=False,
-        jit_forces=bool(jit_forces),
-        use_scan=bool(args.use_scan),
-        solver_device=solver_device,
-    )
-    try:
-        res = run.result
-        if res is not None and hasattr(res, "fsqr2_history"):
-            _ = float(np.asarray(res.fsqr2_history)[-1])
-    finally:
-        jax.profiler.stop_trace()
-
-    print(f"[profile_fixed_boundary] trace saved to {outdir}")
+    summary = _summarize_run(args=args, run=run, wall_time=wall_time, jax_module=jax)
+    _print_run_summary(summary)
+    if args.json_out:
+        json_path = Path(args.json_out).expanduser().resolve()
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(_json_safe(summary), indent=2, sort_keys=True), encoding="utf-8")
+        print(f"[profile_fixed_boundary] summary written to {json_path}")
     return 0
 
 

--- a/tools/diagnostics/profile_fixed_boundary.py
+++ b/tools/diagnostics/profile_fixed_boundary.py
@@ -8,9 +8,18 @@ Example:
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 
 import numpy as np
+
+# Match vmec_jax's import-time defaults before this diagnostics tool imports
+# JAX directly.  Otherwise persistent-cache hits can emit repeated harmless
+# PjRt/XLA compatibility warnings before vmec_jax has a chance to configure the
+# logging environment.
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+os.environ.setdefault("ABSL_MIN_LOG_LEVEL", "2")
+os.environ.setdefault("GLOG_minloglevel", "2")
 
 
 def _parse_args() -> argparse.Namespace:

--- a/tools/diagnostics/profile_fixed_boundary.py
+++ b/tools/diagnostics/profile_fixed_boundary.py
@@ -33,6 +33,15 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--no-jit-forces", action="store_true", help="Disable jit_forces")
     p.add_argument("--use-input-niter", action="store_true", help="Use NITER from input for staging")
     p.add_argument("--use-scan", action="store_true", help="Run the lax.scan iteration path")
+    p.add_argument(
+        "--solver-device",
+        choices=("auto", "default", "cpu", "gpu"),
+        default="auto",
+        help="JAX solver device override passed to run_fixed_boundary (default: auto).",
+    )
+    p.set_defaults(multigrid=None)
+    p.add_argument("--multigrid", dest="multigrid", action="store_true", help="Force multigrid staging.")
+    p.add_argument("--no-multigrid", dest="multigrid", action="store_false", help="Force a direct single-grid solve.")
     p.add_argument("--dump-hlo", action="store_true", help="Dump tomnsps_rzl HLO to the output directory")
     return p.parse_args()
 
@@ -140,6 +149,7 @@ def main() -> int:
     if args.jit_forces and args.no_jit_forces:
         raise SystemExit("Specify at most one of --jit-forces or --no-jit-forces.")
     jit_forces = True if args.jit_forces else False if args.no_jit_forces else True
+    solver_device = None if str(args.solver_device) == "auto" else str(args.solver_device)
 
     if bool(args.dump_hlo):
         _dump_tomnsps_hlo(str(args.input), outdir)
@@ -150,9 +160,11 @@ def main() -> int:
             solver="vmec2000_iter",
             max_iter=int(args.iters),
             multigrid_use_input_niter=bool(args.use_input_niter),
+            multigrid=args.multigrid,
             verbose=False,
             jit_forces=bool(jit_forces),
             use_scan=bool(args.use_scan),
+            solver_device=solver_device,
         )
         try:
             res = warm.result
@@ -179,9 +191,11 @@ def main() -> int:
             solver="vmec2000_iter",
             max_iter=int(args.iters),
             multigrid_use_input_niter=bool(args.use_input_niter),
+            multigrid=args.multigrid,
             verbose=False,
             jit_forces=bool(jit_forces),
             use_scan=bool(args.use_scan),
+            solver_device=solver_device,
         )
         res = run.result
         if res is not None and hasattr(res, "fsqr2_history"):
@@ -195,9 +209,11 @@ def main() -> int:
         solver="vmec2000_iter",
         max_iter=int(args.iters),
         multigrid_use_input_niter=bool(args.use_input_niter),
+        multigrid=args.multigrid,
         verbose=False,
         jit_forces=bool(jit_forces),
         use_scan=bool(args.use_scan),
+        solver_device=solver_device,
     )
     try:
         res = run.result

--- a/tools/diagnostics/profile_fixed_boundary.py
+++ b/tools/diagnostics/profile_fixed_boundary.py
@@ -230,6 +230,7 @@ def _print_run_summary(summary: dict[str, Any]) -> None:
         "multigrid_ns_stages",
         "multigrid_niter_stages",
         "multigrid_stage_modes",
+        "solver_device",
         "use_scan",
         "vmec2000_scan",
         "cli_fixed_boundary_finish_budgets",

--- a/vmec_jax/__init__.py
+++ b/vmec_jax/__init__.py
@@ -13,10 +13,10 @@ _os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
 _os.environ.setdefault("ABSL_MIN_LOG_LEVEL", "2")
 _os.environ.setdefault("GLOG_minloglevel", "2")
 
-# Enable JAX persistent XLA compilation cache by default in a machine-scoped
-# directory. This makes repeated cold-process CLI/API runs much faster while
-# preserving explicit opt-out via VMEC_JAX_COMPILATION_CACHE=0 or
-# VMEC_JAX_COMPILATION_CACHE_DIR=disabled.
+# Enable JAX persistent XLA compilation cache in a machine-scoped directory
+# when requested by the backend/env policy in _compat. Accelerator runs use the
+# cache by default; CPU runs are opt-in to avoid XLA:CPU AOT feature-mismatch
+# warnings on shared or changing runtime environments.
 import jax as _jax
 _jax_cache_dir = _default_jax_cache_dir()
 if _jax_cache_dir is not None:

--- a/vmec_jax/_compat.py
+++ b/vmec_jax/_compat.py
@@ -116,10 +116,12 @@ def _cache_machine_fingerprint() -> str:
 def _default_compilation_cache_dir() -> str | None:
     """Return the configured JAX compilation-cache directory.
 
-    The persistent cache is enabled by default so cold-process CLI/API runs can
-    reuse compiled kernels across invocations.  Users can opt out explicitly
-    with ``VMEC_JAX_COMPILATION_CACHE=0`` or by setting the cache directory to a
-    false/disabled value.
+    The persistent cache is enabled automatically for accelerator-requested
+    runs so cold-process CLI/API runs can reuse compiled kernels across
+    invocations.  CPU persistent-cache entries are native AOT executables and
+    can emit host-feature mismatch errors on some XLA/JAX versions, so CPU cache
+    use is opt-in with ``VMEC_JAX_COMPILATION_CACHE=1`` unless the user provides
+    an explicit cache directory.
     """
     # Already set by the user — respect it.
     if "JAX_COMPILATION_CACHE_DIR" in os.environ:
@@ -137,6 +139,15 @@ def _default_compilation_cache_dir() -> str | None:
 
     cache_flag = os.environ.get("VMEC_JAX_COMPILATION_CACHE", "").strip().lower()
     if cache_flag in ("disabled", "0", "false", "no", "off"):
+        return None
+    cache_forced = cache_flag in ("1", "true", "yes", "on")
+
+    platform_name = os.environ.get("JAX_PLATFORM_NAME", "").strip().lower()
+    platforms = os.environ.get("JAX_PLATFORMS", "").strip().lower()
+    accelerator_requested = platform_name in ("gpu", "cuda", "rocm", "tpu") or any(
+        part.strip() in ("gpu", "cuda", "rocm", "tpu") for part in platforms.split(",")
+    )
+    if not (cache_forced or accelerator_requested):
         return None
 
     # Default cache location: ~/.cache/vmec_jax/jax_cache/<machine-fingerprint>

--- a/vmec_jax/_compat.py
+++ b/vmec_jax/_compat.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from typing import Any, Callable, Tuple
 import hashlib
+from importlib import metadata as importlib_metadata
+import sys
 import threading
 import types
 
@@ -79,7 +81,13 @@ def _cache_machine_fingerprint() -> str:
         platform.system(),
         platform.machine(),
         platform.processor(),
+        f"python={sys.version_info.major}.{sys.version_info.minor}",
     ]
+    for package in ("jax", "jaxlib"):
+        try:
+            parts.append(f"{package}={importlib_metadata.version(package)}")
+        except Exception:
+            pass
     try:
         if os.path.exists("/proc/cpuinfo"):
             wanted = ("model name", "cpu family", "model", "stepping", "flags", "Features")

--- a/vmec_jax/optimization.py
+++ b/vmec_jax/optimization.py
@@ -2260,7 +2260,22 @@ class FixedBoundaryExactOptimizer:
             None,
         )
         if objective_cotangent_factory is not None:
-            cost, final_cotangent = objective_cotangent_factory(packed_final, self._layout)
+            helper_key = (
+                "objective_value_and_cotangent",
+                int(self._layout.size),
+                id(self._residuals_fn),
+            )
+            helper_cache = self._discrete_jacobian_helper_cache.get(helper_key)
+            if helper_cache is None:
+                @jax.jit
+                def _objective_value_and_cotangent_helper(packed_state_arg):
+                    return objective_cotangent_factory(packed_state_arg, self._layout)
+
+                helper_cache = {
+                    "objective_value_and_cotangent": _objective_value_and_cotangent_helper
+                }
+                self._discrete_jacobian_helper_cache[helper_key] = helper_cache
+            cost, final_cotangent = helper_cache["objective_value_and_cotangent"](packed_final)
         else:
             residuals = self._residuals_fn(state)
             residuals = _jnp.asarray(residuals, dtype=_jnp.float64)

--- a/vmec_jax/optimization.py
+++ b/vmec_jax/optimization.py
@@ -899,12 +899,31 @@ def make_qh_residuals_fn(
     def state_cotangent_from_packed(packed_state, layout, residual_cotangent):
         return state_cotangent_operator_from_packed(packed_state, layout)(residual_cotangent)
 
+    def state_objective_value_and_cotangent_from_packed(packed_state, layout):
+        from ._compat import jax, jnp as _jnp
+        from .state import unpack_state
+
+        packed_state = _jnp.asarray(packed_state, dtype=_jnp.float64)
+
+        def _objective(packed):
+            state = unpack_state(packed, layout)
+            aspect = equilibrium_aspect_ratio_from_state(state=state, static=static)
+            aspect_residual = float(aspect_weight) * (aspect - target_aspect)
+            qs = _qs_eval_from_state(state)
+            qs_total = _jnp.asarray(qs["total"], dtype=_jnp.float64) * float(qs_weight) ** 2
+            return 0.5 * aspect_residual * aspect_residual + 0.5 * qs_total
+
+        return jax.value_and_grad(_objective)(packed_state)
+
     residuals_from_state._n_non_qs = 1
     residuals_from_state._qs_total_from_state = (
         lambda state: float(_qs_eval_from_state(state)["total"]) * float(qs_weight) ** 2
     )
     residuals_from_state._state_cotangent_from_packed = state_cotangent_from_packed
     residuals_from_state._state_cotangent_operator_from_packed = state_cotangent_operator_from_packed
+    residuals_from_state._state_objective_value_and_cotangent_from_packed = (
+        state_objective_value_and_cotangent_from_packed
+    )
 
     return residuals_from_state
 
@@ -1136,6 +1155,46 @@ def make_qs_residuals_fn(
     def state_cotangent_from_packed(packed_state, layout, residual_cotangent):
         return state_cotangent_operator_from_packed(packed_state, layout)(residual_cotangent)
 
+    def state_objective_value_and_cotangent_from_packed(packed_state, layout):
+        from ._compat import jax, jnp as _jnp
+        from .state import unpack_state
+
+        packed_state = _jnp.asarray(packed_state, dtype=_jnp.float64)
+
+        def _objective(packed):
+            state = unpack_state(packed, layout)
+            total = _jnp.asarray(0.0, dtype=_jnp.float64)
+            if target_aspect is not None:
+                aspect = equilibrium_aspect_ratio_from_state(state=state, static=static)
+                aspect_residual = float(aspect_weight) * (aspect - target_aspect)
+                total = total + 0.5 * aspect_residual * aspect_residual
+            if target_iota is not None or min_abs_iota is not None:
+                _chips, _iotas, _iotaf = equilibrium_iota_profiles_from_state(
+                    state=state, static=static, indata=_indata, signgs=_signgs,
+                )
+                del _chips, _iotaf
+                iotas = _jnp.asarray(_iotas, dtype=_jnp.float64)
+                mean_iota = (
+                    _jnp.asarray(0.0, dtype=iotas.dtype)
+                    if int(iotas.shape[0]) <= 1
+                    else _jnp.mean(iotas[1:])
+                )
+                if target_iota is not None:
+                    iota_residual = mean_iota - target_iota
+                else:
+                    iota_residual = smooth_min_abs_iota_residual(
+                        mean_iota,
+                        float(min_abs_iota),
+                        softness=float(iota_floor_softness),
+                    )
+                iota_residual = float(iota_weight) * iota_residual
+                total = total + 0.5 * iota_residual * iota_residual
+            qs = _qs_eval_from_state(state)
+            qs_total = _jnp.asarray(qs["total"], dtype=_jnp.float64) * float(qs_weight) ** 2
+            return total + 0.5 * qs_total
+
+        return jax.value_and_grad(_objective)(packed_state)
+
     residuals_from_state._n_non_qs = int(target_aspect is not None) + int(
         target_iota is not None or min_abs_iota is not None
     )
@@ -1144,6 +1203,9 @@ def make_qs_residuals_fn(
     )
     residuals_from_state._state_cotangent_from_packed = state_cotangent_from_packed
     residuals_from_state._state_cotangent_operator_from_packed = state_cotangent_operator_from_packed
+    residuals_from_state._state_objective_value_and_cotangent_from_packed = (
+        state_objective_value_and_cotangent_from_packed
+    )
     return residuals_from_state
 
 
@@ -2192,17 +2254,27 @@ class FixedBoundaryExactOptimizer:
             return self._residuals_fn(unpack_state(packed, self._layout))
 
         t_res_vjp = time.perf_counter()
-        residuals = self._residuals_fn(state)
-        residuals = _jnp.asarray(residuals, dtype=_jnp.float64)
-        cost = 0.5 * _jnp.vdot(residuals, residuals)
-        state_cotangent_operator_factory = getattr(
-            self._residuals_fn, "_state_cotangent_operator_from_packed", None
+        objective_cotangent_factory = getattr(
+            self._residuals_fn,
+            "_state_objective_value_and_cotangent_from_packed",
+            None,
         )
-        if state_cotangent_operator_factory is not None:
-            final_cotangent = state_cotangent_operator_factory(packed_final, self._layout)(residuals)
+        if objective_cotangent_factory is not None:
+            cost, final_cotangent = objective_cotangent_factory(packed_final, self._layout)
         else:
-            _, residual_vjp = jax.vjp(_residuals_from_packed, packed_final)
-            final_cotangent = residual_vjp(residuals)[0]
+            residuals = self._residuals_fn(state)
+            residuals = _jnp.asarray(residuals, dtype=_jnp.float64)
+            cost = 0.5 * _jnp.vdot(residuals, residuals)
+            state_cotangent_operator_factory = getattr(
+                self._residuals_fn, "_state_cotangent_operator_from_packed", None
+            )
+            if state_cotangent_operator_factory is not None:
+                final_cotangent = state_cotangent_operator_factory(packed_final, self._layout)(
+                    residuals
+                )
+            else:
+                _, residual_vjp = jax.vjp(_residuals_from_packed, packed_final)
+                final_cotangent = residual_vjp(residuals)[0]
         # Some state directions are intentionally inactive/gauge-null for a
         # given VMEC symmetry. Reverse-mode rules for sqrt/atan2-style geometry
         # kernels can return NaN cotangents in those unused directions even

--- a/vmec_jax/optimization.py
+++ b/vmec_jax/optimization.py
@@ -1193,7 +1193,14 @@ def make_qs_residuals_fn(
             qs_total = _jnp.asarray(qs["total"], dtype=_jnp.float64) * float(qs_weight) ** 2
             return total + 0.5 * qs_total
 
-        return jax.value_and_grad(_objective)(packed_state)
+        value, cotangent = jax.value_and_grad(_objective)(packed_state)
+        if target_iota is not None or min_abs_iota is not None:
+            # Match state_cotangent_operator_from_packed: the current-driven
+            # iota path has gauge-null state entries that can produce NaNs in
+            # reverse mode but do not contribute on the boundary-parameter
+            # tangent subspace.
+            cotangent = _jnp.nan_to_num(cotangent, nan=0.0, posinf=0.0, neginf=0.0)
+        return value, cotangent
 
     residuals_from_state._n_non_qs = int(target_aspect is not None) + int(
         target_iota is not None or min_abs_iota is not None


### PR DESCRIPTION
## Summary
- add structured fixed-boundary and exact-optimizer profiling controls
- make CPU persistent XLA cache opt-in to avoid host-feature warning spam while keeping accelerator cache automatic
- add and cache scalar-objective cotangent path for exact QS optimization gradients
- document CPU/GPU profiling results and add regression coverage for scalar cotangent gradients

## Validation
- python -m ruff check vmec_jax/optimization.py tests/test_boundary_field.py
- python -m pytest tests/test_boundary_field.py tests/test_compat.py -q
- python -m pytest -q
- python -m sphinx -T -b html docs <private-path>
- manually dispatched CI run 25606733637: fast tests/build/docs/physics-smoke passed; full physics still running as manual/nightly lane
