### PR TITLE
Pre-release QA + CI hardening: ESSOS API, asset URLs, stale lasym test, timeout headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,10 @@ jobs:
   parity:
     name: Parity suite ${{ matrix.shard }} (goldens, coverage)
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Headroom for slow shared runners: the golden solves run ~15-20 min on a
+    # healthy runner but tip over a tighter limit on a slow one (the suite
+    # content is unchanged). 35 absorbs that variance without masking a hang.
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
@@ -244,7 +247,9 @@ jobs:
   gradient:
     name: Implicit-gradient suite (JIT on, coverage)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # ~9-10 min on a healthy runner (JIT-heavy); a slow runner runs the full
+    # 10 and gets cancelled. 15 gives real headroom without hiding a hang.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6.0.2
 

--- a/examples/free_boundary_essos_coils.py
+++ b/examples/free_boundary_essos_coils.py
@@ -50,9 +50,14 @@ if CI:  # smoke budget: one finite-beta point on a coarse grid
     TARGET_BETAS, NS, NITER, FTOL = [1.0], 16, 4000, 1e-8
 
 # --------------------------- coils -> external field ------------------------
-from essos.coils import Coils_from_json  # noqa: E402 (optional heavy import)
+from essos.coils import Coils  # noqa: E402 (optional heavy import)
 
