### PR TITLE
chore: lowercase uwplasma/vmex URLs to match the renamed repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # VMEX
 
 [![PyPI version](https://img.shields.io/pypi/v/vmex.svg)](https://pypi.org/project/vmex/)
-[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://github.com/uwplasma/VMEX/blob/main/pyproject.toml)
-[![License](https://img.shields.io/github/license/uwplasma/vmex)](https://github.com/uwplasma/VMEX/blob/main/LICENSE)
-[![CI](https://img.shields.io/github/actions/workflow/status/uwplasma/vmex/ci.yml?branch=main&label=ci)](https://github.com/uwplasma/VMEX/actions/workflows/ci.yml)
+[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://github.com/uwplasma/vmex/blob/main/pyproject.toml)
+[![License](https://img.shields.io/github/license/uwplasma/vmex)](https://github.com/uwplasma/vmex/blob/main/LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/uwplasma/vmex/ci.yml?branch=main&label=ci)](https://github.com/uwplasma/vmex/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/readthedocs/vmex/latest?label=docs)](https://vmex.readthedocs.io/en/latest/)
 
 > **`vmec_jax` is now `vmex`.** The package was renamed: install with
@@ -59,7 +59,7 @@ pip install vmex
 Development install from source:
 
 ```bash
-git clone https://github.com/uwplasma/VMEX
+git clone https://github.com/uwplasma/vmex
 cd vmex && pip install -e .
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,11 @@ vmex = "vmex.core.cli:main"
 vmec = "vmex.core.cli:main"  # alias
 
 [project.urls]
-Homepage = "https://github.com/uwplasma/VMEX"
+Homepage = "https://github.com/uwplasma/vmex"
 Documentation = "https://vmex.readthedocs.io/en/latest/"
-Repository = "https://github.com/uwplasma/VMEX"
-Issues = "https://github.com/uwplasma/VMEX/issues"
-Changelog = "https://github.com/uwplasma/VMEX/releases"
+Repository = "https://github.com/uwplasma/vmex"
+Issues = "https://github.com/uwplasma/vmex/issues"
+Changelog = "https://github.com/uwplasma/vmex/releases"
 
 [project.optional-dependencies]
 # Differentiable free boundary via virtual casing (plan.md R15.3 + R19).

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -40,8 +40,8 @@ def test_project_metadata_has_public_package_links() -> None:
     assert "stellarator" in project["keywords"]
     assert "Topic :: Scientific/Engineering :: Physics" in project["classifiers"]
     assert project["urls"]["Documentation"] == "https://vmex.readthedocs.io/en/latest/"
-    assert project["urls"]["Repository"] == "https://github.com/uwplasma/VMEX"
-    assert project["urls"]["Changelog"] == "https://github.com/uwplasma/VMEX/releases"
+    assert project["urls"]["Repository"] == "https://github.com/uwplasma/vmex"
+    assert project["urls"]["Changelog"] == "https://github.com/uwplasma/vmex/releases"
 
 
 def test_project_exposes_vmec_console_aliases() -> None:


### PR DESCRIPTION
The GitHub repo was renamed `VMEX → vmex` (lowercase) to match the PyPI trusted publisher (`uwplasma/vmex`), which fixed the `invalid-publisher` OIDC error and published `vmex 0.2.0`. This lowercases the `uwplasma/VMEX` URLs in the README badges and `pyproject.toml` `[project.urls]` for consistency (github.com paths are case-insensitive, so the old links already redirect) and updates the packaging-metadata test assertions to match.