### PR TITLE
Traceable L∇B objective for the implicit lane (plan Item E.1)

### DIFF
--- a/docs/objectives.rst
+++ b/docs/objectives.rst
@@ -41,7 +41,9 @@ optimizer picks it up automatically, so the *same* term list works in both
 gradient modes).  Terms that evaluate wout tables on host NumPy
 (:func:`~vmec_jax.core.optimize.d_merc`,
 :func:`~vmec_jax.core.optimize.l_grad_b`, the wout-lane QI residual, the
-eigenvector-weighted turbulence proxies) work with ``jac=None`` only.
+eigenvector-weighted turbulence proxies) work with ``jac=None`` only —
+for ``L_grad_B`` the traceable lane
+:func:`~vmec_jax.core.optimize.l_grad_b_state` covers ``jac="implicit"``.
 
 .. code-block:: python
 
@@ -110,6 +112,25 @@ Two host-side diagnostics complete the set — they run on the wout engine
 ``jac=None``: :func:`~vmec_jax.core.optimize.d_merc` (Mercier interchange
 criterion) and :func:`~vmec_jax.core.optimize.l_grad_b` (the ``L_grad_B``
 coil-complexity proxy).
+
+``L_grad_B`` additionally has a fully traceable ``(state, runtime)`` lane,
+:func:`~vmec_jax.core.optimize.l_grad_b_state` — same convention
+(``L_grad_B = |B| sqrt(2 / ||grad B||_F^2)``, same sampling grid and radial
+stencils, wout-lane parity to float round-off), rebuilt from the state-field
+chain in pure JAX, so it works under ``jac="implicit"``.  The default hard
+minimum over the surface grid is exact but has a jumping gradient when the
+minimizing gridpoint switches; passing ``softmin_k=k`` selects the smooth
+soft minimum ``-logsumexp(-k L)/k`` (a lower bound within
+``log(ntheta*nphi)/k``) — optimize with the smooth form, report the hard
+minimum (gradient validated against the frozen-path FD to 1.7e-6):
+
+.. code-block:: python
+
+   import functools
+   lgradb = functools.partial(opt.l_grad_b_state, softmin_k=50.0)
+   result = opt.least_squares(
+       [(qs, 0.0, 1.0), (lgradb, 0.35, 1.0)],
+       inp, max_mode=3, jac="implicit")
 
 Omnigenity and quasi-isodynamicity
 ----------------------------------
@@ -294,11 +315,16 @@ Which objectives differentiate how
      - yes
      - yes
      - eigenvalue-only reduction carries JVP + VJP
+   * - :func:`~vmec_jax.core.optimize.l_grad_b_state`
+     - yes
+     - yes
+     - traceable ``L_grad_B`` lane (soft-min via ``softmin_k``)
    * - :func:`~vmec_jax.core.optimize.d_merc`,
        :func:`~vmec_jax.core.optimize.l_grad_b`
      - yes
      - no
-     - host-NumPy wout engine
+     - host-NumPy wout engine (``l_grad_b``: use
+       :func:`~vmec_jax.core.optimize.l_grad_b_state` instead)
    * - :func:`~vmec_jax.core.optimize.quasi_isodynamic_residual` (wout lane)
      - yes
      - no

--- a/plan_pre_vmex.md
+++ b/plan_pre_vmex.md
@@ -218,10 +218,16 @@ consistent bootstrap (Redl) at finite β, DMerc > 0 (Mercier), magnetic well
 NumPy)**: `l_grad_b` (optimize.py:590) and `d_merc` (optimize.py:575 →
 nyquist.mercier_and_jxb) — `jac="implicit"` explicitly rejects them
 (optimize.py:1439). Options per objective: (a) run those terms under `jac=None`
-FD at honest cost, (b) build traceable versions (L∇B from the state-field chain
-is plausible; a traceable Mercier via nyquist-in-JAX is a big lift), or
+FD at honest cost, (b) build traceable versions — **(b) for L∇B DONE
+2026-07-17**: `l_grad_b_state` (optimize.py; physics in
+`statephysics._lgradb_grid`/`_lgradb_state_tables`) rebuilds the wout tables
+traceably (wrout.f Nyquist analysis in jnp), wout-lane parity to float
+round-off on solovev/li383/LandremanPaul-QA, soft-min via `softmin_k`,
+gradient vs frozen-path FD 1.7e-6 (tests/test_lgradb.py) — (a traceable
+Mercier via nyquist-in-JAX remains a big lift), or
 (c) scope the row to the traceable set + bootstrap. Decide when starting;
-(a) for DMerc + (b) for L∇B is the likely sweet spot. After Items A–C.
+(a) for DMerc + the traceable `l_grad_b_state` for L∇B is the likely sweet
+spot. After Items A–C.
 
 ## 7. Item F — Speed deep-dive (#36) — kickoff measurements done 2026-07-16
 

