### PR TITLE
stability: add a traceable JAX Mercier profile

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -97,8 +97,9 @@ Module map
        self-consistency Picard loop
      - (no VMEC2000 equivalent; BOOTSJ-adjacent scope)
    * - :mod:`~vmex.core.stability`
-     - infinite-n ideal-ballooning eigenvalue objective (COBRA-style)
-     - (no VMEC2000 equivalent; COBRA companion code)
+     - traceable Mercier profile and infinite-n ideal-ballooning eigenvalue
+       objective (COBRA-style)
+     - ``mercier.f`` / ``jxbforce.f``; COBRA companion code
    * - :mod:`~vmex.core.turbulence`
      - GK flux-tube geometry adapter + SPECTRAX-GK turbulence proxies
      - (no VMEC2000 equivalent)

--- a/docs/confinement.rst
+++ b/docs/confinement.rst
@@ -299,9 +299,12 @@ geodesic term is a manifestly non-positive Schwarz-inequality remainder. Because
 the individual pieces involve radial derivatives of surface averages, the two
 surfaces nearest the axis and the edge carry the usual numerical noise; a
 practical objective penalizes ``min(DMerc[2:-1], 0)``. ``vmex`` exposes the
-profile as :func:`~vmex.core.optimize.d_merc`, evaluated through the
-parity-proven wout engine (host NumPy, hence ``jac=None``); it is validated
-against VMEC2000 golden ``wout`` files.
+reporting profile as :func:`~vmex.core.optimize.d_merc`, evaluated through the
+parity-proven wout engine.  The symmetric live-state counterpart
+:func:`~vmex.core.stability.d_merc_state` is a pure-JAX port of the same
+``jxbforce.f``/``mercier.f`` path for ``jit``/AD use and agrees with the wout
+profile to floating-point round-off.  Both retain VMEC's near-axis and edge
+limitations; the traceable lane does not yet support ``lasym = True``.
 
 Magnetic well
 ~~~~~~~~~~~~~~
@@ -319,10 +322,9 @@ with :math:`V'=dV/ds` extrapolated from the half-mesh differential volume
 :math:`vp` (VMEC ``bcovar.f``). Positive :math:`W` means :math:`V'` decreases
 outward — a magnetic well, favorable for interchange stability — matching
 simsopt's ``vacuum_well``. Being a pure ``(state, runtime)`` function it carries
-exact implicit gradients and is the traceable stand-in whenever the full
-``DMerc`` profile is too expensive or not differentiable. Near-axis analytic
-context for both measures is in Landreman–Jorge (2020) and Kim–Jorge–Dorland
-(2021); see :doc:`references`.
+exact implicit gradients and is a cheaper Mercier-adjacent target. Near-axis
+analytic context for both measures is in Landreman–Jorge (2020) and
+Kim–Jorge–Dorland (2021); see :doc:`references`.
 
 Ideal ballooning
 ~~~~~~~~~~~~~~~~~

--- a/docs/objectives.rst
+++ b/docs/objectives.rst
@@ -107,11 +107,13 @@ and composable with both gradient modes:
 - :func:`~vmex.core.optimize.magnetic_well` — the standard vacuum-well
   measure (negative = well, stabilizing).
 
-Two host-side diagnostics complete the set — they run on the wout engine
-(exact VMEC2000 ``mercier.f``/``jxbforce`` tables) and therefore need
-``jac=None``: :func:`~vmex.core.optimize.d_merc` (Mercier interchange
-criterion) and :func:`~vmex.core.optimize.l_grad_b` (the ``L_grad_B``
-coil-complexity proxy).
+Two reporting diagnostics run on the host-side wout engine:
+:func:`~vmex.core.optimize.d_merc` (Mercier interchange criterion) and
+:func:`~vmex.core.optimize.l_grad_b` (the ``L_grad_B`` coil-complexity proxy).
+Their live-state counterparts :func:`~vmex.core.stability.d_merc_state`
+(``lasym = False``) and :func:`~vmex.core.optimize.l_grad_b_state` are pure
+JAX and can be composed with implicit differentiation.  Direct optimizer
+integration of ``d_merc_state`` is not yet provided by ``d_merc`` itself.
 
 ``L_grad_B`` additionally has a fully traceable ``(state, runtime)`` lane,
 :func:`~vmex.core.optimize.l_grad_b_state` — same convention

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -24,6 +24,7 @@ import numpy as np
 import pytest
 
 import jax
