### PR TITLE
Robustness: typed errors through pure_callback, penalty-path tests, lint gate, multigrid-gradient FD (plan I.1-4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,40 @@ env:
 permissions:
   contents: read
 
-# Sharded CI (plan.md Phase-2 review item 1): five parallel jobs, each well
-# under the 10-minute wall-time budget, plus a coverage gate that combines
-# the parity + gradient shards and enforces >= 95% on vmec_jax.
+# Sharded CI (plan.md Phase-2 review item 1): five parallel test jobs, each
+# well under the 10-minute wall-time budget, plus a fast lint gate (ruff +
+# mypy) and a coverage gate that combines the parity + gradient shards and
+# enforces >= 95% on vmec_jax.
 jobs:
+  lint:
+    # Fast fail-first gate (plan Item I.3): ruff + mypy over the whole tree,
+    # separate from the test matrix so a lint regression fails in ~1 min
+    # without blocking (or being masked by) the solver shards.  mypy runs on
+    # py3.12 with the full [dev] install so its view of the numpy/jax stubs
+    # matches a local `mypy vmec_jax` (pyproject [tool.mypy] is the config).
+    name: Lint (ruff + mypy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 9
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          python -m pip install ".[dev]"
+
+      - name: ruff
+        run: ruff check vmec_jax tests examples benchmarks tools
+
+      - name: mypy
+        run: mypy vmec_jax
+
   fast:
     name: Fast unit tests (py${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/plan_pre_vmex.md
+++ b/plan_pre_vmex.md
@@ -233,10 +233,16 @@ warm 2.13 s (2.78 ms/iter); **warm implicit gradient of ONE scalar = 32.4 s eage
 / 22.5 s under `jax.jit` (~10-15 forward solves)**; host-callback overhead
 negligible (cached forward 0.02 s). The adjoint GMRES (`adjoint_tol=1e-11`,
 maxiter 300) dominates. Priorities, in measured-value order:
-1. **Adjoint budget**: instrument GMRES iteration counts; sweep `adjoint_tol`
-   1e-11→1e-7 vs gradient accuracy (1e-11 is likely overtight for optimization);
-   adjoint warm-starting across trust-region iterations (GCROT recycle exists —
-   measure, default it if it wins).
+1. **Adjoint budget — tolerance ruled out (measured 2026-07-17)**: sweeping
+   `adjoint_tol` 1e-13→1e-6 leaves the warm gradient wall time FLAT (solovev
+   ~4 s, li383 ~7 s at every tolerance) while accuracy degrades as expected —
+   the preconditioned GMRES hits near-machine residual within its first
+   Arnoldi cycles, so the cost is the FIXED matvec work (each matvec = one
+   residual linearization), not the convergence criterion. Remaining levers,
+   in order: (a) cheaper matvecs (jit/donate the residual linearization),
+   (b) fewer matvecs via cross-eval warm-starting/recycling (GCROT recycle —
+   measure, default it if it wins), (c) the shipped multi-RHS batching for
+   multi-objective campaigns.
 2. **NESTOR loop batching** (freeboundary.py:917-973): per-iteration host
    dispatch with several device→host syncs + per-iteration runtime rebuilds; run
    the `nvacskip` iterations between vacuum updates as one jitted block and move

--- a/plan_pre_vmex.md
+++ b/plan_pre_vmex.md
@@ -265,22 +265,27 @@ in README + docs. Literature notes (§5) may add relevant prior art.
 Two deep audits (source code + roadmap gaps) produced these, ranked. Each is
 small-to-medium and independently PR-able; batch 1-4 as one "robustness" PR.
 
-1. **Typed errors through `pure_callback`** (HIGH): a failing host solve inside
-   `im.run`/`solve_implicit` surfaces as a raw 3.7-KB `JaxRuntimeError` with the
-   typed `VmecConvergenceError`/`VmecJacobianError` lost (measured; this is the
-   double-traceback noise the single-stage runs hit). Stash the typed exception
-   in `_host_solve` (implicit.py:695) and re-raise from the three
-   `pure_callback` call sites (implicit.py:766-797). Add a test.
-2. **Test the `least_squares` zero-crash penalty paths** (HIGH): both lanes'
-   except-bodies (optimize.py:1386-1398, 1897-1932, 1962-1967) have zero
-   coverage — one mid-campaign self-intersecting trial test covers all four.
-3. **mypy debt + lint gate** (MED): 5 `var-annotated` in implicit.py
-   (666/672/681/687/740) + 1 `dict-item` (optimize.py:970); fix (~15 min),
-   delete the pyproject override block (its comment is stale), and add a
-   ruff+mypy CI job so it cannot rot again (CI currently has no lint gate).
-4. **FD-validate the multigrid implicit gradient directly** (MED):
-   `im.run(multigrid=True)` vs `frozen_path_directional_fd` — only exercised
-   indirectly today via `_least_squares_implicit`'s hardcoded multigrid.
+1. [x] **Typed errors through `pure_callback`** (HIGH) — **DONE 2026-07-17**
+   (robustness PR): a failing host solve inside `im.run`/`solve_implicit`
+   surfaced as a raw 3.7-KB `JaxRuntimeError` with the typed
+   `VmecConvergenceError`/`VmecJacobianError` lost. Now `_host_solve_and_mask`
+   stashes the typed exception in the `_HOST_ERROR` slot and the shared
+   `_callback_solve` call site re-raises it (`from None`); tested in
+   `test_implicit_grad.py::test_typed_error_through_pure_callback` (message
+   3681 -> 24 chars).
+2. [x] **Test the `least_squares` zero-crash penalty paths** (HIGH) — **DONE
+   2026-07-17**: `tests/test_optimize_penalty.py` covers all four
+   except-bodies (FD-lane fun, implicit-lane fun, jac last-valid fallback,
+   final diagnostic cold re-solve) with deterministic poisoned-solve
+   campaigns on solovev.
+3. [x] **mypy debt + lint gate** (MED) — **DONE 2026-07-17**: the 5
+   `var-annotated` caches in implicit.py and the `dict-item` in optimize.py
+   annotated, the pyproject override block deleted, and a fail-fast
+   `lint` CI job (ruff + `mypy vmec_jax` on py3.12) added.
+4. [x] **FD-validate the multigrid implicit gradient directly** (MED) —
+   **DONE 2026-07-17**: `test_multigrid_gradient_vs_frozen_path_fd`
+   (`im.run(multigrid=True)` through a genuine ns 5 -> 11 solovev ladder vs
+   `frozen_path_directional_fd`, rel <= 1e-6).
 5. **"Choosing an entry point" docs** (MED): `solver.solve` vs `solve_multigrid`
    vs `opt.solve_equilibrium` vs `im.run` — no when-to-use-which anywhere;
    quickstart teaches the manual `wout_from_state` plumbing while
@@ -304,7 +309,8 @@ small-to-medium and independently PR-able; batch 1-4 as one "robustness" PR.
 10. **PR #22 (mirror geometry) decision**: no longer draft — MERGEABLE,
     +15,052/−1,622 across 44 files (a whole `vmec_jax.mirror` package). Merging
     blows the plan.md §14 size budgets; deferring leaves a large branch rotting.
-    Needs an explicit user decision before VMEX.
+    DECIDED 2026-07-17: deferred — PR #22 is actively developed by its author
+    and will be revisited as the last item before the VMEX rename.
 11. **plan.md §14 DoD reconciliation**: size budgets already exceeded (40 files
     / 23.4k lines vs ≤35/15k; 4 files > 1000 lines; tests 9.1k vs ≤6k lines;
     fresh clone > 10 MB). Either amend the DoD numbers deliberately or schedule

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,10 +120,3 @@ ignore_missing_imports = true
 # blanket to the 8 the core actually needs; name-defined, valid-type,
 # call-arg, misc, type-arg, no-any-return and override are enabled again.
 disable_error_code = ["operator", "union-attr", "assignment", "arg-type", "index", "return-value", "list-item", "attr-defined"]
-
-[[tool.mypy.overrides]]
-# TODO(optimize/implicit agent): one narrow error each —
-#   core/implicit.py:629 [var-annotated] (_MASK_CACHE needs an annotation)
-#   core/optimize.py:977 [dict-item] (heterogeneous dict literal)
-module = ["vmec_jax.core.optimize", "vmec_jax.core.implicit"]
-disable_error_code = ["var-annotated", "dict-item"]

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -27,7 +27,13 @@ against central finite differences through the full host solver):
    the implicit adjoint equals the *frozen-path* central FD
    (``frozen_path_directional_fd``) to solver accuracy on the m=1 modes,
    where a *naive* full re-solve FD sign-flips (adjoint -0.773 vs naive
-   +0.045) — the adjoint is the correct frozen-logic gradient.
+   +0.045) — the adjoint is the correct frozen-logic gradient;
+8. typed errors through the callback (plan Item I.1): an unconvergeable
+   ``im.run`` raises the SHORT typed ``VmecConvergenceError`` (the
+   ``_HOST_ERROR`` relay), not a multi-KB ``JaxRuntimeError``;
+9. the multigrid lane directly (plan Item I.4): ``im.run(multigrid=True)``
+   through a genuine ns 5 -> 11 ladder, ``d(wb)/d(RBC(0,1))`` vs the
+   frozen-path FD.
 
 FD steps (documented choices): central differences with the *same* ftol and
 iteration policy on both sides, converged outputs cached on disk (``/tmp``)
@@ -382,3 +388,80 @@ def test_iota_edge_gradient_vs_frozen_path_fd():
         assert rel <= 3e-4, (
             f"RBC(n={n - ntor},1): adjoint {ad:.5e} vs frozen-path FD {fd:.5e} "
             f"(rel {rel:.2e}) — the implicit gradient must match the frozen path")
+
+
+# ---------------------------------------------------------------------------
+# 8. typed errors through pure_callback (zero-crash policy, plan Item I.1)
+# ---------------------------------------------------------------------------
+
+
+def test_typed_error_through_pure_callback():
+    """A failing host solve raises the SHORT typed exception, not callback noise.
+
+    Before the ``_HOST_ERROR`` relay (see the implicit module docstring,
+    "Zero-crash typed errors through the callback") an unconvergeable
+    ``im.run`` surfaced as a raw ``jax.errors.JaxRuntimeError`` with a
+    ~3.7 KB message embedding the whole host traceback and the typed
+    :class:`VmecConvergenceError` lost (``__cause__`` was ``None``).  Now the
+    original typed exception is stashed by the host callback and re-raised at
+    the ``pure_callback`` call site with ``from None``.
+    """
+    from vmec_jax.core.errors import VmecConvergenceError
+
+    inp = VmecInput.from_file(str(DATA_DIR / "input.solovev"))
+    with pytest.raises(VmecConvergenceError) as excinfo:
+        im.run(inp, ftol=1e-14, max_iterations=3)
+    exc = excinfo.value
+    assert len(str(exc)) < 200, f"typed message must stay short: {len(str(exc))} chars"
+    assert "MORE ITERATIONS REQUIRED" in str(exc)
+    assert exc.__cause__ is None and exc.__suppress_context__  # noise killed
+    assert exc.ftol == 1e-14  # diagnostics preserved
+
+    # the custom-vjp forward rule call site relays the typed exception too
+    p0 = im.params_from_input(inp)
+    with pytest.raises(VmecConvergenceError):
+        jax.grad(lambda p: im.run(inp, p, ftol=1e-14, max_iterations=3).wb)(p0)
+
+
+# ---------------------------------------------------------------------------
+# 9. multigrid implicit gradient vs frozen-path FD (plan Item I.4)
+# ---------------------------------------------------------------------------
+
+
+def test_multigrid_gradient_vs_frozen_path_fd():
+    """``im.run(multigrid=True)`` gradients FD-validated directly.
+
+    ``cfg.multigrid=True`` routes the host solve through ``solve_multigrid``
+    (the lane ``optimize._least_squares_implicit`` hardcodes); only the final
+    fixed point defines the derivative, so the adjoint through a genuine
+    two-stage ladder (ns 5 -> 11 on solovev) must match the frozen-path
+    central FD of ``wb`` along ``RBC(0,1)``.
+    """
+    inp0 = VmecInput.from_file(str(DATA_DIR / "input.solovev"))
+    inp = dataclasses.replace(
+        inp0,
+        ns_array=np.array([5, 11]),
+        ftol_array=np.array([1e-10, 1e-14]),
+        niter_array=np.array([1000, 2000]),
+    )
+    cfg = im.make_config(inp, multigrid=True, ftol=1e-14)
+    assert cfg.multigrid and int(cfg.resolution.ns) == 11
+    p0 = im.params_from_input(inp)
+    ntor = int(inp.ntor)
+
+    grad = jax.grad(
+        lambda p: im.run(inp, p, multigrid=True, ftol=1e-14).wb)(p0)
+    ad = float(np.asarray(grad.rbc)[ntor, 1])
+
+    zero = jax.tree.map(jnp.zeros_like, p0)
+    tangent = dataclasses.replace(zero, rbc=zero.rbc.at[ntor, 1].set(1.0))
+    fd, info = im.frozen_path_directional_fd(p0, cfg, lambda s, rt:
+                                             im.mhd_energy(s, rt)[0],
+                                             tangent, h=3e-5)
+    res = max(info["newton_res"])
+    rel = abs(ad / fd - 1.0)
+    print(f"\n[solovev multigrid ns=5->11] d(wb)/d(RBC(0,1)) h=3e-5: "
+          f"AD={ad:+.10e}  frozen-FD={fd:+.10e}  rel={rel:.2e} "
+          f"(Newton res {res:.0e})")
+    assert res < 1e-8, f"frozen solve not converged (res {res:.1e})"
+    assert rel <= 1e-6

--- a/tests/test_optimize_penalty.py
+++ b/tests/test_optimize_penalty.py
@@ -1,0 +1,154 @@
+"""Zero-crash penalty-path tests for ``optimize.least_squares`` (plan Item I.2).
+
+The zero-crash policy: a mid-campaign trial whose equilibrium solve fails
+(e.g. ``VmecJacobianError`` from a self-intersecting trial boundary) must be
+*penalized* — a large finite residual so the trust region backs off — never
+crash the campaign.  These paths were previously uncovered; the tests below
+exercise all four except-bodies deterministically by making the host solve
+fail on chosen calls (a naturally self-intersecting trial depends on scipy
+trust-region internals and is not deterministic across scipy versions):
+
+- ``jac=None`` (finite-difference lane): the ``fun`` except body
+  (penalize + ``trial solve failed`` print) via a ``solve_equilibrium`` that
+  fails on one finite-difference probe;
+- ``jac="implicit"``: the ``fun`` except body via a poisoned
+  ``implicit._host_solve`` on trial (new-parameter-key) solves — this also
+  exercises the Item I.1 typed-error relay *under jit* (the short sentinel
+  surfaces at the jit boundary and is caught by the penalty lane);
+- ``jac="implicit"``: the ``jac_fn`` last-valid-Jacobian fallback
+  (``trial jacobian failed`` print) via a poison on later memo-hit solves
+  (the Jacobian re-evaluates exactly the parameters ``fun`` just solved);
+- ``jac="implicit"``: the final diagnostic re-solve fallback (hot-seeded
+  ``solve_equilibrium`` fails -> plain cold re-solve).
+
+Each campaign must complete, return a finite cost and record the penalty
+prints (``verbose=1`` -> capsys).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+jax.config.update("jax_enable_x64", True)
+
+from vmec_jax.core import implicit as im  # noqa: E402
+from vmec_jax.core import optimize as opt  # noqa: E402
+from vmec_jax.core.errors import VmecJacobianError  # noqa: E402
+from vmec_jax.core.input import VmecInput  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("_module_jit_enabled")  # full solves: jitted
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "examples" / "data"
+OBJECTIVE = [(opt.aspect_ratio, 4.0, 1.0)]
+
+
+def _boom() -> VmecJacobianError:
+    return VmecJacobianError(
+        "INITIAL JACOBIAN CHANGED SIGN!",
+        hint="deterministic stand-in for a self-intersecting trial boundary")
+
+
+def test_fd_lane_penalty_path(monkeypatch, capsys):
+    """jac=None: a failed trial solve is penalized and the campaign completes."""
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    real = opt.solve_equilibrium
+    calls = {"n": 0, "failed": 0}
+
+    def flaky(trial, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:  # first FD probe after the (required-good) seed eval
+            calls["failed"] += 1
+            raise _boom()
+        return real(trial, **kwargs)
+
+    monkeypatch.setattr(opt, "solve_equilibrium", flaky)
+    res = opt.least_squares(OBJECTIVE, inp, max_mode=1, max_nfev=4,
+                            diff_step=1e-4, verbose=1)
+    out = capsys.readouterr().out
+    assert calls["failed"] == 1
+    assert "trial solve failed" in out  # the penalty branch executed
+    assert np.isfinite(res.cost)
+    assert isinstance(res.input, VmecInput)
+
+
+def test_implicit_lane_fun_penalty_path(monkeypatch, capsys):
+    """jac='implicit': every failed trial solve penalizes; campaign completes.
+
+    The poison hits new-parameter-key host solves (trial boundaries) only, so
+    the seed evaluation, the ``fun(x0)``/``jac(x0)`` memo hits and the final
+    diagnostic re-solve stay healthy while every trust-region trial fails —
+    the campaign must ride the penalty residual to a clean finish at ``x0``.
+    """
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    real = im._host_solve
+    calls = {"new": 0, "poisoned": 0}
+
+    def flaky(cfg, params):
+        hit = im._LAST_SOLVE.get(cfg)
+        if hit is None or hit[0] != im._params_key(params):
+            calls["new"] += 1
+            if calls["new"] >= 2:  # first new key = the x0 seed solve
+                calls["poisoned"] += 1
+                raise _boom()
+        return real(cfg, params)
+
+    monkeypatch.setattr(im, "_host_solve", flaky)
+    res = opt.least_squares(OBJECTIVE, inp, max_mode=1, jac="implicit",
+                            max_nfev=4, verbose=1)
+    out = capsys.readouterr().out
+    assert calls["poisoned"] >= 1
+    assert "trial solve failed" in out  # the penalty branch executed
+    assert "VmecJacobianError" in out   # Item I.1 relay: short sentinel, typed name
+    assert np.isfinite(res.cost)
+    np.testing.assert_allclose(res.x, opt.pack_boundary(inp, 1))  # stayed at x0
+
+
+def test_implicit_lane_jac_fallback_and_diagnostic_resolve(monkeypatch, capsys):
+    """jac='implicit': failed Jacobian reuses the last valid one; final
+    diagnostic re-solve falls back to a cold solve when the hot seed fails.
+
+    The scipy driver evaluates ``jac`` at exactly the accepted iterate
+    ``fun`` just solved (a memo-hit host solve), so poisoning memo-hit
+    solves after the first ``jac(x0)`` fails every later Jacobian while all
+    trial solves stay healthy.  ``solve_equilibrium`` additionally fails
+    whenever hot-seeded, forcing the final diagnostic's cold-solve fallback.
+    """
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    real = im._host_solve
+    calls = {"repeat": 0, "poisoned": 0}
+
+    def flaky(cfg, params):
+        hit = im._LAST_SOLVE.get(cfg)
+        if hit is not None and hit[0] == im._params_key(params):
+            calls["repeat"] += 1
+            # repeats 1-3: residual pre-size, fun(x0), jac(x0); later repeats
+            # are the Jacobians of accepted steps -> fail those.
+            if calls["repeat"] >= 4:
+                calls["poisoned"] += 1
+                raise _boom()
+        return real(cfg, params)
+
+    real_solve_eq = opt.solve_equilibrium
+    seeded = {"n": 0}
+
+    def flaky_solve_eq(trial, *, initial_state=None, **kwargs):
+        if initial_state is not None:  # the hot-seeded diagnostic re-solve
+            seeded["n"] += 1
+            raise _boom()
+        return real_solve_eq(trial, **kwargs)
+
+    monkeypatch.setattr(im, "_host_solve", flaky)
+    monkeypatch.setattr(opt, "solve_equilibrium", flaky_solve_eq)
+    res = opt.least_squares(OBJECTIVE, inp, max_mode=1, jac="implicit",
+                            max_nfev=4, verbose=1)
+    out = capsys.readouterr().out
+    assert calls["poisoned"] >= 1
+    assert "trial jacobian failed" in out  # last-valid-Jacobian fallback ran
+    assert seeded["n"] == 1
+    assert np.isfinite(res.cost)
+    assert res.equilibrium is not None  # cold-solve fallback delivered it
+    assert res.equilibrium.result.converged

--- a/vmec_jax/core/implicit.py
+++ b/vmec_jax/core/implicit.py
@@ -67,6 +67,25 @@ reference for these metrics; :func:`frozen_path_directional_fd` provides the
 correct one (Newton-solve the frozen ``F`` at ``p ± h``), and it reproduces the
 adjoint to solver accuracy — see ``tests/test_implicit_grad.py``.
 
+Zero-crash typed errors through the callback
+--------------------------------------------
+The forward solve runs behind ``jax.pure_callback``, which converts any host
+exception into an opaque ``jax.errors.JaxRuntimeError`` whose message embeds
+the whole host traceback (measured ~3.7 KB) and *loses* the typed exception
+(``__cause__`` is ``None``) — breaking the :mod:`vmec_jax.core.errors`
+zero-crash taxonomy.  The relay: ``_host_solve_and_mask`` catches any
+:class:`~vmec_jax.core.errors.VmecError`, stashes it in the module-level
+``_HOST_ERROR`` slot (host callbacks are serialized per solve, so a single
+slot suffices) and re-raises a SHORT sentinel ``RuntimeError``; the
+``pure_callback`` call sites (``_callback_solve``) catch the runtime error,
+pop the slot and re-raise the ORIGINAL typed exception with ``from None`` to
+suppress the callback noise.  ``im.run`` / :func:`solve_implicit` therefore
+fail with a short :class:`~vmec_jax.core.errors.VmecConvergenceError` /
+:class:`~vmec_jax.core.errors.VmecJacobianError`.  Under ``jax.jit`` the
+error instead surfaces at the jit boundary (where the
+``optimize.least_squares`` zero-crash penalty lanes catch it); the sentinel
+keeps even that message short.
+
 Parameter map
 -------------
 ``runtime_from_params`` rebuilds every p-dependent
@@ -97,6 +116,7 @@ from jax.flatten_util import ravel_pytree
 from solvax import gcrot as _solvax_gcrot
 from solvax import gmres as _solvax_gmres
 
+from .errors import VmecError
 from .fields import magnetic_fields, metric_elements
 from .fourier import Resolution
 from .geometry import half_mesh_jacobian
@@ -663,13 +683,16 @@ def _dof_mask(x_star: SpectralState, rt: SolverRuntime,
 # ---------------------------------------------------------------------------
 
 
-_HOT_CACHE = weakref.WeakKeyDictionary()  # cfg -> last converged SpectralState
+# cfg -> last converged SpectralState
+_HOT_CACHE: weakref.WeakKeyDictionary[ImplicitConfig, SpectralState] = \
+    weakref.WeakKeyDictionary()
 
 # cfg -> (params-bytes key, SolveResult): one-entry memo of the LAST solve.
 # scipy trust-region drivers evaluate jac(x) at exactly the x that fun(x)
 # just converged (DESC's ``_update_equilibrium``/``f_where_x`` pattern), so
 # this removes one full equilibrium solve per accepted iterate (plan R25.1).
-_LAST_SOLVE = weakref.WeakKeyDictionary()
+_LAST_SOLVE: weakref.WeakKeyDictionary[ImplicitConfig, tuple[bytes, SolveResult]] = \
+    weakref.WeakKeyDictionary()
 
 # cfg -> one-shot SpectralState seed for the NEXT host solve (plan R25.4):
 # the optimizer's trial evaluation deposits the DESC-style first-order
@@ -678,13 +701,22 @@ _LAST_SOLVE = weakref.WeakKeyDictionary()
 # (pops) it.  A missing/failed seed falls back silently to the plain
 # ``_HOT_CACHE`` hot restart — only the initial guess changes, never the
 # fixed point.
-_PERTURB_SEED = weakref.WeakKeyDictionary()
+_PERTURB_SEED: weakref.WeakKeyDictionary[ImplicitConfig, SpectralState] = \
+    weakref.WeakKeyDictionary()
 
 # cfg -> {"solves": int, "iterations": int}: cumulative host forward-solve
 # effort of a config (memo hits excluded) — the instrumentation behind the
 # R25.4 warm-start benchmarks (``optimize.least_squares`` attaches it to the
 # scipy result as ``solve_stats``).
-_SOLVE_STATS = weakref.WeakKeyDictionary()
+_SOLVE_STATS: weakref.WeakKeyDictionary[ImplicitConfig, dict[str, int]] = \
+    weakref.WeakKeyDictionary()
+
+# Single-slot relay for typed host exceptions (module docstring, "Zero-crash
+# typed errors through the callback"): ``_host_solve_and_mask`` deposits the
+# :class:`VmecError` it caught right before raising the short sentinel, and
+# ``_callback_solve`` pops and re-raises it.  Host callbacks are serialized
+# per solve, so one slot cannot race.
+_HOST_ERROR: list[VmecError] = []
 
 
 def _params_key(params: ImplicitParams) -> bytes:
@@ -737,12 +769,25 @@ def _host_solve(cfg: ImplicitConfig, params: ImplicitParams) -> SolveResult:
     return result
 
 
-_MASK_CACHE = weakref.WeakKeyDictionary()  # cfg -> host dof mask (structural)
+# cfg -> host dof mask (structural)
+_MASK_CACHE: weakref.WeakKeyDictionary[ImplicitConfig, SpectralState] = \
+    weakref.WeakKeyDictionary()
 
 
 def _host_solve_and_mask(cfg: ImplicitConfig, params_np) -> tuple:
+    _HOST_ERROR.clear()  # fresh callback: drop any stale relayed error
     params = jax.tree.map(jnp.asarray, params_np)
-    result = _host_solve(cfg, params)
+    try:
+        result = _host_solve(cfg, params)
+    except VmecError as exc:
+        # Relay the typed exception (module docstring, "Zero-crash typed
+        # errors through the callback"): stash it and raise a SHORT sentinel
+        # — pure_callback would otherwise bury it in a multi-KB traceback
+        # dump with the typed class lost.
+        _HOST_ERROR.append(exc)
+        raise RuntimeError(
+            f"host equilibrium solve failed with {type(exc).__name__} "
+            "(re-raised typed at the pure_callback call site)") from None
     as_np = lambda t: jax.tree.map(  # noqa: E731
         lambda a: np.asarray(a, dtype=np.float64), t)
     # The dof mask captures *structural* zero patterns (resolution, symmetry,
@@ -754,6 +799,29 @@ def _host_solve_and_mask(cfg: ImplicitConfig, params_np) -> tuple:
         mask = as_np(_dof_mask(result.state, rt, cfg))
         _MASK_CACHE[cfg] = mask
     return as_np(result.state), mask
+
+
+def _callback_solve(params: ImplicitParams, cfg: ImplicitConfig):
+    """``pure_callback`` host solve returning ``(state, dof_mask)``.
+
+    Shared by :func:`solve_implicit`, ``_solve_implicit_fwd`` and
+    :func:`solve_implicit_with_aux`.  Re-raises the ORIGINAL typed
+    :class:`VmecError` deposited in ``_HOST_ERROR`` by
+    ``_host_solve_and_mask`` (``from None`` suppresses the noisy
+    ``JaxRuntimeError`` context) so eager callers see the short typed
+    exception.  Under ``jax.jit`` this try/except is trace-time only and the
+    (short, sentinel-carrying) runtime error surfaces at the jit boundary
+    instead — see the module docstring.
+    """
+    try:
+        return jax.pure_callback(
+            functools.partial(_host_solve_and_mask, cfg),
+            (_state_struct(cfg), _state_struct(cfg)), params,
+        )
+    except Exception:
+        if _HOST_ERROR:
+            raise _HOST_ERROR.pop() from None
+        raise
 
 
 def _state_struct(cfg: ImplicitConfig) -> SpectralState:
@@ -773,28 +841,18 @@ def solve_implicit(params: ImplicitParams, cfg: ImplicitConfig) -> SpectralState
     (:func:`mhd_energy`, :func:`aspect_ratio`, ...) to build objectives, or
     use :func:`run`.
     """
-    state, _ = jax.pure_callback(
-        functools.partial(_host_solve_and_mask, cfg),
-        (_state_struct(cfg), _state_struct(cfg)), params,
-    )
+    state, _ = _callback_solve(params, cfg)
     return state
 
 
 def _solve_implicit_fwd(params, cfg):
-    state, mask = jax.pure_callback(
-        functools.partial(_host_solve_and_mask, cfg),
-        (_state_struct(cfg), _state_struct(cfg)), params,
-    )
+    state, mask = _callback_solve(params, cfg)
     return state, (params, state, mask)
 
 
 def solve_implicit_with_aux(params: ImplicitParams, cfg: ImplicitConfig):
     """Return ``(state, dof_mask)`` using the same callback as solve_implicit."""
-    state, mask = jax.pure_callback(
-        functools.partial(_host_solve_and_mask, cfg),
-        (_state_struct(cfg), _state_struct(cfg)), params,
-    )
-    return state, mask
+    return _callback_solve(params, cfg)
 
 
 def _adjoint_solve(A, b, cfg: ImplicitConfig, *, x0=None, max_restarts=None):

--- a/vmec_jax/core/optimize.py
+++ b/vmec_jax/core/optimize.py
@@ -932,7 +932,7 @@ def boozer_modes_from_wout(
     mboz: int = 18,
     nboz: int = 18,
     jit: bool = False,
-) -> dict[str, np.ndarray]:
+) -> dict[str, Any]:
     """Boozer ``|B|`` spectrum of selected surfaces via ``booz_xform_jax``.
 
     ``wout`` is a :class:`~vmec_jax.core.wout.WoutData` (or any wout-like


### PR DESCRIPTION
## Summary

Plan `plan_pre_vmex.md` Item I points 1-4 as one robustness PR, all with the 2026-07-16 audit's measured evidence:

1. **Typed errors through `pure_callback`** — a failing host solve inside `im.run`/`solve_implicit` now raises the SHORT typed `VmecConvergenceError`/`VmecJacobianError` (measured: **3681-char raw `JaxRuntimeError` → 24-char typed message**) via a single-slot host-error relay (`_HOST_ERROR` + a shared `_callback_solve`; host callbacks are serialized per solve). Works through `jax.grad`; under `jax.jit` the short sentinel surfaces at the jit boundary where the `least_squares` penalty lanes catch it. Mechanism documented in the module docstring; regression-tested.
2. **Zero-crash penalty-path tests** — the four previously-uncovered `least_squares` except-bodies (FD lane, implicit fun, jac last-jac fallback, diagnostic cold re-solve) now execute under deterministic poisoned-solve tests in `tests/test_optimize_penalty.py` (coverage-verified).
3. **mypy debt + lint gate** — the 6 real errors fixed (five `WeakKeyDictionary` cache annotations, one `dict[str, Any]`), the stale `[[tool.mypy.overrides]]` block deleted, and a fail-fast **ruff + mypy CI job** added so it cannot rot again.
4. **Multigrid implicit-gradient FD validation** — `im.run(multigrid=True)` through a genuine ns 5→11 ladder vs `frozen_path_directional_fd`: rel ≤ 1e-6.

Also: plan updates — I.1–I.4 ticked; **PR #22 decision recorded** (deferred, revisited last before the VMEX rename, per 2026-07-17 directive); Item F updated with the adjoint-tolerance sweep result (tolerance is *not* the speed lever — wall time flat 1e-13→1e-6; the cost is fixed matvec work → recycling/matvec-cost are the levers).

## Verification (local)
- `tests/test_implicit_grad.py` **11 passed** (the critical hot-path regression gate, incl. the 2 new tests)
- `tests/test_implicit_multi_rhs.py` 2 passed · `tests/test_optimize_penalty.py` 3 passed · `test_optimize.py -k least_squares` 6 passed
- `ruff check` clean · `mypy vmec_jax` clean (0 errors, no overrides)