### PR TITLE
ci: bump parity shard timeout to 20 min (unblock coverage gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
   parity:
     name: Parity suite ${{ matrix.shard }} (goldens, coverage)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The catch-all parity shard runs 15+ min with coverage instrumentation on busy runners, cancels at the 15-min cap, and skips the coverage gate. Bump to 20 min so the gate actually computes and enforces >=95%. This also lets us read the authoritative post-coils-refactor coverage number.