### PR TITLE
API/docs consolidation: entry-point guide, ImplicitSolution.runtime, physics-helper unification, dead-code prune (plan I.5-8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,19 +282,23 @@ density of the three (reproduce with
 
 ```python
 from vmec_jax.core.input import VmecInput
-from vmec_jax.core.multigrid import solve_multigrid
-from vmec_jax.core.wout import wout_from_state, write_wout
+from vmec_jax.core import optimize as opt
+from vmec_jax.core.wout import write_wout
 from vmec_jax.core.plotting import plot_wout
 
 inp = VmecInput.from_file("input.nfp4_QH_warm_start")
-result = solve_multigrid(inp)          # full NS_ARRAY ladder, VMEC2000 numerics
-print(result.converged, result.iterations, result.wmhd)
+eq = opt.solve_equilibrium(inp)        # full NS_ARRAY ladder, VMEC2000 numerics
+print(eq.result.converged, eq.result.iterations, float(eq.wout.aspect))
 
-wout = wout_from_state(inp=inp, state=result.state, niter=result.iterations,
-                       fsqr=result.fsqr, fsqz=result.fsqz, fsql=result.fsql)
-write_wout("wout_nfp4_QH_warm_start.nc", wout)
-plot_wout(wout, "figures/")
+write_wout("wout_nfp4_QH_warm_start.nc", eq.wout)   # wout built lazily on eq
+plot_wout(eq.wout, "figures/")
 ```
+
+Choosing an entry point: `optimize.solve_equilibrium` for Python analysis and
+objectives (state + runtime + lazy `.wout`); `multigrid.solve_multigrid` when
+you only need the converged state (the CLI's engine); `implicit.run` for
+gradients (`jax.grad`-able `ImplicitSolution`); `solver.solve` as the
+low-level single-grid building block.
 
 Optimization building blocks live in `vmec_jax.core.optimize`
 (quasisymmetry and omnigenity residuals; aspect ratio, iota, mirror ratio,

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -153,6 +153,16 @@ of :doc:`algorithms` for the formulation and cost analysis.
    sol = implicit.run(inp, p0)                        # ImplicitSolution pytree
    grad = jax.grad(lambda p: implicit.run(inp, p).wb)(p0)   # adjoint gradient
 
+:func:`~vmec_jax.core.implicit.run` is the differentiable member of the
+entry-point family (see *Choosing an entry point* in :doc:`quickstart`; the
+non-differentiable Python default is
+:func:`~vmec_jax.core.optimize.solve_equilibrium`).  Besides the scalar
+outputs, the returned solution carries the internally built evaluation
+context as ``sol.runtime`` (a non-pytree convenience attribute), so custom
+objectives can evaluate further ``(state, runtime)`` targets —
+``opt.mean_iota(sol.state, sol.runtime)`` — without rebuilding the runtime
+per evaluation.
+
 Gradient accuracy is validated in CI against central finite differences for
 fixed-boundary degrees of freedom — boundary Fourier coefficients,
 ``phiedge``, and profile parameters (``pres_scale``) — on a 2D (solovev)

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -93,29 +93,61 @@ Python:
 .. code-block:: python
 
    from vmec_jax.core.input import VmecInput
-   from vmec_jax.core.multigrid import solve_multigrid
-   from vmec_jax.core.wout import wout_from_state, write_wout
+   from vmec_jax.core import optimize as opt
+   from vmec_jax.core.wout import write_wout
 
    inp = VmecInput.from_file("input.circular_tokamak")
-   result = solve_multigrid(inp)          # full NS_ARRAY ladder
-   print("converged:", result.converged, "in", result.iterations, "iterations")
+   eq = opt.solve_equilibrium(inp)        # full NS_ARRAY ladder -> Equilibrium
+   r = eq.result
+   print("converged:", r.converged, "in", r.iterations, "iterations")
 
-   wout = wout_from_state(
-       inp=inp, state=result.state,
-       fsqr=float(result.fsqr), fsqz=float(result.fsqz), fsql=float(result.fsql),
-       niter=int(result.iterations), converged=bool(result.converged),
-       input_extension="circular_tokamak",
-   )
-   write_wout("wout_circular_tokamak.nc", wout)
+   print("aspect ratio:", float(eq.wout.aspect))   # wout built lazily, cached
+   write_wout("wout_circular_tokamak.nc", eq.wout)
+
+:func:`~vmec_jax.core.optimize.solve_equilibrium` bundles the converged
+state with its evaluation contexts: ``eq.state`` and ``eq.runtime`` feed the
+differentiable scalar targets of :mod:`~vmec_jax.core.optimize` (e.g.
+``opt.aspect_ratio(eq.state, eq.runtime)``), and ``eq.wout`` is the full
+VMEC2000 wout dataset (built on first access — no manual
+``wout_from_state`` plumbing needed).
 
 ``VmecInput`` is a frozen dataclass with VMEC2000 semantics and defaults —
 you can also build one from scratch in Python (all INDATA fields are keyword
 arguments; see :doc:`input_reference`) and round-trip it to INDATA or
 VMEC++-style JSON.
 
+Choosing an entry point
+-----------------------
+
+Four solve entry points share the same numerics; pick by what you need back:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 24 46
+
+   * - entry point
+     - returns
+     - use when
+   * - :func:`vmec_jax.core.optimize.solve_equilibrium`
+     - ``Equilibrium`` (state + runtime + lazy ``.wout``)
+     - **Default for Python work**: analysis, objectives, anything that
+       reads wout tables or the ``(state, runtime)`` scalar targets.
+   * - :func:`vmec_jax.core.multigrid.solve_multigrid`
+     - ``SolveResult`` (state + convergence data)
+     - You only need the converged state / iteration diagnostics — the
+       engine behind the CLI and ``solve_equilibrium``.
+   * - :func:`vmec_jax.core.implicit.run`
+     - ``ImplicitSolution`` (differentiable pytree, carries ``.runtime``)
+     - Gradients: wrap it in ``jax.grad``/``jax.value_and_grad`` — the
+       implicit-adjoint path of :doc:`optimization`.
+   * - :func:`vmec_jax.core.solver.solve`
+     - ``SolveResult`` (one grid stage)
+     - Low-level single-``ns`` building block (no NS_ARRAY ladder);
+       mainly for solver development and tests.
+
 For gradient-based work, wrap the solve with the implicit-differentiation
-driver in :mod:`vmec_jax.core.implicit` and the objectives in
-:mod:`vmec_jax.core.optimize` — see :doc:`optimization`.
+driver in :mod:`vmec_jax.core.implicit` (:func:`~vmec_jax.core.implicit.run`)
+and the objectives in :mod:`vmec_jax.core.optimize` — see :doc:`optimization`.
 
 Reading wout files
 ------------------

--- a/examples/single_stage_vs_two_stage.py
+++ b/examples/single_stage_vs_two_stage.py
@@ -417,12 +417,11 @@ def phase_single(case: str, out: Path, args, *, warm: bool = False) -> None:
     # The adjoint GMRES at its 1e-11 default dominates each gradient (audit:
     # one warm gradient ~ 10-15 forward solves); 1e-8 is ample for L-BFGS-B.
     run_kw = dict(solve_kwargs(case), adjoint_tol=1e-8)
-    cfg = im.make_config(inp, **solve_kwargs(case))
 
     def objective(x):
         params, cdofs, cur = unpack(x)
         sol = im.run(inp, params, **run_kw)
-        rt = im.runtime_from_params(params, cfg)
+        rt = sol.runtime          # the SolverRuntime im.run built (Item I.6)
         j_qs = jnp.sum(qs.residuals_state(sol.state, rt) ** 2)
         sd = FBD.surface_field_data_from_state(inp, sol.state,
                                                nphi=NPHI, ntheta=NTHETA)
@@ -451,7 +450,7 @@ def phase_single(case: str, out: Path, args, *, warm: bool = False) -> None:
     # NOTE: jax.jit around this value_and_grad fails today with a
     # TracerArrayConversionError inside the FBD/im.run stack (host-side
     # conversions that pass under bare grad) -- jit-closing that path is
-    # plan_pre_vmex Item I.6/F; the adjoint_tol relaxation above is the
+    # plan_pre_vmex Item F; the adjoint_tol relaxation above is the
     # dominant per-eval win meanwhile.
     vg = jax.value_and_grad(objective, has_aux=True)
     hist: list[float] = []

--- a/plan_pre_vmex.md
+++ b/plan_pre_vmex.md
@@ -298,22 +298,38 @@ small-to-medium and independently PR-able; batch 1-4 as one "robustness" PR.
    **DONE 2026-07-17**: `test_multigrid_gradient_vs_frozen_path_fd`
    (`im.run(multigrid=True)` through a genuine ns 5 -> 11 solovev ladder vs
    `frozen_path_directional_fd`, rel <= 1e-6).
-5. **"Choosing an entry point" docs** (MED): `solver.solve` vs `solve_multigrid`
-   vs `opt.solve_equilibrium` vs `im.run` — no when-to-use-which anywhere;
-   quickstart teaches the manual `wout_from_state` plumbing while
-   `solve_equilibrium` appears in no doc page.
-6. **`ImplicitSolution.runtime`** (MED): callers rebuild
-   `runtime_from_params(make_config(...))` per objective eval (e.g. the
-   single-stage example) duplicating work `im.run` already did; also jit the
-   example objectives (measured 30% win from `jit(grad)`).
-7. **Consolidate duplicate physics helpers** (MED): `optimize.aspect_ratio`
-   (wint quadrature) vs `implicit.aspect_ratio` (shoelace), `volume` vs
-   `plasma_volume`, `edge_iota` vs `iota_edge` — same scalars, different math,
-   will drift; one family in `statephysics.py`, re-exported.
-8. **Dead-code prune** (LOW): `_compat.py` numpy-mode block (~250 lines; only 2
-   cache helpers are used), `fourier.angle_grids`, `nyquist.
-   nyquist_mode_table_from_grid` (exported, zero call sites); test-or-gate the
-   untested `recycle=True` Jacobian lane (optimize.py:1806-1829).
+5. [x] **"Choosing an entry point" docs** (MED) — **DONE 2026-07-17**:
+   quickstart gained a four-row entry-point table
+   (`solve_equilibrium` / `solve_multigrid` / `im.run` / `solver.solve`) and
+   its Python API example now uses `opt.solve_equilibrium(...).wout` instead
+   of the manual 6-arg `wout_from_state` plumbing; README carries the
+   3-line version; optimization.rst cross-links `im.run` into the family.
+6. [x] **`ImplicitSolution.runtime`** (MED) — **DONE 2026-07-17**: `im.run`
+   now attaches its internal `SolverRuntime` as `sol.runtime`, registered as
+   a *dropped* pytree field (`register_pytree_dataclass(..., drop=...)` →
+   JAX `drop_fields`), so the established 13-leaf pytree structure is
+   unchanged (resets to `None` across flatten/unflatten); the single-stage
+   example objective uses it instead of rebuilding cfg+runtime per eval.
+   Jitting the example objectives NOT done here — blocked by the FBD-stack
+   `TracerArrayConversionError` (→ Item F).
+7. [x] **Consolidate duplicate physics helpers** (MED) — **DONE 2026-07-17**
+   (conservative variant): the canonical wout-parity family
+   (`aspect_ratio`/`volume` wint quadrature, `mean_iota`/`edge_iota`) moved
+   to `statephysics.py`, re-exported unchanged by `optimize`; the naming
+   flip is closed with aliases (`optimize.iota_edge`, `implicit.edge_iota`)
+   and cross-referencing docstrings.  `implicit.aspect_ratio` /
+   `plasma_volume` deliberately KEEP their historical quadratures
+   (shoelace / `sum(vp)`): `ImplicitSolution.aspect`/`.volume` and the
+   FD-cached solovev gradient table in `test_implicit_grad.py` pin those
+   exact values (the disk cache keys do not version the math); both
+   docstrings document the two conventions (agree to quadrature resolution).
+8. [x] **Dead-code prune** (LOW) — **DONE 2026-07-17**: `_compat.py` numpy-mode
+   block deleted (kept: the cache-policy helpers + the import-time
+   `_configure_jax_environment` env defaults, which were load-bearing side
+   effects of the old `_try_import_jax`); `fourier.angle_grids` and
+   `nyquist.nyquist_mode_table_from_grid` deleted (zero call sites);
+   the `recycle=True` Jacobian lane kept (A/B measurement in flight) with an
+   explicit EXPERIMENTAL/opt-in docstring note.
 9. **Near-axis seeding** (decide): the README/docs claimed pyQSC/pyQIC seeding
    with ZERO implementing code — claim struck 2026-07-16. Either implement it
    properly (near-axis surface → VmecInput; ESSOS has near-axis fields to

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,10 +1,11 @@
-"""Unit tests for :mod:`vmec_jax._compat` (JAX/NumPy backend shim).
+"""Unit tests for :mod:`vmec_jax._compat` (JAX environment + cache policy).
 
-Covers the numpy-mode thread-local override, the no-op jit fallback, the
-machine-scoped compilation-cache policy (env-var precedence table in
-``_default_compilation_cache_dir``), the cache wiring against a recording
-fake JAX module, and the backend helpers (``asarray``/``einsum``/
-``enable_x64``/``x64_enabled``).
+Covers the machine-scoped compilation-cache policy (env-var precedence table
+in ``_default_compilation_cache_dir``), the cache wiring against a recording
+fake JAX module, and the import-time environment defaults
+(``_configure_jax_environment``).  The old JAX/NumPy backend shim
+(``has_jax``/``asarray``/``einsum``/numpy mode/no-op jit) was deleted in the
+Item I.8a dead-code prune — the core is JAX-only.
 """
 
 from __future__ import annotations
@@ -12,39 +13,9 @@ from __future__ import annotations
 import re
 import types
 
-import numpy as np
 import pytest
 
 from vmec_jax import _compat
-
-
-# ---------------------------------------------------------------------------
-# numpy-mode override + jit fallback
-# ---------------------------------------------------------------------------
-
-
-def test_numpy_mode_context_toggles_has_jax():
-    assert _compat.has_jax()  # suite runs with real JAX
-    assert not _compat.numpy_mode_enabled()
-    with _compat.numpy_mode_context():
-        assert _compat.numpy_mode_enabled()
-        assert not _compat.has_jax()
-        # einsum dispatches to numpy inside the context
-        out = _compat.einsum("i,i->", np.arange(3.0), np.arange(3.0))
-        assert isinstance(out, np.ndarray | np.floating | float)
-    assert not _compat.numpy_mode_enabled()
-    assert _compat.has_jax()
-
-
-def test_noop_jit_bare_and_decorator_factory_forms():
-    fn = lambda x: x + 1  # noqa: E731
-    assert _compat._noop_jit(fn) is fn
-    assert _compat._noop_jit(fn, static_argnames=("x",)) is fn
-    # @partial(jit, static_argnames=...) form: jit() returns a decorator
-    deco = _compat._noop_jit(None, static_argnames=("x",))
-    assert deco(fn) is fn
-    deco = _compat._noop_jit()
-    assert deco(fn) is fn
 
 
 # ---------------------------------------------------------------------------
@@ -161,82 +132,21 @@ def test_configure_compilation_cache_gpu_autotune_default(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# backend helpers
+# import-time environment defaults
 # ---------------------------------------------------------------------------
 
 
-def test_asarray_and_einsum_jax_backend():
-    a = _compat.asarray([1.0, 2.0, 3.0])
-    assert float(a.sum()) == 6.0
-    dot = _compat.einsum("i,i->", a, a)
-    assert float(dot) == pytest.approx(14.0)
-    # explicit precision path
-    from jax import lax
+def test_configure_jax_environment_idempotent_and_respects_user_env(monkeypatch):
+    """Re-running the import-time setup is safe and never clobbers user env."""
+    import os
 
-    dot2 = _compat.einsum("i,i->", a, a, precision=lax.Precision.DEFAULT)
-    assert float(dot2) == pytest.approx(14.0)
-
-
-def test_enable_x64_roundtrip_and_query():
-    assert _compat.has_jax()
-    original = _compat.x64_enabled()
-    try:
-        _compat.enable_x64(True)
-        assert _compat.x64_enabled()
-        _compat.enable_x64(False)
-        assert not _compat.x64_enabled()
-    finally:
-        _compat.enable_x64(original)
-    assert _compat.x64_enabled() == original
-
-
-def test_helpers_with_jax_unavailable(monkeypatch):
-    """The no-JAX branches of enable_x64/x64_enabled/einsum."""
-    monkeypatch.setattr(_compat, "jax", None)
-    assert not _compat.has_jax()
-    _compat.enable_x64(True)  # must be a silent no-op
-    assert _compat.x64_enabled() is True  # default-true without JAX
-    out = _compat.einsum("i,i->", np.arange(3.0), np.arange(3.0))
-    assert float(out) == pytest.approx(5.0)
-
-
-def test_x64_enabled_env_fallback(monkeypatch):
-    """When jax.config.read raises, x64_enabled falls back to the env var."""
-    class _Cfg:
-        def read(self, key):
-            raise RuntimeError("no such config")
-
-        def update(self, key, value):
-            raise RuntimeError("frozen")
-
-    monkeypatch.setattr(_compat, "jax", types.SimpleNamespace(config=_Cfg()))
+    monkeypatch.setenv("XLA_FLAGS", "--user_set_flag")
     monkeypatch.setenv("JAX_ENABLE_X64", "1")
-    assert _compat.x64_enabled() is True
-    monkeypatch.setenv("JAX_ENABLE_X64", "0")
-    assert _compat.x64_enabled() is False
-    _compat.enable_x64(True)  # update raising is swallowed
+    monkeypatch.setenv("TF_CPP_MIN_LOG_LEVEL", "0")
+    _compat._configure_jax_environment()  # must not raise (jax already imported)
+    assert os.environ["XLA_FLAGS"] == "--user_set_flag"       # setdefault only
+    assert os.environ["TF_CPP_MIN_LOG_LEVEL"] == "0"          # user wins
+    # the x64 default survives (VMEC parity: float64 mandatory)
+    import jax
 
-
-def test_try_import_jax_mocked_module_falls_back_to_numpy(monkeypatch):
-    """A non-module ``jax`` in sys.modules (docs mocking) -> NumPy fallback."""
-    import sys
-
-    class _Mock:  # not a types.ModuleType instance
-        pass
-
-    monkeypatch.setitem(sys.modules, "jax", _Mock())
-    jax_mod, np_mod, jit = _compat._try_import_jax()
-    assert jax_mod is None
-    assert np_mod is np
-    fn = lambda x: x  # noqa: E731
-    assert jit(fn) is fn  # _noop_jit
-
-
-def test_module_level_backend_objects():
-    assert _compat.jax is not None
-    assert _compat.jnp is not None
-    assert callable(_compat.jit)
-    assert hasattr(_compat.tree_util, "register_pytree_node_class")
-    # _try_import_jax is idempotent
-    jax2, jnp2, jit2 = _compat._try_import_jax()
-    assert jax2 is not None and callable(jit2)
+    assert jax.config.read("jax_enable_x64") is True

--- a/vmec_jax/_compat.py
+++ b/vmec_jax/_compat.py
@@ -1,69 +1,33 @@
-"""Small compatibility layer.
+"""JAX environment defaults + persistent compilation-cache policy.
 
-We want minimal dependencies, but also want the code to be importable in environments
-without JAX (e.g. for parsing / numpy-only debugging). If JAX is available, we use it.
+Historically this module was a full JAX/NumPy backend shim (``has_jax`` /
+``asarray`` / ``einsum`` / a no-op ``jit`` and a thread-local numpy mode).
+The core became JAX-only long ago and nothing imported that machinery any
+more, so it was deleted (plan_pre_vmex Item I.8a).  What remains — and is
+actually used — is:
 
-Notes on float64
-----------------
-VMEC historically relies on float64. JAX defaults to float32 unless x64 is enabled.
-To keep results stable and reduce warning spam, we *default* to enabling x64 when
-JAX is imported, unless the user has explicitly set ``JAX_ENABLE_X64``.
+- :func:`_configure_jax_environment` (run at import, i.e. before
+  ``vmec_jax/__init__`` does ``import jax``): environment defaults that must
+  be set before JAX/XLA initializes — float64 (``JAX_ENABLE_X64``, VMEC
+  parity), synchronous CPU dispatch, quiet XLA/PjRt C++ logging, GPU
+  demand allocation, the machine-scoped persistent compilation-cache
+  directory, and the XLA:CPU fast-compile flags;
+- the compilation-cache policy helpers
+  :func:`_default_compilation_cache_dir` / :func:`_cache_machine_fingerprint`
+  / :func:`_configure_compilation_cache`, consumed by ``vmec_jax/__init__``
+  and re-applied by ``core.solver._harden_compilation_cache`` on every solve
+  path (namespace-package shadowing guard).
 """
 
 from __future__ import annotations
 
-from typing import Any, Callable, Tuple
+from typing import Any
 import hashlib
 from importlib import metadata as importlib_metadata
 import sys
-import threading
-import types
 
 import os
 import platform
-
-import numpy as _np
-
-
-# ---------------------------------------------------------------------------
-# Thread-local NumPy-mode override (for pure-NumPy force hot path).
-# ---------------------------------------------------------------------------
-
-_numpy_mode_local = threading.local()
-
-
-def numpy_mode_enabled() -> bool:
-    """Return True if the current thread is inside a numpy_mode_context."""
-    return getattr(_numpy_mode_local, "active", False)
-
-
-class numpy_mode_context:
-    """Context manager to force pure-NumPy paths in has_jax()-gated code.
-
-    Inside this context, ``has_jax()`` returns False so that all
-    ``jnp.*`` dispatch is replaced by ``np.*`` (via the fallback path).
-    This eliminates all JAX eager-dispatch overhead in the force hot loop.
-    """
-
-    def __enter__(self):
-        _numpy_mode_local.active = True
-        return self
-
-    def __exit__(self, *_):
-        _numpy_mode_local.active = False
-
-
-def _noop_jit(f=None, *args, **_kwargs):
-    """Fallback jit decorator when JAX is unavailable.
-
-    Accepts arbitrary args/kwargs so @partial(jit, static_argnames=...) works
-    in docs builds and numpy-only environments.
-    """
-    if f is None:
-        def _wrap(fn):
-            return fn
-        return _wrap
-    return f
 
 
 def _cache_machine_fingerprint() -> str:
@@ -228,7 +192,14 @@ def _configure_compilation_cache(jax_module: Any, cache_dir: str | None) -> None
         pass
 
 
-def _try_import_jax() -> Tuple[Any, Any, Callable[[Callable[..., Any]], Callable[..., Any]]]:
+def _configure_jax_environment() -> None:
+    """Set JAX/XLA environment defaults, then import + configure JAX.
+
+    Runs once at ``vmec_jax._compat`` import time — before
+    ``vmec_jax/__init__`` (or anything else in the package) imports JAX — so
+    the env-var defaults reliably reach XLA backend initialization.  Every
+    default uses ``setdefault``: an explicit user environment always wins.
+    """
     try:
         # Enable x64 by default for VMEC parity unless the user opted out.
         os.environ.setdefault("JAX_ENABLE_X64", "1")
@@ -300,12 +271,6 @@ def _try_import_jax() -> Tuple[Any, Any, Callable[[Callable[..., Any]], Callable
 
         import jax
 
-        # If Sphinx (or other tooling) has inserted a mock, treat JAX as unavailable.
-        if not isinstance(jax, types.ModuleType):
-            raise ImportError("mocked jax module")
-
-        # Also set via config. This must happen before importing `jax.numpy`
-        # to reliably affect dtype defaults.
         try:
             jax.config.update("jax_enable_x64", os.environ.get("JAX_ENABLE_X64", "0") == "1")
         except Exception:
@@ -322,85 +287,11 @@ def _try_import_jax() -> Tuple[Any, Any, Callable[[Callable[..., Any]], Callable
         # Wire up the compilation cache via jax.config too; the env-var path
         # alone does not cover all JAX/JAXLIB versions and cache thresholds.
         _configure_compilation_cache(jax, _cache_dir)
-
-        import jax.numpy as jnp
-
-        return jax, jnp, jax.jit
     except Exception:
-        # numpy fallback: no autodiff, no jit
-        return None, _np, _noop_jit
-
-
-jax, jnp, jit = _try_import_jax()
-
-try:
-    if jax is None:
-        raise ImportError
-    from jax import tree_util as tree_util  # type: ignore
-except Exception:
-    class _TreeUtilFallback:
-        @staticmethod
-        def register_pytree_node_class(cls):
-            """Register this type as a JAX pytree for JIT and automatic differentiation."""
-            return cls
-
-    tree_util = _TreeUtilFallback()
-
-
-def has_jax() -> bool:
-    """Return whether the active backend is real JAX rather than NumPy fallback."""
-
-    if getattr(_numpy_mode_local, "active", False):
-        return False
-    return jax is not None
-
-
-def enable_x64(enable: bool = True) -> None:
-    """Enable/disable float64 for JAX (no-op if JAX unavailable).
-
-    VMEC historically relies on float64; we therefore enable x64 by default.
-    This helper is useful in scripts/tests to be explicit.
-    """
-    if jax is None:
-        return
-    try:
-        jax.config.update("jax_enable_x64", bool(enable))
-    except Exception:
-        # If JAX is already initialized in a way that disallows toggling,
-        # we silently ignore (the existing dtype policy will apply).
+        # Never block a vmec_jax import over environment tuning (e.g. docs
+        # builds with a mocked JAX): core.solver enforces the hard
+        # requirements (x64, cache hardening) on every solve path anyway.
         pass
 
 
-def x64_enabled() -> bool:
-    """Return the effective JAX x64 setting, defaulting to true without JAX."""
-
-    if jax is None:
-        return True
-    try:
-        return bool(jax.config.read("jax_enable_x64"))
-    except Exception:
-        return bool(os.environ.get("JAX_ENABLE_X64", "0") == "1")
-
-
-def asarray(x: Any, dtype: Any | None = None):
-    """Create an array using the active backend (jax.numpy or numpy)."""
-    return jnp.asarray(x, dtype=dtype)
-
-
-def einsum(expr: str, *operands: Any, precision: Any | None = None):
-    """Backend-aware einsum with high-precision accumulation when available."""
-    if jax is None or getattr(_numpy_mode_local, "active", False):
-        return _np.einsum(expr, *operands)
-    if precision is None:
-        try:
-            from jax import lax
-
-            precision = lax.Precision.HIGHEST
-        except Exception:
-            precision = None
-    if precision is None:
-        return jnp.einsum(expr, *operands)
-    try:
-        return jnp.einsum(expr, *operands, precision=precision)
-    except TypeError:
-        return jnp.einsum(expr, *operands)
+_configure_jax_environment()

--- a/vmec_jax/core/fourier.py
+++ b/vmec_jax/core/fourier.py
@@ -50,7 +50,6 @@ __all__ = [
     "TrigTables",
     "mode_table",
     "trig_tables",
-    "angle_grids",
 ]
 
 
@@ -370,20 +369,3 @@ def trig_tables(res: Resolution) -> TrigTables:
         wint=wint,
     )
 
-
-def angle_grids(res: Resolution) -> tuple[np.ndarray, np.ndarray]:
-    """Return the VMEC internal ``(theta, zeta)`` angle grids.
-
-    VMEC2000: implied by ``read_indata.f`` / ``fixaray.f``.
-
-    - ``lasym=False``: ``theta`` has ``ntheta3 = ntheta2`` points covering
-      ``[0, pi]`` *including* the endpoint pi (reduced symmetric grid).
-    - ``lasym=True``: ``theta`` has ``ntheta3 = ntheta1`` points covering
-      ``[0, 2*pi)`` endpoint-free.
-
-    ``zeta`` always spans one field period ``[0, 2*pi)`` endpoint-free with
-    ``nzeta`` points (the physical toroidal angle is ``zeta / nfp``).
-    """
-    theta = (2.0 * np.pi) * np.arange(res.ntheta3, dtype=float) / float(res.ntheta1)
-    zeta = (2.0 * np.pi) * np.arange(res.nzeta, dtype=float) / float(res.nzeta)
-    return theta, zeta

--- a/vmec_jax/core/implicit.py
+++ b/vmec_jax/core/implicit.py
@@ -147,7 +147,7 @@ __all__ = [
     "make_config", "solve_implicit", "solve_implicit_with_aux",
     "implicit_state_pullback_multi_rhs", "run",
     "mhd_energy", "plasma_volume", "aspect_ratio", "iota_profile",
-    "iota_axis", "iota_edge", "residual_fn", "adjoint_matvec",
+    "iota_axis", "iota_edge", "edge_iota", "residual_fn", "adjoint_matvec",
     "frozen_path_directional_fd",
 ]
 
@@ -1017,7 +1017,15 @@ def mhd_energy(state: SpectralState, rt: SolverRuntime) -> tuple[Array, Array]:
 
 
 def plasma_volume(state: SpectralState, rt: SolverRuntime) -> Array:
-    """Plasma volume ``volume_p`` [m^3] (``= (2 pi)^2 * hs * sum vp``)."""
+    """Plasma volume ``volume_p`` [m^3] (``= (2 pi)^2 * hs * sum vp``).
+
+    Quadrature note (Item I.7): this is the implicit module's historical
+    differential-volume sum, pinned by :class:`ImplicitSolution.volume` and
+    the FD-cached gradient tables of ``tests/test_implicit_grad.py``.  The
+    canonical wout-parity boundary quadrature of the same scalar is
+    :func:`vmec_jax.core.statephysics.volume` (re-exported as
+    ``optimize.volume``); the two agree to quadrature resolution.
+    """
     _, _, _, _, energies = _field_chain(state, rt)
     return (2.0 * jnp.pi) ** 2 * jnp.abs(energies.volume)
 
@@ -1039,6 +1047,15 @@ def aspect_ratio(state: SpectralState, rt: SolverRuntime,
     ``Aminor_p = sqrt(<cross-section area>_zeta / pi)`` with the area from
     the shoelace integral ``-oint Z dR/dtheta dtheta`` on the boundary, and
     ``Rmajor_p = volume_p / (2 pi^2 Aminor_p^2)`` (``aspectratio.f``).
+
+    Quadrature note (Item I.7): this is the implicit module's historical
+    shoelace-on-a-fresh-grid variant, pinned by
+    :class:`ImplicitSolution.aspect` and the FD-cached solovev gradient table
+    of ``tests/test_implicit_grad.py``.  The canonical wout-parity
+    ``aspectratio.f`` boundary quadrature (internal-grid ``wint`` weights,
+    equal to the wout ``aspect`` scalar) is
+    :func:`vmec_jax.core.statephysics.aspect_ratio` (re-exported as
+    ``optimize.aspect_ratio``); the two agree to quadrature resolution.
     """
     rmnc, rmns, zmnc, zmns = _edge_physical(state, rt)
     m = jnp.asarray(np.asarray(rt.modes.m, dtype=float))
@@ -1085,7 +1102,19 @@ def iota_axis(state: SpectralState, rt: SolverRuntime) -> Array:
 
 
 def iota_edge(state: SpectralState, rt: SolverRuntime) -> Array:
+    """Boundary rotational transform ``iotaf[-1]`` (differentiable).
+
+    Naming note (Item I.7): the same physical scalar as
+    :func:`vmec_jax.core.statephysics.edge_iota` (``optimize.edge_iota``) —
+    identical for ``ncurr = 1``; at ``ncurr = 0`` this evaluates the
+    prescribed full-mesh ``iotaf`` endpoint while the wout-parity version
+    extrapolates the half-mesh ``iotas``.  ``edge_iota`` is provided as an
+    alias here so either spelling works in either module.
+    """
     return iota_profile(state, rt)[-1]
+
+
+edge_iota = iota_edge   # naming-flip alias (see the iota_edge docstring)
 
 
 # ---------------------------------------------------------------------------
@@ -1095,7 +1124,21 @@ def iota_edge(state: SpectralState, rt: SolverRuntime) -> Array:
 
 @dataclass(frozen=True)
 class ImplicitSolution:
-    """Differentiable outputs of :func:`run` (a JAX pytree)."""
+    """Differentiable outputs of :func:`run` (a JAX pytree).
+
+    ``runtime`` is the :class:`~vmec_jax.core.solver.SolverRuntime` that
+    :func:`run` built internally (``runtime_from_params(params, cfg)``), so
+    objective callers can evaluate further ``(state, runtime)`` scalar
+    targets without rebuilding it per evaluation.  It is deliberately **not**
+    part of the pytree (registered as a dropped field): the solution's
+    established pytree structure — six state leaves plus seven scalars — is
+    unchanged, and a solution that round-trips through
+    ``flatten``/``unflatten`` (e.g. across a ``jax.jit`` boundary) comes back
+    with ``runtime = None``.  Inside a ``jax.grad``/``jax.value_and_grad``
+    trace of :func:`run` the attribute is available and fully traced, so
+    gradients flow through ``runtime``-consuming objectives exactly as
+    through an explicit ``runtime_from_params`` rebuild.
+    """
 
     state: SpectralState
     wb: Array
@@ -1105,9 +1148,10 @@ class ImplicitSolution:
     aspect: Array
     iota_axis: Array
     iota_edge: Array
+    runtime: SolverRuntime | None = None
 
 
-_register(ImplicitSolution)
+_register(ImplicitSolution, drop=("runtime",))
 
 
 def run(
@@ -1137,6 +1181,13 @@ def run(
     get ``wmhd = nan`` (as in VMEC).  All outputs are differentiable in
     ``params`` (state via the implicit adjoint; scalars additionally through
     their explicit parameter dependence).
+
+    The returned solution also carries the internally built
+    :class:`~vmec_jax.core.solver.SolverRuntime` as ``sol.runtime`` (a
+    non-pytree convenience attribute, see :class:`ImplicitSolution`), so
+    objective code can evaluate additional ``(state, runtime)`` targets —
+    e.g. ``optimize.mean_iota(sol.state, sol.runtime)`` — without repeating
+    ``runtime_from_params(params, make_config(...))`` per evaluation.
     """
     inp = VmecInput.from_file(source) if isinstance(source, str) else source
     cfg = make_config(
@@ -1156,6 +1207,7 @@ def run(
         state=state, wb=wb, wp=wp, wmhd=wmhd, volume=vol,
         aspect=aspect_ratio(state, rt),
         iota_axis=iota_axis(state, rt), iota_edge=iota_edge(state, rt),
+        runtime=rt,
     )
 
 

--- a/vmec_jax/core/nyquist.py
+++ b/vmec_jax/core/nyquist.py
@@ -54,7 +54,6 @@ from .geometry import HalfMeshJacobian, RealSpaceGeometry
 __all__ = [
     "WoutFieldTables",
     "nyquist_limits",
-    "nyquist_mode_table_from_grid",
     "bsubs_half_mesh",
     "bsubs_full_mesh_for_wrout",
     "apply_bsubv_equif_correction",
@@ -79,18 +78,6 @@ def nyquist_limits(trig: TrigTables) -> tuple[int, int]:
     ntheta2 = int(trig.ntheta2)
     nzeta = int(np.asarray(trig.cosnv).shape[0])
     return max(ntheta2 - 1, 0), max(nzeta // 2, 0)
-
-
-def nyquist_mode_table_from_grid(*, mpol: int, ntor: int, ntheta: int, nzeta: int) -> ModeTable:
-    """Nyquist (m, n) mode table from the angular grid sizes (``fixaray.f``).
-
-    ``mnyq = max(ntheta1/2, mpol - 1)``, ``nnyq = max(nzeta/2, ntor)`` with
-    ``ntheta1 = 2*(ntheta//2)``; ordering matches :func:`mode_table`.
-    """
-    ntheta1 = 2 * (int(ntheta) // 2)
-    mnyq = max(ntheta1 // 2, max(int(mpol) - 1, 0))
-    nnyq = max(int(nzeta) // 2, max(int(ntor), 0))
-    return mode_table(mnyq + 1, nnyq)
 
 
 def _analysis_theta_tables(trig: TrigTables) -> tuple[np.ndarray, np.ndarray]:

--- a/vmec_jax/core/optimize.py
+++ b/vmec_jax/core/optimize.py
@@ -102,11 +102,16 @@ from .statephysics import (
     _field_chain,
     _half_grid,
     _interp_half_grid,
-    _iotas_half,
+    _iotas_half as _iotas_half,  # unused here; kept importable for back compat
     _iotas_half_from_fields,
     _lgradb_grid,
     _lgradb_state_tables,
     _mode_matrix,
+    aspect_ratio,
+    edge_iota,
+    iota_edge,
+    mean_iota,
+    volume,
 )
 from .wout import WoutData, wout_from_state
 
@@ -117,6 +122,7 @@ __all__ = [
     "aspect_ratio",
     "mean_iota",
     "edge_iota",
+    "iota_edge",
     "mirror_ratio",
     "volume",
     "magnetic_well",
@@ -490,58 +496,11 @@ class QuasisymmetryRatioResidual:
 # Practical scalar targets — pure functions of (SpectralState, SolverRuntime)
 # ===========================================================================
 
-
-def _aspect_scalars(state: SpectralState, rt: SolverRuntime):
-    """``aspectratio.f`` scalars ``(Aminor_p, Rmajor_p, aspect, volume_p)``.
-
-    Boundary-surface quadrature identical to the wout writer
-    (:func:`vmec_jax.core.postprocess.aspect_ratio_scalars`), kept in JAX.
-    """
-    geometry, _, _, _, _ = _field_chain(state, rt)
-    sqrts_edge = jnp.asarray(rt.setup.sqrts)[-1]
-    rb = jnp.asarray(geometry.R_even)[-1] + sqrts_edge * jnp.asarray(geometry.R_odd)[-1]
-    zub = (jnp.asarray(geometry.dZ_dtheta_even)[-1]
-           + sqrts_edge * jnp.asarray(geometry.dZ_dtheta_odd)[-1])
-    wint = jnp.asarray(rt.trig.wint)
-    t1 = rb * zub * wint
-    volume_p = 2.0 * jnp.pi ** 2 * jnp.abs(jnp.sum(rb * t1))
-    area = 2.0 * jnp.pi * jnp.abs(jnp.sum(t1))
-    area_safe = jnp.where(area != 0.0, area, 1.0)
-    aminor = jnp.sqrt(area_safe / jnp.pi)
-    rmajor = volume_p / (2.0 * jnp.pi * area_safe)
-    return aminor, rmajor, rmajor / aminor, volume_p
-
-
-def aspect_ratio(state: SpectralState, rt: SolverRuntime) -> Array:
-    """VMEC aspect ratio ``Rmajor_p / Aminor_p`` (``aspectratio.f`` convention).
-
-    ``Aminor_p = sqrt(<cross-section area> / pi)``, ``Rmajor_p =
-    volume_p / (2 pi <area>)`` from the boundary surface quadrature; equals
-    the wout ``aspect`` scalar of the same state.
-    """
-    return _aspect_scalars(state, rt)[2]
-
-
-def volume(state: SpectralState, rt: SolverRuntime) -> Array:
-    """Plasma volume ``volume_p`` [m^3] (wout convention, boundary quadrature)."""
-    return _aspect_scalars(state, rt)[3]
-
-
-def mean_iota(state: SpectralState, rt: SolverRuntime) -> Array:
-    """Mean rotational transform over the half-mesh surfaces (axis excluded).
-
-    Matches the legacy optimization ``mean_iota`` convention
-    (``mean(iotas[1:])``, i.e. the mean of the wout ``iotas`` profile).
-    """
-    iotas = _iotas_half(state, rt)
-    return jnp.mean(iotas[1:])
-
-
-def edge_iota(state: SpectralState, rt: SolverRuntime) -> Array:
-    """Rotational transform at the boundary (wout ``iotaf[-1]`` convention:
-    linear extrapolation of the half mesh, ``1.5 iotas[-1] - 0.5 iotas[-2]``)."""
-    iotas = _iotas_half(state, rt)
-    return 1.5 * iotas[-1] - 0.5 * iotas[-2]
+# The canonical wout-parity scalars — aspect_ratio / volume (aspectratio.f
+# boundary quadrature) and mean_iota / edge_iota (wout iotas / iotaf[-1]
+# conventions) — live in statephysics.py (Item I.7 consolidation) and are
+# re-exported here unchanged; ``iota_edge`` is the naming-flip alias of
+# ``edge_iota`` (implicit.py exposes the mirror alias).
 
 
 def mirror_ratio(state: SpectralState, rt: SolverRuntime, *, s_index: int = -1) -> Array:
@@ -1768,6 +1727,9 @@ def _least_squares_implicit(
     def jacobian_rows_recycled(x: jnp.ndarray, C: jnp.ndarray,
                                U: jnp.ndarray):
         """``jacobian_rows`` with GCROT recycle carry (plan R25.3).
+
+        EXPERIMENTAL / opt-in (``recycle=True``), currently untested in CI;
+        an A/B measurement of this lane is running separately (Item I.8c).
 
         Same ``cfg.adjoint_tol`` / ``cfg.adjoint_maxiter`` budget per solve
         as the default path; the Jacobian matches to solver tolerance *when

--- a/vmec_jax/core/statephysics.py
+++ b/vmec_jax/core/statephysics.py
@@ -12,6 +12,17 @@ One home (R26a consolidation) for the small private helpers that
   behind every solver-native scalar target;
 - :func:`_iotas_half` / :func:`_iotas_half_from_fields` — the ``ncurr``-aware
   half-mesh rotational transform (``add_fluxes.f90`` conventions);
+- the **canonical wout-parity scalar targets** (plan_pre_vmex Item I.7):
+  :func:`aspect_ratio` / :func:`volume` (``aspectratio.f`` boundary
+  quadrature, equal to the wout ``aspect``/``volume_p`` scalars) and
+  :func:`mean_iota` / :func:`edge_iota` (wout ``iotas``/``iotaf[-1]``
+  conventions), re-exported unchanged by :mod:`~vmec_jax.core.optimize`.
+  :mod:`~vmec_jax.core.implicit` keeps its historical ``aspect_ratio`` /
+  ``plasma_volume`` variants (shoelace boundary area on a fresh grid /
+  ``sum(vp)``) because :class:`~vmec_jax.core.implicit.ImplicitSolution`
+  fields and the FD-cached gradient tables of ``tests/test_implicit_grad.py``
+  pin those exact quadratures — the two families agree to quadrature
+  resolution, and each module's docstrings cross-reference the other;
 - the half-mesh radial sampling primitives :func:`_half_grid` /
   :func:`_interp_half_grid` and the wout-table utilities :func:`_as_1d` /
   :func:`_mode_matrix`;
@@ -139,6 +150,87 @@ def _iotas_half(state: SpectralState, rt: SolverRuntime) -> jnp.ndarray:
         return jnp.asarray(setup.iotas)
     _, _, _, fields, _ = _field_chain(state, rt)
     return _iotas_half_from_fields(setup, fields)
+
+
+# ---------------------------------------------------------------------------
+# Canonical wout-parity scalar targets (plan_pre_vmex Item I.7)
+# ---------------------------------------------------------------------------
+
+
+def _aspect_scalars(state: SpectralState, rt: SolverRuntime):
+    """``aspectratio.f`` scalars ``(Aminor_p, Rmajor_p, aspect, volume_p)``.
+
+    Boundary-surface quadrature identical to the wout writer
+    (:func:`vmec_jax.core.postprocess.aspect_ratio_scalars`), kept in JAX.
+    """
+    geometry, _, _, _, _ = _field_chain(state, rt)
+    sqrts_edge = jnp.asarray(rt.setup.sqrts)[-1]
+    rb = jnp.asarray(geometry.R_even)[-1] + sqrts_edge * jnp.asarray(geometry.R_odd)[-1]
+    zub = (jnp.asarray(geometry.dZ_dtheta_even)[-1]
+           + sqrts_edge * jnp.asarray(geometry.dZ_dtheta_odd)[-1])
+    wint = jnp.asarray(rt.trig.wint)
+    t1 = rb * zub * wint
+    volume_p = 2.0 * jnp.pi ** 2 * jnp.abs(jnp.sum(rb * t1))
+    area = 2.0 * jnp.pi * jnp.abs(jnp.sum(t1))
+    area_safe = jnp.where(area != 0.0, area, 1.0)
+    aminor = jnp.sqrt(area_safe / jnp.pi)
+    rmajor = volume_p / (2.0 * jnp.pi * area_safe)
+    return aminor, rmajor, rmajor / aminor, volume_p
+
+
+def aspect_ratio(state: SpectralState, rt: SolverRuntime) -> Array:
+    """VMEC aspect ratio ``Rmajor_p / Aminor_p`` (``aspectratio.f`` convention).
+
+    ``Aminor_p = sqrt(<cross-section area> / pi)``, ``Rmajor_p =
+    volume_p / (2 pi <area>)`` from the boundary surface quadrature; equals
+    the wout ``aspect`` scalar of the same state.  This is the canonical
+    (wout-parity) implementation, re-exported as
+    ``vmec_jax.core.optimize.aspect_ratio``;
+    :func:`vmec_jax.core.implicit.aspect_ratio` is the implicit module's
+    historical shoelace-quadrature variant of the same scalar (see there).
+    """
+    return _aspect_scalars(state, rt)[2]
+
+
+def volume(state: SpectralState, rt: SolverRuntime) -> Array:
+    """Plasma volume ``volume_p`` [m^3] (wout convention, boundary quadrature).
+
+    Canonical (wout-parity) implementation, re-exported as
+    ``vmec_jax.core.optimize.volume``;
+    :func:`vmec_jax.core.implicit.plasma_volume` is the implicit module's
+    ``sum(vp)`` variant of the same scalar (see there).
+    """
+    return _aspect_scalars(state, rt)[3]
+
+
+def mean_iota(state: SpectralState, rt: SolverRuntime) -> Array:
+    """Mean rotational transform over the half-mesh surfaces (axis excluded).
+
+    Matches the legacy optimization ``mean_iota`` convention
+    (``mean(iotas[1:])``, i.e. the mean of the wout ``iotas`` profile).
+    """
+    iotas = _iotas_half(state, rt)
+    return jnp.mean(iotas[1:])
+
+
+def edge_iota(state: SpectralState, rt: SolverRuntime) -> Array:
+    """Rotational transform at the boundary (wout ``iotaf[-1]`` convention:
+    linear extrapolation of the half mesh, ``1.5 iotas[-1] - 0.5 iotas[-2]``).
+
+    Naming note (Item I.7): ``optimize.edge_iota`` and
+    :func:`vmec_jax.core.implicit.iota_edge` are the same physical scalar —
+    identical for ``ncurr = 1`` (both reconstruct iota from the converged
+    ``chips``); at ``ncurr = 0`` this wout-parity version extrapolates the
+    prescribed half-mesh ``iotas`` while the implicit variant evaluates the
+    prescribed full-mesh ``iotaf`` endpoint directly.  ``iota_edge`` is
+    provided as an alias here (and ``edge_iota`` in ``implicit``) so either
+    spelling works in either module.
+    """
+    iotas = _iotas_half(state, rt)
+    return 1.5 * iotas[-1] - 0.5 * iotas[-2]
+
+
+iota_edge = edge_iota   # naming-flip alias (see the edge_iota docstring)
 
 
 # ---------------------------------------------------------------------------

--- a/vmec_jax/core/transforms.py
+++ b/vmec_jax/core/transforms.py
@@ -61,15 +61,23 @@ Array = Any
 _DERIVATIVES = ("value", "dtheta", "dzeta")
 
 
-def register_pytree_dataclass(cls, *, meta: tuple[str, ...] = ()):
+def register_pytree_dataclass(cls, *, meta: tuple[str, ...] = (),
+                              drop: tuple[str, ...] = ()):
     """Register a result dataclass as a JAX pytree (``meta`` fields static).
 
     The one shared registration helper of all core result containers (R26a;
     formerly copied in fields/forces/geometry/residuals/setup/solver/implicit).
+
+    ``drop`` fields (which must have defaults) are excluded from the pytree
+    entirely: they do not appear as leaves *or* in the treedef, and are reset
+    to their default on unflatten.  Use for host-side convenience attributes
+    (e.g. :attr:`~vmec_jax.core.implicit.ImplicitSolution.runtime`) that must
+    not change an established pytree structure.
     """
-    names = [f.name for f in dataclass_fields(cls) if f.name not in meta]
+    names = [f.name for f in dataclass_fields(cls)
+             if f.name not in meta and f.name not in drop]
     return jax.tree_util.register_dataclass(
-        cls, data_fields=names, meta_fields=list(meta)
+        cls, data_fields=names, meta_fields=list(meta), drop_fields=list(drop)
     )
 
 


### PR DESCRIPTION
## Summary

Plan Item I points 5–8 as one consolidation PR (audit-driven):

- **I.5 — "Choosing an entry point"**: quickstart + README now explain when to use `solver.solve` vs `solve_multigrid` vs `opt.solve_equilibrium` vs `im.run`; the quickstart's manual 6-arg `wout_from_state` plumbing is replaced with `solve_equilibrium(...).wout` (previously `solve_equilibrium` appeared in no doc page).
- **I.6 — `ImplicitSolution.runtime`**: the solve's `SolverRuntime` rides on the solution via `register_dataclass(drop_fields=...)` — **pytree structure verified byte-identical** (13 leaves, treedef unchanged, resets to None across jit boundaries); inside `jax.grad` it is the fully traced runtime, so objectives can drop their per-eval `make_config` + `runtime_from_params` rebuild (the single-stage example now does).
- **I.7 — physics-helper unification**: the wout-parity family (`aspect_ratio`/`volume`/`mean_iota`/`edge_iota`) is canonical in `statephysics.py`, re-exported as identical objects (zero value change). `implicit.aspect_ratio`/`plasma_volume` deliberately keep their quadratures — `ImplicitSolution` fields and FD-cached test tables pin those exact values and the disk cache does not version the math (families agree to ~1e-7). The `edge_iota`/`iota_edge` naming flip is closed with documented aliases both ways.
- **I.8 — dead-code prune**: `_compat.py` numpy-mode shim deleted (406→~300 lines) with its **load-bearing import-time env defaults preserved** as an explicit `_configure_jax_environment()`; orphan exports `fourier.angle_grids` and `nyquist.nyquist_mode_table_from_grid` deleted (grep-verified); the experimental `recycle=True` Jacobian lane kept with an explicit opt-in note.

## Gates (all green)
`test_implicit_grad.py` 11/11 · `test_optimize.py` 20/20 · `test_lgradb.py`+`test_compat.py` 13/13 (compat tests rewritten with the shim removal) · ruff + mypy clean · `sphinx -W` clean · both example CI smokes exit 0.