--- a/tests/test_lgradb.py
+++ b/tests/test_lgradb.py
@@ -1,0 +1,204 @@
+"""Traceable ``L_grad_B`` objective (plan_pre_vmex Item E, part 1).
+
+Validation gates for :func:`vmec_jax.core.optimize.l_grad_b_state`, the
+implicit-adjoint-compatible ``(state, runtime)`` lane of the wout-engine
+:func:`~vmec_jax.core.optimize.l_grad_b`:
+
+a. **Value parity** — the traceable hard-min lane vs the wout lane on three
+   decks (solovev 2D, li383_low_res 3D ncurr=1, LandremanPaul2021_QA_lowres
+   3D QA), same sampling surfaces.  Both lanes share the pointwise math
+   (:func:`vmec_jax.core.statephysics._lgradb_grid`); the traceable lane
+   rebuilds the wout coefficient tables (``rmnc/zmns`` renormalization, the
+   ``wrout.f`` Nyquist analysis of ``B^u/B^v``) in jnp, so they agree to
+   float round-off — measured 0 to 4.4e-16 relative on all three decks
+   (2026-07-17, x64 CPU); asserted at rtol 1e-12 (headroom for BLAS/einsum
+   reassociation), far inside the 1e-6 plan gate.
+b. **Gradient** — ``jax.grad`` of the smooth (soft-min) objective through
+   the implicit solve vs :func:`vmec_jax.core.implicit.frozen_path_directional_fd`
+   on solovev, one boundary dof: measured rel 1.7e-6, gate 1e-4.
+c. A ``jac="implicit"`` least-squares smoke including the new term.
+
+Converged states are cached in ``/tmp`` (same pattern as test_optimize.py) so
+repeated runs skip the solves.  No golden fixtures needed — every comparison
+is self-referential against the wout engine / frozen-path FD of the same
+state.  The LandremanPaul deck exhausts its iteration budget at this
+resolution (``converged=False``); parity is a property of the returned state,
+not of convergence, so it is asserted regardless.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+pytest.importorskip("netCDF4")
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp  # noqa: E402
+
+from vmec_jax.core.input import VmecInput  # noqa: E402
+from vmec_jax.core import implicit as im  # noqa: E402
+from vmec_jax.core import optimize as opt  # noqa: E402
+
+pytestmark = [pytest.mark.usefixtures("_module_jit_enabled")]  # full solves: jitted
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "examples" / "data"
+CACHE_DIR = Path("/tmp/vmec_jax_test_cache_lgradb")
+
+_STATE_FIELDS = ("R_cos", "R_sin", "Z_cos", "Z_sin", "L_cos", "L_sin")
+
+# Value-parity decks; achieved relative difference measured 2026-07-17
+# (x64 CPU): solovev 4.4e-16, li383_low_res 0.0, LandremanPaul 0.0.
+PARITY_DECKS = ("solovev", "li383_low_res", "LandremanPaul2021_QA_lowres")
+PARITY_RTOL = 1e-12          # asserted (plan gate: 1e-6)
+
+SOFTMIN_K = 50.0             # [1/m]; soft-min bias <= log(24*24)/k ~ 0.127 m
+
+
+def _cached_eq(deck: str) -> opt.Equilibrium:
+    """Converged (or budget-exhausted) equilibrium of a bundled deck, cached."""
+    from vmec_jax.core.solver import (
+        SpectralState,
+        prepare_runtime,
+        resolution_from_input,
+    )
+
+    inp = VmecInput.from_file(DATA_DIR / f"input.{deck}")
+    cache = CACHE_DIR / f"{deck}_state.npz"
+    if cache.exists():
+        data = np.load(cache)
+        state = SpectralState(**{k: jnp.asarray(data[k]) for k in _STATE_FIELDS})
+        result = SimpleNamespace(
+            fsqr=float(data["fsqr"]), fsqz=float(data["fsqz"]),
+            fsql=float(data["fsql"]), iterations=int(data["iterations"]),
+            converged=bool(data["converged"]))
+        ns = int(np.shape(state.R_cos)[0])
+        runtime = prepare_runtime(inp, resolution_from_input(inp, ns=ns))
+        return opt.Equilibrium(inp=inp, state=state, runtime=runtime, result=result)
+    eq = opt.solve_equilibrium(inp)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    np.savez(cache,
+             **{k: np.asarray(getattr(eq.state, k)) for k in _STATE_FIELDS},
+             fsqr=eq.result.fsqr, fsqz=eq.result.fsqz, fsql=eq.result.fsql,
+             iterations=eq.result.iterations, converged=eq.result.converged)
+    return eq
+
+
+# ---------------------------------------------------------------------------
+# a. value parity: traceable hard-min lane vs the wout lane
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("deck", PARITY_DECKS)
+def test_value_parity_vs_wout_lane(deck):
+    """Hard-min ``l_grad_b_state`` == wout-lane ``l_grad_b`` to float round-off.
+
+    Checked on the default (edge) surface and one interior surface — the
+    interior case additionally exercises the central (two-sided) radial
+    stencil of the half-mesh field tables.
+    """
+    eq = _cached_eq(deck)
+    ns = int(np.shape(eq.state.R_cos)[0])
+    for s_index in (-1, ns // 2):
+        ref = float(opt.l_grad_b(eq, s_index=s_index))
+        got = float(opt.l_grad_b_state(eq.state, eq.runtime, s_index=s_index))
+        assert np.isfinite(ref) and ref > 0.0
+        np.testing.assert_allclose(
+            got, ref, rtol=PARITY_RTOL,
+            err_msg=f"{deck}, s_index={s_index}: traceable vs wout lane")
+
+
+def test_value_parity_nondefault_grid():
+    """Parity holds on a non-default angular sampling grid too."""
+    eq = _cached_eq("li383_low_res")
+    ref = float(opt.l_grad_b(eq, ntheta=36, nphi=30))
+    got = float(opt.l_grad_b_state(eq.state, eq.runtime, ntheta=36, nphi=30))
+    np.testing.assert_allclose(got, ref, rtol=PARITY_RTOL)
+
+
+def test_jit_parity_and_softmin_bounds():
+    """jit == eager; the soft minimum is a lower bound within log(N)/k."""
+    eq = _cached_eq("solovev")
+    hard = float(opt.l_grad_b_state(eq.state, eq.runtime))
+    jitted = float(jax.jit(
+        lambda s: opt.l_grad_b_state(s, eq.runtime))(eq.state))
+    np.testing.assert_allclose(jitted, hard, rtol=1e-12)
+    soft = float(opt.l_grad_b_state(eq.state, eq.runtime, softmin_k=SOFTMIN_K))
+    assert soft <= hard + 1e-12
+    assert hard - soft <= np.log(24 * 24) / SOFTMIN_K
+
+
+def test_implicit_lane_dispatch_accepts_state_term():
+    """``_traceable_term`` accepts the (state, rt) lane; still rejects the wout lane."""
+    assert opt._traceable_term(opt.l_grad_b_state) is opt.l_grad_b_state
+    smooth = functools.partial(opt.l_grad_b_state, softmin_k=SOFTMIN_K)
+    assert opt._traceable_term(smooth) is smooth
+    with pytest.raises(ValueError, match="l_grad_b_state"):
+        opt._traceable_term(opt.l_grad_b)      # wout lane: FD-only, by design
+
+
+# ---------------------------------------------------------------------------
+# b. gradient of the smooth objective vs frozen-path FD (solovev)
+# ---------------------------------------------------------------------------
+
+
+def test_gradient_vs_frozen_path_fd():
+    """``jax.grad`` of the soft-min objective == frozen-path central FD.
+
+    One boundary dof (``RBC(0,1)``, h = 3e-5 — the solovev boundary step of
+    test_implicit_grad.py) through the implicit solve.  Measured rel 1.7e-6
+    (2026-07-17, x64 CPU); gate 1e-4.
+    """
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    cfg = im.make_config(inp, ftol=1e-14, max_iterations=2000)
+    p0 = im.params_from_input(inp)
+    ntor = int(inp.ntor)
+
+    def metric(state, rt):
+        return opt.l_grad_b_state(state, rt, softmin_k=SOFTMIN_K)
+
+    ad = float(np.asarray(jax.grad(
+        lambda p: metric(im.solve_implicit(p, cfg),
+                         im.runtime_from_params(p, cfg)))(p0).rbc)[ntor, 1])
+
+    zero = jax.tree.map(jnp.zeros_like, p0)
+    tangent = dataclasses.replace(zero, rbc=zero.rbc.at[ntor, 1].set(1.0))
+    fd, info = im.frozen_path_directional_fd(p0, cfg, metric, tangent, h=3e-5)
+    res = max(info["newton_res"])
+    rel = abs(ad / fd - 1.0)
+    print(f"\n[solovev] d(softmin L_grad_B)/d(RBC(0,1)) h=3e-5: "
+          f"AD={ad:+.10e}  frozen-FD={fd:+.10e}  rel={rel:.2e} "
+          f"(Newton res {res:.0e})")
+    assert res < 1e-8, f"frozen solve not converged (res {res:.1e})"
+    assert rel <= 1e-4
+
+
+# ---------------------------------------------------------------------------
+# c. jac="implicit" least-squares smoke including the new term
+# ---------------------------------------------------------------------------
+
+
+def test_least_squares_implicit_smoke_with_lgradb():
+    """3-nfev implicit least squares with an ``l_grad_b_state`` term improves.
+
+    Aspect target plus the smooth ``L_grad_B`` term — the combination the
+    objectives README row optimizes — through ``jac="implicit"`` end to end
+    (term dispatch, implicit Jacobian rows, trust-region step).
+    """
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    eq0 = _cached_eq("solovev")
+    term = functools.partial(opt.l_grad_b_state, softmin_k=SOFTMIN_K)
+    terms = [(opt.aspect_ratio, 4.0, 1.0), (term, 3.0, 0.5)]
+    cost0 = 0.5 * sum(
+        (w * (float(f(eq0.state, eq0.runtime)) - t)) ** 2 for f, t, w in terms)
+    res = opt.least_squares(terms, inp, max_mode=1, jac="implicit", max_nfev=3)
+    assert res.nfev <= 3
+    assert np.isfinite(res.cost)
+    assert res.cost < cost0
+    assert isinstance(res.input, VmecInput)

--- a/vmec_jax/core/optimize.py
+++ b/vmec_jax/core/optimize.py
@@ -51,8 +51,10 @@ terms exposing a ``residuals_state`` method
 residual vector, matching the finite-difference stacked-residual cost and
 Gauss-Newton geometry (internal-grid sampling instead of the wout grid).
 Wout-engine terms (:func:`d_merc`, :func:`l_grad_b`, the Boozer-based QI
-residual) run on host NumPy and are finite-difference-only.  The implicit
-parameter map does not implement the lasym ``readin.f`` delta rotation, so
+residual) run on host NumPy and are finite-difference-only —
+:func:`l_grad_b_state` is the traceable ``(state, rt)`` lane of the same
+``L_grad_B`` convention for ``jac="implicit"``.  The implicit parameter map
+does not implement the lasym ``readin.f`` delta rotation, so
 ``jac="implicit"`` requires ``lasym = False``.
 
 Measured cost (2026-07-10, RTX A4000, nfp2 circular seed, QS + aspect +
@@ -102,6 +104,8 @@ from .statephysics import (
     _interp_half_grid,
     _iotas_half,
     _iotas_half_from_fields,
+    _lgradb_grid,
+    _lgradb_state_tables,
     _mode_matrix,
 )
 from .wout import WoutData, wout_from_state
@@ -118,6 +122,7 @@ __all__ = [
     "magnetic_well",
     "d_merc",
     "l_grad_b",
+    "l_grad_b_state",
     "quasi_isodynamic_residual",
     "boozer_modes_from_wout",
     "quasi_isodynamic_residual_from_wout",
@@ -600,104 +605,71 @@ def l_grad_b(eq, *, s_index: int = -1, ntheta: int = 24, nphi: int = 24) -> Arra
     basis vectors and their derivatives spectrally from ``rmnc/zmns``, and
     radial derivatives from the native half/full-mesh finite differences
     (one-sided at the edge) — so values agree with the legacy diagnostic at
-    discretization level, not bitwise.
+    discretization level, not bitwise (the pointwise math lives in
+    :func:`vmec_jax.core.statephysics._lgradb_grid`, shared with the
+    traceable :func:`l_grad_b_state`).
 
     Returns the (hard) minimum over a uniform ``(theta, phi)`` grid on the
     selected surface (``s_index`` indexes the ``ns``-long half-mesh arrays;
     default edge).  Larger is better; a practical least-squares term is
     ``max(1/L - 1/threshold, 0)``.  Symmetric configurations only (lasym
     sine partners are ignored).  Accepts an :class:`Equilibrium` or wout-like.
+    This lane consumes host-NumPy wout tables (finite-difference-only); use
+    :func:`l_grad_b_state` for ``jac="implicit"``.
     """
     wout = eq.wout if isinstance(eq, Equilibrium) else eq
