### PR TITLE
Generalize reverse ad implicit path to a vector of objectives

### DIFF
--- a/tests/test_implicit_multi_rhs.py
+++ b/tests/test_implicit_multi_rhs.py
@@ -1,0 +1,63 @@
+"""Parity tests for the batched reverse-AD helpers (PR #24).
+
+``solve_implicit_with_aux`` and ``implicit_state_pullback_multi_rhs`` add a
+vectorized state-cotangent pullback for callers with several objectives sharing
+one fixed point (it reuses the residual/projector/VJP setup once and batches the
+adjoint solves).  These check it reproduces the scalar ``solve_implicit`` VJP
+exactly, so the batched path is a pure efficiency win with identical gradients.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from vmec_jax.core import implicit as im
+from vmec_jax.core.input import VmecInput
+
+DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
+
+
+def _solovev_setup():
+    inp = VmecInput.from_file(str(DATA / "input.solovev"))
+    cfg = im.make_config(inp, ftol=1e-13, max_iterations=2000)
+    p0 = im.params_from_input(inp)
+    return inp, cfg, p0
+
+
+def test_solve_implicit_with_aux_matches_solve_implicit():
+    """The aux helper returns the same converged state as solve_implicit."""
+    _, cfg, p0 = _solovev_setup()
+    state_aux, mask = im.solve_implicit_with_aux(p0, cfg)
+    state_ref = im.solve_implicit(p0, cfg)
+    for a, b in zip(jax.tree.leaves(state_aux), jax.tree.leaves(state_ref)):
+        assert np.allclose(np.asarray(a), np.asarray(b), rtol=0, atol=1e-12)
+    # the mask is a 0/1 SpectralState of the same structure as the state
+    assert jax.tree.structure(mask) == jax.tree.structure(state_ref)
+
+
+def test_multi_rhs_pullback_matches_scalar_vjp():
+    """Batched pullback == stacking the scalar solve_implicit VJP per cotangent."""
+    _, cfg, p0 = _solovev_setup()
+    x_star, mask = im.solve_implicit_with_aux(p0, cfg)
+
+    # three distinct state cotangents (same pytree structure as x_star)
+    keys = jax.random.split(jax.random.PRNGKey(0), 3)
+    gbars = [jax.tree.map(lambda a, k=k: jax.random.normal(k, a.shape, a.dtype), x_star)
+             for k in keys]
+    gbar_batch = jax.tree.map(lambda *a: jnp.stack(a), *gbars)
+
+    g_multi = im.implicit_state_pullback_multi_rhs(p0, cfg, x_star, mask, gbar_batch)
+
+    # scalar reference: the actual solve_implicit custom-VJP, applied per cotangent
+    _, pullback = jax.vjp(lambda p: im.solve_implicit(p, cfg), p0)
+    for i, gbar in enumerate(gbars):
+        g_scalar = pullback(gbar)[0]
+        g_multi_i = jax.tree.map(lambda a: a[i], g_multi)
+        for a, b in zip(jax.tree.leaves(g_scalar), jax.tree.leaves(g_multi_i)):
+            a = np.asarray(a); b = np.asarray(b)
+            scale = np.max(np.abs(a)) + 1e-30
+            assert np.max(np.abs(a - b)) <= 1e-8 * scale, "multi-rhs != scalar VJP"

--- a/vmec_jax/core/implicit.py
+++ b/vmec_jax/core/implicit.py
@@ -107,7 +107,8 @@ from .transforms import (
 __all__ = [
     "ImplicitParams", "ImplicitConfig", "ImplicitSolution",
     "params_from_input", "input_with_params", "runtime_from_params",
-    "make_config", "solve_implicit", "run",
+    "make_config", "solve_implicit", "solve_implicit_with_aux",
+    "implicit_state_pullback_multi_rhs", "run",
     "mhd_energy", "plasma_volume", "aspect_ratio", "iota_profile",
     "iota_axis", "iota_edge", "residual_fn", "adjoint_matvec",
 ]
@@ -769,6 +770,15 @@ def _solve_implicit_fwd(params, cfg):
     return state, (params, state, mask)
 
 
+def solve_implicit_with_aux(params: ImplicitParams, cfg: ImplicitConfig):
+    """Return ``(state, dof_mask)`` using the same callback as solve_implicit."""
+    state, mask = jax.pure_callback(
+        functools.partial(_host_solve_and_mask, cfg),
+        (_state_struct(cfg), _state_struct(cfg)), params,
+    )
+    return state, mask
+
+
 def _adjoint_solve(A, b, cfg: ImplicitConfig, *, x0=None, max_restarts=None):
     """Adjoint linear solve ``(dF/dz)^T lambda = b`` via ``solvax.gmres``.
 
@@ -862,6 +872,41 @@ def _solve_implicit_bwd(cfg, res, gbar):
 
 
 solve_implicit.defvjp(_solve_implicit_fwd, _solve_implicit_bwd)
+
+
+def implicit_state_pullback_multi_rhs(
+    params: ImplicitParams,
+    cfg: ImplicitConfig,
+    x_star: SpectralState,
+    dof_mask: SpectralState,
+    gbar_batch: SpectralState,
+) -> ImplicitParams:
+    """Batched state-cotangent pullback with shared implicit-linearization setup.
+
+    This preserves the scalar solve_implicit VJP and only adds a helper for
+    callers that already have several state cotangents for the same fixed
+    point.  It reuses the residual/projector/VJP setup once, then applies the
+    existing single-RHS GMRES per row.
+    """
+    frozen = jax.lax.stop_gradient(x_star)
+    edge_mask = _edge_mask(cfg)
+    P = _dof_projector(cfg, dof_mask)
+    F = residual_fn(cfg, frozen, dof_mask)
+    z_star = P(x_star)
+
+    _, vjp_z = jax.vjp(lambda z: F(z, params), z_star)
+    _, vjp_p = jax.vjp(lambda prm: F(z_star, prm), params)
+    _, vjp_p2 = jax.vjp(
+        lambda prm: _assemble(z_star, runtime_from_params(prm, cfg),
+                              frozen, P, edge_mask), params)
+
+    rhs_batch = jax.vmap(P)(gbar_batch)
+    lam_batch = jax.vmap(
+        lambda rhs: _adjoint_solve(lambda v: vjp_z(v)[0], rhs, cfg)[0]
+    )(rhs_batch)
+    g1_batch = jax.vmap(lambda lam: vjp_p(jax.tree.map(jnp.negative, lam))[0])(lam_batch)
+    g2_batch = jax.vmap(lambda gbar: vjp_p2(gbar)[0])(gbar_batch)
+    return jax.tree.map(jnp.add, g1_batch, g2_batch)
 
 
 def adjoint_matvec(cfg: ImplicitConfig, params: ImplicitParams,


### PR DESCRIPTION
Adding helper for doing vectorized pullback of cotagents in reverse ad implicit solver