### PR TITLE
implicit: differentiable gradients for LASYM (non-stellarator-symmetric) boundaries

### DIFF
--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -518,3 +518,274 @@ def test_multigrid_gradient_vs_frozen_path_fd():
           f"(Newton res {res:.0e})")
     assert res < 1e-8, f"frozen solve not converged (res {res:.1e})"
     assert rel <= 1e-6
+
+
+# ===========================================================================
+# lasym (non-stellarator-symmetric) implicit-gradient lane
+# ===========================================================================
+#
+# simsopt 1.10.3 / VMEC++ 0.6.0 added non-stellarator-symmetric boundary
+# optimization (up-down-asymmetric tokamaks, reconstruction).  The traceable
+# parameter map (implicit._boundary_from_params) reproduces the readin.f
+# ``delta`` theta-normalization and the four internal-block families
+# (rbcc/rbss/rbcs/rbsc, zbcc/zbss/zbcs/zbsc) for lasym, so ``jax.grad`` /
+# ``jax.jacrev`` through ``im.run`` now differentiate an rbs/zbc boundary dof.
+#
+# The 2D lasym golden deck ``up_down_asymmetric_tokamak`` exhausts NITER at its
+# native ns = 17; ns = 11 / ftol = 1e-12 converges and is the fixed-boundary
+# case here (the same "modified deck" pattern as the multigrid test above).
+#
+# On this deck the m = 1 lasym constraint (residue.f90 ``constrain_m1`` on the
+# asymmetric ``force_Z_cc`` pair) floors the *frozen* residual F that the
+# implicit adjoint linearizes at ~1e-7 even after the solver's force metric
+# crosses ftol — the same convergence-floor phenomenon the li383 3D tests
+# document.  That anchor shift caps the naive/frozen FD-vs-AD agreement of the
+# full ``im.run`` gradient at a solver-limited ~1e-4 (asserted with margin, and
+# printed, below), while the gradient *itself* is exact:
+#   * the traceable p -> boundary map derivative FD-validates to <= 1e-6 with
+#     no solver in the loop (``test_lasym_boundary_map_derivative_vs_fd``), and
+#   * the analytic directional derivative equals the frozen-path central FD to
+#     solver accuracy (<= 5e-5) once *both* are anchored at a Newton-refined
+#     fixed point, isolating the linearization
+#     (``test_lasym_adjoint_vs_frozen_path_fd``).
+
+LASYM_CASE = dict(ns=11, ftol=1e-12, max_iterations=4000)
+
+
+@pytest.fixture(scope="module")
+def lasym():
+    """Converged fixed-boundary 2D lasym case (up_down deck, ns = 11)."""
+    inp0 = VmecInput.from_file(str(DATA_DIR / "input.up_down_asymmetric_tokamak"))
+    inp = dataclasses.replace(
+        inp0,
+        ns_array=np.array([LASYM_CASE["ns"]]),
+        ftol_array=np.array([LASYM_CASE["ftol"]]),
+        niter_array=np.array([LASYM_CASE["max_iterations"]]),
+    )
+    assert bool(inp.lasym)
+    cfg = im.make_config(inp, ftol=LASYM_CASE["ftol"],
+                         max_iterations=LASYM_CASE["max_iterations"])
+    p0 = im.params_from_input(inp)
+    result = solver.solve(inp, cfg.resolution, ftol=cfg.ftol,
+                          max_iterations=cfg.max_iterations, mode="cli")
+    assert result.converged
+    rt = im.runtime_from_params(p0, cfg)
+    mask = im._dof_mask(result.state, rt, cfg)
+    return "up_down_asymmetric_tokamak", inp, cfg, p0, result.state, rt, mask
+
+
+def test_lasym_delta_rotation_traceable():
+    """``implicit._lasym_delta_rotation_traceable`` reproduces the numeric
+    ``setup._lasym_delta_rotation`` (the readin.f theta-normalization) to
+    ~1e-12 on the golden lasym deck, and stays differentiable in the (0,1)
+    coefficients that set ``delta``."""
+    from vmex.core import setup as setup_mod
+
+    inp = VmecInput.from_file(str(DATA_DIR / "input.up_down_asymmetric_tokamak"))
+    cfg = im.make_config(inp, ftol=1e-12, max_iterations=10)
+    mpol, ntor = int(inp.mpol), int(inp.ntor)
+    rbc = np.asarray(inp.rbc, dtype=float)
+    rbs = np.asarray(inp.rbs, dtype=float)
+    zbc = np.asarray(inp.zbc, dtype=float)
+    zbs = np.asarray(inp.zbs, dtype=float)
+    ref = setup_mod._lasym_delta_rotation(rbc, rbs, zbc, zbs, mpol=mpol, ntor=ntor)
+    tr = im._lasym_delta_rotation_traceable(
+        jnp.asarray(rbc), jnp.asarray(rbs), jnp.asarray(zbc), jnp.asarray(zbs),
+        cfg, mpol=mpol, ntor=ntor)
+    worst = 0.0
+    for nm, a, b in zip(("rbc", "rbs", "zbc", "zbs"), tr, ref):
+        err = float(np.max(np.abs(np.asarray(a) - np.asarray(b))))
+        worst = max(worst, err)
+        assert err <= 1e-12, f"delta rotation {nm}: {err:.2e}"
+    print(f"\n[up_down] traceable delta rotation vs setup reference: "
+          f"max abs err = {worst:.2e}")
+
+    # delta is a smooth function of RBS(0,1)/ZBC(0,1) -> finite gradient
+    def rot_scalar(rbs_a):
+        out = im._lasym_delta_rotation_traceable(
+            jnp.asarray(rbc), rbs_a, jnp.asarray(zbc), jnp.asarray(zbs),
+            cfg, mpol=mpol, ntor=ntor)
+        return jnp.sum(out[1])  # rotated rbs block
+    g = jax.grad(rot_scalar)(jnp.asarray(rbs))
+    assert np.all(np.isfinite(np.asarray(g)))
+
+
+def test_lasym_runtime_from_params_matches_run_setup(lasym):
+    """The lasym traceable map reproduces ``prepare_runtime`` at the base
+    parameters (all four boundary families, rcon0/zcon0)."""
+    name, inp, cfg, p0, _, rt_p, _ = lasym
+    rt_ref = solver.prepare_runtime(inp, cfg.resolution, ftol=cfg.ftol,
+                                    max_iterations=cfg.max_iterations)
+    for f in dataclasses.fields(type(rt_ref.setup)):
+        a = getattr(rt_ref.setup, f.name)
+        b = getattr(rt_p.setup, f.name)
+        if isinstance(a, (bool, int)):
+            assert a == b, f"{name}: setup.{f.name}"
+            continue
+        np.testing.assert_allclose(
+            np.asarray(a), np.asarray(b), rtol=0.0, atol=1e-13,
+            err_msg=f"{name}: setup.{f.name}")
+    np.testing.assert_allclose(np.asarray(rt_ref.rcon0), np.asarray(rt_p.rcon0),
+                               rtol=0.0, atol=1e-15, err_msg=f"{name}: rcon0")
+    np.testing.assert_allclose(np.asarray(rt_ref.zcon0), np.asarray(rt_p.zcon0),
+                               rtol=0.0, atol=1e-15, err_msg=f"{name}: zcon0")
+    # the asymmetric edge families actually carry the RBS content of the deck
+    assert float(np.max(np.abs(np.asarray(rt_p.setup.boundary_R_sin)))) > 0.0
+
+
+def test_lasym_residual_zero_at_fixed_point(lasym):
+    name, inp, cfg, p0, x_star, rt, mask = lasym
+    P = im._dof_projector(cfg, mask)
+    F = im.residual_fn(cfg, jax.lax.stop_gradient(x_star), mask)
+    r0 = _tnorm(F(P(x_star), p0))
+    delta = jax.tree.map(lambda a: a * (1.0 + 1e-3), x_star)
+    r1 = _tnorm(F(P(delta), p0))
+    assert r1 > 0.0
+    assert r0 < 1e-4 * r1, f"{name}: |F(x*)| = {r0:.3e} vs |F(x*+d)| = {r1:.3e}"
+
+
+def test_lasym_boundary_map_derivative_vs_fd(lasym):
+    """The traceable ``p -> processed boundary`` map derivative FD-validates to
+    <= 1e-6 for *all four* families (rbc/zbs/rbs/zbc) — no solver in the loop,
+    so this isolates the correctness of the lasym readin.f map (delta rotation,
+    the asymmetric internal-block accumulation, lflip, and the m=1 lconm1
+    constraint) from any solver-convergence floor."""
+    name, inp, cfg, p0, _, _, _ = lasym
+    ntor = int(inp.ntor)
+
+    def bnd_scalar(p):
+        s = im.runtime_from_params(p, cfg).setup
+        wsum = lambda a, c: jnp.sum(a * jnp.arange(1, a.size + 1)) * c  # noqa: E731
+        return (wsum(s.boundary_R_cos, 1.0) + wsum(s.boundary_R_sin, 1.3)
+                + wsum(s.boundary_Z_cos, 0.7) + wsum(s.boundary_Z_sin, 1.9))
+
+    g = jax.grad(bnd_scalar)(p0)
+    print(f"\n[{name}] boundary-map derivative AD vs FD (no solver):")
+    for field, idx in (("rbc", (ntor, 1)), ("zbs", (ntor, 2)),
+                       ("rbs", (ntor, 1)), ("rbs", (ntor, 2)),
+                       ("zbc", (ntor, 1)), ("zbc", (ntor, 2))):
+        h = 1e-6
+        fp = float(bnd_scalar(_perturb(p0, field, idx, h)))
+        fm = float(bnd_scalar(_perturb(p0, field, idx, -h)))
+        fd = (fp - fm) / (2.0 * h)
+        ad = float(np.asarray(getattr(g, field))[idx])
+        rel = abs(ad / fd - 1.0) if fd else abs(ad - fd)
+        print(f"  d/d({field}{idx}): AD={ad:+.10e} FD={fd:+.10e} rel={rel:.2e}")
+        assert rel <= 1e-6, f"{field}{idx}: boundary-map rel {rel:.2e}"
+
+
+def test_lasym_wb_aspect_gradient_vs_fd(lasym):
+    """``d(wb)/d`` and ``d(aspect)/d`` an rbs/zbc boundary dof vs central FD
+    through the host solve.  The naive re-solve FD is the physical total
+    derivative; the implicit adjoint (the *frozen*-path gradient) matches it to
+    the solver-limited floor of this m=1-constrained deck (~1e-4, printed), the
+    same documented-noise-floor pattern as the li383 3D tests.  Clean m = 2
+    asymmetric dofs (outside both the delta denominator and the m = 1 lconm1
+    constraint) are used."""
+    name, inp, cfg, p0, _, _, _ = lasym
+    ntor = int(inp.ntor)
+
+    def outs(p):
+        sol = im.run(inp, p, ftol=cfg.ftol, max_iterations=cfg.max_iterations)
+        return jnp.stack([sol.wb, sol.aspect])
+
+    jac = jax.jacrev(outs)(p0)
+    row = {"wb": 0, "aspect": 1}
+    checks = [
+        ("wb", "rbs", (ntor, 2), 3e-5, 2e-4),
+        ("aspect", "rbs", (ntor, 2), 3e-5, 1e-3),
+        ("wb", "zbc", (ntor, 2), 3e-5, 2e-4),
+        ("aspect", "zbc", (ntor, 2), 3e-5, 5e-4),
+    ]
+    print(f"\n[{name}] lasym boundary gradient vs naive central FD "
+          f"(forward ftol = {cfg.ftol:g}, solver-limited ~1e-4):")
+    for out, field, idx, h, tol in checks:
+        fd = _fd(name, inp, cfg, p0, field, idx, h)[out]
+        ad = float(np.asarray(getattr(jac, field))[row[out], idx[0], idx[1]])
+        rel = abs(ad / fd - 1.0)
+        print(f"  d({out})/d({field}{idx}) h={h:.0e}: "
+              f"AD={ad:+.10e} FD={fd:+.10e} rel={rel:.2e}")
+        assert rel <= tol, f"{out}/{field}{idx}: rel {rel:.3e} > {tol:.0e}"
+
+
+def test_lasym_adjoint_vs_frozen_path_fd(lasym):
+    """Definitive lasym-adjoint correctness lock.
+
+    The analytic directional derivative of the frozen fixed-point map and its
+    central frozen-path FD, BOTH anchored at the *same* Newton-refined fixed
+    point (the frozen residual driven to ~1e-14), agree to solver accuracy.
+    This removes the forward-solver anchor shift (see the section header) and
+    isolates the linearization ``dz = -(dF/dz)^{-1} dF/dp t`` plus the boundary
+    map — proving the implicit lasym gradient is exact, not merely close.
+    """
+    name, inp, _cfg, p0, x_star, _, mask = lasym
+    ntor = int(inp.ntor)
+    # Tight adjoint budget so the frozen-Newton refinement reaches ~1e-14 (the
+    # fixture cfg's optimizer-grade 1e-11 would floor it near 1e-10 and leave
+    # ~1e-4 FD noise); the fixed point and the resolution are unchanged.
+    cfg = im.make_config(inp, ftol=_cfg.ftol, max_iterations=_cfg.max_iterations,
+                         adjoint_tol=1e-14, adjoint_maxiter=800)
+    im._template_runtime(cfg)  # warm the host template before any trace below
+    P = im._dof_projector(cfg, mask)
+    edge_mask = im._edge_mask(cfg)
+    metric = lambda s, rt: im.mhd_energy(s, rt)[0]  # noqa: E731
+
+    def _norm(t):
+        return float(jnp.sqrt(sum(jnp.vdot(v, v).real
+                                  for v in jax.tree.leaves(t))))
+
+    def _newton(z, p, F, steps=40, tol=1e-14):
+        r0 = max(_norm(F(z, p)), 1.0)
+        for _ in range(steps):
+            fz = F(z, p)
+            if _norm(fz) <= tol * r0:
+                break
+            _, jvp = jax.linearize(lambda zz: F(zz, p), z)
+            step, _ = im._adjoint_solve(jvp, fz, cfg)
+            z = jax.tree.map(lambda a, b: a - b, z, step)
+        return z
+
+    # Newton-refine the fixed point, then re-freeze F there so the analytic
+    # anchor and the FD base point coincide exactly.
+    frozen0 = jax.lax.stop_gradient(x_star)
+    z_ref = _newton(P(x_star), p0, im.residual_fn(cfg, frozen0, mask))
+    rt0 = im.runtime_from_params(p0, cfg)
+    frozen = jax.lax.stop_gradient(im._assemble(z_ref, rt0, frozen0, P, edge_mask))
+    F = im.residual_fn(cfg, frozen, mask)
+    z0 = P(frozen)
+    base_res = _norm(F(z0, p0))
+    assert base_res < 1e-11, f"refined base residual {base_res:.1e}"
+
+    def Fz(dz):
+        return jax.jvp(lambda zz: F(zz, p0), (z0,), (dz,))[1]
+
+    def G(zz, prm):
+        rt = im.runtime_from_params(prm, cfg)
+        return metric(im._assemble(zz, rt, frozen, P, edge_mask), rt)
+
+    def analytic_dir(tangent):
+        b = jax.jvp(lambda prm: F(z0, prm), (p0,), (tangent,))[1]
+        dz, _ = im._adjoint_solve(Fz, jax.tree.map(jnp.negative, b), cfg)
+        return float(jax.jvp(G, (z0, p0), (P(dz), tangent))[1])
+
+    def frozen_fd(tangent, h=1e-5):
+        vals = []
+        for sign in (+1.0, -1.0):
+            p_h = jax.tree.map(lambda a, d, s=sign: a + s * h * d, p0, tangent)
+            zz = _newton(z0, p_h, F)
+            rt = im.runtime_from_params(p_h, cfg)
+            vals.append(float(metric(im._assemble(zz, rt, frozen, P, edge_mask), rt)))
+        return (vals[0] - vals[1]) / (2.0 * h)
+
+    zero = jax.tree.map(jnp.zeros_like, p0)
+    print(f"\n[{name}] lasym adjoint vs frozen-path FD at refined fixed point "
+          f"(base |F| = {base_res:.1e}):")
+    for field, idx in (("rbs", (ntor, 2)), ("zbc", (ntor, 2)), ("zbs", (ntor, 1))):
+        tangent = dataclasses.replace(
+            zero, **{field: getattr(zero, field).at[idx].set(1.0)})
+        an = analytic_dir(tangent)
+        fd = frozen_fd(tangent)
+        rel = abs(an / fd - 1.0) if fd else abs(an - fd)
+        print(f"  d(wb)/d({field}{idx}): analytic={an:+.9e} "
+              f"frozen-FD={fd:+.9e} rel={rel:.2e}")
+        assert rel <= 5e-5, f"{field}{idx}: adjoint vs frozen-path FD rel {rel:.2e}"

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -302,28 +302,66 @@ def _template_runtime(cfg: ImplicitConfig) -> SolverRuntime:
 # ---------------------------------------------------------------------------
 
 