-    ns = int(wout.ns)
-    j = max(1, min(s_index % ns, ns - 1))
-    hs = 1.0 / (ns - 1)
-    xm = jnp.asarray(np.asarray(wout.xm, dtype=float))
-    xn = jnp.asarray(np.asarray(wout.xn, dtype=float))
-    xmn = jnp.asarray(np.asarray(wout.xm_nyq, dtype=float))
-    xnn = jnp.asarray(np.asarray(wout.xn_nyq, dtype=float))
-    rmnc = jnp.asarray(np.asarray(wout.rmnc, dtype=float))
-    zmns = jnp.asarray(np.asarray(wout.zmns, dtype=float))
-    bsupu_t = jnp.asarray(np.asarray(wout.bsupumnc, dtype=float))
-    bsupv_t = jnp.asarray(np.asarray(wout.bsupvmnc, dtype=float))
+    grid = _lgradb_grid(
+        xm=jnp.asarray(np.asarray(wout.xm, dtype=float)),
+        xn=jnp.asarray(np.asarray(wout.xn, dtype=float)),
+        xm_nyq=jnp.asarray(np.asarray(wout.xm_nyq, dtype=float)),
+        xn_nyq=jnp.asarray(np.asarray(wout.xn_nyq, dtype=float)),
+        rmnc=jnp.asarray(np.asarray(wout.rmnc, dtype=float)),
+        zmns=jnp.asarray(np.asarray(wout.zmns, dtype=float)),
+        bsupumnc=jnp.asarray(np.asarray(wout.bsupumnc, dtype=float)),
+        bsupvmnc=jnp.asarray(np.asarray(wout.bsupvmnc, dtype=float)),
+        ns=int(wout.ns), nfp=int(wout.nfp),
+        s_index=s_index, ntheta=ntheta, nphi=nphi,
+    )
+    return jnp.min(grid)
 
