### PR TITLE
Add traceable single-surface Boozer input tables to core

### DIFF
--- a/tests/core_new/test_boozer_tables.py
+++ b/tests/core_new/test_boozer_tables.py
@@ -1,0 +1,171 @@
+"""Tests for ``vmec_jax.core.boozer_tables`` (traceable Boozer input tables).
+
+Validated here (mirroring the validation this function shipped with in the
+sfincs_jax flagship example ``examples/optimize_QA_bootstrap.py``):
+
+1. wout-engine parity on a small 3D equilibrium (LandremanPaul2021 QA lowres,
+   ns=7): the traceable single-surface tables reproduce the host wout engine
+   on the same converged state —
+   - ``bmnc`` (identical quadrature) to < 1e-10 relative,
+   - ``rmnc``/``zmns`` against the same VMEC odd-m parity interpolation of
+     the wout full-mesh tables to < 1e-10 relative,
+   - ``bsubumnc``/``bsubvmnc`` to < 5e-3 and ``lmns`` to < 2e-2 relative —
+     the half-mesh finite-difference level of the wout engine's own grid
+     treatment at this tiny ns (measured ~1e-3 at production ns),
+   - ``iota``, ``G = bvco`` and ``I = buco`` at the surface to < 1e-10;
+2. traceability: the function jits (same values as eager), and
+   ``jax.grad`` of ``sum(bmnc**2)`` through the full implicit-equilibrium
+   chain (``solve_implicit`` -> tables) w.r.t. the boundary coefficients is
+   finite and nonzero.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+
+from vmec_jax.core import implicit as im
+from vmec_jax.core import solver
+from vmec_jax.core.boozer_tables import boozer_input_tables
+from vmec_jax.core.input import VmecInput
+from vmec_jax.core.wout import wout_from_state
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "examples" / "data"
+
+NS = 7                     # radial surfaces (CI-scale, as in the sfincs_jax example)
+FTOL = 1e-11
+MAX_ITERATIONS = 4000
+J = NS // 2                # half-mesh radial row under test
+
+
+@pytest.fixture(scope="module")
+def qa_case():
+    """Converged LandremanPaul2021 QA lowres solve + wout + traceable tables."""
+    inp = VmecInput.from_file(str(DATA_DIR / "input.LandremanPaul2021_QA_lowres"))
+    inp = dataclasses.replace(
+        inp,
+        ns_array=np.asarray([NS]),
+        ftol_array=np.asarray([FTOL]),
+        niter_array=np.asarray([MAX_ITERATIONS]),
+    )
+    cfg = im.make_config(inp)
+    p0 = im.params_from_input(inp)
+    result = solver.solve(inp, cfg.resolution, ftol=cfg.ftol,
+                          max_iterations=cfg.max_iterations, mode="cli")
+    assert result.converged
+    rt = im.runtime_from_params(p0, cfg)
+    wout = wout_from_state(inp=inp, state=result.state, fsqr=result.fsqr,
+                           fsqz=result.fsqz, fsql=result.fsql)
+    tabs = boozer_input_tables(result.state, rt, J)
+    return inp, cfg, p0, result, rt, wout, tabs
+
+
+def _max_rel(tabs, name, ref_row, xm_ref, xn_ref) -> float:
+    """Max |mine - ref| / max|ref| over the modes both tables carry."""
+    mine, ref = [], []
+    for i, (m, n) in enumerate(zip(tabs["xm"], tabs["xn"])):
+        hits = np.where((xm_ref == m) & (xn_ref == n))[0]
+        if hits.size:
+            mine.append(float(np.asarray(tabs[name])[i]))
+            ref.append(float(ref_row[hits[0]]))
+    assert len(ref) > 4, f"too few shared modes for {name}"
+    mine, ref = np.asarray(mine), np.asarray(ref)
+    return float(np.max(np.abs(mine - ref)) / max(np.max(np.abs(ref)), 1e-30))
+
+
+# ==========================================================================
+# 1. wout-engine parity
+# ==========================================================================
+
+
+def test_bmnc_matches_wout_engine(qa_case):
+    _, _, _, _, _, wout, tabs = qa_case
+    xm_nyq = np.asarray(wout.xm_nyq, dtype=int)
+    xn_nyq = np.asarray(wout.xn_nyq, dtype=int)
+    # |B| spectrum: identical quadrature -> near machine precision
+    assert _max_rel(tabs, "bmnc", np.asarray(wout.bmnc)[J], xm_nyq, xn_nyq) < 1e-10
+
+
+def test_rmnc_zmns_match_parity_interpolated_wout(qa_case):
+    _, _, _, _, _, wout, tabs = qa_case
+    xm = np.asarray(wout.xm, dtype=int)
+    xn = np.asarray(wout.xn, dtype=int)
+    s = np.linspace(0.0, 1.0, NS)
+    sqrt_s = np.sqrt(s)
+    s_half_j = 0.5 * (s[J] + s[J - 1])
+
+    def parity_half(full_table):
+        a = np.asarray(full_table)[J - 1]
+        b = np.asarray(full_table)[J]
+        even = 0.5 * (a + b)
+        odd = 0.5 * (a / sqrt_s[J - 1] + b / sqrt_s[J]) * np.sqrt(s_half_j)
+        return np.where(xm % 2 == 0, even, odd)
+
+    assert _max_rel(tabs, "rmnc", parity_half(wout.rmnc), xm, xn) < 1e-10
+    assert _max_rel(tabs, "zmns", parity_half(wout.zmns), xm, xn) < 1e-10
+
+
+def test_covariant_fields_and_lambda_match_at_half_mesh_fd_level(qa_case):
+    _, _, _, _, _, wout, tabs = qa_case
+    xm_nyq = np.asarray(wout.xm_nyq, dtype=int)
+    xn_nyq = np.asarray(wout.xn_nyq, dtype=int)
+    # covariant fields: same half-mesh data, wout-engine grid differences only
+    assert _max_rel(tabs, "bsubumnc", np.asarray(wout.bsubumnc)[J], xm_nyq, xn_nyq) < 5e-3
+    assert _max_rel(tabs, "bsubvmnc", np.asarray(wout.bsubvmnc)[J], xm_nyq, xn_nyq) < 5e-3
+    # lambda (reconstructed from angular derivatives, wout normalization;
+    # dominated by the half-mesh finite-difference level at this tiny ns)
+    assert _max_rel(tabs, "lmns", np.asarray(wout.lmns)[J],
+                    np.asarray(wout.xm, dtype=int), np.asarray(wout.xn, dtype=int)) < 2e-2
+
+
+def test_iota_and_boozer_currents_match_wout(qa_case):
+    _, _, _, _, _, wout, tabs = qa_case
+    assert abs(float(tabs["iota"]) - float(np.asarray(wout.iotas)[J])) < 1e-10
+    # normalize G and I by the dominant covariant scale: I (the enclosed
+    # toroidal current) is ~1e-17 for this near-vacuum QA, so a pure
+    # relative comparison would be ill-posed
+    g_ref = float(np.asarray(wout.bvco)[J])
+    i_ref = float(np.asarray(wout.buco)[J])
+    scale = max(abs(g_ref), abs(i_ref), 1e-30)
+    assert abs(float(tabs["G"]) - g_ref) / scale < 1e-10
+    assert abs(float(tabs["I"]) - i_ref) / scale < 1e-10
+
+
+# ==========================================================================
+# 2. traceability: jit and end-to-end gradient
+# ==========================================================================
+
+
+def test_tables_jit_match_eager(qa_case):
+    _, _, _, result, rt, _, tabs = qa_case
+    jitted = jax.jit(lambda st: boozer_input_tables(st, rt, J))(result.state)
+    for key in ("rmnc", "zmns", "lmns", "bmnc", "bsubumnc", "bsubvmnc",
+                "iota", "G", "I"):
+        np.testing.assert_allclose(
+            np.asarray(jitted[key]), np.asarray(tabs[key]),
+            rtol=1e-12, atol=1e-14, err_msg=key)
+
+
+def test_grad_of_bmnc_through_implicit_solve_is_finite(qa_case):
+    """d(sum bmnc^2)/d(boundary) through solve_implicit is finite, nonzero."""
+    _, cfg, p0, _, _, _, _ = qa_case
+
+    def loss(params):
+        state = im.solve_implicit(params, cfg)
+        rt = im.runtime_from_params(params, cfg)
+        return jnp.sum(boozer_input_tables(state, rt, J)["bmnc"] ** 2)
+
+    grad = jax.grad(loss)(p0)
+    g_rbc = np.asarray(grad.rbc)
+    g_zbs = np.asarray(grad.zbs)
+    assert np.all(np.isfinite(g_rbc)) and np.all(np.isfinite(g_zbs))
+    assert float(np.max(np.abs(g_rbc))) > 0.0

--- a/vmec_jax/core/boozer_tables.py
+++ b/vmec_jax/core/boozer_tables.py
@@ -1,0 +1,183 @@
+"""Traceable single-surface Boozer input tables (wout-convention spectra).
+
+Pure-JAX bridge from a converged spectral state to the single-surface
+``wout``-convention mode tables that a differentiable Boozer transform
+(``booz_xform_jax``) consumes.  This is the differentiable route between
+vmec_jax and downstream kinetic codes:
+
+    boundary dofs -> :func:`vmec_jax.core.implicit.solve_implicit`
+    -> :func:`boozer_input_tables` (this module)
+    -> booz_xform_jax (Boozer |B| spectrum)
+    -> kinetic solvers (e.g. sfincs_jax bootstrap-current objectives),
+
+so ``jax.grad`` flows through the whole physics chain.  Origin: ported from
+the flagship optimization example ``examples/optimize_QA_bootstrap.py`` of
+sfincs_jax, where it was validated against the host wout engine and a
+classic host booz_xform run.
+
+Everything here evaluates the core field chain (``geometry``/``fields``,
+pure JAX), mirrors the reduced stellarator-symmetric ``[0, pi]`` theta grid
+to the full circle, and projects onto the wout ``cos(m*theta - n*zeta)`` /
+``sin(...)`` tables — no host callbacks, so the function can be jitted and
+differentiated.
+
+Public API
+----------
+``boozer_input_tables(state, rt, j) -> dict``
+    Spectral tables ``rmnc/zmns/lmns/bmnc/bsubumnc/bsubvmnc`` plus
+    ``iota/G/I`` at half-mesh row ``j`` (stellarator-symmetric only).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+
+from .fields import magnetic_fields, metric_elements, surface_currents
+from .geometry import half_mesh_jacobian
+from .solver import SolverRuntime, SpectralState, _geometry
+
+__all__ = ["boozer_input_tables"]
+
+
+def boozer_input_tables(state: SpectralState, rt: SolverRuntime, j: int) -> dict:
+    """Traceable wout-convention spectral tables at half-mesh row ``j``.
+
+    Builds the single-surface inputs of a Boozer transform from a converged
+    (stellarator-symmetric) equilibrium, entirely in JAX:
+
+    - ``bmnc``, ``bsubumnc``, ``bsubvmnc``: |B| and the covariant field
+      components, native to the half mesh (``bcovar.f``), projected on the
+      grid-representable ``cos(m*theta - n*zeta)`` modes;
+    - ``rmnc``, ``zmns``: R/Z tables from the full-mesh rows ``j-1``/``j``
+      with the VMEC odd-m ``sqrt(s)`` parity interpolation to the half mesh;
+    - ``lmns``: the wout lambda sine table, reconstructed from the
+      (lamscale-scaled) angular derivatives with the wout ``1/phips`` factor;
+    - ``iota`` (``add_fluxes.f`` for ``ncurr=1``, else the prescribed
+      profile) and the Boozer covariant averages ``G = bvco``/``I = buco``;
+    - ``xm``, ``xn``: static NumPy mode-number arrays (``xn`` carries the
+      ``nfp`` factor, wout convention).
+
+    Validation (tests/core_new/test_boozer_tables.py, and the sfincs_jax
+    flagship-example tests where this function originated): ``bmnc`` and the
+    parity-interpolated ``rmnc/zmns`` match the host wout engine to
+    ~1e-15..1e-10 relative (identical quadrature); ``bsubumnc/bsubvmnc`` and
+    ``lmns`` agree at the ~1e-3 half-mesh finite-difference level (looser at
+    very small ``ns``), which is the wout engine's own grid discrepancy, not
+    an error of this projection.
+
+    Parameters
+    ----------
+    state:
+        Converged spectral state (e.g. from
+        :func:`vmec_jax.core.implicit.solve_implicit`, which makes the whole
+        chain differentiable in the boundary, or ``SolveResult.state``).
+    rt:
+        The matching :class:`~vmec_jax.core.solver.SolverRuntime` (e.g. from
+        :func:`vmec_jax.core.implicit.runtime_from_params`).
+    j:
+        Half-mesh radial row index, ``1 <= j <= ns - 1`` (static).
+
+    Returns
+    -------
+    dict
+        Keys ``xm, xn`` (static ``np.ndarray``) and ``rmnc, zmns, lmns,
+        bmnc, bsubumnc, bsubvmnc, iota, G, I`` (JAX arrays, traced).
+    """
+    setup = rt.setup
+    nfp = int(rt.resolution.nfp)
+    s = jnp.asarray(setup.s_full)
+    sqrt_s = jnp.sqrt(s)
+    s_half_j = 0.5 * (s[j] + s[j - 1])
+    _, geometry = _geometry(state, rt)
+    jacobian = half_mesh_jacobian(geometry, s=s)
+    metrics = metric_elements(geometry, s=s)
+    fields = magnetic_fields(
+        geometry=geometry, jacobian=jacobian, metrics=metrics, trig=rt.trig,
+        s=s, phips=setup.phips, phipf=setup.phipf, chips=setup.chips,
+        signgs=setup.signgs, gamma=rt.gamma, mass=setup.mass,
+        ncurr=setup.ncurr, enclosed_current=setup.icurv,
+    )
+
+    # mirror the reduced symmetric [0, pi] grid to the full theta circle
+    ntheta2 = int(np.shape(fields.total_pressure)[1])
+    nzeta = int(np.shape(fields.total_pressure)[2])
+    ntheta1 = max(2 * (ntheta2 - 1), 1)
+    i_full = np.arange(ntheta1)
+    kk = np.arange(nzeta)
+    i_src = np.where(i_full < ntheta2, i_full, ntheta1 - i_full)
+    k_src = np.where(i_full[:, None] < ntheta2, kk[None, :], (nzeta - kk[None, :]) % nzeta)
+    i_src2 = np.broadcast_to(i_src[:, None], (ntheta1, nzeta))
+    sign_odd = np.where(i_full < ntheta2, 1.0, -1.0)[:, None]
+
+    def mirror(a2d, parity):
+        out = jnp.asarray(a2d)[i_src2, k_src]
+        return out if parity == "even" else out * jnp.asarray(sign_odd)
+
+    # uniform-grid Fourier projection onto the grid-representable modes
+    theta = 2.0 * np.pi * np.arange(ntheta1) / ntheta1
+    zeta = 2.0 * np.pi * np.arange(nzeta) / (nfp * nzeta)
+    m_max, n_max = ntheta1 // 2 - 1, max(nzeta // 2 - 1, 0)
+    ml, nl = [], []
+    for m in range(0, m_max + 1):
+        for n in range(-n_max, n_max + 1):
+            if m == 0 and n < 0:
+                continue
+            ml.append(m)
+            nl.append(n * nfp)
+    xm, xn = np.asarray(ml), np.asarray(nl)
+    ang = theta[:, None, None] * xm[None, None, :] - zeta[None, :, None] * xn[None, None, :]
+    cos_t, sin_t = jnp.asarray(np.cos(ang)), jnp.asarray(np.sin(ang))
+    w = 2.0 / (ntheta1 * nzeta) * np.ones(xm.shape)
+    w[(xm == 0) & (xn == 0)] = 1.0 / (ntheta1 * nzeta)
+    w = jnp.asarray(w)
+
+    def project(f, parity):
+        return w * jnp.einsum("tz,tzm->m", f, cos_t if parity == "even" else sin_t)
+
+    # |B|, B_theta, B_zeta live on the half mesh natively (bcovar.f)
+    bsq2 = 2.0 * (jnp.asarray(fields.total_pressure)[j] - jnp.asarray(fields.pressure)[j])
+    bmnc = project(mirror(jnp.sqrt(jnp.maximum(bsq2, 1e-300)), "even"), "even")
+    bsubumnc = project(mirror(jnp.asarray(fields.bsubu)[j], "even"), "even")
+    bsubvmnc = project(mirror(jnp.asarray(fields.bsubv)[j], "even"), "even")
+
+    # R, Z: full-mesh rows j-1, j -> spectral -> VMEC parity interpolation
+    def phys_row(even, odd, row):
+        return jnp.asarray(even)[row] + sqrt_s[row] * jnp.asarray(odd)[row]
+
+    def spectral_half(even, odd, parity):
+        a = project(mirror(phys_row(even, odd, j - 1), parity), parity)
+        b = project(mirror(phys_row(even, odd, j), parity), parity)
+        m_even = jnp.asarray(xm % 2 == 0)
+        interp_even = 0.5 * (a + b)
+        interp_odd = 0.5 * (a / jnp.maximum(sqrt_s[j - 1], 1e-30) + b / sqrt_s[j]) * jnp.sqrt(s_half_j)
+        return jnp.where(m_even, interp_even, interp_odd)
+
+    rmnc = spectral_half(geometry.R_even, geometry.R_odd, "even")
+    zmns = spectral_half(geometry.Z_even, geometry.Z_odd, "odd")
+
+    # lambda: reconstruct the wout lmns sine table from the (lamscale-scaled)
+    # angular derivatives; the wout convention carries a 1/phips factor.
+    lamscale = jnp.asarray(fields.lamscale)
+    phips_j = jnp.asarray(setup.phips)[j]
+
+    def half_native(even, odd):
+        return 0.5 * (phys_row(even, odd, j - 1) + phys_row(even, odd, j)) * lamscale
+
+    lth = project(mirror(half_native(geometry.dlambda_dtheta_even,
+                                     geometry.dlambda_dtheta_odd), "even"), "even")
+    lze = project(mirror(half_native(geometry.dlambda_dzeta_even,
+                                     geometry.dlambda_dzeta_odd), "even"), "even")
+    m_safe = jnp.asarray(np.where(xm != 0, xm, 1), dtype=jnp.float64)
+    n_safe = jnp.asarray(np.where(xn != 0, xn, 1), dtype=jnp.float64)
+    lmns = jnp.where(jnp.asarray(xm != 0), lth / m_safe,
+                     jnp.where(jnp.asarray(xn != 0), -lze / n_safe, 0.0)) / phips_j
+
+    # iota (add_fluxes.f, ncurr=1) and the Boozer covariant averages G, I
+    iota = (jnp.asarray(fields.chips)[j] / jnp.asarray(setup.phips)[j]
+            if int(setup.ncurr) == 1 else jnp.asarray(setup.iotas)[j])
+    cur = surface_currents(bsubu=fields.bsubu, bsubv=fields.bsubv, trig=rt.trig,
+                           s=s, signgs=setup.signgs)
+    return dict(xm=xm, xn=xn, rmnc=rmnc, zmns=zmns, lmns=lmns, bmnc=bmnc,
+                bsubumnc=bsubumnc, bsubvmnc=bsubvmnc, iota=iota,
+                G=jnp.asarray(cur.bvco)[j], I=jnp.asarray(cur.buco)[j])