-def _boundary_from_params(params: ImplicitParams, cfg: ImplicitConfig):
-    """Traceable ``readin.f`` boundary processing (symmetric inputs).
+def _lasym_delta_rotation_traceable(rbc, rbs, zbc, zbs, cfg: ImplicitConfig,
+                                    *, mpol: int, ntor: int):
+    """Traceable ``readin.f`` lasym theta-normalization.
 
-    Reproduces :func:`vmex.core.setup.boundary_from_input` for
-    ``lasym = False`` with the theta-flip decision frozen from the reference
-    input (it is a discrete function of ``p`` — constant in any neighborhood
-    where the gradient exists).  Returns the internal-normalized,
-    m=1-constrained signed helical arrays plus the physical ``r00``.
+    Reproduces :func:`vmex.core.setup._lasym_delta_rotation`: rotate theta so
+    ``RBS(0, 1) = ZBC(0, 1)``, every ``(n, m)`` pair mixed by ``m*delta``.  The
+    *discrete* rotate/don't-rotate decision (``mpol < 2``, a zero denominator,
+    or ``delta == 0`` — each a measure-zero surface in parameter space) is
+    frozen from the reference input ``cfg.inp``, exactly like ``lflip``; the
+    ``delta`` value and the ``cos(m*delta)/sin(m*delta)`` family mixing are
+    smooth functions of the ``(0, 1)`` coefficients and are traced.
+    """
+    r0 = np.asarray(cfg.inp.rbc, dtype=float)
+    s0 = np.asarray(cfg.inp.rbs, dtype=float)
+    c0 = np.asarray(cfg.inp.zbc, dtype=float)
+    z0 = np.asarray(cfg.inp.zbs, dtype=float)
+    if mpol < 2:
+        return rbc, rbs, zbc, zbs
+    denom0 = abs(r0[ntor, 1]) + abs(z0[ntor, 1])
+    if denom0 == 0.0:
+        return rbc, rbs, zbc, zbs
+    if float(np.arctan((s0[ntor, 1] - c0[ntor, 1]) / denom0)) == 0.0:
+        return rbc, rbs, zbc, zbs
+    denom = jnp.abs(rbc[ntor, 1]) + jnp.abs(zbs[ntor, 1])
+    delta = jnp.arctan((rbs[ntor, 1] - zbc[ntor, 1]) / denom)
+    m = jnp.arange(mpol, dtype=rbc.dtype)[None, :]
+    cos_md, sin_md = jnp.cos(m * delta), jnp.sin(m * delta)
+    rbc_new = rbc * cos_md + rbs * sin_md
+    rbs_new = rbs * cos_md - rbc * sin_md
+    zbc_new = zbc * cos_md + zbs * sin_md
+    zbs_new = zbs * cos_md - zbc * sin_md
+    return rbc_new, rbs_new, zbc_new, zbs_new
+
+
+def _boundary_from_params(params: ImplicitParams, cfg: ImplicitConfig):
+    """Traceable ``readin.f`` boundary processing (symmetric and lasym inputs).
+
+    Reproduces :func:`vmex.core.setup.boundary_from_input` with the discrete
+    decisions — the theta-flip (``lflip``) and the lasym ``delta`` rotate/skip
+    branch — frozen from the reference input (they are discrete functions of
+    ``p``, constant in any neighborhood where the gradient exists).  Returns
+    the internal-normalized, m=1-constrained signed helical arrays
+    ``(R_cos, R_sin, Z_cos, Z_sin)`` plus the physical ``r00``; for
+    ``lasym = False`` the ``R_sin``/``Z_cos`` arrays are zero.
     """
     res = cfg.resolution
-    if res.lasym:
-        raise NotImplementedError(
-            "implicit parameter map: lasym boundary processing (the readin.f "
-            "delta rotation) is not implemented yet; run with lasym = False"
-        )
     mpol, ntor = int(res.mpol), int(res.ntor)
     modes, trig = _static_tables(res)[0], _static_tables(res)[1]
     template = _template_runtime(cfg)
     lflip = bool(template.setup.lflip)
+    lthreed = ntor > 0
+    lasym = bool(res.lasym)
 
     rbc = jnp.asarray(params.rbc)
     zbs = jnp.asarray(params.zbs)
+    if lasym:
+        rbs = jnp.asarray(params.rbs)
+        zbc = jnp.asarray(params.zbc)
+        rbc, rbs, zbc, zbs = _lasym_delta_rotation_traceable(
+            rbc, rbs, zbc, zbs, cfg, mpol=mpol, ntor=ntor)
 
     # readin.f accumulation into the internal (|n|, m) blocks.
     shape = (ntor + 1, mpol)
@@ -331,7 +369,11 @@ def _boundary_from_params(params: ImplicitParams, cfg: ImplicitConfig):
     rbss = jnp.zeros(shape, dtype=rbc.dtype)
     zbcs = jnp.zeros(shape, dtype=rbc.dtype)
     zbsc = jnp.zeros(shape, dtype=rbc.dtype)
-    lthreed = ntor > 0
+    if lasym:
+        rbsc = jnp.zeros(shape, dtype=rbc.dtype)
+        rbcs = jnp.zeros(shape, dtype=rbc.dtype)
+        zbcc = jnp.zeros(shape, dtype=rbc.dtype)
+        zbss = jnp.zeros(shape, dtype=rbc.dtype)
     for m in range(mpol):
         if cfg.inp.lfreeb and 1 < cfg.inp.mfilter_fbdy < m:
             continue
@@ -346,6 +388,14 @@ def _boundary_from_params(params: ImplicitParams, cfg: ImplicitConfig):
                 if m > 0:
                     rbss = rbss.at[ni, m].add(isgn * rbc[j, m])
                 zbcs = zbcs.at[ni, m].add(-isgn * zbs[j, m])
+            if lasym:
+                if m > 0:
+                    rbsc = rbsc.at[ni, m].add(rbs[j, m])
+                zbcc = zbcc.at[ni, m].add(zbc[j, m])
+                if lthreed:
+                    rbcs = rbcs.at[ni, m].add(-isgn * rbs[j, m])
+                    if m > 0:
+                        zbss = zbss.at[ni, m].add(isgn * zbc[j, m])
 
     r00 = rbcc[0, 0]
 
@@ -356,31 +406,58 @@ def _boundary_from_params(params: ImplicitParams, cfg: ImplicitConfig):
         zbsc = keep0(-signs * zbsc, zbsc)
         rbss = keep0(-signs * rbss, rbss)
         zbcs = keep0(signs * zbcs, zbcs)
+        if lasym:
+            rbsc = keep0(-signs * rbsc, rbsc)
+            zbcc = keep0(signs * zbcc, zbcc)
+            rbcs = keep0(signs * rbcs, rbcs)
+            zbss = keep0(-signs * zbss, zbss)
 
     # internal blocks -> signed helical packing (setup._helical_from_internal_blocks)
     m_arr = np.asarray(modes.m, dtype=int)
     n_arr = np.asarray(modes.n, dtype=int)
-    R_list, Z_list = [], []
+    R_cos_list, Z_sin_list = [], []
+    R_sin_list, Z_cos_list = [], []
     for m, n in zip(m_arr, n_arr):
         ni = abs(n)
         if m == 0 and n != 0:
             isgn = 1 if n > 0 else -1
-            R_list.append(rbcc[ni, m])
-            Z_list.append(-isgn * zbcs[ni, m])
+            R_cos_list.append(rbcc[ni, m])
+            Z_sin_list.append(-isgn * zbcs[ni, m])
+            if lasym:
+                R_sin_list.append(-isgn * rbcs[ni, m])
+                Z_cos_list.append(zbcc[ni, m])
         elif n == 0:
-            R_list.append(rbcc[ni, m])
-            Z_list.append(zbsc[ni, m])
+            R_cos_list.append(rbcc[ni, m])
+            Z_sin_list.append(zbsc[ni, m])
+            if lasym:
+                R_sin_list.append(rbsc[ni, m])
+                Z_cos_list.append(zbcc[ni, m])
         elif n > 0:
-            R_list.append(0.5 * (rbcc[ni, m] + rbss[ni, m]))
-            Z_list.append(0.5 * (zbsc[ni, m] - zbcs[ni, m]))
+            R_cos_list.append(0.5 * (rbcc[ni, m] + rbss[ni, m]))
+            Z_sin_list.append(0.5 * (zbsc[ni, m] - zbcs[ni, m]))
+            if lasym:
+                R_sin_list.append(0.5 * (rbsc[ni, m] - rbcs[ni, m]))
+                Z_cos_list.append(0.5 * (zbcc[ni, m] + zbss[ni, m]))
         else:
-            R_list.append(0.5 * (rbcc[ni, m] - rbss[ni, m]))
-            Z_list.append(0.5 * (zbsc[ni, m] + zbcs[ni, m]))
+            R_cos_list.append(0.5 * (rbcc[ni, m] - rbss[ni, m]))
+            Z_sin_list.append(0.5 * (zbsc[ni, m] + zbcs[ni, m]))
+            if lasym:
+                R_sin_list.append(0.5 * (rbsc[ni, m] + rbcs[ni, m]))
+                Z_cos_list.append(0.5 * (zbcc[ni, m] - zbss[ni, m]))
     scale = jnp.asarray(physical_to_internal_scale(modes, trig))
-    R_cos = jnp.stack(R_list) * scale
-    Z_sin = jnp.stack(Z_list) * scale
-    zeros = jnp.zeros_like(R_cos)
+    R_cos = jnp.stack(R_cos_list) * scale
+    Z_sin = jnp.stack(Z_sin_list) * scale
 
+    if lasym:
+        R_sin = jnp.stack(R_sin_list) * scale
+        Z_cos = jnp.stack(Z_cos_list) * scale
+        R_cos2, Z_sin2, R_sin2, Z_cos2 = m1_physical_to_constrained(
+            R_cos[None, :], Z_sin[None, :], R_sin[None, :], Z_cos[None, :],
+            modes=modes, lthreed=lthreed, lasym=True, lconm1=cfg.lconm1,
+        )
+        return R_cos2[0], R_sin2[0], Z_cos2[0], Z_sin2[0], r00
+
+    zeros = jnp.zeros_like(R_cos)
     R_cos2, Z_sin2, _, _ = m1_physical_to_constrained(
         R_cos[None, :], Z_sin[None, :], None, None,
         modes=modes, lthreed=lthreed, lasym=False, lconm1=cfg.lconm1,

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -951,41 +951,81 @@ def _dof_modes(inp: VmecInput, max_mode: int) -> list[tuple[int, int]]:
     return out
 
 
+def _n_boundary_families(inp: VmecInput) -> int:
+    """Packed boundary Fourier families: 2 (``rbc``/``zbs``) for a
+    stellarator-symmetric boundary, 4 (``rbc``/``zbs``/``rbs``/``zbc``) when
+    ``inp.lasym`` — the non-stellarator-symmetric families that simsopt 1.10.3
+    / VMEC++ 0.6.0 added for up-down-asymmetric tokamaks and reconstruction.
+    """
+    return 4 if bool(inp.lasym) else 2
+
+
 def boundary_dof_names(inp: VmecInput, max_mode: int) -> list[str]:
-    """Human-readable labels ("RBC(n,m)" / "ZBS(n,m)", INDATA index order)."""
+    """Human-readable labels ("RBC(n,m)" / "ZBS(n,m)", INDATA index order).
+
+    For ``lasym`` boundaries the non-symmetric ``RBS(n,m)`` / ``ZBC(n,m)``
+    families are appended (same ``(m, n)`` order as the symmetric block).
+    """
     modes = _dof_modes(inp, max_mode)
-    return ([f"RBC({n},{m})" for (m, n) in modes]
-            + [f"ZBS({n},{m})" for (m, n) in modes])
+    names = ([f"RBC({n},{m})" for (m, n) in modes]
+             + [f"ZBS({n},{m})" for (m, n) in modes])
+    if bool(inp.lasym):
+        names += ([f"RBS({n},{m})" for (m, n) in modes]
+                  + [f"ZBC({n},{m})" for (m, n) in modes])
+    return names
 
 
 def pack_boundary(inp: VmecInput, max_mode: int) -> np.ndarray:
-    """Flat boundary-dof vector ``[rbc..., zbs...]`` (see :func:`_dof_modes`).
+    """Flat boundary-dof vector (see :func:`_dof_modes`).
 
     Inverse of :func:`unpack_boundary`; ``RBC(0,0)`` is excluded (fixed major
-    radius).  Only the stellarator-symmetric ``rbc``/``zbs`` families are
-    packed — lasym boundary optimization is out of scope here.
+    radius).  For a stellarator-symmetric boundary the layout is
+    ``[rbc..., zbs...]``; for ``lasym`` the non-symmetric families are appended
+    as ``[rbc..., zbs..., rbs..., zbc...]`` (four families — the same
+    ``m = 0 / RBC(0,0)`` fixing convention applies to every family, so the
+    rigid vertical shift ``ZBC(0,0)`` and the identically-zero ``RBS(0,0)`` are
+    excluded too).
     """
     modes = _dof_modes(inp, max_mode)
     ntor = int(inp.ntor)
     rbc = np.asarray(inp.rbc, dtype=float)
     zbs = np.asarray(inp.zbs, dtype=float)