-    theta = jnp.linspace(0.0, 2.0 * jnp.pi, int(ntheta), endpoint=False)
-    phi = jnp.linspace(0.0, 2.0 * jnp.pi / int(wout.nfp), int(nphi), endpoint=False)
 
-    def tables(m, n):
-        ang = (theta[:, None, None] * m[None, None, :]
-               - phi[None, :, None] * n[None, None, :])
-        return jnp.cos(ang), jnp.sin(ang)
+def l_grad_b_state(
+    state: SpectralState,
+    rt: SolverRuntime,
+    *,
+    s_index: int = -1,
+    ntheta: int = 24,
+    nphi: int = 24,
+    softmin_k: float | None = None,
+) -> Array:
+    """Traceable ``min L_grad_B`` of a core state (implicit-adjoint ready).
 
-    cosang, sinang = tables(xm, xn)
+    The ``(state, runtime)`` lane of :func:`l_grad_b` (plan_pre_vmex Item E):
+    identical convention — ``L_grad_B = |B| sqrt(2/(grad B : grad B))``
+    minimized over the same uniform ``(theta, phi)`` grid of one half-mesh
+    surface — with the wout coefficient tables rebuilt traceably from the
+    state (:func:`~vmec_jax.core.statephysics._lgradb_state_tables`: physical
+    ``rmnc/zmns`` from the spectral state, the ``wrout.f`` Nyquist analysis
+    of ``B^u/B^v`` as jnp einsums) and the same half/full-mesh radial
+    finite-difference stencils, so the default hard minimum matches the
+    wout lane to float round-off.  Fully jnp: usable directly as a
+    two-positional objective term under ``jac="implicit"``.
 
-    def series(coeff, parity, second: bool = True):
-        """Value + angular derivatives of a cos/sin(m theta - n phi) series."""
-        base, alt = (cosang, sinang) if parity == "cos" else (sinang, cosang)
-        s1 = -1.0 if parity == "cos" else 1.0
-        val = jnp.einsum("m,tpm->tp", coeff, base)
-        d_t = s1 * jnp.einsum("m,tpm,m->tp", coeff, alt, xm)
-        d_p = -s1 * jnp.einsum("m,tpm,m->tp", coeff, alt, xn)
-        if not second:
-            return val, d_t, d_p, None, None, None
-        d_tt = -jnp.einsum("m,tpm,m->tp", coeff, base, xm * xm)
-        d_tp = jnp.einsum("m,tpm,m->tp", coeff, base, xm * xn)
-        d_pp = -jnp.einsum("m,tpm,m->tp", coeff, base, xn * xn)
-        return val, d_t, d_p, d_tt, d_tp, d_pp
-
-    # Full-mesh R/Z -> half-mesh values + radial derivatives (exact on half mesh).
-    R, Ru, Rv, Ruu, Ruv, Rvv = series(0.5 * (rmnc[j - 1] + rmnc[j]), "cos")
-    Z, Zu, Zv, Zuu, Zuv, Zvv = series(0.5 * (zmns[j - 1] + zmns[j]), "sin")
-    Rs, Rsu, Rsv, _, _, _ = series((rmnc[j] - rmnc[j - 1]) / hs, "cos", second=False)
-    Zs, Zsu, Zsv, _, _, _ = series((zmns[j] - zmns[j - 1]) / hs, "sin", second=False)
-
-    cphi, sphi = jnp.cos(phi)[None, :], jnp.sin(phi)[None, :]
-
-    def cart(vR, vP, vZ):
-        """Cylindrical (R, phi, Z) components -> Cartesian (x, y, z)."""
-        return jnp.stack([vR * cphi - vP * sphi, vR * sphi + vP * cphi, vZ], axis=-1)
-
-    zero = jnp.zeros_like(R)
-    e_s, e_u, e_v = cart(Rs, zero, Zs), cart(Ru, zero, Zu), cart(Rv, R, Zv)
-    # d(e_u)/du, d(e_u)/dv=d(e_v)/du, d(e_v)/dv, d(e_u)/ds, d(e_v)/ds
-    deu_u = cart(Ruu, zero, Zuu)
-    deu_v = cart(Ruv, Ru, Zuv)
-    dev_v = cart(Rvv - R, 2.0 * Rv, Zvv)
-    deu_s = cart(Rsu, zero, Zsu)
-    dev_s = cart(Rsv, Rs, Zsv)
-
-    # Half-mesh contravariant field (Nyquist modes) + radial derivative.
-    cosn, sinn = tables(xmn, xnn)
-
-    def nyq(coeff):
-        return (jnp.einsum("m,tpm->tp", coeff, cosn),
-                -jnp.einsum("m,tpm,m->tp", coeff, sinn, xmn),
-                jnp.einsum("m,tpm,m->tp", coeff, sinn, xnn))
-
-    bu, bu_t, bu_p = nyq(bsupu_t[j])
-    bv, bv_t, bv_p = nyq(bsupv_t[j])
-    lo, hi = (j - 1, j + 1) if 1 < j < ns - 1 else ((j, j + 1) if j == 1 else (j - 1, j))
-    span = hs * (hi - lo)
-    bu_s, _, _ = nyq((bsupu_t[hi] - bsupu_t[lo]) / span)
-    bv_s, _, _ = nyq((bsupv_t[hi] - bsupv_t[lo]) / span)
-
-    B = bu[..., None] * e_u + bv[..., None] * e_v
-    dB = jnp.stack([
-        bu_s[..., None] * e_u + bv_s[..., None] * e_v
-        + bu[..., None] * deu_s + bv[..., None] * dev_s,
-        bu_t[..., None] * e_u + bv_t[..., None] * e_v
-        + bu[..., None] * deu_u + bv[..., None] * deu_v,
-        bu_p[..., None] * e_u + bv_p[..., None] * e_v
-        + bu[..., None] * deu_v + bv[..., None] * dev_v,
-    ], axis=-2)                                        # (t, p, coord, cart)
-
-    basis = jnp.stack([e_s, e_u, e_v], axis=-2)
-    g = jnp.einsum("...ic,...jc->...ij", basis, basis)
-    ginv = jnp.linalg.inv(g)
-    grad_sq = jnp.einsum("...ic,...ij,...jc->...", dB, ginv, dB)
-    tiny = jnp.asarray(jnp.finfo(grad_sq.dtype).tiny, dtype=grad_sq.dtype)
-    bmag = jnp.sqrt(jnp.maximum(jnp.sum(B * B, axis=-1), tiny))
-    return jnp.min(bmag * jnp.sqrt(2.0 / jnp.maximum(grad_sq, tiny)))
+    ``softmin_k`` selects the reduction: ``None`` (default) is the hard
+    ``min`` — exact, and differentiable almost everywhere (the subgradient
+    follows the argmin point), but its gradient jumps when the minimizing
+    gridpoint switches.  A float ``k`` [1/m] returns the smooth soft minimum
+    ``-logsumexp(-k * L) / k``, a lower bound on the hard minimum within
+    ``log(ntheta * nphi) / k`` (about ``6.4 / k`` m at the default 24x24
+    grid; ``k = 50`` biases a ~1 m scale length by < 0.13 m).  Optimize with
+    the smooth form, report the hard minimum.
+    """
+    tables = _lgradb_state_tables(state, rt)
+    grid = _lgradb_grid(s_index=s_index, ntheta=ntheta, nphi=nphi, **tables)
+    if softmin_k is None:
+        return jnp.min(grid)
+    k = jnp.asarray(float(softmin_k), dtype=grid.dtype)
+    return -jax.scipy.special.logsumexp(-k * grid) / k
 
 
 # ===========================================================================