+import jax.numpy as jnp
 
 jax.config.update("jax_enable_x64", True)
 
@@ -66,6 +67,14 @@ def shaped_eq():
     return eq
 
 
+@pytest.fixture(scope="module")
+def finite_beta_3d_eq():
+    """Small finite-beta, current-constrained stellarator equilibrium."""
+    eq = opt.solve_equilibrium(VmecInput.from_file(DATA_DIR / "input.li383_low_res"))
+    assert eq.result.converged
+    return eq
+
+
 def test_zero_pressure_case_is_ballooning_stable(vacuum_eq):
     lam = np.asarray(stab.ballooning_lambda(vacuum_eq.state, vacuum_eq.runtime, **FAST))
     assert lam.shape == (3, 4, 1)  # default surfaces x alphas x zeta0s
@@ -91,6 +100,45 @@ def test_growth_rate_sign_agrees_with_mercier(shaped_eq):
     lam_max = float(stab.ballooning_growth_rate(
         shaped_eq.state, shaped_eq.runtime, reduction="max", **FAST))
     assert lam_max < 0.0
+
+
+def test_traceable_dmerc_matches_wout_and_has_state_jvp(shaped_eq):
+    """Pure-JAX Mercier profile retains wout parity and a finite tangent."""
+    state, rt = shaped_eq.state, shaped_eq.runtime
+    expected = np.asarray(opt.d_merc(shaped_eq))
+    actual = np.asarray(jax.jit(stab.d_merc_state)(state, rt))
+    np.testing.assert_allclose(actual[2:-1], expected[2:-1], rtol=1e-8,
+                               atol=1e-13)
+
+    tangent = jax.tree.map(jnp.zeros_like, state)
+    tangent = dataclasses.replace(tangent, R_cos=jnp.ones_like(state.R_cos))
+    _, dmerc_tangent = jax.jvp(lambda st: stab.d_merc_state(st, rt),
+                               (state,), (tangent,))
+    interior = np.asarray(dmerc_tangent)[2:-1]
+    assert np.all(np.isfinite(interior))
+    assert np.any(interior != 0.0)
+
+    def total_dmerc(pressure_scale):
+        setup = dataclasses.replace(rt.setup, mass=rt.setup.mass * pressure_scale)
+        return jnp.sum(stab.d_merc_state(
+            state, dataclasses.replace(rt, setup=setup))[2:-1])
+
+    pressure_grad = jax.grad(total_dmerc)(1.0)
+    assert np.isfinite(float(pressure_grad))
+    assert float(pressure_grad) != 0.0
+    h = 1e-3
+    pressure_fd = (total_dmerc(1.0 + h) - total_dmerc(1.0 - h)) / (2.0 * h)
+    np.testing.assert_allclose(pressure_grad, pressure_fd, rtol=1e-7)
+
+
+def test_traceable_dmerc_matches_wout_in_3d(finite_beta_3d_eq):
+    """The traceable current reconstruction retains toroidal-mode parity."""
+    eq = finite_beta_3d_eq
+    actual = np.asarray(stab.d_merc_state(eq.state, eq.runtime))
+    expected = np.asarray(opt.d_merc(eq))
+    scale = np.max(np.abs(expected[2:-1]))
+    np.testing.assert_allclose(actual[2:-1], expected[2:-1], rtol=1e-10,
+                               atol=1e-13 * scale)
 
 
 def test_reductions_hard_and_smooth_max(highbeta_eq):