-    return np.asarray([rbc[n + ntor, m] for (m, n) in modes]
-                      + [zbs[n + ntor, m] for (m, n) in modes], dtype=float)
+    vals = ([rbc[n + ntor, m] for (m, n) in modes]
+            + [zbs[n + ntor, m] for (m, n) in modes])
+    if bool(inp.lasym):
+        rbs = np.asarray(inp.rbs, dtype=float)
+        zbc = np.asarray(inp.zbc, dtype=float)
+        vals += ([rbs[n + ntor, m] for (m, n) in modes]
+                 + [zbc[n + ntor, m] for (m, n) in modes])
+    return np.asarray(vals, dtype=float)
 
 
 def unpack_boundary(inp: VmecInput, x, max_mode: int) -> VmecInput:
-    """New :class:`VmecInput` with the boundary dofs ``x`` applied."""
+    """New :class:`VmecInput` with the boundary dofs ``x`` applied.
+
+    Handles both the 2-family symmetric layout and the 4-family ``lasym``
+    layout (see :func:`pack_boundary`).
+    """
     modes = _dof_modes(inp, max_mode)
+    nm = len(modes)
     x = np.asarray(x, dtype=float).ravel()
-    if x.size != 2 * len(modes):
-        raise ValueError(f"expected {2 * len(modes)} dofs, got {x.size}")
+    nfam = _n_boundary_families(inp)
+    if x.size != nfam * nm:
+        raise ValueError(f"expected {nfam * nm} dofs, got {x.size}")
     ntor = int(inp.ntor)
     rbc = np.array(inp.rbc, dtype=float, copy=True)
     zbs = np.array(inp.zbs, dtype=float, copy=True)
     for k, (m, n) in enumerate(modes):
         rbc[n + ntor, m] = x[k]
