### PR TITLE
core: expose device selection in free-boundary and CLI solves

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,8 @@ options:
   --outdir PATH          directory for wout/boozmn/figure output
   --mode {cli,jit}       jitted blocks with live printing (cli, default)
                          or a single lax.while_loop (jit)
+  --device PLATFORM      auto (default), none (follow JAX), cpu, gpu,
+                         cuda, rocm, or tpu; applies to all solve paths
   --ftol F               override the final-stage FTOL_ARRAY tolerance
   --max-iter N           override the final-stage NITER_ARRAY cap
   --coils PATH           ESSOS-style coils file: drive an LFREEB = T deck
@@ -479,9 +481,9 @@ options:
   --quiet                silence the VMEC-style stdout
 ```
 
-`vmec` follows the selected JAX backend: with CPU-only JAX it runs on the
-CPU; with CUDA-enabled JAX it uses the GPU for the solver stages where that
-is faster (`JAX_PLATFORMS=cpu|cuda` pins it explicitly).
+`vmec` detects the available JAX hardware without environment variables and
+uses CPU or GPU according to the measured per-stage policy. Use
+`--device cpu` or `--device gpu` to override it explicitly.
 
 ## Documentation
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -54,6 +54,10 @@ Options
      - Solver lane: ``cli`` (jitted blocks with host residual checks, live
        printing, exact-``ftol`` exit; default) or ``jit`` (single
        ``lax.while_loop``).
+   * - ``--device {auto,none,cpu,gpu,cuda,rocm,tpu}``
+     - JAX solve placement. ``auto`` (default) applies VMEX's measured policy,
+       ``none`` leaves placement to JAX, and the other values request a
+       platform explicitly. This applies to fixed- and free-boundary solves.
    * - ``--ftol X``
      - Override the final-stage ``FTOL_ARRAY`` tolerance.
    * - ``--max-iter N``

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -39,6 +39,8 @@ writes ``wout_circular_tokamak.nc`` next to the input file. Useful flags:
 - ``--quiet`` — silence the iteration table,
 - ``--ftol X`` / ``--max-iter N`` — override the final-stage tolerance or
   iteration cap,
+- ``--device cpu|gpu`` — select a platform explicitly; ``auto`` applies
+  VMEX's measured policy and ``none`` leaves placement to JAX,
 - ``--mode jit`` — run the fully traced ``lax.while_loop`` solver lane instead
   of the default host-blocked CLI lane (see :doc:`architecture`).
 

--- a/tests/test_cli_device.py
+++ b/tests/test_cli_device.py
@@ -1,0 +1,63 @@
+"""Focused CLI device-selection parsing and solver forwarding tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vmex.core import cli, freeboundary, multigrid, solver
+
+
+def test_device_option_parses_supported_choices():
+    parser = cli.build_parser()
+    assert parser.parse_args(["input.case"]).device == "auto"
+    assert parser.parse_args(["input.case", "--device", "none"]).device == "none"
+    assert parser.parse_args(["input.case", "--device", "gpu"]).device == "gpu"
+    with pytest.raises(SystemExit):
+        parser.parse_args(["input.case", "--device", "quantum"])
+
+
+@pytest.mark.parametrize(("choice", "expected"), [("none", None), ("cpu", "cpu")])
+def test_fixed_boundary_cli_forwards_device(monkeypatch, tmp_path, choice, expected):
+    args = cli.build_parser().parse_args(["input.case", "--quiet", "--device", choice])
+    inp = object()
+    seen = {}
+
+    monkeypatch.setattr(cli, "_read_input", lambda _: inp)
+    monkeypatch.setattr(cli, "_free_boundary_plan", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "_stage_overrides", lambda *a, **k: (None, None))
+    monkeypatch.setattr(cli, "_write_wout_from_result", lambda *a, **k: object())
+
+    def fake_solve(source, **kwargs):
+        seen.update(kwargs)
+        return SimpleNamespace(converged=True, ier_flag=0)
+
+    monkeypatch.setattr(multigrid, "solve_multigrid", fake_solve)
+    assert cli._solve_input_file(args, tmp_path / "input.case", tmp_path, emit=print) == 0
+    assert seen["device"] == expected
+
+
+def test_free_boundary_cli_forwards_device(monkeypatch, tmp_path):
+    args = cli.build_parser().parse_args(
+        ["input.case", "--quiet", "--device", "gpu"]
+    )
+    inp = SimpleNamespace(ns_array=[11])
+    plan = SimpleNamespace(solver_kwargs={})
+    resolution = object()
+    seen = {}
+
+    monkeypatch.setattr(cli, "_read_input", lambda _: inp)
+    monkeypatch.setattr(cli, "_free_boundary_plan", lambda *a, **k: plan)
+    monkeypatch.setattr(cli, "_final_stage_params", lambda *a, **k: (11, 1e-8, 3))
+    monkeypatch.setattr(cli, "_write_wout_from_result", lambda *a, **k: object())
+    monkeypatch.setattr(solver, "resolution_from_input", lambda *a, **k: resolution)
+
+    def fake_solve(source, **kwargs):
+        seen.update(kwargs)
+        return SimpleNamespace(converged=True, ier_flag=0)
+
+    monkeypatch.setattr(freeboundary, "solve_free_boundary", fake_solve)
+    assert cli._solve_input_file(args, tmp_path / "input.case", tmp_path, emit=print) == 0
+    assert seen["device"] == "gpu"
+    assert seen["resolution"] is resolution

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -13,6 +13,7 @@ import jax
 import pytest
 
 from vmex.core import device as dev
+from vmex.core import freeboundary
 from vmex.core.fourier import Resolution
 
 
@@ -156,3 +157,30 @@ def test_device_context_wraps_default_device_for_explicit_cpu():
     assert not isinstance(ctx, contextlib.nullcontext)
     with ctx:
         pass
+
+
+def test_free_boundary_uses_shared_device_context(monkeypatch):
+    resolution = _res(ns=11, mpol=6, ntor=0)
+    seen = {}
+
+    @contextlib.contextmanager
+    def fake_context(device, resolved):
+        seen["context"] = (device, resolved)
+        yield
+
+    def fake_solve(inp, **kwargs):
+        seen["solve"] = (inp, kwargs)
+        return "result"
+
+    monkeypatch.setattr(freeboundary, "device_context", fake_context)
+    monkeypatch.setattr(freeboundary, "_solve_free_boundary_impl", fake_solve)
+    inp = object()
+    result = freeboundary.solve_free_boundary(
+        inp, resolution=resolution, device="cpu", max_iterations=3
+    )
+
+    assert result == "result"
+    assert seen["context"] == ("cpu", resolution)
+    assert seen["solve"][0] is inp
+    assert seen["solve"][1]["resolution"] is resolution
+    assert seen["solve"][1]["max_iterations"] == 3

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -191,6 +191,16 @@ def build_parser() -> argparse.ArgumentParser:
             "printing, exact-ftol exit) or 'jit' (single lax.while_loop)."
         ),
     )
+    p.add_argument(
+        "--device",
+        type=str,
+        default="auto",
+        choices=("auto", "none", "cpu", "gpu", "cuda", "rocm", "tpu"),
+        help=(
+            "JAX solve placement: automatic VMEX policy (default), 'none' to "
+            "follow JAX, or an explicit platform."
+        ),
+    )
     p.add_argument("--ftol", type=float, default=None, help="Override the final-stage FTOL_ARRAY tolerance.")
     p.add_argument("--max-iter", type=int, default=None, help="Override the final-stage NITER_ARRAY iteration cap.")
     p.add_argument(
@@ -586,6 +596,7 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
             verbose=verbose,
             emit=emit,
             error_on_no_convergence=False,
+            device=None if args.device == "none" else args.device,
             **freeb_plan.solver_kwargs,
         )
     else:
@@ -599,6 +610,7 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
             mode=str(args.mode),
             verbose=verbose,
             emit=emit,
+            device=None if args.device == "none" else args.device,
         )
     solve_s = time.perf_counter() - t1
 

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -51,6 +51,7 @@ import jax.numpy as jnp
 from jax import lax
 
 from . import profiles as _profiles
+from .device import AUTO, device_context
 from .errors import MORE_ITER_FLAG, SUCCESSFUL_TERM_FLAG
 from .fields import magnetic_fields, metric_elements
 from .fourier import ModeTable
@@ -974,7 +975,7 @@ def _make_vacuum_lane(fused: FusedVacuum):
 # ---------------------------------------------------------------------------
 
 
-def solve_free_boundary(
+def _solve_free_boundary_impl(
     inp: VmecInput,
     *,
     mgrid_path: str | Path | None = None,
@@ -1192,3 +1193,37 @@ def solve_free_boundary(
     if ier == SUCCESSFUL_TERM_FLAG:
         return _result_from_carry(carry, rt_freeb if fb.turned_on else rt_fixed)
     return _finalize(carry, rt_freeb if fb.turned_on else rt_fixed)
+
+
+def solve_free_boundary(
+    inp: VmecInput,
+    *,
+    mgrid_path: str | Path | None = None,
+    external_field: MgridField | None = None,
+    resolution=None,
+    ftol: float | None = None,
+    max_iterations: int | None = None,
+    verbose: bool = False,
+    emit=print,
+    error_on_no_convergence: bool = True,
+    device: Any = AUTO,
+) -> SolveResult:
+    """Run a single-grid free-boundary solve on the selected JAX device.
+
+    ``device`` has the same semantics as :func:`vmex.core.solver.solve`:
+    explicit devices are honored, ``"auto"`` applies VMEX's measured policy,
+    and ``None`` leaves placement to JAX.
+    """
+    resolved = resolution if resolution is not None else resolution_from_input(inp)
+    with device_context(device, resolved):
+        return _solve_free_boundary_impl(
+            inp,
+            mgrid_path=mgrid_path,
+            external_field=external_field,
+            resolution=resolved,
+            ftol=ftol,
+            max_iterations=max_iterations,
+            verbose=verbose,
+            emit=emit,
+            error_on_no_convergence=error_on_no_convergence,
+        )


### PR DESCRIPTION
## Summary

Expose the device contract through the remaining public core solve paths and command-line interface.

## Main changes

- Add `device=` to the free-boundary solver and run the complete operation under the selected context.
- Add `--device {auto,none,cpu,gpu,cuda,rocm,tpu}` to the CLI.
- Forward selection through fixed- and free-boundary solve paths.
- Document and test explicit selection and JAX-controlled placement.

## Results

- Fixed- and free-boundary device forwarding tests pass.
- Existing CLI examples and package API tests remain green.
- Explicit CPU/GPU forward states agree to the established numerical tolerances.
- Solovev CPU/GPU solves take the same 183 iterations.
- A CTH multigrid `[5, 9, 15]` solve takes the same 325 iterations on CPU/GPU;
  the largest reported relative field difference is `1.90e-13`.
- A converged CTH free-boundary solve takes the same 574 iterations on CPU/GPU;
  the largest reported relative field difference is `3.43e-13`.
- Cross-device hot restart takes 298 iterations versus 435 cold, with CPU/GPU
  hot-state relative differences no larger than `2.65e-13`.
- On the same 1% CTH boundary perturbation, VMEX cold matches VMEC2000 cold in
  `wb/rmnc/zmns/iota` to `2.95e-14` or better. VMEX's adapted-state restart
  takes 298 iterations; VMEC2000's raw WOUT reset takes 444 versus 435 cold,
  showing that restart speed is a policy/path property rather than a parity gate.

## Scope

Mirror-equilibrium placement is unchanged; its host/SciPy execution model needs a separately measured policy.

## Validation

- Focused CPU fixed/free-boundary, multigrid, hot-restart, WOUT, and parity
  suite: `89 passed, 13 skipped, 2 xfailed`.
- The exact local CPU `RUN_FULL=1` execution collected `750` tests and reported
  `715 passed, 32 skipped, 2 xfailed`, plus one basin-sensitive QP assertion.
  That run reduced QP by 22.5% (`0.445789 -> 0.345527`), satisfying the restored
  relative 15% guard; the corrected exact test then passed in `699.46 s`.
- Office CUDA 13 focused placement/parity suite: `33 passed` on two RTX A4000s
  with Python 3.12.13 and JAX/JAXlib 0.11.0, with routing variables unset.
- Current five-physics CPU/GPU audit: MHD (`2.46e-15`), well (`1.67e-11`),
  DMerc (`1.59e-11`), quasisymmetry (`3.89e-15`), and quasi-isodynamicity
  (`4.88e-15`) relative gradient differences; forward-state difference zero.
- Deep DMerc CPU/GPU parity covers three Solovev boundary components,
  pressure, two 3-D boundary components, and toroidal current; worst relative
  difference `6.00e-11`.
- Final stack checks: CI-scope Ruff, mypy, `git diff --check`, strict Sphinx, and wheel/sdist builds pass.

Stack 3/8. Depends on `codex/implicit-device-api`; merge before `codex/gpu-ci`.