-coils = Coils_from_json(str(COILS_JSON))
+if hasattr(Coils, "from_json"):
+    coils = Coils.from_json(str(COILS_JSON))
+else:  # legacy ESSOS predating the Coils.from_json classmethod
+    from essos.coils import Coils_from_json
+
+    coils = Coils_from_json(str(COILS_JSON))
 currents = np.asarray(coils.currents)  # symmetry-expanded physical currents [A]
 mean_current = float(np.mean(np.abs(currents)))
 print(f"ESSOS coils: {currents.shape[0]} filaments after nfp={coils.nfp}/stellsym "

--- a/examples/single_stage_essos_coils_opt.py
+++ b/examples/single_stage_essos_coils_opt.py
@@ -250,13 +250,18 @@ def main() -> None:
     if not FBD.have_virtual_casing_jax():
         raise SystemExit("needs virtual_casing_jax (pip install -e /path/to/virtual_casing_jax)")
     try:
-        from essos.coils import Coils_from_json
+        from essos.coils import Coils
     except ImportError as exc:  # pragma: no cover - optional heavy dependency
         raise SystemExit("needs essos (pip install -e /path/to/ESSOS)") from exc
     if not COILS_JSON.exists():
         raise SystemExit(f"missing {COILS_JSON.name} in {DATA}")
 
-    coils = Coils_from_json(str(COILS_JSON))
+    if hasattr(Coils, "from_json"):
+        coils = Coils.from_json(str(COILS_JSON))
+    else:  # legacy ESSOS predating the Coils.from_json classmethod
+        from essos.coils import Coils_from_json
+
+        coils = Coils_from_json(str(COILS_JSON))
     coil_field = make_coil_field(coils.gamma, coils.gamma_dash, int(coils.nfp), bool(coils.stellsym))
     base0 = np.asarray(coils.dofs_currents, dtype=float) * float(coils.currents_scale)
     print(f"ESSOS LP-QA coils: {int(np.asarray(coils.currents).shape[0])} filaments "

--- a/tests/test_package_api.py
+++ b/tests/test_package_api.py
@@ -119,7 +119,9 @@ def _coils_payload():
 def test_coils_mgrid_field_json_and_npz(tmp_path):
     # vmex is coil-agnostic: --coils loads ESSOS coils and tabulates them
     # into an in-memory mgrid, returning a plain MgridField.
-    pytest.importorskip("essos")
+    Coils = pytest.importorskip("essos.coils").Coils
+    if not hasattr(Coils, "to_mgrid"):
+        pytest.skip("ESSOS build lacks Coils.to_mgrid (coils->mgrid export)")
     payload = _coils_payload()
 
     jpath = tmp_path / "coils.json"

--- a/tests/test_validation_guards.py
+++ b/tests/test_validation_guards.py
@@ -91,13 +91,26 @@ def test_least_squares_rejects_unknown_jac():
         opt.least_squares([(opt.aspect_ratio, 6.0, 1.0)], inp, jac="magic")
 
 
-def test_least_squares_implicit_rejects_lasym_decks():
+def test_least_squares_implicit_boundary_map_supports_lasym():
+    """The implicit lane's boundary parameter map handles non-stellarator-
+    symmetric (lasym) decks via the four RBC/ZBS/RBS/ZBC families — the map
+    that lets ``jac="implicit"`` optimise lasym boundaries (the end-to-end
+    differentiable lasym gradients are validated in ``test_implicit_grad.py``).
+    Fast, pure-function check of the pack/unpack round-trip; no solve."""
     from vmex.core.input import VmecInput
 
     inp = VmecInput.from_file(str(DATA_DIR / "input.up_down_asymmetric_tokamak"))
     assert bool(inp.lasym)
-    with pytest.raises(NotImplementedError, match="lasym"):
-        opt.least_squares([(opt.aspect_ratio, 6.0, 1.0)], inp, jac="implicit")
+    assert opt._n_boundary_families(inp) == 4  # rbc/zbs/rbs/zbc
+
+    names = opt.boundary_dof_names(inp, 1)
+    assert any(nm.startswith("RBS") for nm in names)
+    assert any(nm.startswith("ZBC") for nm in names)
+
+    x = opt.pack_boundary(inp, 1)
+    assert x.size == len(names)
+    inp2 = opt.unpack_boundary(inp, x, 1)
+    np.testing.assert_allclose(opt.pack_boundary(inp2, 1), x)
 
 
 def test_traceable_term_vetting():

--- a/tools/fetch_assets.py
+++ b/tools/fetch_assets.py
@@ -19,7 +19,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 REFERENCE_TAG = "assets-20260316-nc"
-REFERENCE_ASSET_NAME = "vmex_assets_20260316_nc_only.tar.gz"
+# NOTE: the published release tarball keeps the pre-rename "vmec_jax_" prefix --
+# it was uploaded before the vmec_jax -> vmex repo rename, and only the repo and
+# its code were renamed, not the already-published GitHub release assets. Keep
+# this in sync with the actual asset filename, not the current package name.
+REFERENCE_ASSET_NAME = "vmec_jax_assets_20260316_nc_only.tar.gz"
 REFERENCE_URL = (
     "https://github.com/uwplasma/vmex/releases/download/"
     f"{REFERENCE_TAG}/{REFERENCE_ASSET_NAME}"
@@ -27,7 +31,8 @@ REFERENCE_URL = (
 REFERENCE_SHA256 = "3344fc2401fffed240ee57ae741ec521594c592627c76dae203503f485e4c0d8"
 
 WOUT_FIXTURES_TAG = "assets-20260526-wout-fixtures"
-WOUT_FIXTURES_ASSET_NAME = "vmex_wout_fixtures_20260526.tar.gz"
+# Same pre-rename asset-filename caveat as REFERENCE_ASSET_NAME above.
+WOUT_FIXTURES_ASSET_NAME = "vmec_jax_wout_fixtures_20260526.tar.gz"
 WOUT_FIXTURES_URL = (
     "https://github.com/uwplasma/vmex/releases/download/"
     f"{WOUT_FIXTURES_TAG}/{WOUT_FIXTURES_ASSET_NAME}"

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -393,6 +393,15 @@ def _coils_mgrid_field(path: Path, *, nr: int = 96, nphi: int = 32,
     rmin, rmax = max(1.0e-2, float(r.min()) - rpad), float(r.max()) + rpad
     zmin, zmax = float(z.min()) - zpad, float(z.max()) + zpad
 
+    if not hasattr(coils, "to_mgrid"):
+        raise VmecInputError(
+            WERROR_MESSAGES[INPUT_ERROR_FLAG],
+            hint=(
+                "--coils needs an ESSOS build providing Coils.to_mgrid "
+                "(coils->mgrid export); update ESSOS (pip install -U essos)"
+            ),
+        )
+
     with tempfile.TemporaryDirectory() as tmp:
         mgrid_path = Path(tmp) / "essos_coils_mgrid.nc"
         coils.to_mgrid(str(mgrid_path), nr=int(nr), nphi=int(nphi), nz=int(nz),

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -333,7 +333,7 @@ def _coils_mgrid_field(path: Path, *, nr: int = 96, nphi: int = 32,
     vmex keeps no coil code — coils live in ESSOS
     (:class:`essos.coils.Coils`).  This loads the coils from the
     ``essos.coils.Coils.to_json`` layout (``.json``, via
-    ``essos.coils.Coils_from_json``) or the same keys in an ``.npz`` archive
+    ``essos.coils.Coils.from_json``) or the same keys in an ``.npz`` archive
     (``dofs_curves`` with shape ``(n_base_coils, 3, 2*order + 1)``,
     ``dofs_currents``, ``n_segments``, ``nfp``, ``stellsym``, optional
     ``currents_scale``), tabulates the coil field onto a cylindrical grid
@@ -347,7 +347,7 @@ def _coils_mgrid_field(path: Path, *, nr: int = 96, nphi: int = 32,
     import numpy as np
 
     try:
-        from essos.coils import Coils, Coils_from_json, Curves
+        from essos.coils import Coils, Curves
     except ImportError as exc:
         raise VmecInputError(
             WERROR_MESSAGES[INPUT_ERROR_FLAG],
@@ -367,7 +367,11 @@ def _coils_mgrid_field(path: Path, *, nr: int = 96, nphi: int = 32,
             stellsym = bool(np.asarray(data.get("stellsym", False)).reshape(-1)[0])
             scale = float(np.asarray(data.get("currents_scale", 1.0)).reshape(-1)[0])
             coils = Coils(Curves(dofs, n_segments, nfp, stellsym), currents * scale)
-        else:
+        elif hasattr(Coils, "from_json"):
+            coils = Coils.from_json(str(path))
+        else:  # legacy ESSOS predating the Coils.from_json classmethod
+            from essos.coils import Coils_from_json
+
             coils = Coils_from_json(str(path))
     except (KeyError, ValueError, OSError, TypeError) as exc:
         raise VmecInputError(

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -54,8 +54,9 @@ Wout-engine terms (:func:`d_merc`, :func:`l_grad_b`, the Boozer-based QI
 residual) run on host NumPy and are finite-difference-only —
 :func:`l_grad_b_state` is the traceable ``(state, rt)`` lane of the same
 ``L_grad_B`` convention for ``jac="implicit"``.  The implicit parameter map
-does not implement the lasym ``readin.f`` delta rotation, so
-``jac="implicit"`` requires ``lasym = False``.
+supports lasym via the four RBC/ZBS/RBS/ZBC boundary families and a traceable
+``readin.f`` delta rotation (FD-validated), so ``jac="implicit"`` handles
+``lasym = True`` as well (the QS-ratio traceable term is symmetric-only).
 
 Measured cost (2026-07-10, RTX A4000, nfp2 circular seed, QS + aspect +
 iota objective, ``max_mode=2`` -> 24 dofs): warm implicit Jacobian 2.5 s
@@ -1198,9 +1199,10 @@ def least_squares(
     docstring): every term traceable in ``(state, runtime)`` (vector terms
     expose ``residuals_state``; wout-engine terms like :func:`d_merc` /
     :func:`l_grad_b` / the Boozer QI residual need ``jac=None`` — for
-    ``L_grad_B`` use the traceable :func:`l_grad_b_state` instead) and
-    ``lasym = False`` (the implicit parameter map does not implement the
-    lasym ``readin.f`` boundary rotation).
+    ``L_grad_B`` use the traceable :func:`l_grad_b_state` instead).  Both
+    stellarator-symmetric and ``lasym`` boundaries are supported: the implicit
+    parameter map packs the four RBC/ZBS/RBS/ZBC families and a traceable
+    ``readin.f`` delta rotation.
     ``jac_chunk_size`` (R17.1 memory knob, ``jac="implicit"`` only) chunks the
     per-dof Jacobian columns via :func:`solvax.chunk_map`: ``"auto"`` (default)
     lets :func:`solvax.auto_chunk_size` pick a memory-bounded width (the


### PR DESCRIPTION
Fixes surfaced by a full pre-release example + test-suite sweep. (Context: the GitHub Actions incident on 2026-07-20 cancelled CI on the last several `main` merges, so `main`'s true green state was unverified — running the suites locally is what caught the stale test below.)

## ESSOS API drift
1. **`Coils.from_json`** — current ESSOS renamed the loader to the `Coils.from_json` classmethod and removed the `Coils_from_json` free function, breaking the `--coils <file>.json` CLI path and the two ESSOS coil examples at import time. Switched to `Coils.from_json` with a `hasattr` fallback. Verified end-to-end (loads the shipped LandremanPaulQA coils: 16 filaments, nfp 2).
2. **`Coils.to_mgrid` guard** — the `--coils` direct-coils→mgrid path calls `coils.to_mgrid(...)`, which some ESSOS builds predate; added a `hasattr` guard raising a clear `VmecInputError` instead of an opaque `AttributeError`, and a matching `pytest.skip` in `test_coils_mgrid_field_json_and_npz` so it skips (not hard-fails) on such builds.

## Broken fixture download
3. **`tools/fetch_assets.py`** pointed at `vmex_*.tar.gz` release tarballs that don't exist — the published fixture bundles kept their pre-rename `vmec_jax_*.tar.gz` names. Both downloads 404'd, blocking every example needing fetched mgrid/wout fixtures. Repointed at the real filenames; **independently verified** `vmec_jax_*` → 200, `vmex_*` → 404, and the SHA256 of the real tarballs matches the hardcoded expected hashes.

## Stale test from the LASYM-gradient work
4. **`test_least_squares_implicit_rejects_lasym_decks`** asserted `jac="implicit"` *rejects* lasym decks — stale since the LASYM-gradient work (implicit `_lasym_delta_rotation_traceable` + the 4-family RBC/ZBS/RBS/ZBC boundary map) made lasym a supported, FD-validated implicit lane. Replaced with a fast pure-function round-trip test of the 4-family boundary map (end-to-end lasym gradients already covered in `test_implicit_grad.py`), and fixed the two matching stale `optimize.py` docstrings.

## CI robustness
5. **Timeout headroom** — the parity goldens shard (25→35 min) and implicit-gradient suite (10→15 min) sit right at their limits and were cancelled on slow post-incident runners; bumped for headroom (a real hang still hits the higher limit; a real failure still fails fast).

## Verification
ruff + mypy clean · `import vmex.core.cli` clean · fetch URLs → 200 · gradient suite **19 passed** locally · new lasym boundary-map test passes (0.17 s) · parity-c shard green locally after the fixes.