### PR TITLE
ci: relieve chronically-slow parity shard c (rebalance + timeout)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
   parity:
     name: Parity suite ${{ matrix.shard }} (goldens, coverage)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -172,7 +172,9 @@ jobs:
                    tests/test_freeboundary.py \
                    tests/test_cli_freeboundary.py \
                    tests/test_solver_end_to_end.py"
-          B_FILES="tests/test_golden_digests.py"
+          B_FILES="tests/test_golden_digests.py \
+                   tests/test_bootstrap.py \
+                   tests/test_wout_golden.py"
           D_FILES="tests/test_optimize.py"
           if [ "${{ matrix.shard }}" = "a" ]; then
             pytest -q -n 4 --dist loadscope $A_FILES --durations=15 --cov=vmex --cov-report=term


### PR DESCRIPTION
## Summary

Shard c (the `pytest -n 4` catch-all over all non-A/B/D test files, with coverage instrumentation) has intermittently exceeded the 20-min parity timeout and cancelled — on PRs #35, #40, and even the docs-only #41. Root cause: it carries the most files, including the heaviest (`test_bootstrap` 614 lines, `test_wout_golden` 399, `test_preconditioner`, `test_turbulence`, …).

- **Rebalance**: move `test_bootstrap.py` + `test_wout_golden.py` into shard b (which held only `test_golden_digests`). The catch-all excludes `B_FILES` automatically, so every file stays in exactly one shard and coverage completeness is preserved.
- **Headroom**: parity job timeout 20 → 25 min.

Workflow-only; no source or test behavior changes. Coverage gate combines the same four parity shards + gradient + examples as before.