@@ -1225,7 +1197,8 @@ def least_squares(
     one full equilibrium solve per dof.  Requirements (see the module
     docstring): every term traceable in ``(state, runtime)`` (vector terms
     expose ``residuals_state``; wout-engine terms like :func:`d_merc` /
-    :func:`l_grad_b` / the Boozer QI residual need ``jac=None``) and
+    :func:`l_grad_b` / the Boozer QI residual need ``jac=None`` — for
+    ``L_grad_B`` use the traceable :func:`l_grad_b_state` instead) and
     ``lasym = False`` (the implicit parameter map does not implement the
     lasym ``readin.f`` boundary rotation).
     ``jac_chunk_size`` (R17.1 memory knob, ``jac="implicit"`` only) chunks the
@@ -1437,7 +1410,8 @@ def _traceable_term(fun: Callable) -> Callable:
         f"objective term {fun!r} is not implicit-differentiable: jac='implicit' "
         "needs traceable (state, runtime) callables or a residuals_state method. "
         "Wout-engine terms (d_merc, l_grad_b, the Boozer QI residual) run on "
-        "host NumPy — use jac=None (finite differences) for those.")
+        "host NumPy — use jac=None (finite differences) for those, or the "
+        "traceable l_grad_b_state for L_grad_B.")
 
 
 def _least_squares_implicit(

--- a/vmec_jax/core/statephysics.py
+++ b/vmec_jax/core/statephysics.py
@@ -14,7 +14,14 @@ One home (R26a consolidation) for the small private helpers that
   half-mesh rotational transform (``add_fluxes.f90`` conventions);
 - the half-mesh radial sampling primitives :func:`_half_grid` /
   :func:`_interp_half_grid` and the wout-table utilities :func:`_as_1d` /
-  :func:`_mode_matrix`.
+  :func:`_mode_matrix`;
+- the ``L_grad_B`` primitives (plan_pre_vmex Item E): :func:`_lgradb_grid`
+  (the pointwise magnetic-gradient scale length from wout-convention
+  coefficient tables, pure jnp — shared by the wout-lane and traceable
+  objectives) and :func:`_lgradb_state_tables` (those tables rebuilt
+  *traceably* from ``(state, runtime)``: physical ``rmnc/zmns`` from the
+  spectral state and the ``wrout.f`` Nyquist analysis of ``B^u/B^v`` as jnp
+  einsums over host-constant trig tables).
 
 This module sits directly above :mod:`vmec_jax.core.solver` in the import
 graph; it must not import the objective modules.  ``optimize`` re-exports
@@ -23,6 +30,8 @@ these names for backward compatibility.
 
 from __future__ import annotations
 
+import dataclasses
+import functools
 from typing import Any
 
 import numpy as np
@@ -30,8 +39,11 @@ import numpy as np
 import jax.numpy as jnp
 
 from .fields import energies_and_force_norms, magnetic_fields, metric_elements
+from .fourier import Resolution, mode_table, trig_tables
 from .geometry import half_mesh_jacobian
+from .residuals import m1_constrained_to_physical
 from .solver import SolverRuntime, SpectralState, _geometry
+from .transforms import physical_to_internal_scale
 
 Array = Any
 
@@ -127,3 +139,228 @@ def _iotas_half(state: SpectralState, rt: SolverRuntime) -> jnp.ndarray:
         return jnp.asarray(setup.iotas)
     _, _, _, fields, _ = _field_chain(state, rt)
     return _iotas_half_from_fields(setup, fields)
+
+
+# ---------------------------------------------------------------------------
+# Magnetic-gradient scale length L_grad_B (plan_pre_vmex Item E)
+# ---------------------------------------------------------------------------
+
+
+def _lgradb_grid(
+    *,
+    xm: jnp.ndarray,
+    xn: jnp.ndarray,
+    xm_nyq: jnp.ndarray,
+    xn_nyq: jnp.ndarray,
+    rmnc: jnp.ndarray,
+    zmns: jnp.ndarray,
+    bsupumnc: jnp.ndarray,
+    bsupvmnc: jnp.ndarray,
+    ns: int,
+    nfp: int,
+    s_index: int = -1,
+    ntheta: int = 24,
+    nphi: int = 24,
+) -> jnp.ndarray:
+    """Pointwise ``L_grad_B`` on one half-mesh surface, from wout-convention tables.
+
+    ``L_grad_B = |B| sqrt(2 / (grad B : grad B))`` with ``grad B : grad B``
+    the squared Frobenius norm of the Cartesian field-gradient tensor.  Inputs
+    are the wout-normalized coefficient tables: full-mesh ``rmnc/zmns`` on the
+    main modes ``(xm, xn)`` and half-mesh ``bsupumnc/bsupvmnc`` on the Nyquist
+    modes ``(xm_nyq, xn_nyq)`` (``xn`` conventions include the ``nfp``
+    factor).  ``B^u``/``B^v`` are synthesized spectrally, the coordinate basis
+    vectors and their derivatives spectrally from ``rmnc/zmns``, and radial
+    derivatives use the native half/full-mesh finite differences (exact
+    half-mesh derivative of the full-mesh ``R/Z``; central — one-sided at the
+    edges — differences of the half-mesh field).  Returns the
+    ``(ntheta, nphi)`` array of ``L_grad_B`` values on a uniform
+    ``(theta, phi)`` grid of the surface selected by ``s_index`` (indexing the
+    ``ns``-long half-mesh arrays; default edge).  Pure jnp — shared by the
+    wout-lane :func:`vmec_jax.core.optimize.l_grad_b` and the traceable
+    :func:`vmec_jax.core.optimize.l_grad_b_state` (via
+    :func:`_lgradb_state_tables`), which therefore agree to float round-off.
+    Symmetric configurations only (lasym sine partners are ignored).
+    """
+    ns = int(ns)
+    j = max(1, min(int(s_index) % ns, ns - 1))
+    hs = 1.0 / (ns - 1)
+
+    theta = jnp.linspace(0.0, 2.0 * jnp.pi, int(ntheta), endpoint=False)
+    phi = jnp.linspace(0.0, 2.0 * jnp.pi / int(nfp), int(nphi), endpoint=False)
+
+    def tables(m, n):
+        ang = (theta[:, None, None] * m[None, None, :]
+               - phi[None, :, None] * n[None, None, :])
+        return jnp.cos(ang), jnp.sin(ang)
+
+    cosang, sinang = tables(xm, xn)
+
+    def series(coeff, parity, second: bool = True):
+        """Value + angular derivatives of a cos/sin(m theta - n phi) series."""
+        base, alt = (cosang, sinang) if parity == "cos" else (sinang, cosang)
+        s1 = -1.0 if parity == "cos" else 1.0
+        val = jnp.einsum("m,tpm->tp", coeff, base)
+        d_t = s1 * jnp.einsum("m,tpm,m->tp", coeff, alt, xm)
+        d_p = -s1 * jnp.einsum("m,tpm,m->tp", coeff, alt, xn)
+        if not second:
+            return val, d_t, d_p, None, None, None
+        d_tt = -jnp.einsum("m,tpm,m->tp", coeff, base, xm * xm)
+        d_tp = jnp.einsum("m,tpm,m->tp", coeff, base, xm * xn)
+        d_pp = -jnp.einsum("m,tpm,m->tp", coeff, base, xn * xn)
+        return val, d_t, d_p, d_tt, d_tp, d_pp
+
+    # Full-mesh R/Z -> half-mesh values + radial derivatives (exact on half mesh).
+    R, Ru, Rv, Ruu, Ruv, Rvv = series(0.5 * (rmnc[j - 1] + rmnc[j]), "cos")
+    Z, Zu, Zv, Zuu, Zuv, Zvv = series(0.5 * (zmns[j - 1] + zmns[j]), "sin")
+    Rs, Rsu, Rsv, _, _, _ = series((rmnc[j] - rmnc[j - 1]) / hs, "cos", second=False)
+    Zs, Zsu, Zsv, _, _, _ = series((zmns[j] - zmns[j - 1]) / hs, "sin", second=False)
+
+    cphi, sphi = jnp.cos(phi)[None, :], jnp.sin(phi)[None, :]
+
+    def cart(vR, vP, vZ):
+        """Cylindrical (R, phi, Z) components -> Cartesian (x, y, z)."""
+        return jnp.stack([vR * cphi - vP * sphi, vR * sphi + vP * cphi, vZ], axis=-1)
+
+    zero = jnp.zeros_like(R)
+    e_s, e_u, e_v = cart(Rs, zero, Zs), cart(Ru, zero, Zu), cart(Rv, R, Zv)
+    # d(e_u)/du, d(e_u)/dv=d(e_v)/du, d(e_v)/dv, d(e_u)/ds, d(e_v)/ds
+    deu_u = cart(Ruu, zero, Zuu)
+    deu_v = cart(Ruv, Ru, Zuv)
+    dev_v = cart(Rvv - R, 2.0 * Rv, Zvv)
+    deu_s = cart(Rsu, zero, Zsu)
+    dev_s = cart(Rsv, Rs, Zsv)
+
+    # Half-mesh contravariant field (Nyquist modes) + radial derivative.
+    cosn, sinn = tables(xm_nyq, xn_nyq)
+
+    def nyq(coeff):
+        return (jnp.einsum("m,tpm->tp", coeff, cosn),
+                -jnp.einsum("m,tpm,m->tp", coeff, sinn, xm_nyq),
+                jnp.einsum("m,tpm,m->tp", coeff, sinn, xn_nyq))
+
+    bu, bu_t, bu_p = nyq(bsupumnc[j])
+    bv, bv_t, bv_p = nyq(bsupvmnc[j])
+    lo, hi = (j - 1, j + 1) if 1 < j < ns - 1 else ((j, j + 1) if j == 1 else (j - 1, j))
+    span = hs * (hi - lo)
+    bu_s, _, _ = nyq((bsupumnc[hi] - bsupumnc[lo]) / span)
+    bv_s, _, _ = nyq((bsupvmnc[hi] - bsupvmnc[lo]) / span)
+
+    B = bu[..., None] * e_u + bv[..., None] * e_v
+    dB = jnp.stack([
+        bu_s[..., None] * e_u + bv_s[..., None] * e_v
+        + bu[..., None] * deu_s + bv[..., None] * dev_s,
+        bu_t[..., None] * e_u + bv_t[..., None] * e_v
+        + bu[..., None] * deu_u + bv[..., None] * deu_v,
+        bu_p[..., None] * e_u + bv_p[..., None] * e_v
+        + bu[..., None] * deu_v + bv[..., None] * dev_v,
+    ], axis=-2)                                        # (t, p, coord, cart)
+
+    basis = jnp.stack([e_s, e_u, e_v], axis=-2)
+    g = jnp.einsum("...ic,...jc->...ij", basis, basis)
+    ginv = jnp.linalg.inv(g)
+    grad_sq = jnp.einsum("...ic,...ij,...jc->...", dB, ginv, dB)
+    tiny = jnp.asarray(jnp.finfo(grad_sq.dtype).tiny, dtype=grad_sq.dtype)
+    bmag = jnp.sqrt(jnp.maximum(jnp.sum(B * B, axis=-1), tiny))
+    return bmag * jnp.sqrt(2.0 / jnp.maximum(grad_sq, tiny))
+
+
+@functools.lru_cache(maxsize=None)
+def _nyquist_analysis_constants(res: Resolution):
+    """Host-NumPy ``wrout.f`` Nyquist-analysis constants for a resolution.
+
+    The wout engine analyzes the internal-grid fields on the Nyquist-extended
+    trig tables (:func:`vmec_jax.core.wout.wout_from_state`); this rebuilds
+    the identical mode table and integration-weighted trig products —
+    :func:`vmec_jax.core.nyquist._wrout_theta_tables` /
+    ``_wrout_zeta_tables`` / ``_wrout_dmult`` on
+    ``mode_table(max(ntheta1/2, mpol-1) + 1, max(nzeta/2, ntor))`` — as
+    static NumPy constants so :func:`_wrout_cos_coeffs_state` can run the
+    same analysis as traceable jnp einsums.  Cached per (hashable)
+    :class:`~vmec_jax.core.fourier.Resolution`.
+    """
+    from .nyquist import _wrout_dmult, _wrout_theta_tables, _wrout_zeta_tables
+
+    mnyq = max(res.ntheta1 // 2, res.mpol - 1)
+    nnyq = max(res.nzeta // 2, res.ntor)
+    trig_nyq = trig_tables(dataclasses.replace(res, mpol=mnyq + 1, ntor=nnyq))
+    modes_nyq = mode_table(mnyq + 1, nnyq)
+    cosmui, sinmui = _wrout_theta_tables(trig_nyq)
+    cosnv, sinnv = _wrout_zeta_tables(trig_nyq)
+    m_idx = np.asarray(modes_nyq.m, dtype=int)
+    n_idx = np.abs(np.asarray(modes_nyq.n, dtype=int))
+    sgn = np.where(np.asarray(modes_nyq.n, dtype=int) < 0, -1.0, 1.0)
+    dmult = _wrout_dmult(modes_nyq, trig_nyq)
+    nt2 = int(trig_nyq.ntheta2)
+    return modes_nyq, (cosmui, sinmui, cosnv, sinnv, m_idx, n_idx, sgn, dmult, nt2)
+
+
+def _wrout_cos_coeffs_state(f: jnp.ndarray, consts) -> jnp.ndarray:
+    """Traceable ``wrout.f`` Nyquist cosine analysis, shape ``(ns, mnmax_nyq)``.
+
+    The jnp mirror of :func:`vmec_jax.core.nyquist.wrout_cos_coeffs`
+    (identical math, host-constant tables from
+    :func:`_nyquist_analysis_constants`), so gradients flow through the
+    analyzed internal-grid field ``f``.
+    """
+    cosmui, sinmui, cosnv, sinnv, m_idx, n_idx, sgn, dmult, nt2 = consts
+    f = jnp.asarray(f)[:, :nt2, :]
+    f_theta_cos = jnp.einsum("sik,im->smk", f, jnp.asarray(cosmui))
+    f_theta_sin = jnp.einsum("sik,im->smk", f, jnp.asarray(sinmui))
+    cos_zeta = jnp.einsum("smk,kn->smn", f_theta_cos, jnp.asarray(cosnv))
+    sin_zeta = jnp.einsum("smk,kn->smn", f_theta_sin, jnp.asarray(sinnv))
+    coeff = cos_zeta[:, m_idx, n_idx] + jnp.asarray(sgn)[None, :] * sin_zeta[:, m_idx, n_idx]
+    return coeff * jnp.asarray(dmult)[None, :]
+
+
+def _lgradb_state_tables(state: SpectralState, rt: SolverRuntime) -> dict:
+    """Traceable wout-convention ``L_grad_B`` input tables from ``(state, rt)``.
+
+    Rebuilds exactly the tables the wout engine feeds the wout-lane
+    :func:`vmec_jax.core.optimize.l_grad_b`, fully in jnp:
+
+    - ``rmnc/zmns``: the m=1 constraint undone
+      (:func:`~vmec_jax.core.residuals.m1_constrained_to_physical`) and the
+      internal ``mscale*nscale`` normalization multiplied back
+      (``wout_from_state``'s ``mode_scale``);
+    - ``bsupumnc/bsupvmnc``: the half-mesh contravariant field of
+      :func:`_field_chain` pushed through the ``wrout.f`` Nyquist cosine
+      analysis (:func:`_wrout_cos_coeffs_state`).  The (never-used) axis row
+      is zeroed first so no axis-slot garbage can leak into reverse-mode AD.
+
+    Returns the keyword dict for :func:`_lgradb_grid` (minus the sampling
+    controls).  Symmetric configurations only (``lasym = False``).
+    """
+    setup = rt.setup
+    if bool(setup.lasym):
+        raise NotImplementedError(
+            "l_grad_b_state supports lasym = False only (the wout-lane "
+            "l_grad_b ignores the lasym sine partners too)")
+    res = rt.resolution
+    nfp = int(res.nfp)
+    ns = int(np.shape(state.R_cos)[0])
+
+    R_cos_p, Z_sin_p, _, _ = m1_constrained_to_physical(
+        state.R_cos, state.Z_sin, state.R_sin, state.Z_cos,
+        modes=rt.modes, lthreed=bool(setup.lthreed), lasym=bool(setup.lasym),
+        lconm1=bool(setup.lconm1),
+    )
+    mode_scale = 1.0 / physical_to_internal_scale(rt.modes, rt.trig)
+    rmnc = jnp.asarray(R_cos_p) * jnp.asarray(mode_scale)[None, :]
+    zmns = jnp.asarray(Z_sin_p) * jnp.asarray(mode_scale)[None, :]
+
+    _, _, _, fields, _ = _field_chain(state, rt)
+    modes_nyq, consts = _nyquist_analysis_constants(res)
+    bsupu = jnp.asarray(fields.bsupu).at[0].set(0.0)
+    bsupv = jnp.asarray(fields.bsupv).at[0].set(0.0)
+    bsupumnc = _wrout_cos_coeffs_state(bsupu, consts)
+    bsupvmnc = _wrout_cos_coeffs_state(bsupv, consts)
+
+    return dict(
+        xm=jnp.asarray(np.asarray(rt.modes.m, dtype=float)),
+        xn=jnp.asarray(np.asarray(rt.modes.n, dtype=float) * nfp),
+        xm_nyq=jnp.asarray(np.asarray(modes_nyq.m, dtype=float)),
+        xn_nyq=jnp.asarray(np.asarray(modes_nyq.n, dtype=float) * nfp),
+        rmnc=rmnc, zmns=zmns, bsupumnc=bsupumnc, bsupvmnc=bsupvmnc,
+        ns=ns, nfp=nfp,
+    )


### PR DESCRIPTION
## Summary

Builds the traceable magnetic-gradient scale-length objective so the objectives README row (plan Item E) can optimize L∇B with `jac="implicit"` — previously the wout-engine `l_grad_b` was host-NumPy, FD-only, and rejected by the implicit lane by name.

- **Shared pointwise core** (`statephysics._lgradb_grid`): the Kappel/Landreman convention `L_∇B = |B|·√(2/(∇B:∇B))` (Frobenius norm of the Cartesian field-gradient tensor), hard-min over a `(θ,φ)` grid on a half-mesh surface. The existing wout-lane `l_grad_b` is refactored onto the same core (behavior unchanged) — so lane parity holds **by construction**.
- **`optimize.l_grad_b_state(state, rt, *, s_index, ntheta, nphi, softmin_k)`** — fully traceable: wout tables rebuilt in jnp (`rmnc/zmns` via the m1 constraint map + mscale/nscale renormalization; `bsupumnc/bsupvmnc` via the `wrout.f` Nyquist cosine analysis as einsums over per-Resolution cached host constants). Two-positional-arg signature → the existing `_traceable_term` dispatch accepts it with no registration change.
- **Smooth option**: `softmin_k` gives `−logsumexp(−k·L)/k` (documented lower-bound bias `log(N)/k`) for differentiable optimization; default stays the exact hard min ("optimize smooth, report hard", matching the `mirror_ratio` precedent).

## Validation (hard gates, all pass)
- **Value parity vs the wout lane** (rtol gate 1e-6, asserted at 1e-12): solovev **4.4e-16**, li383_low_res **0.0**, LandremanPaul QA **0.0** (edge + interior surface + non-default grids).
- **Gradient through the implicit solve** vs `frozen_path_directional_fd` (solovev RBC(0,1)): AD +8.351634e-01 vs FD +8.351648e-01 — **rel 1.7e-6**.
- `tests/test_lgradb.py` 8/8 (incl. a `least_squares(jac="implicit")` smoke with the new term); `test_optimize.py` 20/20; `test_implicit_grad.py` 11/11; ruff + mypy clean.

Docs: `docs/objectives.rst` gains the traceable row + usage; plan Item E option (b) ticked.