--- a/vmex/core/__init__.py
+++ b/vmex/core/__init__.py
@@ -18,7 +18,7 @@ Module map (each header docstring names its VMEC2000 counterpart):
 - ``solver``          single-grid fixed-boundary solve loop (funct3d.f, eqsolve.f)
 - ``statephysics``    shared state-physics primitives (_field_chain, half-mesh iota/sampling)
 - ``implicit``        implicit differentiation of the equilibrium (custom VJP + adjoint GMRES)
-- ``stability``       differentiable ideal-MHD stability (infinite-n ballooning; COBRA port)
+- ``stability``       differentiable ideal-MHD stability (Mercier and infinite-n ballooning)
 - ``freeboundary_diff`` differentiable free-boundary residual via virtual casing (R15.3/R19)
 - ``device``          CPU/GPU placement policy (measured: benchmarks/gpu_baseline.json)
 

--- a/vmex/core/stability.py
+++ b/vmex/core/stability.py
@@ -43,13 +43,9 @@ Scope notes
 - Stellarator-symmetric states only (``lasym = False``), matching the other
   traceable objectives in :mod:`vmex.core.optimize`.
 - Surfaces need ``ι ≠ 0`` (the field-line parameterization divides by ι).
-- A *traceable* Mercier ``DMerc`` was considered for this pass and cut: the
-  parity-proven port (:func:`vmex.core.nyquist.mercier_and_jxb`) needs
-  the jxbforce-filtered covariant field tables and ``bsubs`` synthesis
-  (host-side Nyquist machinery), so a faithful jnp translation is a larger
-  follow-up.  Use :func:`vmex.core.optimize.d_merc` (wout engine,
-  finite-difference-only) and :func:`vmex.core.optimize.magnetic_well`
-  (traceable) for Mercier-adjacent targets meanwhile.
+- :func:`d_merc_state` is the traceable counterpart of the parity-proven
+  wout calculation.  As in VMEC2000, its first two surfaces and edge are not
+  suitable stability targets; use the validated interior profile.
 """
 
 from __future__ import annotations
@@ -66,6 +62,7 @@ from .statephysics import _field_chain, _iotas_half_from_fields
 from .transforms import physical_to_internal_scale
 
 __all__ = [
+    "d_merc_state",
     "ballooning_lambda",
     "ballooning_growth_rate",
 ]
@@ -73,6 +70,156 @@ __all__ = [
 Array = Any
 
 _NEWTON_ITERATIONS = 12  # θ_vmec(θ*) root solve; λ is small, converges fast
+
+
+# ---------------------------------------------------------------------------
+# Mercier profile (mercier.f / jxbforce.f)
+# ---------------------------------------------------------------------------
+
+
+def _mercier_bsubs(geometry, jacobian, fields, s: Array) -> Array:
+    """Traceable ``bss.f`` covariant radial field on the half mesh."""
+    s = jnp.asarray(s)
+    sh = jnp.sqrt(
+        jnp.maximum(
+            jnp.concatenate([0.5 * (s[1:2] + s[:1]), 0.5 * (s[1:] + s[:-1])]),
+            0.0,
+        )
+    )[:, None, None]
+    safe_sh = jnp.where(sh != 0.0, sh, 1.0)
+    rv12 = 0.5 * (
+        geometry.dR_dzeta_even[1:]
+        + geometry.dR_dzeta_even[:-1]
+        + sh[1:] * (geometry.dR_dzeta_odd[1:] + geometry.dR_dzeta_odd[:-1])
+    )
+    zv12 = 0.5 * (
+        geometry.dZ_dzeta_even[1:]
+        + geometry.dZ_dzeta_even[:-1]
+        + sh[1:] * (geometry.dZ_dzeta_odd[1:] + geometry.dZ_dzeta_odd[:-1])
+    )
+    rs12 = jacobian.dR_ds[1:] + 0.25 * (geometry.R_odd[1:] + geometry.R_odd[:-1]) / safe_sh[1:]
+    zs12 = jacobian.dZ_ds[1:] + 0.25 * (geometry.Z_odd[1:] + geometry.Z_odd[:-1]) / safe_sh[1:]
+    rs12 = jnp.concatenate([rs12[:1], rs12])
+    zs12 = jnp.concatenate([zs12[:1], zs12])
+    rv12 = jnp.concatenate([rv12[:1], rv12])
+    zv12 = jnp.concatenate([zv12[:1], zv12])
+    gsu = rs12 * jacobian.ru12 + zs12 * jacobian.zu12
+    gsv = rs12 * rv12 + zs12 * zv12
+    return fields.bsupu * gsu + fields.bsupv * gsv
+
+
+def _mercier_current_tables(bsubu: Array, bsubv: Array, bsubs: Array, rt: SolverRuntime) -> tuple[Array, Array, Array]:
+    """Traceable symmetric jxbforce filter and ``B_s`` derivatives."""
+    trig = rt.trig
+    mmax, nmax = int(rt.resolution.mpol) - 1, int(rt.resolution.ntor)
+    nt2 = int(trig.ntheta2)
+    cosmu = jnp.asarray(trig.cosmu[:nt2, : mmax + 1])
+    sinmu = jnp.asarray(trig.sinmu[:nt2, : mmax + 1])
+    cosmui = jnp.asarray(trig.cosmui[:nt2, : mmax + 1])
+    sinmui = jnp.asarray(trig.sinmui[:nt2, : mmax + 1])
+    cosnv = jnp.asarray(trig.cosnv[:, : nmax + 1])
+    sinnv = jnp.asarray(trig.sinnv[:, : nmax + 1])
+    dmult = jnp.ones((mmax + 1, nmax + 1), dtype=jnp.asarray(bsubu).dtype)
+    mnyq, nnyq = nt2 - 1, int(np.asarray(trig.cosnv).shape[0]) // 2
+    if 0 < mnyq <= mmax:
+        dmult = dmult.at[mnyq].multiply(0.5)
+    if 0 < nnyq <= nmax:
+        dmult = dmult.at[:, nnyq].multiply(0.5)
+
+    def analyze(f, theta, zeta):
+        return jnp.einsum("smk,kn->smn", jnp.einsum("sik,im->smk", f[:, :nt2], theta), zeta) * dmult
+
+    def filter_field(f):
+        c1 = jnp.einsum("smk,kn->smn", jnp.einsum("sik,im->smk", f[:, :nt2], cosmui), cosnv) * dmult
+        c2 = jnp.einsum("smk,kn->smn", jnp.einsum("sik,im->smk", f[:, :nt2], sinmui), sinnv) * dmult
+        return jnp.einsum("smn,im,kn->sik", c1, cosmu, cosnv) + jnp.einsum("smn,im,kn->sik", c2, sinmu, sinnv)
+
+    bsubu, bsubv = filter_field(bsubu), filter_field(bsubv)
+    bsubs_full = bsubs.at[1:-1].set(0.5 * (bsubs[1:-1] + bsubs[2:]))
+    bsubs_full = bsubs_full.at[0].set(0.0)
+    c1 = analyze(bsubs_full[:, :nt2], sinmui, cosnv)
+    c2 = analyze(bsubs_full[:, :nt2], cosmui, sinnv)
+    bsubsu = jnp.einsum("smn,im,kn->sik", c1, jnp.asarray(trig.cosmum[:nt2, : mmax + 1]), cosnv) + jnp.einsum(
+        "smn,im,kn->sik", c2, jnp.asarray(trig.sinmum[:nt2, : mmax + 1]), sinnv
+    )
+    bsubsv = jnp.einsum("smn,im,kn->sik", c1, sinmu, jnp.asarray(trig.sinnvn[:, : nmax + 1])) + jnp.einsum(
+        "smn,im,kn->sik", c2, cosmu, jnp.asarray(trig.cosnvn[:, : nmax + 1])
+    )
+    return bsubu, bsubv, (bsubsu, bsubsv)
+
+
+def d_merc_state(state: SpectralState, rt: SolverRuntime) -> Array:
+    """Traceable VMEC ``DMerc`` profile on the full radial mesh.
+
+    Positive interior values indicate Mercier stability.  This is a pure-JAX
+    port of the symmetric ``jxbforce.f``/``mercier.f`` path used by
+    :func:`vmex.core.nyquist.mercier_and_jxb`; it accepts a live converged
+    ``(state, runtime)`` pair and supports ``jit``, JVP and reverse-mode AD.
+    The axis, first near-axis surface and edge retain VMEC's zero/noisy output
+    convention and should be excluded from objectives (normally ``[2:-1]``).
+    """
+    setup = rt.setup
+    if bool(setup.lasym):
+        raise NotImplementedError("traceable DMerc supports lasym = False only")
+    s = jnp.asarray(setup.s_full)
+    ns = int(s.shape[0])
+    if ns < 3:
+        return jnp.zeros_like(s)
+    geometry, jacobian, _, fields, energies = _field_chain(state, rt)
+    bsubs = _mercier_bsubs(geometry, jacobian, fields, s)
+    bsubu, bsubv, (bsubsu, bsubsv) = _mercier_current_tables(fields.bsubu, fields.bsubv, bsubs, rt)
+
+    hs = 1.0 / float(ns - 1)
+    sign_jac = float(np.sign(setup.signgs)) if int(setup.signgs) != 0 else 1.0
+    wint = jnp.asarray(rt.trig.wint)
+    phip_real = (2.0 * jnp.pi) * jnp.asarray(setup.phips) * sign_jac
+    safe_phip = jnp.where(phip_real != 0.0, phip_real, 1.0)
+    vp_real = sign_jac * (2.0 * jnp.pi) ** 2 * jnp.asarray(energies.vp) / safe_phip
+    vp_real = vp_real.at[0].set(0.0)
+    iotas = _iotas_half_from_fields(setup, fields)
+
+    itheta = jnp.zeros_like(bsubs).at[1:-1].set(bsubsv[1:-1] - (bsubv[2:] - bsubv[1:-1]) / hs)
+    izeta = jnp.zeros_like(bsubs).at[1:-1].set(-bsubsu[1:-1] + (bsubu[2:] - bsubu[1:-1]) / hs)
+    izeta = izeta.at[0].set(2.0 * izeta[1] - izeta[2])
+    izeta = izeta.at[-1].set(2.0 * izeta[-2] - izeta[-3])
+    bdotk = (
+        jnp.zeros_like(bsubs)
+        .at[1:-1]
+        .set(itheta[1:-1] * 0.5 * (bsubu[2:] + bsubu[1:-1]) + izeta[1:-1] * 0.5 * (bsubv[2:] + bsubv[1:-1]))
+    )
+
+    torcur = jnp.zeros_like(s).at[1:].set(sign_jac * (2.0 * jnp.pi) * jnp.einsum("sij,ij->s", bsubu[1:], wint))
+    phip_full = 0.5 * (phip_real[2:] + phip_real[1:-1])
+    denom = 1.0 / (hs * phip_full)
+    shear = (iotas[2:] - iotas[1:-1]) * denom
+    vpp = (vp_real[2:] - vp_real[1:-1]) * denom
+    pres = jnp.asarray(fields.pressure)
+    presp = (pres[2:] - pres[1:-1]) * denom
+    ip = (torcur[2:] - torcur[1:-1]) * denom
+
+    sqs = jnp.sqrt(s[1:-1])[:, None, None]
+    r1f = geometry.R_even[1:-1] + sqs * geometry.R_odd[1:-1]
+    rtf = geometry.dR_dtheta_even[1:-1] + sqs * geometry.dR_dtheta_odd[1:-1]
+    ztf = geometry.dZ_dtheta_even[1:-1] + sqs * geometry.dZ_dtheta_odd[1:-1]
+    rzf = geometry.dR_dzeta_even[1:-1] + sqs * geometry.dR_dzeta_odd[1:-1]
+    zzf = geometry.dZ_dzeta_even[1:-1] + sqs * geometry.dZ_dzeta_odd[1:-1]
+    gsqrt_raw = 0.5 * (jacobian.sqrt_g[1:-1] + jacobian.sqrt_g[2:])
+    gsqrt_full = gsqrt_raw / phip_full[:, None, None]
+    gtt = rtf * rtf + ztf * ztf
+    gpp = gsqrt_full**2 / (gtt * r1f**2 + (rtf * zzf - rzf * ztf) ** 2)
+    b2 = 2.0 * (jnp.asarray(fields.total_pressure) - pres[:, None, None])
+    b2i = 0.5 * (b2[1:-1] + b2[2:])
+    factor = (2.0 * jnp.pi) ** 2
+    tpp = jnp.einsum("sij,ij->s", gsqrt_full / b2i, wint) * factor
+    tbb = jnp.einsum("sij,ij->s", b2i * gsqrt_full * gpp, wint) * factor
+    # ``itheta/izeta`` above omit jxbforce.f's 1/mu0 conversion; mercier.f
+    # multiplies their resulting J.B back by mu0, so the factors cancel.
+    bdotj_norm = jnp.where(gsqrt_raw != 0.0, bdotk[1:-1] / gsqrt_raw, 0.0)
+    jdotb = bdotj_norm * gpp * gsqrt_full
+    tjb = jnp.einsum("sij,ij->s", jdotb, wint) * factor
+    tjj = jnp.einsum("sij,ij->s", jdotb * bdotj_norm / b2i, wint) * factor
+    dmerc = 0.25 * shear**2 - shear * (tjb - ip * tbb) + presp * (vpp - presp * tpp) * tbb + tjb**2 - tbb * tjj
+    return jnp.zeros_like(s).at[1:-1].set(dmerc)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a pure-JAX Mercier stability calculation that participates in JIT and automatic differentiation.

## Main changes

- Port the symmetric `jxbforce.f`/`mercier.f` calculation to live VMEX state/runtime data.
- Add the public `d_merc_state(state, runtime)` API.
- Keep the existing host/wout DMerc calculation as the parity reference.
- Validate axisymmetric and three-dimensional stellarator-symmetric equilibria.
- Add JIT and state-JVP coverage.

## Results

- Traceable profiles agree with the parity-proven wout calculation.
- JIT and JVP evaluation produce finite results.
- CPU/GPU DMerc values agree to `9.17e-15` relative difference.
- CPU/GPU DMerc gradients agree to `2.79e-12` relative difference.

## Limitations

Traceable DMerc currently supports `lasym=False`. The first two surfaces and edge retain VMEC's noisy/undefined convention and are not optimization targets.

## Validation

- Focused CPU fixed/free-boundary, multigrid, hot-restart, WOUT, and parity
  suite: `89 passed, 13 skipped, 2 xfailed`.
- The exact local CPU `RUN_FULL=1` execution collected `750` tests and reported
  `715 passed, 32 skipped, 2 xfailed`, plus one basin-sensitive QP assertion.
  That run reduced QP by 22.5% (`0.445789 -> 0.345527`), satisfying the restored
  relative 15% guard; the corrected exact test then passed in `699.46 s`.
- Office CUDA 13 focused placement/parity suite: `33 passed` on two RTX A4000s
  with Python 3.12.13 and JAX/JAXlib 0.11.0, with routing variables unset.
- Current five-physics CPU/GPU audit: MHD (`2.46e-15`), well (`1.67e-11`),
  DMerc (`1.59e-11`), quasisymmetry (`3.89e-15`), and quasi-isodynamicity
  (`4.88e-15`) relative gradient differences; forward-state difference zero.
- Deep DMerc CPU/GPU parity covers three Solovev boundary components,
  pressure, two 3-D boundary components, and toroidal current; worst relative
  difference `6.00e-11`.
- Final stack checks: CI-scope Ruff, mypy, `git diff --check`, strict Sphinx, and wheel/sdist builds pass.

Stack 5/8. Depends on `codex/gpu-ci`; merge before `codex/dmerc-implicit`.
