### PR TITLE
implicit: expose explicit CPU and GPU placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,9 @@ for QP. Three measured optimizations keep each campaign in the minutes range:
 
 The implicit path runs on CPU by default, where it is fastest at production
 sizes; high-resolution forward solves can use the GPU. The device policy
-chooses per stage.
+chooses per stage, and `device="cpu"` / `device="gpu"` explicitly overrides
+it without environment variables. Passing `device=None` leaves placement to
+JAX; omitting it retains VMEX's measured automatic policy.
 
 ### Beyond quasisymmetry: any objective, same gradients
 

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -148,10 +148,17 @@ of :doc:`algorithms` for the formulation and cost analysis.
    from vmex.core.input import VmecInput
 
    inp = VmecInput.from_file("input.solovev")
-   p0 = implicit.params_from_input(inp)
+   p0 = implicit.params_from_input(inp, device="gpu")
 
    sol = implicit.run(inp, p0)                        # ImplicitSolution pytree
    grad = jax.grad(lambda p: implicit.run(inp, p).wb)(p0)   # adjoint gradient
+
+Pass ``device="cpu"`` / ``"gpu"`` (or a ``jax.Device``) to
+:func:`~vmex.core.implicit.params_from_input` or
+:func:`~vmex.core.implicit.run` to select the implicit-gradient hardware
+without environment variables.  ``device=None`` leaves placement to JAX;
+omitting the argument (or passing ``"auto"``) keeps VMEX's default CPU
+preference for this launch-bound path.
 
 :func:`~vmex.core.implicit.run` is the differentiable member of the
 entry-point family (see *Choosing an entry point* in :doc:`quickstart`; the

--- a/tests/test_implicit_device.py
+++ b/tests/test_implicit_device.py
@@ -1,0 +1,95 @@
+"""Focused placement tests for the public implicit-differentiation API."""
+
+from __future__ import annotations
+
+import jax
+import pytest
+
+from vmex.core import implicit as im
+from vmex.core import optimize as opt
+from vmex.core.device import AUTO
+from vmex.core.input import VmecInput
+
+
+class _Stop(Exception):
+    pass
+
+
+def _device(kind):
+    try:
+        return jax.devices(kind)[0]
+    except RuntimeError:
+        pytest.skip(f"{kind.upper()} unavailable")
+
+
+def _platforms(params):
+    def platform(array):
+        device = array.device
+        return (device() if callable(device) else device).platform
+
+    return {platform(leaf) for leaf in jax.tree.leaves(params)}
+
+
+@pytest.mark.parametrize("kind", ["cpu", "gpu"])
+def test_params_from_input_honors_explicit_device(kind):
+    params = im.params_from_input(VmecInput(), device=_device(kind))
+    assert _platforms(params) == {kind}
+
+
+@pytest.mark.parametrize("requested", [AUTO, None, "cpu"])
+def test_run_forwards_device_when_constructing_params(monkeypatch, requested):
+    seen = []
+
+    def params_from_input(inp, *, device=None):
+        seen.append(device)
+        raise _Stop
+
+    monkeypatch.setattr(im, "params_from_input", params_from_input)
+    with pytest.raises(_Stop):
+        im.run(VmecInput(), device=requested)
+    assert seen == [requested]
+
+
+def test_run_preserves_supplied_params_for_auto_and_none(monkeypatch):
+    params = im.params_from_input(VmecInput(), device="cpu")
+
+    def solve_implicit(got, cfg):
+        assert got is params
+        raise _Stop
+
+    monkeypatch.setattr(im, "solve_implicit", solve_implicit)
+    for requested in (AUTO, None):
+        with pytest.raises(_Stop):
+            im.run(VmecInput(), params, device=requested)
+
+
+@pytest.mark.parametrize("kind", ["cpu", "gpu"])
+def test_run_places_supplied_params_on_requested_device(monkeypatch, kind):
+    requested = _device(kind)
+    inp = VmecInput()
+    params = im.params_from_input(inp, device="cpu")
+
+    def solve_implicit(got, cfg):
+        assert _platforms(got) == {kind}
+        raise _Stop
+
+    monkeypatch.setattr(im, "solve_implicit", solve_implicit)
+    with pytest.raises(_Stop):
+        im.run(inp, params, device=requested)
+
+
+def test_least_squares_places_params_on_jacobian_device(monkeypatch):
+    requested = _device("cpu")
+    seen = []
+
+    def params_from_input(inp, *, device=None):
+        seen.append(device)
+        raise _Stop
+
+    monkeypatch.setattr(im, "params_from_input", params_from_input)
+    with pytest.raises(_Stop):
+        opt.least_squares(
+            [(opt.aspect_ratio, 4.0, 1.0)], VmecInput(), jac="implicit",
+            device=requested,
+        )
+    assert seen == [requested]

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -117,6 +117,7 @@ from jax.flatten_util import ravel_pytree
 from solvax import gcrot as _solvax_gcrot
 from solvax import gmres as _solvax_gmres
 
+from .device import AUTO, resolve_implicit_device
 from .errors import VmecError
 from .fields import magnetic_fields, metric_elements
 from .fourier import Resolution
@@ -188,7 +189,7 @@ class ImplicitParams:
 _register(ImplicitParams)
 
 
-def params_from_input(inp: VmecInput) -> ImplicitParams:
+def params_from_input(inp: VmecInput, *, device: Any = AUTO) -> ImplicitParams:
     """Extract the differentiable parameters of an input as a pytree.
 
     On an accelerator box the pytree is *committed* to the CPU
@@ -199,10 +200,11 @@ def params_from_input(inp: VmecInput) -> ImplicitParams:
     An active ``jax.default_device`` context, user JAX platform pin, or an
     already-CPU backend stands the pin down; ``optimize.least_squares``
     applies the same rule to its dof vector.
+    Pass ``device="cpu"`` / ``"gpu"`` or a ``jax.Device`` to override
+    the automatic policy without configuring the process environment;
+    ``device=None`` leaves placement to JAX.
     """
-    from .device import AUTO, resolve_implicit_device
-
-    dev = resolve_implicit_device(AUTO, None)
+    dev = resolve_implicit_device(device, None)
     if dev is None:
         arr = lambda a: jnp.asarray(np.asarray(a, dtype=np.float64))  # noqa: E731
     else:
@@ -1384,6 +1386,7 @@ def run(
     adjoint_maxiter: int = 300,
     adjoint_gcrot_m: int = 100,
     adjoint_gcrot_k: int = 20,
+    device: Any = AUTO,
 ) -> ImplicitSolution:
     """Differentiable fixed-boundary equilibrium: input -> outputs pytree.
 
@@ -1391,13 +1394,20 @@ def run(
     traced :class:`ImplicitParams` to differentiate::
 
         inp = VmecInput.from_file("input.solovev")
-        p0 = params_from_input(inp)
+        p0 = params_from_input(inp, device="gpu")
         grad = jax.grad(lambda p: run(inp, p).wb)(p0)
 
     ``wmhd`` follows the printed ``WMHD`` normalization; ``gamma = 1`` inputs
     get ``wmhd = nan`` (as in VMEC).  All outputs are differentiable in
     ``params`` (state via the implicit adjoint; scalars additionally through
     their explicit parameter dependence).
+
+    ``device`` selects where implicit residual and adjoint operations run.
+    It accepts ``"cpu"``, ``"gpu"`` or a ``jax.Device``; ``"auto"`` keeps
+    the default CPU preference for this launch-bound path, while ``None``
+    leaves placement to JAX.  When ``params`` is supplied, an explicit
+    hardware device moves the complete parameter pytree consistently;
+    otherwise its existing placement is preserved.
 
     The returned solution also carries the internally built
     :class:`~vmex.core.solver.SolverRuntime` as ``sol.runtime`` (a
@@ -1414,7 +1424,13 @@ def run(
         adjoint_gcrot_m=adjoint_gcrot_m, adjoint_gcrot_k=adjoint_gcrot_k,
     )
     if params is None:
-        params = params_from_input(inp)
+        params = params_from_input(inp, device=device)
+    elif device is not None and not (
+        isinstance(device, str) and device.strip().lower() == AUTO
+    ):
+        dev = resolve_implicit_device(device, cfg.resolution)
+        if dev is not None:
+            params = jax.tree.map(lambda a: jax.device_put(a, dev), params)
     state = solve_implicit(params, cfg)
     rt = runtime_from_params(params, cfg)
     wb, wp = mhd_energy(state, rt)

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -1454,8 +1454,8 @@ def _least_squares_implicit(
     :func:`vmex.core.device.resolve_implicit_device` — the CPU by default,
     where the per-dof vmapped adjoint GMRES is far faster than the
     launch-bound, dof-count-scaling GPU compile (R1); an explicit
-    ``device=`` overrides this.  The forward equilibrium solve is a host
-    callback and always runs on the CPU regardless.
+    ``device=`` overrides this.  The forward equilibrium callback uses the
+    solver's independent automatic per-stage placement policy.
     """
     import scipy.optimize
 
@@ -1513,7 +1513,7 @@ def _least_squares_implicit(
         a = jnp.asarray(x, dtype=jnp.float64)
         return a if jac_device is None else jax.device_put(a, jac_device)
 
-    params0 = imp.params_from_input(inp)
+    params0 = imp.params_from_input(inp, device=jac_device)
     imp._template_runtime(cfg)  # host-built template: warm the per-cfg cache
     # eagerly so runtime_from_params stays traceable under jit below
 


### PR DESCRIPTION
## Summary

Allow implicit solves and gradients to select hardware through the Python API.

## Main changes

- Add `device=` to `implicit.params_from_input` and `implicit.run`.
- Place the complete parameter pytree consistently for an explicit device.
- Preserve an existing parameter pytree's placement when no override is requested.
- Align implicit least-squares initialization with the selected device.
- Test automatic, JAX-controlled, CPU, GPU, and `jax.Device` behavior.

## Results

- Explicit CPU/GPU parameter and gradient-tree placement pass.
- CPU/GPU implicit MHD-energy gradient relative difference: `6.2e-15`.
- Automatic implicit placement still prefers CPU on the measured GPUs because this path is launch-bound; users can explicitly request GPU without environment variables.

## Validation

- Focused CPU fixed/free-boundary, multigrid, hot-restart, WOUT, and parity
  suite: `89 passed, 13 skipped, 2 xfailed`.
- The exact local CPU `RUN_FULL=1` execution collected `750` tests and reported
  `715 passed, 32 skipped, 2 xfailed`, plus one basin-sensitive QP assertion.
  That run reduced QP by 22.5% (`0.445789 -> 0.345527`), satisfying the restored
  relative 15% guard; the corrected exact test then passed in `699.46 s`.
- Office CUDA 13 focused placement/parity suite: `33 passed` on two RTX A4000s
  with Python 3.12.13 and JAX/JAXlib 0.11.0, with routing variables unset.
- Current five-physics CPU/GPU audit: MHD (`2.46e-15`), well (`1.67e-11`),
  DMerc (`1.59e-11`), quasisymmetry (`3.89e-15`), and quasi-isodynamicity
  (`4.88e-15`) relative gradient differences; forward-state difference zero.
- Deep DMerc CPU/GPU parity covers three Solovev boundary components,
  pressure, two 3-D boundary components, and toroidal current; worst relative
  difference `6.00e-11`.
- Final stack checks: CI-scope Ruff, mypy, `git diff --check`, strict Sphinx, and wheel/sdist builds pass.

Stack 2/8. Depends on `codex/device-contract`; merge before `codex/public-device-api`.
