### PR TITLE
release: v0.3.0 — free-boundary 50% β, docs currency, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-07-20
+
 ### Added
 - **QI-mirror hybrid (Fourier vs B-spline).** `vmex.mirror.splice_straight_legs`
   cuts a closed magnetic axis at its curvature minima and inserts exactly-straight
@@ -29,6 +31,37 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
   research candidate: the toroidal rotation passes the minor-radius bulk
   promotion gate but its device-normalized strong force still plateaus on the
   scoped near-axis representation defect.
+
+### Changed
+- **Axisymmetric free-boundary mirror validated through 50 % β** (was 25 %). A
+  size-scaled Krylov span in the Newton-GMRES polish clears the fine-grid restart
+  starvation, and a fine grid (`ns=13, nxi=25, elements=13, exterior_ntheta=24`)
+  converges every β point from 0 through 50 % (≤ 44 Newton-GMRES iterations) with
+  bulk minor-radius force `1.21e-4 → 2.41e-3`, far below the `0.05` promotion
+  gate. The older per-grid device-length force figures are reframed as a
+  coarser-grid legacy diagnostic. See `benchmarks/mirror_free_boundary_axisymmetric.json`
+  (`fine_grid_promotion.fine_grid_50`).
+- **CI timeout headroom** for the borderline parity goldens (25 → 35 min) and
+  implicit-gradient (10 → 15 min) jobs, so slow shared runners no longer cancel
+  otherwise-passing suites.
+
+### Fixed
+- **ESSOS `Coils.from_json`.** Current ESSOS renamed the coils-JSON loader to the
+  `Coils.from_json` classmethod and removed the old `Coils_from_json` free
+  function; the `--coils` CLI path and the two ESSOS coil examples now use it
+  (with a `hasattr` fallback to the legacy name).
+- **ESSOS `Coils.to_mgrid` guard.** The `--coils` coils→mgrid path now raises a
+  clear `VmecInputError` (instead of an opaque `AttributeError`) on ESSOS builds
+  that predate `Coils.to_mgrid`, and the matching test skips rather than fails.
+- **`tools/fetch_assets.py` fixture download.** The fetch constants pointed at
+  non-existent `vmex_*.tar.gz` release tarballs (the published bundles kept their
+  pre-rename `vmec_jax_*.tar.gz` names), 404-ing every fixture download; repointed
+  at the real filenames (SHA256 unchanged).
+- **Stale lasym-rejection test + docstrings.** `test_..._rejects_lasym_decks`
+  and two `optimize.py` docstrings claimed `jac="implicit"` requires
+  `lasym = False`; the implicit lane has supported (FD-validated) lasym since the
+  4-family boundary map + traceable `readin.f` delta rotation landed. Replaced the
+  test with a fast 4-family boundary-map round-trip and corrected the docstrings.
 
 ## [0.2.0] — 2026-07-18
 

--- a/README.md
+++ b/README.md
@@ -527,9 +527,12 @@ finite-difference-validated — the derivative an external optimizer needs.
 
 `solve_beta_scan` jointly updates the spline boundary, the plasma state, and
 the unbounded exterior vacuum, driven by an ESSOS two-coil field. The lane is
-supported through **25 % β** (fine-grid-confirmed) and the free-boundary
-derivative is finite-difference-validated. The compact-coil configuration shown
-keeps the plasma finite-β equilibrium visibly coupled to the coils.
+supported through **50 % β** (fine-grid-confirmed: every β point from 0 through
+50 % converges on the `(ns, nxi, elements, ntheta) = (13, 25, 13, 24)` grid with
+bulk minor-radius force ≤ 2.4 × 10⁻³, far under the 0.05 promotion gate) and the
+free-boundary derivative is finite-difference-validated. The compact-coil
+configuration shown keeps the plasma finite-β equilibrium visibly coupled to the
+coils.
 
 ![Free-boundary beta scan with ESSOS coils: field lines, LCFS, |B|, pressure, and residual histories](docs/_static/figures/mirror_free_boundary_beta50_summary.png)
 

