### PR TITLE
Drift-gate the R25.3 recycled-Jacobian carry

### DIFF
--- a/tests/test_optimize_penalty.py
+++ b/tests/test_optimize_penalty.py
@@ -152,3 +152,22 @@ def test_implicit_lane_jac_fallback_and_diagnostic_resolve(monkeypatch, capsys):
     assert np.isfinite(res.cost)
     assert res.equilibrium is not None  # cold-solve fallback delivered it
     assert res.equilibrium.result.converged
+
+
+def test_recycled_jacobian_lane_scan_shapes() -> None:
+    """The drift-gated recycled Jacobian lane (recycle=True) must run.
+
+    Exercises optimize.jacobian_rows_recycled's lax.scan carry — the path that
+    threads and drift-gates the GCROT pair across dof chunks. A shape bug there
+    (gating against the full stacked recs leaf instead of a single lane) makes
+    lax.scan reject the carry-type mismatch; this pins that the lane completes
+    on a real (small) equilibrium and returns a usable result. The recycled
+    lane is otherwise opt-in and was previously uncovered in CI.
+    """
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    res = opt.least_squares(
+        OBJECTIVE, inp, max_mode=1, jac="implicit", recycle=True,
+        max_nfev=3, verbose=0,
+    )
+    assert isinstance(res.input, VmecInput)
+    assert np.all(np.isfinite(np.asarray(res.x)))

--- a/tests/test_recycle_drift.py
+++ b/tests/test_recycle_drift.py
@@ -1,0 +1,60 @@
+"""Drift-aware GCROT recycling at the implicit-solver integration point.
+
+The R25.3 recycled-Jacobian lane threads a GCROT pair through solves whose
+operator drifts between accepted trust-region iterates. solvax >= 0.8.7
+reports ``recycle_drift`` on every warm start; these tests pin the vmex-side
+contract that the drift-gated carry in ``optimize.jacobian_rows_recycled``
+relies on: zero on a cold start, machine-floor for an unchanged operator, and
+growing with the operator step.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import vmex.core.implicit as imp
+
+jax.config.update("jax_enable_x64", True)
+
+
+@pytest.mark.skipif(
+    not imp._GCROT_REPORTS_DRIFT,
+    reason="installed solvax predates recycle_drift (needs >= 0.8.7)",
+)
+def test_recycled_solve_surfaces_drift() -> None:
+    n = 80
+    rng = np.random.default_rng(0)
+    base = jnp.asarray(np.eye(n) + 0.4 * rng.standard_normal((n, n)) / np.sqrt(n))
+    step = jnp.asarray(rng.standard_normal((n, n)) / np.sqrt(n))
+    b = {"f": jnp.asarray(rng.standard_normal(n - 10)),
+         "g": jnp.asarray(rng.standard_normal(10))}
+    cfg = SimpleNamespace(adjoint_tol=1e-10, adjoint_restart=30, adjoint_maxiter=50)
+
+    def operator(matrix):
+        def apply(v):
+            flat = jnp.concatenate([v["f"], v["g"]])
+            out = matrix @ flat
+            return {"f": out[: n - 10], "g": out[n - 10:]}
+        return apply
+
+    cold_pair = (jnp.zeros((n, imp._RECYCLE_K)), jnp.zeros((n, imp._RECYCLE_K)))
+    _, sol0 = imp._recycled_solve(operator(base), b, cfg, cold_pair)
+    assert bool(sol0.converged)
+    assert float(sol0.recycle_drift) == 0.0  # cold start
+
+    _, sol_same = imp._recycled_solve(operator(base), b, cfg, sol0.recycle)
+    assert float(sol_same.recycle_drift) < 1e-10  # unchanged operator
+
+    drifts = []
+    for eps in (1e-4, 1e-3, 1e-2):
+        _, sol_moved = imp._recycled_solve(
+            operator(base + eps * step), b, cfg, sol0.recycle
+        )
+        drifts.append(float(sol_moved.recycle_drift))
+    assert drifts[0] < drifts[1] < drifts[2]  # grows with the operator step
+    assert drifts[2] < 0.5  # well below the carry gate at these steps

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -894,6 +894,19 @@ def _adjoint_solve(A, b, cfg: ImplicitConfig, *, x0=None, max_restarts=None):
 # depth; 10 matches the solvax default and the GCRO-DR literature.
 _RECYCLE_K = 10
 
+# solvax >= 0.8.7 reports ``recycle_drift`` on warm-started gcrot solves: the
+# mean principal-angle sine between the incoming recycle image space and its
+# re-established span under the current operator (zero for an unchanged
+# operator, growing linearly with the operator step — the gap-free bound
+# sin(theta) <= ||dA|| ||U||). Probe once; older solvax simply lacks the field
+# and the drift-gated carry below degenerates to the previous behavior.
+try:
+    from solvax.krylov import KrylovSolution as _KrylovSolution
+
+    _GCROT_REPORTS_DRIFT = "recycle_drift" in _KrylovSolution._fields
+except ImportError:  # pragma: no cover - solvax is a hard dependency
+    _GCROT_REPORTS_DRIFT = False
+
 
 def _recycled_solve(A, b, cfg: ImplicitConfig, recycle):
     """Linearized solve via :func:`solvax.gcrot` with subspace recycling.
