### PR TITLE
core: define explicit JAX device-placement semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
 ## [Unreleased]
 
 ### Changed
+- **Explicit device semantics.** Omitted or ``device="auto"`` placement keeps
+  VMEX's measured policy; explicit ``device=None`` now follows ordinary JAX
+  placement. Explicit platform names and ``jax.Device`` objects always win.
 - **QI-mirror hybrid: tangent-aligned legs at all four symmetry planes.**
   `splice_straight_legs` now inserts each straight mirror leg *along the local
   axis tangent* (rather than a shared transverse "bisector" that produced a

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -177,23 +177,25 @@ decks finish faster on the CPU. The measured crossover is
 and ``"gpu"`` at or above it, per multigrid stage.
 
 :func:`~vmex.core.device.resolve_device` turns this into a concrete
-placement with strict precedence rules: an explicit ``device=`` argument to
-``solve``/``solve_multigrid`` always wins; a user pin via ``JAX_PLATFORMS``
-or ``JAX_PLATFORM_NAME`` makes the automatic policy stand down entirely; and
-the recommendation is applied only when the recommended platform is actually
-available. :func:`~vmex.core.device.device_context` wraps a stage in the
-corresponding ``jax.default_device``.
+placement with strict precedence rules: an explicit device always wins;
+``device=None`` follows JAX placement; and the default ``device="auto"``
+policy stands down for an active ``jax.default_device`` context or a
+user-pinned JAX platform.  The recommendation is applied only when its
+platform is available. :func:`~vmex.core.device.device_context` wraps a stage
+in the corresponding ``jax.default_device``.
 
 The optimization path is different:
-:func:`~vmex.core.device.resolve_implicit_device` **always pins the
-implicit-gradient work to the CPU** by default. The ``jac="implicit"``
-Jacobian builds a per-dof vmapped forward-implicit-differentiation graph —
+:func:`~vmex.core.device.resolve_implicit_device` **pins the
+implicit-gradient work to the CPU by default when VMEX owns placement**. The
+``jac="implicit"`` Jacobian builds a per-dof vmapped
+forward-implicit-differentiation graph —
 dozens of preconditioned GMRES solves with inner control flow — whose XLA
 compile time grows with the dof count and whose execution is
 kernel-launch-bound; measured on GPU it is slower than the CPU at every
-optimization size tested, while the forward equilibrium solve inside it is a
-host callback that never touches the accelerator anyway. Explicit
-``device=`` arguments and user platform pins are still honored.
+optimization size tested. The forward equilibrium callback uses the solver's
+independent automatic per-stage placement policy; the implicit-device choice
+controls the residual and Jacobian graphs. Explicit ``device=`` arguments and
+JAX placement contexts are still honored for those graphs.
 
 Naming conventions
 ------------------

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -353,13 +353,16 @@ only:
 
 - an explicit ``device=`` argument to ``solve``/``solve_multigrid`` always
   wins;
-- if you pinned the platform yourself via ``JAX_PLATFORMS`` (or
-  ``JAX_PLATFORM_NAME``), the automatic policy stands down entirely.
+- ``device=None`` leaves placement to JAX;
+- an active ``jax.default_device`` context or a user-pinned JAX platform makes
+  the default ``device="auto"`` policy stand down entirely.
 
-.. code-block:: bash
+.. code-block:: python
 
-   JAX_PLATFORMS=cpu  vmex input.solovev      # force CPU
-   JAX_PLATFORMS=cuda vmex input.big_case     # force GPU
+   solve(inp, device="cpu")
+   solve(inp, device="gpu")
+   with jax.default_device(jax.devices("gpu")[0]):
+       solve(inp)  # AUTO respects this context
 
 Persistent compilation cache
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -31,10 +31,48 @@ def test_iteration_work_and_recommendation_threshold():
     assert dev.recommended_device(big) == "gpu"
 
 
-def test_pinned_platform_is_never_overridden(monkeypatch):
-    monkeypatch.setenv("JAX_PLATFORMS", "cpu")
-    # even a GPU-recommended resolution is left alone when the user pinned.
-    assert dev.resolve_device(None, _res(ns=201, mpol=16, ntor=16, nfp=5)) is None
+@pytest.mark.parametrize("key", ["jax_platforms", "jax_platform_name"])
+def test_selected_jax_platform_is_never_overridden(key):
+    previous = jax.config.values.get(key)
+    try:
+        jax.config.update(key, "cpu")
+        # Even a GPU-recommended resolution is left alone when JAX is pinned.
+        assert dev.resolve_device(
+            dev.AUTO, _res(ns=201, mpol=16, ntor=16, nfp=5)
+        ) is None
+    finally:
+        jax.config.update(key, previous)
+
+
+def test_none_leaves_placement_to_jax(monkeypatch):
+    monkeypatch.setattr(dev, "recommended_device", lambda _: pytest.fail("auto policy ran"))
+    assert dev.resolve_device(None, _res(ns=11, mpol=6, ntor=0)) is None
+    assert dev.resolve_implicit_device(None, None) is None
+
+
+def test_omitted_device_uses_auto_policy(monkeypatch):
+    seen = []
+    monkeypatch.delenv("JAX_PLATFORMS", raising=False)
+    monkeypatch.delenv("JAX_PLATFORM_NAME", raising=False)
+    monkeypatch.setattr(dev, "recommended_device", lambda res: seen.append(res) or "cpu")
+    dev.resolve_device(resolution=_res(ns=11, mpol=6, ntor=0))
+    assert len(seen) == 1
+
+
+def test_auto_without_resolution_has_a_clear_error():
+    with pytest.raises(ValueError, match="resolution is required"):
+        dev.resolve_device()
+    with pytest.raises(ValueError, match="resolution is required"):
+        dev.device_context()
+
+
+def test_default_device_context_is_never_overridden(monkeypatch):
+    # Pretend the process default backend is an accelerator: absent the active
+    # CPU context, AUTO would explicitly return a CPU device for this deck.
+    monkeypatch.setattr(jax, "default_backend", lambda: "gpu")
+    with jax.default_device(jax.devices("cpu")[0]):
+        assert dev.resolve_device(dev.AUTO, _res(ns=11, mpol=6, ntor=0)) is None
+        assert dev.resolve_implicit_device(dev.AUTO, None) is None
 
 
 def test_auto_cpu_recommendation_is_a_noop_on_cpu(monkeypatch):
@@ -42,7 +80,7 @@ def test_auto_cpu_recommendation_is_a_noop_on_cpu(monkeypatch):
     monkeypatch.delenv("JAX_PLATFORM_NAME", raising=False)
     # CPU-recommended + default backend already CPU -> nothing to place.
     if jax.default_backend() == "cpu":
-        assert dev.resolve_device(None, _res(ns=11, mpol=6, ntor=0)) is None
+        assert dev.resolve_device(dev.AUTO, _res(ns=11, mpol=6, ntor=0)) is None
 
 
 def test_auto_gpu_recommendation_without_accelerator(monkeypatch):
@@ -50,7 +88,7 @@ def test_auto_gpu_recommendation_without_accelerator(monkeypatch):
     monkeypatch.delenv("JAX_PLATFORM_NAME", raising=False)
     # GPU-recommended but CPU-only machine -> None (nothing to do).
     if jax.default_backend() == "cpu":
-        assert dev.resolve_device(None, _res(ns=201, mpol=16, ntor=16, nfp=5)) is None
+        assert dev.resolve_device(dev.AUTO, _res(ns=201, mpol=16, ntor=16, nfp=5)) is None
 
 
 def test_explicit_cpu_returns_a_cpu_device():
@@ -79,7 +117,7 @@ def test_resolve_implicit_device_defaults_to_cpu(monkeypatch):
     monkeypatch.delenv("JAX_PLATFORMS", raising=False)
     monkeypatch.delenv("JAX_PLATFORM_NAME", raising=False)
     res = _res(ns=35, mpol=6, ntor=6, nfp=4)  # a QH-class stage
-    resolved = dev.resolve_implicit_device(None, res)
+    resolved = dev.resolve_implicit_device(dev.AUTO, res)
     if jax.default_backend() == "cpu":
         # already on CPU -> nothing to place (the implicit path stays put).
         assert resolved is None
@@ -88,22 +126,28 @@ def test_resolve_implicit_device_defaults_to_cpu(monkeypatch):
         assert resolved is not None and resolved.platform == "cpu"
 
 
-def test_resolve_implicit_device_honors_explicit_and_pin(monkeypatch):
+def test_resolve_implicit_device_honors_explicit_and_pin():
     res = _res(ns=35, mpol=6, ntor=6, nfp=4)
     # explicit device is honored (delegated to resolve_device).
     explicit = dev.resolve_implicit_device("cpu", res)
     assert explicit is not None and explicit.platform == "cpu"
-    # a user platform pin stands the auto policy down.
-    monkeypatch.setenv("JAX_PLATFORMS", "cpu")
-    assert dev.resolve_implicit_device(None, res) is None
+    # A JAX platform pin stands the auto policy down.
+    previous = jax.config.jax_platforms
+    try:
+        jax.config.update("jax_platforms", "cpu")
+        assert dev.resolve_implicit_device(dev.AUTO, res) is None
+    finally:
+        jax.config.update("jax_platforms", previous)
 
 
 def test_device_context_is_a_nullcontext_when_placement_untouched(monkeypatch):
-    monkeypatch.setenv("JAX_PLATFORMS", "cpu")
-    ctx = dev.device_context(None, _res(ns=11, mpol=6, ntor=0))
-    assert isinstance(ctx, contextlib.nullcontext)
-    with ctx:
-        pass
+    monkeypatch.setattr(dev, "_user_selected_placement", lambda: True)
+    res = _res(ns=11, mpol=6, ntor=0)
+    for choice in (None, dev.AUTO):
+        ctx = dev.device_context(choice, res)
+        assert isinstance(ctx, contextlib.nullcontext)
+        with ctx:
+            pass
 
 
 def test_device_context_wraps_default_device_for_explicit_cpu():

--- a/vmex/core/device.py
+++ b/vmex/core/device.py
@@ -33,20 +33,20 @@ by 2-3x and increasingly more with size.  The threshold ``100_000`` sits
 between the two clusters (geometric mean of 24.3e3 and 491.5e3 ~ 109e3).
 
 The policy is a *default* only: an explicit ``device=`` argument to
-``solve``/``solve_multigrid`` always wins, and when the user pinned the JAX
-platform themselves (``JAX_PLATFORMS``/``JAX_PLATFORM_NAME``) the automatic
-policy stands down entirely (:func:`resolve_device` returns ``None``).
+``solve``/``solve_multigrid`` always wins, while ``device=None`` follows
+JAX placement.  The automatic policy stands down when the user selected a
+JAX default device or platform themselves.
 """
 
 from __future__ import annotations
 
 import contextlib
-import os
 from typing import Any
 
 import jax
 
 __all__ = [
+    "AUTO",
     "GPU_MIN_ITERATION_WORK",
     "iteration_work",
     "recommended_device",
@@ -54,6 +54,10 @@ __all__ = [
     "resolve_implicit_device",
     "device_context",
 ]
+
+#: Apply VMEX's measured placement policy.  ``None`` deliberately has the
+#: usual JAX meaning: do not add a placement context.
+AUTO = "auto"
 
 #: Minimum ``ns * mnmax * nznt`` per-iteration work for the GPU to be the
 #: recommended default (see the measured table in the module docstring).
@@ -75,29 +79,38 @@ def recommended_device(resolution: Any) -> str:
     return "cpu" if iteration_work(resolution) < GPU_MIN_ITERATION_WORK else "gpu"
 
 
-def _user_pinned_platform() -> bool:
-    """True when the user pinned the JAX platform via the environment."""
-    return bool(
-        os.environ.get("JAX_PLATFORMS", "").strip()
-        or os.environ.get("JAX_PLATFORM_NAME", "").strip()
+def _user_selected_placement() -> bool:
+    """True when the user selected a JAX default device or platform."""
+    return (
+        jax.config.jax_default_device is not None
+        or bool(jax.config.jax_platforms)
+        or bool(jax.config.values.get("jax_platform_name"))
     )
 
 
-def resolve_device(device: Any, resolution: Any):
+def resolve_device(device: Any = AUTO, resolution: Any = None):
     """Map a ``device=`` argument to a concrete ``jax.Device`` (or ``None``).
 
     ``None`` means "leave placement alone" (no ``jax.default_device`` wrap):
 
     - explicit ``device`` (``"cpu"``/``"gpu"``/``"cuda"``/``"rocm"``/``"tpu"``
       or a ``jax.Device``) is always honored — missing hardware raises;
-    - ``device=None`` applies :func:`recommended_device` **unless** the user
-      pinned ``JAX_PLATFORMS``/``JAX_PLATFORM_NAME`` (never override an
-      explicit choice), the recommended platform is not available, or the
-      recommendation already matches the default backend.
+    - ``device=None`` does not intervene in JAX placement;
+    - ``device="auto"`` applies :func:`recommended_device` **unless** the user
+      selected an active :func:`jax.default_device` context or pinned
+      ``JAX_PLATFORMS``/``JAX_PLATFORM_NAME``, the recommended platform is not
+      available, or it already matches the default backend.
     """
     if device is None:
-        if _user_pinned_platform():
+        return None
+    if hasattr(device, "platform"):  # already a jax.Device
+        return device
+    kind = str(device).strip().lower()
+    if kind == AUTO:
+        if _user_selected_placement():
             return None
+        if resolution is None:
+            raise ValueError("resolution is required when device='auto'")
         kind = recommended_device(resolution)
         default = jax.default_backend()
         if kind == "gpu":
@@ -110,20 +123,17 @@ def resolve_device(device: Any, resolution: Any):
         if default == "cpu":
             return None  # already on CPU
         return jax.devices("cpu")[0]
-    if hasattr(device, "platform"):  # already a jax.Device
-        return device
-    kind = str(device).strip().lower()
     if kind in ("gpu", "cuda", "rocm"):
         return jax.devices("gpu")[0]
     if kind in ("cpu", "tpu"):
         return jax.devices(kind)[0]
     raise ValueError(
-        f"unknown device {device!r}; expected 'cpu', 'gpu', 'cuda', 'rocm', "
-        "'tpu' or a jax.Device"
+        f"unknown device {device!r}; expected 'auto', None, 'cpu', 'gpu', "
+        "'cuda', 'rocm', 'tpu' or a jax.Device"
     )
 
 
-def resolve_implicit_device(device: Any, resolution: Any):
+def resolve_implicit_device(device: Any = AUTO, resolution: Any = None):
     """Device for the implicit-gradient Jacobian / adjoint GMRES (or ``None``).
 
     Unlike the forward solve, the ``jac="implicit"`` path builds a per-dof
@@ -133,23 +143,24 @@ def resolve_implicit_device(device: Any, resolution: Any):
     bound.  Measured on 2x RTX A4000 (R1, ``benchmarks`` notes) it is
     *slower* on the GPU than on the CPU at every optimization size tested: a
     ``max_mode=2`` QH stage (24 dofs) did not finish a single Jacobian eval in
-    37 min on the GPU, versus minutes on the CPU; the forward solve itself is a
-    host callback that never touches the accelerator.  So the default here is
+    37 min on the GPU, versus minutes on the CPU.  The forward equilibrium
+    callback uses the solver's independent automatic per-stage policy; this
+    resolver controls only the residual/Jacobian work.  So the default here is
     always the CPU:
 
-    - an explicit ``device`` (``"cpu"``/``"gpu"``/... or a ``jax.Device``) is
-      still honored (delegated to :func:`resolve_device`);
-    - a user ``JAX_PLATFORMS``/``JAX_PLATFORM_NAME`` pin stands down
-      (returns ``None`` — leave placement alone);
-    - otherwise pin to the CPU when the default backend is an accelerator, or
-      leave placement untouched (``None``) when already on the CPU.
+    - explicit devices are honored (delegated to :func:`resolve_device`);
+    - ``None`` leaves placement to JAX;
+    - ``"auto"`` stands down for an active JAX device/platform selection and
+      otherwise pins to CPU on an accelerator backend.
 
     ``resolution`` is accepted for signature parity with :func:`resolve_device`
     (and in case a size-dependent rule is wanted later); it is unused today.
     """
-    if device is not None:
+    if device is None:
+        return None
+    if not (isinstance(device, str) and device.strip().lower() == AUTO):
         return resolve_device(device, resolution)
-    if _user_pinned_platform():
+    if _user_selected_placement():
         return None
     if jax.default_backend() == "cpu":
         return None
@@ -159,7 +170,7 @@ def resolve_implicit_device(device: Any, resolution: Any):
         return None
 
 
-def device_context(device: Any, resolution: Any):
+def device_context(device: Any = AUTO, resolution: Any = None):
     """Context manager placing a solve stage on the resolved device.
 
     Returns ``jax.default_device(dev)`` for the :func:`resolve_device` result,

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -196,12 +196,13 @@ def params_from_input(inp: VmecInput) -> ImplicitParams:
     a ``jax.grad``/``jax.jacrev`` over :func:`run` then executes there, which
     is where the launch-bound implicit adjoint is fastest — measured 57 s
     (GPU) vs seconds (CPU) for one solovev ``value_and_grad`` (R24).
-    A user ``JAX_PLATFORMS`` pin or an already-CPU backend stands the pin
-    down; ``optimize.least_squares`` applies the same rule to its dof vector.
+    An active ``jax.default_device`` context, user JAX platform pin, or an
+    already-CPU backend stands the pin down; ``optimize.least_squares``
+    applies the same rule to its dof vector.
     """
-    from .device import resolve_implicit_device
+    from .device import AUTO, resolve_implicit_device
 
-    dev = resolve_implicit_device(None, None)
+    dev = resolve_implicit_device(AUTO, None)
     if dev is None:
         arr = lambda a: jnp.asarray(np.asarray(a, dtype=np.float64))  # noqa: E731
     else:

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -40,7 +40,7 @@ import numpy as np
 
 import jax.numpy as jnp
 
-from .device import device_context
+from .device import AUTO, device_context
 from .errors import MORE_ITER_FLAG, SUCCESSFUL_TERM_FLAG
 from .fourier import ModeTable
 from .input import VmecInput
@@ -188,7 +188,7 @@ def solve_multigrid(
     initial_state: SpectralState | None = None,
     time_step: float | None = None, tcon0: float | None = None,
     gamma: float | None = None, nstep: int | None = None,
-    device: Any = None,
+    device: Any = AUTO,
     raise_on_max_iterations: bool = True,
 ) -> SolveResult:
     """Fixed-boundary multigrid solve over the ``NS_ARRAY`` ladder.
@@ -230,9 +230,10 @@ def solve_multigrid(
 
     ``device`` places each stage's jitted lanes (see
     :func:`vmex.core.solver.solve`): an explicit ``"cpu"``/``"gpu"``/
-    ``jax.Device`` is always honored; ``None`` (default) applies the measured
-    per-stage policy of :mod:`vmex.core.device` (small per-iteration work
-    solves on CPU) unless the user pinned ``JAX_PLATFORMS``.
+    ``jax.Device`` is always honored; ``"auto"`` (default) applies the
+    measured per-stage policy of :mod:`vmex.core.device`, while ``None``
+    follows JAX placement.  Auto never overrides an active JAX device or
+    platform selection.
 
     Returns the final stage's :class:`~vmex.core.solver.SolveResult`.
     """

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -85,6 +85,7 @@ from solvax import (
     chunk_map,
 )
 
+from .device import AUTO
 from .input import VmecInput
 from .multigrid import solve_multigrid
 from .solver import (
@@ -1136,7 +1137,7 @@ def least_squares(
     warm_start: str | None = "perturbation",
     use_ess: bool = False,
     ess_alpha: float = 1.2,
-    device: Any = None,
+    device: Any = AUTO,
     solve_kwargs: dict | None = None,
     verbose: int = 0,
     **scipy_kwargs,
@@ -1185,7 +1186,8 @@ def least_squares(
     solver reuses one XLA executable across all boundary trials
     (``vmex.core.solver`` Phase-2 cache; only the first solve of
     a stage compiles).  ``device`` is forwarded to the solver
-    (:mod:`vmex.core.device` policy applies when ``None``).
+    (``"auto"`` applies :mod:`vmex.core.device`'s policy; ``None`` follows
+    JAX placement).
 
     ``use_ess`` enables Exponential Spectral Scaling of the trust region
     (:func:`_ess_scale`, ``ess_alpha``), the legacy ``use_ess`` option.
@@ -1331,8 +1333,7 @@ def least_squares(
         raise ValueError(f"jac must be None or 'implicit', got {jac!r}")
 
     solve_kwargs = dict(solve_kwargs or {})
-    if device is not None:
-        solve_kwargs.setdefault("device", device)
+    solve_kwargs.setdefault("device", device)
     if use_ess:
         scipy_kwargs.setdefault("x_scale", _ess_scale_full())
     if x0 is None:
@@ -1428,7 +1429,7 @@ def _least_squares_implicit(
     recycle: bool = False,
     warm_start: str | None = "perturbation",
     solve_kwargs: dict,
-    device: Any = None,
+    device: Any = AUTO,
     verbose: int = 0,
     **scipy_kwargs,
 ):

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -125,7 +125,7 @@ _harden_compilation_cache()
 import jax.numpy as jnp
 from jax import lax
 
-from .device import device_context
+from .device import AUTO, device_context
 from .errors import (
     BAD_JACOBIAN_FLAG, JAC75_FLAG, MISC_ERROR_FLAG, MORE_ITER_FLAG,
     NORM_TERM_FLAG, SUCCESSFUL_TERM_FLAG, VmecConvergenceError,
@@ -1450,7 +1450,7 @@ def solve(
     gamma: float | None = None, nstep: int | None = None,
     lconm1: bool = True, verbose: bool = False, emit=print,
     initial_state: SpectralState | None = None,
-    device: Any = None,
+    device: Any = AUTO,
     precon_type: str | None = None, prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
 ) -> SolveResult:
@@ -1484,10 +1484,10 @@ def solve(
     the interior and lambda are kept.
 
     ``device`` places the jitted iteration lanes: ``"cpu"``/``"gpu"``/
-    ``"cuda"``/``"tpu"`` or a ``jax.Device`` (always honored), or ``None``
-    (default) to apply the measured small-work-to-CPU policy of
-    :mod:`vmex.core.device` — which never overrides a user-pinned
-    ``JAX_PLATFORMS``/``JAX_PLATFORM_NAME``.
+    ``"cuda"``/``"tpu"`` or a ``jax.Device`` (always honored), ``"auto"``
+    (default) to apply the measured small-work-to-CPU policy, or ``None`` to
+    follow JAX placement.  The automatic policy never overrides an active
+    ``jax.default_device`` context or user-pinned JAX platform.
 
     ``precon_type`` (``"NONE"`` default) with a finite ``prec2d_threshold`` —
     or an explicit ``prec2d``


### PR DESCRIPTION
## Summary

Define a consistent JAX device-placement contract without requiring platform-selection environment variables.

## Main changes

- Distinguish omitted/`"auto"` placement from explicit `device=None`.
- Preserve VMEX's measured size-based CPU/GPU policy for automatic forward solves.
- Honor explicit CPU, GPU, CUDA, ROCm, TPU, and `jax.Device` selections.
- Respect active `jax.default_device(...)` contexts and existing JAX platform pins.
- Read user placement through JAX's configuration API rather than inspecting
  platform-selection environment variables in the resolver.
- Raise a clear error when the resolution-dependent automatic helper is called
  without a resolution, instead of failing with an attribute error.
- Apply the same contract across solver, multigrid, optimizer, and implicit defaults.

## Results

- Device resolution, explicit override, unavailable-hardware, and active-context tests pass.
- The cumulative stack passes the focused CPU/GPU parity and feature campaigns listed below.
- Existing calls that omit `device` retain VMEX's automatic policy; explicit `None` intentionally follows JAX.

## Validation

- Focused CPU fixed/free-boundary, multigrid, hot-restart, WOUT, and parity
  suite: `89 passed, 13 skipped, 2 xfailed`.
- The exact local CPU `RUN_FULL=1` execution collected `750` tests and reported
  `715 passed, 32 skipped, 2 xfailed`, plus one basin-sensitive QP assertion.
  That run reduced QP by 22.5% (`0.445789 -> 0.345527`), satisfying the restored
  relative 15% guard; the corrected exact test then passed in `699.46 s`.
- Office CUDA 13 focused placement/parity suite: `33 passed` on two RTX A4000s
  with Python 3.12.13 and JAX/JAXlib 0.11.0, with routing variables unset.
- Current five-physics CPU/GPU audit: MHD (`2.46e-15`), well (`1.67e-11`),
  DMerc (`1.59e-11`), quasisymmetry (`3.89e-15`), and quasi-isodynamicity
  (`4.88e-15`) relative gradient differences; forward-state difference zero.
- Deep DMerc CPU/GPU parity covers three Solovev boundary components,
  pressure, two 3-D boundary components, and toroidal current; worst relative
  difference `6.00e-11`.
- Final stack checks: CI-scope Ruff, mypy, `git diff --check`, strict Sphinx, and wheel/sdist builds pass.

Stack 1/8. Merge before `codex/implicit-device-api`.