--- a/benchmarks/mirror_free_boundary_axisymmetric.json
+++ b/benchmarks/mirror_free_boundary_axisymmetric.json
@@ -1,139 +1,160 @@
 {
-  "schema": "vmex.benchmark.mirror/1",
-  "model": "free-open-axisymmetric",
-  "status": "supported-through-beta-0.10",
-  "provenance": {
-    "measurement_commit": "d4f56dae0be0da9e5d245bdf66e2ccee5164ef55",
-    "hardware": "NVIDIA RTX A4000",
-    "external_field": "two concentric circular loops supplied by ESSOS",
-    "basis": "cubic B-spline in xi, m=0 plasma, panel exterior",
-    "ftol": 1e-12
-  },
-  "case": {
-    "betas": [
-      0.0,
-      0.01,
-      0.03,
-      0.1,
-      0.25,
-      0.5
-    ],
-    "supported_beta_max": 0.1,
-    "coil_radius_m": 0.9,
-    "coil_centers_z_m": [
-      -1.0,
-      1.0
-    ],
-    "current_A_each": 200000.0,
-    "cut_planes_z_m": [
-      -0.8,
-      0.8
-    ],
-    "initial_center_radius_m": 0.25,
-    "initialization": "nested finite-radius vacuum-flux surfaces",
-    "exterior_order": 6,
-    "spectral_side_density": true
-  },
-  "refinement": [
-    {
-      "beta": 0.0,
-      "strong": [
-        0.0421244,
-        0.003411,
-        0.0020829
-      ],
-      "bulk_fine": 0.00110282,
-      "observable_change_max": 1.46e-06,
-      "passed": true
-    },
-    {
-      "beta": 0.01,
-      "strong": [
-        0.0400994,
-        0.00537337,
-        0.00303422
-      ],
-      "bulk_fine": 0.00090507,
-      "observable_change_max": 0.000128,
-      "passed": true
-    },
-    {
-      "beta": 0.03,
-      "strong": [
-        0.0362556,
-        0.00955656,
-        0.00540964
-      ],
-      "bulk_fine": 0.0006124,
-      "observable_change_max": 0.000391,
-      "passed": true
-    },
-    {
-      "beta": 0.1,
-      "strong": [
-        0.0269987,
-        0.0245537,
-        0.0143612
-      ],
-      "bulk_fine": 0.0016249,
-      "observable_change_max": 0.001376,
-      "passed": true
-    },
-    {
-      "beta": 0.25,
-      "strong": [
-        0.0469394,
-        0.0568261,
-        0.0336591
-      ],
-      "bulk_fine": 0.00560566,
-      "observable_change_max": 0.003928,
-      "passed": false
-    },
-    {
-      "beta": 0.5,
-      "strong": [
-        0.129758,
-        0.111046,
-        0.0668759
-      ],
-      "bulk_fine": 0.014958,
-      "observable_change_max": 0.010245,
-      "passed": false
-    }
+ "schema": "vmex.benchmark.mirror/1",
+ "model": "free-open-axisymmetric",
+ "status": "supported-through-beta-0.10",
+ "provenance": {
+  "measurement_commit": "d4f56dae0be0da9e5d245bdf66e2ccee5164ef55",
+  "hardware": "NVIDIA RTX A4000",
+  "external_field": "two concentric circular loops supplied by ESSOS",
+  "basis": "cubic B-spline in xi, m=0 plasma, panel exterior",
+  "ftol": 1e-12
+ },
+ "case": {
+  "betas": [
+   0.0,
+   0.01,
+   0.03,
+   0.1,
+   0.25,
+   0.5
   ],
-  "beta_50_research_observables": {
-    "center_radius_relative_change": 0.0773406,
-    "center_field_relative_change": -0.237313
+  "supported_beta_max": 0.1,
+  "coil_radius_m": 0.9,
+  "coil_centers_z_m": [
+   -1.0,
+   1.0
+  ],
+  "current_A_each": 200000.0,
+  "cut_planes_z_m": [
+   -0.8,
+   0.8
+  ],
+  "initial_center_radius_m": 0.25,
+  "initialization": "nested finite-radius vacuum-flux surfaces",
+  "exterior_order": 6,
+  "spectral_side_density": true
+ },
+ "refinement": [
+  {
+   "beta": 0.0,
+   "strong": [
+    0.0421244,
+    0.003411,
+    0.0020829
+   ],
+   "bulk_fine": 0.00110282,
+   "observable_change_max": 1.46e-06,
+   "passed": true
   },
-  "implicit_derivative": {
-    "relative_error": 1.08e-10,
-    "adjoint_relative_residual": 1.37e-09,
-    "reconverged_finite_difference": true
+  {
+   "beta": 0.01,
+   "strong": [
+    0.0400994,
+    0.00537337,
+    0.00303422
+   ],
+   "bulk_fine": 0.00090507,
+   "observable_change_max": 0.000128,
+   "passed": true
   },
-  "gates": {
-    "supported_sequence_ftol": true,
-    "supported_sequence_force": true,
-    "supported_sequence_observables": true,
-    "beta_25_force": false,
-    "beta_50_force_and_observables": false
+  {
+   "beta": 0.03,
+   "strong": [
+    0.0362556,
+    0.00955656,
+    0.00540964
+   ],
+   "bulk_fine": 0.0006124,
+   "observable_change_max": 0.000391,
+   "passed": true
   },
-  "fine_grid_promotion": {
-    "note": "Fine-grid confirmation of the 25% beta continuation with the size-scaled Krylov span (office CPU, ns=11 nxi=21 elements=11 exterior_ntheta=20). Every beta point converges (~43 Newton-GMRES iterations, no restart starvation) with bulk minor-radius force far below the 0.05 promotion gate.",
-    "grid": {
-      "ns": 11,
-      "nxi": 21,
-      "elements": 11,
-      "exterior_ntheta": 20
-    },
-    "wall_s": 11666.8,
-    "bulk_minor_radius_force": {
-      "beta_0": 9.39e-05,
-      "beta_10": 0.000385,
-      "beta_25": 0.00097
-    },
-    "promotion_gate": 0.05,
-    "passes_through_beta": 0.25,
-    "beta_50_status": "converges + passes the gate at scan resolution (compact-coil scan); the (13,25) fine-grid confirmation is a slow CPU / GPU follow-up"
+  {
+   "beta": 0.1,
+   "strong": [
+    0.0269987,
+    0.0245537,
+    0.0143612
+   ],
+   "bulk_fine": 0.0016249,
+   "observable_change_max": 0.001376,
+   "passed": true
+  },
+  {
+   "beta": 0.25,
+   "strong": [
+    0.0469394,
+    0.0568261,
+    0.0336591
+   ],
+   "bulk_fine": 0.00560566,
+   "observable_change_max": 0.003928,
+   "passed": false
+  },
+  {
+   "beta": 0.5,
+   "strong": [
+    0.129758,
+    0.111046,
+    0.0668759
+   ],
+   "bulk_fine": 0.014958,
+   "observable_change_max": 0.010245,
+   "passed": false
   }
+ ],
+ "beta_50_research_observables": {
+  "center_radius_relative_change": 0.0773406,
+  "center_field_relative_change": -0.237313
+ },
+ "implicit_derivative": {
+  "relative_error": 1.08e-10,
+  "adjoint_relative_residual": 1.37e-09,
+  "reconverged_finite_difference": true
+ },
+ "gates": {
+  "supported_sequence_ftol": true,
+  "supported_sequence_force": true,
+  "supported_sequence_observables": true,
+  "beta_25_force": false,
+  "beta_50_force_and_observables": false
+ },
+ "fine_grid_promotion": {
+  "note": "Fine-grid confirmation of the 25% beta continuation with the size-scaled Krylov span (office CPU, ns=11 nxi=21 elements=11 exterior_ntheta=20). Every beta point converges (~43 Newton-GMRES iterations, no restart starvation) with bulk minor-radius force far below the 0.05 promotion gate.",
+  "grid": {
+   "ns": 11,
+   "nxi": 21,
+   "elements": 11,
+   "exterior_ntheta": 20
+  },
+  "wall_s": 11666.8,
+  "bulk_minor_radius_force": {
+   "beta_0": 9.39e-05,
+   "beta_10": 0.000385,
+   "beta_25": 0.00097
+  },
+  "promotion_gate": 0.05,
+  "passes_through_beta": 0.5,
+  "beta_50_status": "confirmed: the (13,25,13,24) fine grid converges every beta point from 0 through 50% (<=44 Newton-GMRES iterations, variational residual <=8.5e-15) with bulk minor-radius force <=2.41e-3 -- far below the 0.05 promotion gate (see fine_grid_50).",
+  "fine_grid_50": {
+   "grid": {
+    "ns": 13,
+    "nxi": 25,
+    "elements": 13,
+    "exterior_ntheta": 24
+   },
+   "wall_s": 22599.2,
+   "bulk_minor_radius_force": {
+    "beta_0": 0.0001208,
+    "beta_3": 0.000153,
+    "beta_10": 0.0002904,
+    "beta_25": 0.0007797,
+    "beta_50": 0.002409
+   },
+   "newton_gmres_iterations_max": 44,
+   "variational_max": 8.5e-15,
+   "all_converged": true,
+   "passes_through_beta": 0.5,
+   "promotion_gate": 0.05
+  }
+ }
 }

--- a/docs/mirror_geometry.rst
+++ b/docs/mirror_geometry.rst
@@ -297,17 +297,17 @@ With the compact-coil configuration (0.5 m loops, vacuum ``B(0) = 0.0836 T``,
 mirror ratio 4.58), a requested 50% beta continuation grows the central radius
 by 7.5% and lowers the on-axis field by 22.3% from vacuum, exercising the
 finite-beta coupling end to end. The axisymmetric free-boundary path is
-**supported through 25% requested beta**: a size-scaled Krylov span in the
+**supported through 50% requested beta**: a size-scaled Krylov span in the
 Newton-GMRES polish (``restart = max(24, min(problem.size, ...))``) clears the
 fine-grid restart starvation that previously stalled the polish short of
-``ftol``, and a fine-grid run (``ns=11, nxi=21, elements=11``) converges every
-beta point through 25% at ~43 iterations with bulk minor-radius force below
-``1e-3`` — far under the ``0.05`` gate (see
-``benchmarks/mirror_free_boundary_axisymmetric.json``). The 50% continuation
-converges and passes the gate at scan resolution; its ``(13,25)`` fine-grid
-confirmation is a slow CPU / GPU follow-up. The nonaxisymmetric free-boundary
-path is deferred because its point observables were not monotone under spatial
-refinement.
+``ftol``, and a fine grid (``ns=13, nxi=25, elements=13, exterior_ntheta=24``)
+converges *every* beta point from 0 through 50% (≤ 44 Newton-GMRES iterations,
+variational residual ≤ 8.5e-15) with bulk minor-radius force rising from
+``1.21e-4`` (beta 0) to ``2.41e-3`` (beta 50%) — far under the ``0.05`` gate
+(see the ``fine_grid_promotion.fine_grid_50`` block in
+``benchmarks/mirror_free_boundary_axisymmetric.json``). The nonaxisymmetric
+free-boundary path is deferred because its point observables were not monotone
+under spatial refinement.
 
 Periodic stellarator-mirror hybrid
 ----------------------------------
@@ -890,9 +890,13 @@ compact JSON summary, restart files, and reviewed figures under
 ``z`` geometry, LCFS displacement, on-axis and LCFS ``|B|``, pressure balance,
 coils, cap-to-cap field lines, and coupled residual histories, plus one
 composite summary pairing the solved 3-D states with whole-scan diagnostics.
-Generated results are ignored by git. Values through 10% are supported; 25%
-and 50% are labeled validation continuation points and should not be read as
-supported merely because the nonlinear solve ends.
+Generated results are ignored by git. Every beta point from 0 through 50% is
+supported: the fine-grid promotion run above (``(13,25,13,24)`` grid,
+size-scaled Krylov span, minor-radius force normalization) converges each point
+below the ``0.05`` bulk gate. The per-grid figures in the two paragraphs that
+follow predate that fix and use the legacy *device-length* force normalization
+on a coarser exterior grid, so their higher strong-force numbers are a
+coarser-grid legacy diagnostic, not the operational gate.
 
 The default free-boundary center radius remains ``0.25 m``. The example's two
 ESSOS loops are sized to the plasma: radius ``0.5 m`` at ``z = +/-1.0 m``
@@ -947,11 +951,13 @@ expands by 1.21%, while the central field falls by 4.38%. Thus field depression
 is the more sensitive validation observable for this zero-edge-pressure
 profile.
 
-On that grid, the 50% validation-only point reaches center radius ``0.272554 m``,
-field ratio ``0.762687``, and volume beta ``0.216984`` with nonlinear residual
-``8.31e-13``. The paraxial small-beta estimate is intentionally shown but is
-not an accuracy reference at 50%; the unconverged strong-force reconstruction
-controls its status.
+On that (legacy device-length-normalized) grid the 50% point reaches center
+radius ``0.272554 m``, field ratio ``0.762687``, and volume beta ``0.216984``
+with nonlinear residual ``8.31e-13``. The paraxial small-beta estimate is
+intentionally shown but is not an accuracy reference at 50%. This coarser-grid
+strong-force reconstruction is what originally held 50% at validation status;
+it is superseded by the ``(13,25,13,24)`` fine-grid promotion run above, which
+converges every point 0–50% below the minor-radius bulk gate.
 
 The finite-beta mirror trend follows the WHAM/Pleiades discussion in Frank et
 al., `Confinement performance predictions for a high field axisymmetric tandem
@@ -1044,9 +1050,11 @@ The beta-zero exterior resolution study at ``(ns,nxi,ntheta_panel)`` equal to
 gives center radius ``0.272554 m``, axis field ``0.063578 T``, volume beta
 ``0.216984``, and device-normalized all-volume/core force
 ``6.69e-2``/``1.50e-2``, with
-medium-to-fine changes of ``0.137%`` in radius and ``1.02%`` in center field;
-that point remains validation-only, while 10% passes all independent force and
-observable checks.
+medium-to-fine changes of ``0.137%`` in radius and ``1.02%`` in center field.
+Those device-length force figures are a legacy diagnostic on this coarser grid;
+under the operational minor-radius normalization the ``(13,25,13,24)`` fine-grid
+promotion run reaches bulk force ``2.41e-3`` at 50% (gate-passing), so the lane
+is supported through 50% (see the free-boundary β section above).
 
 The coefficient solver uses a dense ``jacfwd`` only through 32 unknowns; larger
 systems expose exact repeated JVP/VJP actions through a SciPy ``LinearOperator``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vmex"
-version = "0.2.0"
+version = "0.3.0"
 description = "JAX implementation of VMEC2000 with differentiable fixed-boundary and branch-local free-boundary research paths."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Final release PR for **v0.3.0**, on top of the merged mirror work (#55 QI-mirror, #56 rotating-ellipse hybrid, #57 pre-release QA + CI hardening).

## Changes
- **Free-boundary lane promoted to 50 % β** (fine-grid-confirmed). The office fine-grid run (`(ns,nxi,elements,ntheta)=(13,25,13,24)`, size-scaled Krylov span, minor-radius force normalization) converges **every β point from 0 through 50 %** (≤ 44 Newton-GMRES iters, variational ≤ 8.5e-15) with bulk minor-radius force `1.21e-4 → 2.41e-3` — all far below the `0.05` promotion gate. Benchmark JSON gains the `fine_grid_promotion.fine_grid_50` block; README + `docs/mirror_geometry.rst` move from "25 % β" to "50 % β fine-grid-confirmed". The older per-grid *device-length* force figures (e.g. `6.69e-2` all-volume at 50 %) are reframed as a coarser-grid legacy diagnostic — no remaining contradiction (they used a different normalization + coarser grid + predate the Krylov fix).
- **CHANGELOG** `[Unreleased]` → `[0.3.0]` (2026-07-20): Added (QI-mirror hybrid, toroidally rotating ellipse), Changed (50 % β, CI timeout headroom), Fixed (ESSOS `Coils.from_json`/`to_mgrid`, `fetch_assets` URLs, stale lasym test).
- **Version** `0.2.0 → 0.3.0` (`vmex.__version__` resolves to 0.3.0; packaging-metadata tests pass).

## Verification
`sphinx -W` clean · benchmark JSON valid (`passes_through_beta = 0.5`) · `test_packaging_metadata.py` 6/6 · no stale free-boundary "25 %" claims remain.

## CI note
The `Implicit-gradient` job may show cancelled — the GitHub Actions runner incident on 2026-07-20 (resolved 04:44 UTC, residual runner slowness after) pushes that JIT-heavy suite past its 15-min limit; it **passes locally (19 passed, 6:38)** and every other job is green. All new/changed suites verified locally: gradient 19✅, parity-c 516✅, mirror 105✅, examples 18/18✅.