### PR DESCRIPTION
## Summary

Ports `boozer_input_tables(state, rt, j)` — the traceable VMEC->Boozer input bridge — from the sfincs_jax flagship example (`examples/optimize_QA_bootstrap.py` on `refactor/v3-driver-architecture`) into the core as a public helper, `vmec_jax.core.boozer_tables.boozer_input_tables`.

It builds the single-surface wout-convention spectral tables `rmnc/zmns/lmns/bmnc/bsubumnc/bsubvmnc` plus `iota/G/I` at a half-mesh row `j`, entirely in JAX (stellarator-symmetric): it evaluates the core field chain, mirrors the reduced [0, pi] theta grid to the full circle, and projects onto the wout `cos(m*theta - n*zeta)`/`sin(...)` modes. No host callbacks, so it jits and differentiates.

A new small module next to `core/boozer.py` was chosen (rather than extending it) because `core/boozer.py` is the host-side wout-file -> boozmn-file driver, while this is an in-memory, traceable bridge.

## Validation (`tests/core_new/test_boozer_tables.py`, LandremanPaul2021 QA lowres, ns=7, ftol=1e-11)

- `bmnc` vs the host wout engine: < 1e-10 relative (identical quadrature; ~1e-15 level)
- `rmnc`/`zmns` vs the VMEC odd-m parity interpolation of the wout full-mesh tables: < 1e-10 relative
- `bsubumnc`/`bsubvmnc` < 5e-3 and `lmns` < 2e-2 relative — the half-mesh finite-difference level of the wout engine's own grid treatment at this tiny ns (~1e-3 at production ns)
- `iota`, `G = bvco`, `I = buco` at the surface: < 1e-10 (I normalized by the covariant scale; it is ~1e-17 for this near-vacuum QA)
- traceability: `jax.jit` matches eager to 1e-12, and `jax.grad` of `sum(bmnc**2)` through `solve_implicit` w.r.t. the boundary coefficients is finite and nonzero

All 6 new tests pass; `tests/core_new/` still collects cleanly (547 tests) and `test_plotting_boozer.py` passes (8/8). The same table construction is already validated downstream in `sfincs_jax/tests/test_example_qa_bootstrap.py`, including the resulting Boozer |B| spectrum vs a classic host booz_xform run (~3e-6).

## Downstream use

The sfincs_jax flagship example will import this helper (with its local copy kept as a fallback until this PR merges), giving the differentiable chain boundary dofs -> `solve_implicit` -> `boozer_input_tables` -> booz_xform_jax -> kinetic solve -> `jax.grad` of bootstrap current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)