-        zbs[n + ntor, m] = x[len(modes) + k]
-    return dataclasses.replace(inp, rbc=rbc, zbs=zbs)
+        zbs[n + ntor, m] = x[nm + k]
+    if not bool(inp.lasym):
+        return dataclasses.replace(inp, rbc=rbc, zbs=zbs)
+    rbs = np.array(inp.rbs, dtype=float, copy=True)
+    zbc = np.array(inp.zbc, dtype=float, copy=True)
+    for k, (m, n) in enumerate(modes):
+        rbs[n + ntor, m] = x[2 * nm + k]
+        zbc[n + ntor, m] = x[3 * nm + k]
+    return dataclasses.replace(inp, rbc=rbc, zbs=zbs, rbs=rbs, zbc=zbc)
 
 
 #: curtor dof storage scale (dof = CURTOR/1e6, i.e. MA) — keeps the trust
@@ -1073,7 +1113,8 @@ def _ess_scale(inp: VmecInput, max_mode: int, alpha: float) -> np.ndarray:
     ``least_squares_solve``); passed to scipy as ``x_scale``.
     """
     modes = _dof_modes(inp, max_mode)
-    levels = np.asarray([max(abs(m), abs(n)) for (m, n) in modes] * 2, dtype=float)
+    levels = np.asarray([max(abs(m), abs(n)) for (m, n) in modes]
+                        * _n_boundary_families(inp), dtype=float)
     if alpha <= 0.0:
         return np.ones_like(levels)
     return np.exp(-alpha * levels) / np.exp(-alpha)
@@ -1296,7 +1337,7 @@ def least_squares(
         x0 = pack_boundary(inp, max_mode)
         if k_cur:
             x0 = np.concatenate([x0, _pack_current(inp, k_cur, ac_scale)])
-    nb = 2 * len(_dof_modes(inp, max_mode))
+    nb = _n_boundary_families(inp) * len(_dof_modes(inp, max_mode))
 
     def unpack_full(x: np.ndarray) -> VmecInput:
         trial = unpack_boundary(inp, np.asarray(x, dtype=float)[:nb], max_mode)
@@ -1418,13 +1459,19 @@ def _least_squares_implicit(
     from . import implicit as imp
     from .device import resolve_implicit_device
 
-    if bool(inp.lasym):
+    lasym = bool(inp.lasym)
+    if lasym and int(inp.ntor) > 0:
+        # The 4-family traceable map (implicit._boundary_from_params) and the
+        # dof plumbing below handle a general lasym boundary, but the 3D lasym
+        # forward+adjoint path has not yet been FD-validated end to end; guard
+        # it explicitly rather than ship an unchecked Jacobian.
         raise NotImplementedError(
-            "jac='implicit' requires lasym = False (the implicit parameter map "
-            "does not implement the lasym readin.f boundary rotation)")
+            "jac='implicit' for lasym is currently validated for 2D (ntor = 0) "
+            "boundaries only; use jac=None (finite differences) for 3D lasym")
     terms = [(_traceable_term(f), float(t), float(w)) for (f, t, w) in objective_terms]
     modes = _dof_modes(inp, max_mode)
     nm = len(modes)
+    nfam = _n_boundary_families(inp)
     ntor = int(inp.ntor)
     row_idx = np.asarray([n + ntor for (_, n) in modes], dtype=int)
     col_idx = np.asarray([m for (m, _) in modes], dtype=int)
@@ -1432,7 +1479,8 @@ def _least_squares_implicit(
     # tangents through ImplicitParams.ac / .curtor (runtime_from_params
     # already traces both).
     k_cur, ac_scale = _current_dof_setup(inp, current_dofs)
-    ndof = 2 * nm + (k_cur + 1 if k_cur else 0)
+    nboundary = nfam * nm
+    ndof = nboundary + (k_cur + 1 if k_cur else 0)
     # multigrid=True routes the host solve through solve_multigrid (even for
     # single-stage ladders) so NITER-exhausted trials are penalized instead
     # of raising, matching the finite-difference path's trial policy.
@@ -1468,13 +1516,16 @@ def _least_squares_implicit(
     # eagerly so runtime_from_params stays traceable under jit below
 
     def params_of(x: jnp.ndarray):
-        rbc = params0.rbc.at[row_idx, col_idx].set(x[:nm])
-        zbs = params0.zbs.at[row_idx, col_idx].set(x[nm:2 * nm])
-        params = dataclasses.replace(params0, rbc=rbc, zbs=zbs)
+        repl = dict(rbc=params0.rbc.at[row_idx, col_idx].set(x[:nm]),
+                    zbs=params0.zbs.at[row_idx, col_idx].set(x[nm:2 * nm]))
+        if lasym:  # non-symmetric families [rbs..., zbc...] (see pack_boundary)
+            repl["rbs"] = params0.rbs.at[row_idx, col_idx].set(x[2 * nm:3 * nm])
+            repl["zbc"] = params0.zbc.at[row_idx, col_idx].set(x[3 * nm:4 * nm])
+        params = dataclasses.replace(params0, **repl)
         if k_cur:
-            ac = params0.ac.at[:k_cur].set(x[2 * nm:2 * nm + k_cur] * ac_scale)
+            ac = params0.ac.at[:k_cur].set(x[nboundary:nboundary + k_cur] * ac_scale)
             params = dataclasses.replace(
-                params, ac=ac, curtor=x[2 * nm + k_cur] * _CURTOR_SCALE)
+                params, ac=ac, curtor=x[nboundary + k_cur] * _CURTOR_SCALE)
         return params
 
     def term_rows(state, rt) -> jnp.ndarray:
@@ -1503,21 +1554,32 @@ def _least_squares_implicit(
 
     # One-hot dof tangents in ImplicitParams space, stacked over dofs
     # (leading axis ndof) so chunk_map can process them in fixed-size chunks:
-    # boundary rbc/zbs rows first, then the scaled AC/CURTOR rows.
+    # boundary rbc/zbs (and, for lasym, rbs/zbc) rows first, then the scaled
+    # AC/CURTOR rows.
     t_rbc = np.zeros((ndof,) + np.shape(params0.rbc))
     t_zbs = np.zeros((ndof,) + np.shape(params0.zbs))
+    t_rbs = np.zeros((ndof,) + np.shape(params0.rbs))
+    t_zbc = np.zeros((ndof,) + np.shape(params0.zbc))
     t_ac = np.zeros((ndof,) + np.shape(params0.ac))
     t_curtor = np.zeros((ndof,))
     for j in range(nm):
         t_rbc[j, row_idx[j], col_idx[j]] = 1.0
         t_zbs[nm + j, row_idx[j], col_idx[j]] = 1.0
+        if lasym:
+            t_rbs[2 * nm + j, row_idx[j], col_idx[j]] = 1.0
+            t_zbc[3 * nm + j, row_idx[j], col_idx[j]] = 1.0
     for j in range(k_cur):
-        t_ac[2 * nm + j, j] = ac_scale
+        t_ac[nboundary + j, j] = ac_scale
     if k_cur:
-        t_curtor[2 * nm + k_cur] = _CURTOR_SCALE
+        t_curtor[nboundary + k_cur] = _CURTOR_SCALE
     zerop = jax.tree.map(jnp.zeros_like, params0)
-    tangent_stack = (jnp.asarray(t_rbc), jnp.asarray(t_zbs),
-                     jnp.asarray(t_ac), jnp.asarray(t_curtor))
+    if lasym:
+        tangent_stack = (jnp.asarray(t_rbc), jnp.asarray(t_zbs),
+                         jnp.asarray(t_rbs), jnp.asarray(t_zbc),
+                         jnp.asarray(t_ac), jnp.asarray(t_curtor))
+    else:
+        tangent_stack = (jnp.asarray(t_rbc), jnp.asarray(t_zbs),
+                         jnp.asarray(t_ac), jnp.asarray(t_curtor))
 
     # R17.1 memory knob: chunk_size None == one wide vmap (current behavior),
     # an int / "auto" caps peak Jacobian memory at that many dofs at a time.
@@ -1558,6 +1620,10 @@ def _least_squares_implicit(
             return jax.jvp(lambda z: F(z, params), (z_star,), (dz,))[1]
 
         def tangent_of(tp):
+            if lasym:
+                return dataclasses.replace(zerop, rbc=tp[0], zbs=tp[1],
+                                           rbs=tp[2], zbc=tp[3],
+                                           ac=tp[4], curtor=tp[5])
             return dataclasses.replace(zerop, rbc=tp[0], zbs=tp[1],
                                        ac=tp[2], curtor=tp[3])
 
@@ -1579,7 +1645,7 @@ def _least_squares_implicit(
         geometry to scipy.  Columns are mathematically independent, so the
         result is identical across chunk sizes to float64 round-off.
         Also returns the per-dof state responses ``dz_j`` (leading axis
-        ``2*nm``): they are the R25.4 perturbation warm-start linearization,
+        ``ndof``): they are the R25.4 perturbation warm-start linearization,
         already paid for by the column solves.
         """
         Fz, tangent_of, rhs_of, column_of, _ = _jac_parts(x)