@@ -919,6 +932,10 @@ def _recycled_solve(A, b, cfg: ImplicitConfig, recycle):
         m=cfg.adjoint_restart, k=_RECYCLE_K,
         max_restarts=cfg.adjoint_maxiter, recycle=recycle,
     )
+    # On solvax >= 0.8.7, ``sol.recycle_drift`` measures how far the operator
+    # has rotated the recycled space since the pair was built — the quantity
+    # callers need to decide whether carrying the pair is still worthwhile
+    # (see optimize.jacobian_rows_recycled's drift-gated carry).
     return unravel(sol.x), sol
 
 

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -1769,9 +1769,12 @@ def _least_squares_implicit(
             # measured drift says the incoming space no longer matches the
             # operator, in which case the next chunk cold-starts.
             drift0 = drifts[0]
+            # recs leaves are vmapped over the chunk (shape (chunk, n, k)); the
+            # carried pair is a single lane (n, k), so gate lane 0 against a
+            # zero of *lane* shape, not the whole stack.
             pair = jax.tree.map(
                 lambda a: jnp.where(drift0 > _RECYCLE_DRIFT_LIMIT,
-                                    jnp.zeros_like(a), a[0]),
+                                    jnp.zeros_like(a[0]), a[0]),
                 recs)
             return pair, (cols_chunk, drift0)
 

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -1720,6 +1720,11 @@ def _least_squares_implicit(
     # have zero RHS (gcrot converges in zero cycles) and are discarded.
     n_flat = sum(int(np.prod(s.shape))
                  for s in jax.tree.leaves(imp._state_struct(cfg)))
+    # A recycled pair rotated past this mean principal-angle sine no longer
+    # deflates the current operator usefully (drift ~1 is an orthogonal
+    # rotation); measured drift per accepted trust-region step is ~1e-3 on
+    # slowly-varying operators, so 0.5 only trips on genuinely large steps.
+    _RECYCLE_DRIFT_LIMIT = 0.5
     csize = int(chunk) if chunk else ndof
     nchunks = -(-ndof // csize)
     pad = nchunks * csize - ndof
@@ -1734,35 +1739,52 @@ def _least_squares_implicit(
         Same ``cfg.adjoint_tol`` / ``cfg.adjoint_maxiter`` budget per solve
         as the default path; the Jacobian matches to solver tolerance *when
         the solves converge within budget*.  See the ``recycle`` note in
-        :func:`least_squares` for why this is opt-in: the solvax v0.1
-        recycle space measurably slows warm-started columns on the
-        production operator, so budget-capped columns can come back with
-        larger residuals than the GMRES path.
+        :func:`least_squares` for why this started opt-in: an unconditioned
+        carry of a stale recycle space measurably slowed warm-started columns
+        on the production operator.  On solvax >= 0.8.7 the carry is
+        **drift-gated**: every warm-started solve reports ``recycle_drift``
+        (mean principal-angle sine between the incoming recycle image space
+        and its re-established span; grows linearly with the operator step,
+        ``sin(theta) <= ||dA|| ||U||``), and a pair whose lane-0 drift exceeds
+        ``_RECYCLE_DRIFT_LIMIT`` is dropped to a cold start instead of being
+        carried — a stale pair from a large accepted trust-region step can
+        therefore slow at most the one chunk that measures it.  The maximum
+        drift over chunks is returned for observability.  On older solvax the
+        gate degenerates to the previous unconditional carry.
         """
         Fz, tangent_of, rhs_of, column_of, _ = _jac_parts(x)
 
         def column(tp_stack_j, rec):
             tp = tangent_of(tp_stack_j)
             dz, sol = imp._recycled_solve(Fz, rhs_of(tp), cfg, rec)
-            return column_of(dz, tp), sol.recycle
+            drift = (sol.recycle_drift if imp._GCROT_REPORTS_DRIFT
+                     else jnp.asarray(0.0))
+            return column_of(dz, tp), sol.recycle, drift
 
         def scan_body(carry, tp_chunk):
-            cols_chunk, recs = jax.vmap(
+            cols_chunk, recs, drifts = jax.vmap(
                 column, in_axes=(0, None))(tp_chunk, carry)
             # Lane 0 is always a real dof (pad < csize): its updated pair
-            # seeds the next chunk / the next Jacobian evaluation.
-            return jax.tree.map(lambda a: a[0], recs), cols_chunk
+            # seeds the next chunk / the next Jacobian evaluation — unless its
+            # measured drift says the incoming space no longer matches the
+            # operator, in which case the next chunk cold-starts.
+            drift0 = drifts[0]
+            pair = jax.tree.map(
+                lambda a: jnp.where(drift0 > _RECYCLE_DRIFT_LIMIT,
+                                    jnp.zeros_like(a), a[0]),
+                recs)
+            return pair, (cols_chunk, drift0)
 
         def pad_stack(t):
             t = jnp.concatenate(
                 [t, jnp.zeros((pad,) + t.shape[1:], t.dtype)])
             return t.reshape((nchunks, csize) + t.shape[1:])
 
-        (C, U), cols = jax.lax.scan(
+        (C, U), (cols, drifts) = jax.lax.scan(
             scan_body, (C, U),
             tuple(pad_stack(t) for t in tangent_stack))
         cols = cols.reshape((nchunks * csize,) + cols.shape[2:])[:ndof]
-        return jnp.transpose(cols), C, U
+        return jnp.transpose(cols), C, U, jnp.max(drifts)
 
     if jac_solver not in ("block", "gmres"):
         raise ValueError(
@@ -1848,7 +1870,10 @@ def _least_squares_implicit(
     def jac_fn(x: np.ndarray) -> np.ndarray:
         try:
             if recycle:
-                rows, C, U = jac_jit(_place(x), *holder["recycle"])
+                rows, C, U, drift = jac_jit(_place(x), *holder["recycle"])
+                holder["recycle_drift"] = float(drift)
+                if verbose and holder["recycle_drift"] > 0.0:
+                    print(f"[least_squares] recycle drift {holder['recycle_drift']:.2e}")
                 holder["recycle"] = (C, U)  # deflate the next jac evaluation
                 jac = np.asarray(jax.device_get(rows), dtype=float)
             else:


### PR DESCRIPTION
Closes the loop on the plan-R25.3 recycled implicit-Jacobian lane using the new solvax 0.8.7 drift diagnostic. Additive and capability-guarded: behavior is unchanged on older solvax, and unchanged everywhere unless `recycle=True` is already in use.

## Context (why this lane was stuck)
R25.3 threads one GCROT deflation pair `(C, U)` through all `2*nm` per-dof implicit solves — `lax.scan` over dof chunks, vmapped within a chunk, lane-0 pair advanced — and stashes it between `jac` calls (the R18b shared-solver consolidation made all of these `solvax.gcrot`). It stayed **opt-in/EXPERIMENTAL** for a measured reason documented in `jacobian_rows_recycled` and the `least_squares` note: after a large accepted trust-region step the operator `Fz` has moved, the stashed pair no longer deflates it, and *the recycle space measurably slowed warm-started columns* — the Item I.8c A/B question. The lane had no way to know a pair had gone stale.

## What this adds
solvax ≥ 0.8.7 (`recycle_drift`, uwplasma/SOLVAX#32) measures exactly that staleness on every warm start, inside the existing warm-start QR at **zero extra matvecs**: the mean principal-angle sine between the incoming recycle image space and its re-established span, with the gap-free bound `sinΘ ≤ ‖ΔA‖‖U‖` (linear in the trust-region step; measured ~1e-3/step on slowly-varying operators, ratio 10.0 per decade of step size).

- `implicit._recycled_solve` now surfaces the diagnostic (probe `_GCROT_REPORTS_DRIFT`, same capability idiom as `_SCHUR_ACCEPTS_D_BLOCK`).
- `optimize.jacobian_rows_recycled` **drift-gates the carry**: lane-0 drift beyond `_RECYCLE_DRIFT_LIMIT = 0.5` (an essentially rotated-away space) drops the pair to a cold start for the next chunk — a stale pair can now slow at most the one chunk that measures it, directly addressing the I.8c slowdown mechanism. Max drift over chunks is returned, stashed in the holder, and printed under `verbose`.

## Intrusiveness
- No new dependencies (`solvax` already core); no API changes; `recycle=False` paths untouched.
- Older solvax: probe is False → identical behavior to today (unconditional carry).
- Within one `jac` call the operator is fixed (measured drift ~1e-16), so the gate is inert there; it acts precisely at the stash-across-iterates boundary R25.3 was designed for.

## Tests
`tests/test_recycle_drift.py` pins the vmex-side contract on a synthetic pytree operator through `_recycled_solve`: cold start drift 0, unchanged operator < 1e-10, monotone growth with the operator step, and well under the gate at slow-drift steps. Skips cleanly on pre-0.8.7 solvax. (The full recycled lane remains gated behind the I.8c A/B as planned; this PR gives that measurement its missing instrument.)