### PR TITLE
release: VMEX 0.2.0 (rename banner, docs title, version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-07-18
+
+First release under the **VMEX** name (formerly `vmec-jax`). Highlights:
+the `vmec_jax → vmex` rename, the `vmex.mirror` open/closed magnetic-mirror
+equilibrium package, `vmex.parallel` concurrent ensembles, the traceable
+`l_grad_b` objective and objectives showcase, the cold-start single-stage
+plasma+coil benchmark, NESTOR free-boundary speedups (warm now faster than
+VMEC2000 on every benchmark row), and typed errors through the callback
+boundary. See the entries below.
+
 ### Changed
 - **Renamed `vmec_jax` → VMEX.** The import package is now `vmex`, the PyPI
   distribution is `vmex`, and the primary CLI command is `vmex`. The `vmec`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/uwplasma/vmex/ci.yml?branch=main&label=ci)](https://github.com/uwplasma/VMEX/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/readthedocs/vmex/latest?label=docs)](https://vmex.readthedocs.io/en/latest/)
 
+> **`vmec_jax` is now `vmex`.** The package was renamed: install with
+> `pip install vmex` and `import vmex`. The `vmec` CLI command still works as an
+> alias, and `import vmec_jax` keeps working (with a deprecation warning) for
+> one release. Full documentation: **[vmex.readthedocs.io](https://vmex.readthedocs.io/en/latest/)**.
+
 **VMEX** is a clean-room, JAX-native reimplementation of the
 [VMEC2000](https://princetonuniversity.github.io/STELLOPT/VMEC) ideal-MHD
 equilibrium code for stellarators and tokamaks. It reproduces VMEC2000

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,9 @@ with (_ROOT / "pyproject.toml").open("rb") as _f:
     release = tomllib.load(_f)["project"]["version"]
 version = ".".join(release.split(".")[:2])
 
+# Clean, un-versioned documentation title (browser tab / sidebar).
+html_title = "VMEX documentation"
+
 
 # -- General configuration ------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vmex"
-version = "0.1.0"
+version = "0.2.0"
 description = "JAX implementation of VMEC2000 with differentiable fixed-boundary and branch-local free-boundary research paths."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Release prep for the first PyPI publish under the **VMEX** name.

- **README**: top banner announcing `vmec_jax → vmex` (`pip install vmex` / `import vmex`; `vmec` CLI alias and `vmec_jax` import shim remain one release) + a prominent link to [vmex.readthedocs.io](https://vmex.readthedocs.io/en/latest/).
- **docs/conf.py**: `html_title = "VMEX documentation"` so the site reads "VMEX documentation" rather than "vmex 0.1.0 documentation".
- **Version 0.1.0 → 0.2.0**: `v0.1.0` is already tagged/released as the prior `vmec-jax`; the inaugural VMEX release publishes as **0.2.0** (rename + `vmex.mirror` + `vmex.parallel` + traceable L∇B/objectives + single-stage benchmark + NESTOR speedups + typed errors).
- **CHANGELOG**: 0.2.0 entry finalized (2026-07-18).

After merge: tag `v0.2.0` + GitHub Release → the `publish-pypi` trusted-publisher workflow uploads `vmex` 0.2.0 to PyPI.

Gate: version consistent (`vmex.__version__ == 0.2.0`), `test_packaging_metadata` passes, `sphinx -W` clean (title verified).