### PR TITLE
implicit: memoize the dof mask by structural signature (gradient mode-wall fix)

### DIFF
--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -220,6 +220,59 @@ def test_residual_zero_at_fixed_point(case):
 
 
 # ---------------------------------------------------------------------------
+# 2b. the dof mask is a structural invariant -> memoized by structural key
+# ---------------------------------------------------------------------------
+
+
+def _mask_bit_ident(a, b) -> bool:
+    return all(np.array_equal(np.asarray(getattr(a, f)), np.asarray(getattr(b, f)))
+               for f in im._STATE_FIELDS)
+
+
+def test_dof_mask_structural_invariance_and_cache(solovev):
+    """The dof mask depends only on the structure (resolution / lconm1 / ncurr),
+    not on the parameter values or the ``ImplicitConfig`` object identity, so
+    ``_MASK_CACHE`` (keyed by ``_mask_cache_key``) reuses it across the fresh
+    configs ``make_config``/``run`` mint on every call.  Proven here: the mask
+    is *bit-identical* when recomputed (a different random perturbation seed, and
+    a runtime built from perturbed parameters), and the module cache hits across
+    two fresh configs of the same structure (one entry, no recompute)."""
+    name, inp, cfg, p0, x_star, rt, mask = solovev
+
+    # fresh configs of the same structure share one hashable structural key,
+    # even though ImplicitConfig is eq=False (object-identity equality).
+    cfg_a = im.make_config(inp, **CASES[name])
+    cfg_b = im.make_config(inp, **CASES[name])
+    assert cfg_a is not cfg_b and cfg_a != cfg_b
+    key = im._mask_cache_key(cfg)
+    assert im._mask_cache_key(cfg_a) == key == im._mask_cache_key(cfg_b)
+    assert hash(im._mask_cache_key(cfg_a)) == hash(key)
+
+    # structural invariance: recompute with a different random seed and with a
+    # runtime built from PERTURBED parameters -> bit-identical every time.
+    mask_seed = im._dof_mask(x_star, rt, cfg, seed=7)
+    p1 = _perturb(p0, "rbc", (int(inp.ntor), 1), 0.01)
+    rt1 = im.runtime_from_params(p1, cfg)
+    mask_pert = im._dof_mask(x_star, rt1, cfg, seed=0)
+    assert _mask_bit_ident(mask, mask_seed), f"{name}: mask not seed-invariant"
+    assert _mask_bit_ident(mask, mask_pert), f"{name}: mask not parameter-invariant"
+
+    # end-to-end: the module cache hits across two fresh configs (one entry).
+    saved = dict(im._MASK_CACHE)
+    try:
+        im._MASK_CACHE.clear()
+        _, m_a = im._host_solve_and_mask(cfg_a, p0)
+        assert len(im._MASK_CACHE) == 1
+        _, m_b = im._host_solve_and_mask(cfg_b, p0)  # fresh cfg -> cache HIT
+        assert len(im._MASK_CACHE) == 1, "a second structural entry was minted"
+        assert _mask_bit_ident(m_a, m_b)
+        assert _mask_bit_ident(mask, m_a)
+    finally:
+        im._MASK_CACHE.clear()
+        im._MASK_CACHE.update(saved)
+
+
+# ---------------------------------------------------------------------------
 # 3. solovev gradient table vs central FD (rtol <= 1e-6)
 # ---------------------------------------------------------------------------
 

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -769,9 +769,30 @@ def _host_solve(cfg: ImplicitConfig, params: ImplicitParams) -> SolveResult:
     return result
 
 
-# cfg -> host dof mask (structural)
-_MASK_CACHE: weakref.WeakKeyDictionary[ImplicitConfig, SpectralState] = \
-    weakref.WeakKeyDictionary()
+# structural-signature -> host dof mask.  The mask is a *structural* property
+# (module docstring / ``_dof_mask``): it depends only on the resolution, the
+# symmetry/lconm1 mode families and the ncurr force branch — NOT on the
+# parameter values, and NOT on the ``ImplicitConfig`` object identity.  Keying
+# by identity (the previous ``WeakKeyDictionary``) missed on every ``run`` /
+# ``make_config`` call, because :class:`ImplicitConfig` is ``eq=False`` and
+# ``make_config`` mints a fresh object per call, so an optimization loop that
+# calls ``im.run`` hundreds of times at one resolution recomputed the mask
+# (the eager ``evaluate_forces`` x2 + VJP, measured 20-40 s) every time.
+# A plain dict keyed by the structural signature hits across all such calls.
+_MASK_CACHE: dict[tuple, SpectralState] = {}
+
+
+def _mask_cache_key(cfg: ImplicitConfig) -> tuple:
+    """Structural identity of the dof mask (see :func:`_dof_mask`).
+
+    Everything the mask's zero pattern depends on and nothing else, so two
+    configs that differ only in parameter values, tolerances, iteration caps,
+    the multigrid schedule or object identity share one entry.  ``resolution``
+    is a value-hashable frozen dataclass (``mpol/ntor/ntheta/nzeta/nfp/lasym/
+    ns``); ``lconm1`` drives the m=1 pair equalization; ``ncurr`` is carried as
+    a conservative safety margin for the current-constrained force branch.
+    """
+    return (cfg.resolution, bool(cfg.lconm1), int(cfg.inp.ncurr))
 
 
 def _host_solve_and_mask(cfg: ImplicitConfig, params_np) -> tuple:
@@ -790,14 +811,27 @@ def _host_solve_and_mask(cfg: ImplicitConfig, params_np) -> tuple:
             "(re-raised typed at the pure_callback call site)") from None
     as_np = lambda t: jax.tree.map(  # noqa: E731
         lambda a: np.asarray(a, dtype=np.float64), t)
+    # Prime the per-cfg-identity differentiable template *concretely* here (this
+    # host callback runs outside any trace).  The jitted residual ``F`` later
+    # calls ``runtime_from_params(params, cfg)`` -> ``_template_runtime(cfg)``
+    # under a ``jax.jit`` trace, where the host-side ``run_setup`` cannot run;
+    # its ``lru_cache`` must therefore be filled by a concrete call first.  The
+    # forward solve used to fill it as a side effect of building ``rt`` for the
+    # mask — preserve that guarantee even when the structural mask cache hits
+    # and skips that rebuild (``_template_runtime`` is keyed by object identity,
+    # so a fresh ``make_config``/``run`` config needs its own concrete prime).
+    _template_runtime(cfg)
     # The dof mask captures *structural* zero patterns (resolution, symmetry,
     # lconm1 pairing) — invariant across the parameter values of one config,
     # so repeated solves of an optimization reuse the first solve's mask.
-    mask = _MASK_CACHE.get(cfg)
+    # Keyed by structural signature (not object identity) so a fresh
+    # ``make_config``/``run`` at the same resolution hits — see ``_MASK_CACHE``.
+    cache_key = _mask_cache_key(cfg)
+    mask = _MASK_CACHE.get(cache_key)
     if mask is None:
         rt = runtime_from_params(params, cfg)
         mask = as_np(_dof_mask(result.state, rt, cfg))
-        _MASK_CACHE[cfg] = mask
+        _MASK_CACHE[cache_key] = mask
     return as_np(result.state), mask
 
 


### PR DESCRIPTION
## Summary

First fix for the measured implicit-gradient mode-number wall. A profiling pass found that in an optimization loop `im.run` is called hundreds of times at one resolution, yet the structure-invariant **dof mask** was recomputed on every gradient (16–41 s at mpol 6–12).

Root cause: `_MASK_CACHE` existed but was a `WeakKeyDictionary` keyed by **`ImplicitConfig` object identity** — and `make_config`/`run` mint a fresh config each call, so it missed every time. Re-keyed by a hashable structural signature `(resolution, lconm1, ncurr)`, so repeated calls at the same resolution hit.

Companion fix (found via the FD gate): the old miss-path primed `_template_runtime(cfg)` as a side effect of building the runtime; once the mask cache starts hitting, that priming was skipped and the jitted residual `F` traced the host `run_setup` → `TracerArrayConversionError`. `_host_solve_and_mask` now primes the template unconditionally (idempotent, net cost unchanged).

## Correctness (unchanged gradients)
- New `test_dof_mask_structural_invariance_and_cache`: the mask is **bit-identical** under a different random perturbation seed and under a runtime from perturbed parameters; the cache hits across two fresh configs.
- Gradient values bit-identical: `gnorm_rbc = 0.04089183921…` reproduces the reference to all digits.

## Measured (CPU, x64)
- mpol=8, ns=25: `_dof_mask` skipped on the second call (mask time saved 5.15 s warm; 16–41 s in cold/optimization-loop settings). Same-process first/second gradient **56.10 → 46.47 s**.
- mpol=10, ns=25: same-process first/second gradient **66.03 → 56.06 s**. No recompile-per-call bug (the persistent XLA cache serves the structurally-identical residual executable).

## Gates
`pytest tests/test_implicit_grad.py -q` → **12 passed** (11 frozen-path FD correctness tests + the new mask test) · `test_optimize.py -k "least_squares or implicit"` 6 passed · ruff + mypy clean.

## Documented follow-ups (higher risk, not in this PR)
1. **`vjp_p_apply` (parameter VJP)** — the dominant high-mpol term: 62.5 s at mpol=12 (vs 15–23 s at mpol 8–10), scaling super-linearly at mn=196. The real remaining "mode wall."
2. **Adjoint preconditioner / iteration count** — GMRES exhausts its restart budget without converging at ns=25 while GCROT(100,20) converges (1828 iters/31.7 s); a better adjoint preconditioner or GCROT default would cut iteration count.