@@ -1604,7 +1670,7 @@ def _least_squares_implicit(
     # is the same solution through either: assemble the raw blocks once with
     # 3-colored jvp probes (cost ~3*(3*mn) residual linearizations,
     # independent of the dof count), factor once (solvax block Thomas), and
-    # backsolve all 2*nm right-hand sides — then one short preconditioned
+    # backsolve every dof right-hand side — then one short preconditioned
     # GMRES pass per column (warm-started at the direct solution) certifies
     # cfg.adjoint_tol in the same norm as the default path: solvax checks
     # the initial residual before the first Arnoldi cycle, so columns whose
@@ -1710,7 +1776,7 @@ def _least_squares_implicit(
             chunk_size=chunk)
         return jnp.transpose(cols), dz_cols
 
-    # R25.3 recycled variant: all 2*nm solves share the operator Fz (and Fz
+    # R25.3 recycled variant: all ndof solves share the operator Fz (and Fz
     # drifts slowly between accepted trust-region iterates), so a GCROT
     # deflation pair (C, U) is threaded through a lax.scan over fixed-size
     # dof chunks — vmapped *within* a chunk with the incoming pair shared
@@ -1880,9 +1946,9 @@ def _least_squares_implicit(
 
     result = scipy.optimize.least_squares(fun, np.asarray(x0, dtype=float),
                                           jac=jac_fn, **scipy_kwargs)
-    result.input = unpack_boundary(inp, result.x[:2 * nm], max_mode)
+    result.input = unpack_boundary(inp, result.x[:nboundary], max_mode)
     if k_cur:
-        result.input = _apply_current(result.input, result.x[2 * nm:],
+        result.input = _apply_current(result.input, result.x[nboundary:],
                                       k_cur, ac_scale)
     stats = imp._SOLVE_STATS.get(cfg)
     result.solve_stats = None if stats is None else dict(stats)


### PR DESCRIPTION
## Summary

Implements implicit-lane (differentiable) gradients for non-stellarator-symmetric (`lasym = True`) equilibria — the differentiable lane previously rejected lasym at three sites. Forward lasym solves already worked (golden `up_down_asymmetric_tokamak`, parity `cth_like_free_bdy_lasym_small`); now all four boundary families are optimizable in 2D. Demand: simsopt v1.10.3 and VMEC++ v0.6.0 both added non-SS optimization; up-down-asymmetric tokamaks and equilibrium reconstruction need it.

## What landed
1. **Traceable delta rotation** (`_lasym_delta_rotation_traceable`): a jnp version of `setup._lasym_delta_rotation` (readin.f `delta = atan((rbs₀₁−zbc₀₁)/(|rbc₀₁|+|zbs₀₁|))`, family mixing by m·delta). The discrete rotate/skip branch is frozen from `cfg.inp` like `lflip`; the rest is traced. **Reproduces the numeric reference to 5.55e-17.**
2. **`_boundary_from_params` extended for lasym**: accumulates the asymmetric families with the readin.f signs, applies `lflip` to all four internal blocks, extends the internal→helical packing to emit `R_sin`/`Z_cos` through `m1_physical_to_constrained(lasym=True)`. `runtime_from_params` matches `prepare_runtime` for lasym to **4.16e-17**.
3. **Dof packing + ESS** (`optimize.py`): `pack_boundary`/`unpack_boundary`/`boundary_dof_names`/`_ess_scale` emit 4 families `[rbc, zbs, rbs, zbc]` when `inp.lasym`; `_least_squares_implicit` extended to the 4-family dof vector. The blanket rejection is removed; a guard remains for the not-yet-validated 3D lasym adjoint.

## Validation (FD-locked two ways)
- Isolated boundary-map derivative (no solver): ≤ **1e-6** for all four families.
- Adjoint lock — analytic directional derivative vs frozen-path central FD, both anchored at a Newton-refined fixed point: **rbs(0,2) 3.1e-8, zbc(0,2) 5.8e-6, zbs(0,1) 9.0e-6**.
- Full `im.run` gradient vs naive FD agrees to a solver-limited ~1e-4 (the m=1 lasym constraint floors the frozen residual at ~1e-7 on this deck — the same convergence-floor documented for the li383 3D tests; the gradient itself is exact, proven by the two anchored checks above).

## Now optimizable
2D lasym **RBC, ZBS, RBS, ZBC** via `least_squares(jac="implicit")` and `jax.grad(im.run)`; a short lasym implicit optimization reduces an aspect objective, moving all four families.

## Deferred (honest)
3D lasym (stellarator) `jac="implicit"` raises `NotImplementedError` — the traceable map handles it generically but I could not FD-validate the 3D-lasym adjoint in scope (no readily-converging 3D-lasym fixed-boundary deck); the `jac=None` FD path works for both 2D and 3D lasym.

## Gates
`tests/test_implicit_grad.py` **18 passed** (12 + 6 new lasym) · `tests/test_optimize.py` 20 passed · `tests/test_wout_golden.py -k asymmetric` 3 passed (forward parity unbroken) · ruff + mypy clean.