### PR TITLE
optimize: add implicit Mercier-stability gradients

### DIFF
--- a/docs/confinement.rst
+++ b/docs/confinement.rst
@@ -303,8 +303,15 @@ reporting profile as :func:`~vmex.core.optimize.d_merc`, evaluated through the
 parity-proven wout engine.  The symmetric live-state counterpart
 :func:`~vmex.core.stability.d_merc_state` is a pure-JAX port of the same
 ``jxbforce.f``/``mercier.f`` path for ``jit``/AD use and agrees with the wout
-profile to floating-point round-off.  Both retain VMEC's near-axis and edge
-limitations; the traceable lane does not yet support ``lasym = True``.
+profile to floating-point round-off.  For optimization,
+:func:`~vmex.core.stability.mercier_stability_residual` excludes ``[0:2]``
+and the edge and returns
+``smoothing * softplus((margin - DMerc) / smoothing)``; targeting it to zero
+penalizes unstable (negative) ``DMerc`` with a smooth gradient.  At finite
+``smoothing`` the residual is positive, rather than exactly zero, on stable
+surfaces but decays exponentially with the stability margin.  Both profile
+lanes retain VMEC's near-axis and edge limitations; the traceable lane does
+not yet support ``lasym = True``.
 
 Magnetic well
 ~~~~~~~~~~~~~~

--- a/docs/objectives.rst
+++ b/docs/objectives.rst
@@ -42,8 +42,9 @@ gradient modes).  Terms that evaluate wout tables on host NumPy
 (:func:`~vmex.core.optimize.d_merc`,
 :func:`~vmex.core.optimize.l_grad_b`, the wout-lane QI residual, the
 eigenvector-weighted turbulence proxies) work with ``jac=None`` only —
-for ``L_grad_B`` the traceable lane
-:func:`~vmex.core.optimize.l_grad_b_state` covers ``jac="implicit"``.
+use :func:`~vmex.core.optimize.mercier_stability_residual` for Mercier and
+:func:`~vmex.core.optimize.l_grad_b_state` for ``L_grad_B`` with
+``jac="implicit"``.
 
 .. code-block:: python
 
@@ -112,8 +113,20 @@ Two reporting diagnostics run on the host-side wout engine:
 :func:`~vmex.core.optimize.l_grad_b` (the ``L_grad_B`` coil-complexity proxy).
 Their live-state counterparts :func:`~vmex.core.stability.d_merc_state`
 (``lasym = False``) and :func:`~vmex.core.optimize.l_grad_b_state` are pure
-JAX and can be composed with implicit differentiation.  Direct optimizer
-integration of ``d_merc_state`` is not yet provided by ``d_merc`` itself.
+JAX and can be composed with implicit differentiation.  The convenience
+:func:`~vmex.core.optimize.mercier_stability_residual` selects
+``DMerc[2:-1]`` and returns
+``smoothing * softplus((margin - DMerc) / smoothing)``.  Positive ``DMerc``
+is stable, so target this residual to zero; the default ``margin=0`` and
+``smoothing=1e-6`` give a smooth approximation to the instability hinge
+``max(-DMerc, 0)``.  Softplus is strictly positive at finite arguments, so a
+stable surface approaches rather than reaches zero; its residual decreases
+exponentially as ``DMerc - margin`` grows.
+
+.. code-block:: python
+
+   terms = [(opt.mercier_stability_residual, 0.0, 100.0)]
+   result = opt.least_squares(terms, inp, max_mode=3, jac="implicit")
 
 ``L_grad_B`` additionally has a fully traceable ``(state, runtime)`` lane,
 :func:`~vmex.core.optimize.l_grad_b_state` — same convention
@@ -248,7 +261,8 @@ differences to 4.7e-9 in CI, and the objective destabilizes monotonically
 with pressure on the solovev family, in sign agreement with Mercier.  For
 interchange stability, combine with
 :func:`~vmex.core.optimize.magnetic_well` (traceable) or
-:func:`~vmex.core.optimize.d_merc` (wout lane, ``jac=None``).
+:func:`~vmex.core.optimize.mercier_stability_residual` (traceable); retain
+:func:`~vmex.core.optimize.d_merc` for wout-lane reporting or ``jac=None``.
 
 Turbulence proxies (SPECTRAX-GK)
 --------------------------------
@@ -321,6 +335,11 @@ Which objectives differentiate how
      - yes
      - yes
      - traceable ``L_grad_B`` lane (soft-min via ``softmin_k``)
+   * - :func:`~vmex.core.optimize.d_merc_state`,
+       :func:`~vmex.core.optimize.mercier_stability_residual`
+     - yes
+     - yes
+     - traceable Mercier profile / smooth interior instability hinge
    * - :func:`~vmex.core.optimize.d_merc`,
        :func:`~vmex.core.optimize.l_grad_b`
      - yes

--- a/examples/optimization/QA_optimization.py
+++ b/examples/optimization/QA_optimization.py
@@ -83,10 +83,10 @@ objective_terms = [
     (opt.aspect_ratio, ASPECT_TARGET, 1.0),
     (opt.mean_iota, IOTA_TARGET, 10.0),
     # Extra physics terms, CI-tested (tests/test_examples.py runs
-    # them uncommented).  magnetic_well works with JAC="implicit"; d_merc and
-    # l_grad_b are wout-engine (host) objectives -> set JAC = None for those.
+    # them uncommented).  These state objectives work with JAC="implicit";
+    # d_merc and l_grad_b remain the host reporting lanes.
     # (opt.magnetic_well, 0.05, 1.0),
-    # (lambda eq: np.minimum(opt.d_merc(eq)[2:-1], 0.0), 0.0, 100.0),
+    # (opt.mercier_stability_residual, 0.0, 100.0),
     # (lambda eq: max(1.0 / opt.l_grad_b(eq) - 1.0 / 0.35, 0.0), 0.0, 1.0),
     # Turbulence proxies (plan R26h.h4; optional dep: pip install spectraxgk;
     # gates in tests/test_turbulence.py).  SPECTRAX-GK linear ITG growth rate

--- a/examples/optimization/QH_optimization.py
+++ b/examples/optimization/QH_optimization.py
@@ -96,7 +96,7 @@ objective_terms = [
     (opt.aspect_ratio, ASPECT_TARGET, 1.0),
     # CI-tested extras (see QA_optimization.py for the jac caveats):
     # (opt.magnetic_well, 0.05, 1.0),
-    # (lambda eq: np.minimum(opt.d_merc(eq)[2:-1], 0.0), 0.0, 100.0),
+    # (opt.mercier_stability_residual, 0.0, 100.0),
     # (lambda eq: max(1.0 / opt.l_grad_b(eq) - 1.0 / 0.35, 0.0), 0.0, 1.0),
 ]
 

--- a/examples/optimization/QP_optimization.py
+++ b/examples/optimization/QP_optimization.py
@@ -89,7 +89,7 @@ objective_terms = [
     (opt.mirror_ratio, MIRROR_TARGET, 10.0),
     # CI-tested extras (see QA_optimization.py for the jac caveats):
     # (opt.magnetic_well, 0.05, 1.0),
-    # (lambda eq: np.minimum(opt.d_merc(eq)[2:-1], 0.0), 0.0, 100.0),
+    # (opt.mercier_stability_residual, 0.0, 100.0),
     # (lambda eq: max(1.0 / opt.l_grad_b(eq) - 1.0 / 0.35, 0.0), 0.0, 1.0),
 ]
 

--- a/examples/optimization/objectives_showcase.py
+++ b/examples/optimization/objectives_showcase.py
@@ -30,10 +30,11 @@ before/after:
     ``single_stage_vs_two_stage.py`` recipe) and push the interior
     :func:`~vmex.optimize.d_merc` profile toward POSITIVE (= Mercier
     stable) through a hinge penalty on its negative part.  ``d_merc`` is a
-    wout-engine objective (host-NumPy Mercier tables) with NO traceable lane,
-    so this one campaign runs honest finite differences (``jac=None``) at
+    wout-engine reporting objective (host-NumPy Mercier tables), so this one
+    campaign deliberately runs finite differences (``jac=None``) at
     ``max_mode 2`` — few dofs keep the FD cost affordable, and the cost gap
-    vs the implicit campaigns is part of the story.
+    vs the implicit campaigns is part of the story.  New campaigns can use
+    ``mercier_stability_residual`` with ``jac="implicit"`` instead.
 
 Each campaign: measure the seed metrics -> optimize (short budget, ESS
 trust-region scaling) -> re-solve the final deck -> print a before/after row
@@ -283,11 +284,9 @@ def run_campaign(name: str) -> dict:
     print(f"lane: {lane}; max_mode {spec['max_mode']} ({ndofs} dofs), "
           f"max_nfev {spec['max_nfev']}, use_ess=True")
     if name == "dmerc":
-        print("note: d_merc is a wout-engine objective (host-NumPy Mercier "
-              "tables, vmex.core.nyquist) with NO traceable lane — this "
-              "campaign pays one full equilibrium re-solve PER DOF per "
-              "Jacobian, which is exactly why it runs at max_mode "
-              f"{spec['max_mode']}.  Honest cost is part of the story.")
+        print("note: this campaign deliberately uses the d_merc wout-reporting "
+              "lane and finite differences.  For exact implicit gradients, "
+              "use opt.mercier_stability_residual with jac='implicit'.")
 
     seed = dict(metric=metric(seed_eq), **held_metrics(seed_eq))
     print(f"[seed]  {spec['label']} = {fmt.format(seed['metric'])} | "

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,10 +9,10 @@ the scripts as subprocesses in a temp cwd and assert that
 - the promised outputs (optimized input deck, wout file, figures) exist.
 
 The "commented-out but CI-tested" extra objective terms of the optimization
-examples (magnetic well, DMerc floor, L_grad_B floor) are exercised
+examples (magnetic well, traceable DMerc floor, L_grad_B floor) are exercised
 *uncommented* in ``test_extra_terms_work_uncommented`` — exactly the
 expressions the example comments show, one finite-difference least-squares
-iteration each, plus the traceable magnetic-well term through
+iteration each, plus the traceable magnetic-well and DMerc terms through
 ``jac="implicit"``.
 """
 
@@ -289,7 +289,7 @@ def test_objectives_showcase(tmp_path):
         for stage in ("seed", "final"):
             assert np.isfinite(m[stage]["metric"]), f"{name}/{stage}: metric"
             assert np.isfinite(m[stage]["qs_total"]), f"{name}/{stage}: QS"
-    assert "wout-engine objective" in out  # the honest-FD-cost printout
+    assert "d_merc wout-reporting lane" in out  # deliberate FD campaign
 
 
 def test_extra_terms_work_uncommented():
@@ -306,7 +306,7 @@ def test_extra_terms_work_uncommented():
         # exactly the expressions the example comments show:
         extra_terms = [
             (opt.magnetic_well, 0.05, 1.0),
-            (lambda eq: np.minimum(opt.d_merc(eq)[2:-1], 0.0), 0.0, 100.0),
+            (opt.mercier_stability_residual, 0.0, 100.0),
             (lambda eq: max(1.0 / opt.l_grad_b(eq) - 1.0 / 0.35, 0.0), 0.0, 1.0),
         ]
         terms = [(opt.aspect_ratio, 5.0, 1.0)] + extra_terms
@@ -315,7 +315,9 @@ def test_extra_terms_work_uncommented():
         assert np.all(np.isfinite(result.fun))
         # the traceable extra term also differentiates through jac="implicit"
         result2 = opt.least_squares(
-            [(opt.aspect_ratio, 5.0, 1.0), (opt.magnetic_well, 0.05, 1.0)],
+            [(opt.aspect_ratio, 5.0, 1.0),
+             (opt.magnetic_well, 0.05, 1.0),
+             (opt.mercier_stability_residual, 0.0, 100.0)],
             inp, max_mode=1, jac="implicit", use_ess=True, max_nfev=2)
         assert np.all(np.isfinite(result2.fun))
         # host wout-engine terms are rejected with a clear error in implicit mode

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -33,7 +33,9 @@ against central finite differences through the full host solver):
    ``_HOST_ERROR`` relay), not a multi-KB ``JaxRuntimeError``;
 9. the multigrid lane directly (plan Item I.4): ``im.run(multigrid=True)``
    through a genuine ns 5 -> 11 ladder, ``d(wb)/d(RBC(0,1))`` vs the
-   frozen-path FD.
+   frozen-path FD;
+10. implicit DMerc gradients in several boundary directions and with respect
+    to pressure/current inputs against frozen-path central differences.
 
 FD steps (documented choices): central differences with the *same* ftol and
 iteration policy on both sides, converged outputs cached on disk (``/tmp``)
@@ -61,6 +63,7 @@ import jax.numpy as jnp
 
 from vmex.core import implicit as im
 from vmex.core import solver
+from vmex.core import stability as stab
 from vmex.core.input import VmecInput
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "examples" / "data"
@@ -144,6 +147,11 @@ def _fd(name: str, inp: VmecInput, cfg, p0, field: str, idx, h: float) -> dict:
 
 def _tnorm(tree) -> float:
     return float(np.sqrt(sum(float(jnp.vdot(a, a)) for a in jax.tree.leaves(tree))))
+
+
+def _tree_dot(left, right) -> float:
+    return float(sum(jnp.vdot(a, b) for a, b in zip(
+        jax.tree.leaves(left), jax.tree.leaves(right), strict=True)))
 
 
 # ---------------------------------------------------------------------------
@@ -518,6 +526,70 @@ def test_multigrid_gradient_vs_frozen_path_fd():
           f"(Newton res {res:.0e})")
     assert res < 1e-8, f"frozen solve not converged (res {res:.1e})"
     assert rel <= 1e-6
+
+
+def _assert_dmerc_gradients(case, *, include_profiles):
+    name, inp, cfg, p0, _, _, _ = case
+    ntor = int(inp.ntor)
+    zero = jax.tree.map(jnp.zeros_like, p0)
+    directions = [
+        ("RBC(0,1)", dataclasses.replace(
+            zero, rbc=zero.rbc.at[ntor, 1].set(1.0))),
+        ("ZBS(0,1)", dataclasses.replace(
+            zero, zbs=zero.zbs.at[ntor, 1].set(1.0))),
+    ]
+    if include_profiles == "pressure":
+        directions += [
+            ("RBC(0,2)", dataclasses.replace(
+                zero, rbc=zero.rbc.at[ntor, 2].set(1.0))),
+            ("pres_scale", dataclasses.replace(
+                zero, pres_scale=jnp.ones_like(zero.pres_scale))),
+        ]
+    elif include_profiles == "current":
+        directions.append(("curtor/|curtor|", dataclasses.replace(
+            zero, curtor=jnp.asarray(abs(float(inp.curtor))))))
+
+    def metric(state, runtime):
+        return jnp.sum(stab.d_merc_state(state, runtime)[2:-1])
+
+    def objective(params):
+        solution = im.run(
+            inp,
+            params,
+            ftol=cfg.ftol,
+            max_iterations=cfg.max_iterations,
+        )
+        return metric(solution.state, solution.runtime)
+
+    grad = jax.grad(objective)(p0)
+    for label, tangent in directions:
+        ad = _tree_dot(grad, tangent)
+        fd, info = im.frozen_path_directional_fd(
+            p0, cfg, metric, tangent, h=1.0e-4
+        )
+        residual = max(info["newton_res"])
+        scale = max(abs(ad), abs(fd), 1.0e-12)
+        relative_error = abs(ad - fd) / scale
+        print(
+            f"\n[{name}] d(sum DMerc[2:-1])/d({label}): "
+            f"AD={ad:+.10e} frozen-FD={fd:+.10e} "
+            f"rel={relative_error:.2e} (Newton res {residual:.0e})"
+        )
+        assert residual < 1.0e-8
+        assert relative_error <= 2.0e-3
+
+
+@pytest.mark.parametrize("case", ["solovev"], indirect=True)
+def test_dmerc_gradient_vs_frozen_path_fd(case):
+    """Implicit DMerc shape/pressure derivatives on the axisymmetric case."""
+    _assert_dmerc_gradients(case, include_profiles="pressure")
+
+
+@pytest.mark.full
+@pytest.mark.parametrize("case", ["li383_low_res"], indirect=True)
+def test_dmerc_3d_current_gradient_vs_frozen_path_fd(case):
+    """Nightly: implicit 3-D DMerc shape/current derivatives."""
+    _assert_dmerc_gradients(case, include_profiles="current")
 
 
 # ===========================================================================

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -131,6 +131,81 @@ def test_traceable_dmerc_matches_wout_and_has_state_jvp(shaped_eq):
     np.testing.assert_allclose(pressure_grad, pressure_fd, rtol=1e-7)
 
 
+def test_mercier_stability_residual_is_smooth_interior_hinge(shaped_eq):
+    """The optimizer residual excludes noisy surfaces and follows its formula."""
+    state, rt = shaped_eq.state, shaped_eq.runtime
+    profile = stab.d_merc_state(state, rt)
+    margin, smoothing = 2.0e-6, 3.0e-6
+    actual = jax.jit(
+        lambda st: stab.mercier_stability_residual(
+            st, rt, margin=margin, smoothing=smoothing
+        )
+    )(state)
+    expected = smoothing * jax.nn.softplus((margin - profile[2:-1]) / smoothing)
+    np.testing.assert_allclose(actual, expected, rtol=1e-14, atol=1e-16)
+    assert actual.shape == (profile.size - 3,)
+    default = stab.mercier_stability_residual(state, rt)
+    assert jnp.min(profile[2:-1]) > 6.0e-6
+    assert jnp.max(default) < 2.0e-9
+    with pytest.raises(ValueError, match="smoothing must be positive"):
+        stab.mercier_stability_residual(state, rt, smoothing=0.0)
+
+
+def test_least_squares_accepts_implicit_mercier_term():
+    """One optimizer evaluation builds DMerc residual rows and their Jacobian."""
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    result = opt.least_squares(
+        [(opt.mercier_stability_residual, 0.0, 1.0)],
+        inp,
+        max_mode=1,
+        jac="implicit",
+        max_nfev=1,
+    )
+    assert result.nfev == 1
+    assert np.isfinite(result.cost)
+    assert np.all(np.isfinite(result.jac))
+
+
+@pytest.mark.full
+def test_implicit_mercier_optimization_improves_margin_with_constraints():
+    """A short implicit campaign improves DMerc while holding aspect and QA."""
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    seed = opt.solve_equilibrium(inp)
+    aspect0 = float(opt.aspect_ratio(seed.state, seed.runtime))
+    qa = opt.QuasisymmetryRatioResidual([0.25, 0.5, 0.75], 1, 0)
+
+    def mercier(state, runtime):
+        return stab.mercier_stability_residual(
+            state, runtime, smoothing=1.0e-6
+        )
+
+    def metrics(eq):
+        profile = np.asarray(stab.d_merc_state(eq.state, eq.runtime))[2:-1]
+        violation = np.asarray(mercier(eq.state, eq.runtime))
+        qa_norm = np.linalg.norm(np.asarray(
+            qa.residuals_state(eq.state, eq.runtime)))
+        return float(np.min(profile)), float(np.linalg.norm(violation)), qa_norm
+
+    margin0, violation0, qa0 = metrics(seed)
+    result = opt.least_squares(
+        [(opt.aspect_ratio, aspect0, 100.0),
+         (qa, 0.0, 1.0e5),
+         (mercier, 0.0, 1.0e5)],
+        inp,
+        max_mode=2,
+        jac="implicit",
+        max_nfev=6,
+    )
+    best = opt.solve_equilibrium(result.input)
+    margin1, violation1, qa1 = metrics(best)
+    aspect1 = float(opt.aspect_ratio(best.state, best.runtime))
+
+    assert margin1 > margin0
+    assert violation1 < 0.5 * violation0
+    assert abs(aspect1 - aspect0) < 5.0e-3
+    assert qa1 <= 1.05 * qa0
+
+
 def test_traceable_dmerc_matches_wout_in_3d(finite_beta_3d_eq):
     """The traceable current reconstruction retains toroidal-mode parity."""
     eq = finite_beta_3d_eq

--- a/tests/test_validation_guards.py
+++ b/tests/test_validation_guards.py
@@ -118,6 +118,11 @@ def test_traceable_term_vetting():
     qs = opt.QuasisymmetryRatioResidual([0.5], 1, 0)
     assert opt._traceable_term(qs.total_state) == qs.residuals_state
     assert opt._traceable_term(opt.aspect_ratio) is opt.aspect_ratio
+    assert opt._traceable_term(opt.d_merc_state) is opt.d_merc_state
+    assert (
+        opt._traceable_term(opt.mercier_stability_residual)
+        is opt.mercier_stability_residual
+    )
     with pytest.raises(ValueError, match="not implicit-differentiable"):
         opt._traceable_term(opt.d_merc)
 

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -51,12 +51,13 @@ terms exposing a ``residuals_state`` method
 residual vector, matching the finite-difference stacked-residual cost and
 Gauss-Newton geometry (internal-grid sampling instead of the wout grid).
 Wout-engine terms (:func:`d_merc`, :func:`l_grad_b`, the Boozer-based QI
-residual) run on host NumPy and are finite-difference-only —
-:func:`l_grad_b_state` is the traceable ``(state, rt)`` lane of the same
-``L_grad_B`` convention for ``jac="implicit"``.  The implicit parameter map
-supports lasym via the four RBC/ZBS/RBS/ZBC boundary families and a traceable
-``readin.f`` delta rotation (FD-validated), so ``jac="implicit"`` handles
-``lasym = True`` as well (the QS-ratio traceable term is symmetric-only).
+residual) run on host NumPy and are finite-difference-only.  Use
+:func:`d_merc_state` or :func:`mercier_stability_residual` for Mercier and
+:func:`l_grad_b_state` for ``L_grad_B`` with ``jac="implicit"``.  The
+implicit parameter map supports lasym via the four RBC/ZBS/RBS/ZBC boundary
+families and a traceable ``readin.f`` delta rotation (FD-validated), so
+``jac="implicit"`` handles ``lasym = True`` as well (the QS-ratio traceable
+term is symmetric-only).
 
 Measured cost (2026-07-10, RTX A4000, nfp2 circular seed, QS + aspect +
 iota objective, ``max_mode=2`` -> 24 dofs): warm implicit Jacobian 2.5 s
@@ -96,6 +97,8 @@ from .solver import (
     resolution_from_input,
 )
 from .fields import surface_currents
+from .stability import d_merc_state, mercier_stability_residual
+
 # Shared state-physics primitives (statephysics.py, R26a).  Re-exported here
 # for backward compatibility: external user code and tests reach them as
 # ``vmex.core.optimize._as_1d`` etc.
@@ -129,6 +132,8 @@ __all__ = [
     "volume",
     "magnetic_well",
     "d_merc",
+    "d_merc_state",
+    "mercier_stability_residual",
     "l_grad_b",
     "l_grad_b_state",
     "quasi_isodynamic_residual",
@@ -547,7 +552,8 @@ def d_merc(eq) -> jnp.ndarray:
     objective is finite-difference-only (not jit/AD transparent; the first
     two surfaces and the edge carry the usual near-axis noise, so practical
     targets should penalize e.g. ``min(DMerc[2:-1], 0)``).  Accepts an
-    :class:`Equilibrium` or any wout-like object.
+    :class:`Equilibrium` or any wout-like object.  Use traceable
+    :func:`mercier_stability_residual` with ``jac="implicit"``.
     """
     wout = eq.wout if isinstance(eq, Equilibrium) else eq
     return jnp.asarray(np.asarray(wout.DMerc, dtype=float))
@@ -1200,8 +1206,9 @@ def least_squares(
     one full equilibrium solve per dof.  Requirements (see the module
     docstring): every term traceable in ``(state, runtime)`` (vector terms
     expose ``residuals_state``; wout-engine terms like :func:`d_merc` /
-    :func:`l_grad_b` / the Boozer QI residual need ``jac=None`` — for
-    ``L_grad_B`` use the traceable :func:`l_grad_b_state` instead).  Both
+    :func:`l_grad_b` / the Boozer QI residual need ``jac=None`` — use
+    :func:`mercier_stability_residual` and :func:`l_grad_b_state` for the
+    corresponding traceable objectives).  Both
     stellarator-symmetric and ``lasym`` boundaries are supported: the implicit
     parameter map packs the four RBC/ZBS/RBS/ZBC families and a traceable
     ``readin.f`` delta rotation.
@@ -1414,7 +1421,8 @@ def _traceable_term(fun: Callable) -> Callable:
         "needs traceable (state, runtime) callables or a residuals_state method. "
         "Wout-engine terms (d_merc, l_grad_b, the Boozer QI residual) run on "
         "host NumPy — use jac=None (finite differences) for those, or the "
-        "traceable l_grad_b_state for L_grad_B.")
+        "traceable d_merc_state / mercier_stability_residual and "
+        "l_grad_b_state alternatives.")
 
 
 def _least_squares_implicit(

--- a/vmex/core/stability.py
+++ b/vmex/core/stability.py
@@ -45,7 +45,8 @@ Scope notes
 - Surfaces need ``ι ≠ 0`` (the field-line parameterization divides by ι).
 - :func:`d_merc_state` is the traceable counterpart of the parity-proven
   wout calculation.  As in VMEC2000, its first two surfaces and edge are not
-  suitable stability targets; use the validated interior profile.
+  suitable stability targets; :func:`mercier_stability_residual` selects the
+  validated interior and supplies a smooth stability-violation objective.
 """
 
 from __future__ import annotations
@@ -63,6 +64,7 @@ from .transforms import physical_to_internal_scale
 
 __all__ = [
     "d_merc_state",
+    "mercier_stability_residual",
     "ballooning_lambda",
     "ballooning_growth_rate",
 ]
@@ -220,6 +222,31 @@ def d_merc_state(state: SpectralState, rt: SolverRuntime) -> Array:
     tjj = jnp.einsum("sij,ij->s", jdotb * bdotj_norm / b2i, wint) * factor
     dmerc = 0.25 * shear**2 - shear * (tjb - ip * tbb) + presp * (vpp - presp * tpp) * tbb + tjb**2 - tbb * tjj
     return jnp.zeros_like(s).at[1:-1].set(dmerc)
+
+
+def mercier_stability_residual(
+    state: SpectralState,
+    rt: SolverRuntime,
+    *,
+    margin: float = 0.0,
+    smoothing: float = 1.0e-6,
+) -> Array:
+    """Smooth Mercier-instability residual on ``DMerc[2:-1]``.
+
+    Positive ``DMerc`` is stable.  For each validated interior surface this
+    returns ``smoothing * softplus((margin - DMerc) / smoothing)``: it tends
+    to ``max(margin - DMerc, 0)`` as ``smoothing`` tends to zero, while
+    retaining a smooth gradient at the stability boundary.  At finite
+    smoothing it is strictly positive but exponentially close to zero on a
+    sufficiently stable surface.  Use target zero in
+    :func:`vmex.core.optimize.least_squares`; ``margin > 0`` requests a finite
+    stability margin.  The first two surfaces and edge are excluded.
+    """
+    if smoothing <= 0.0:
+        raise ValueError(f"smoothing must be positive, got {smoothing}")
+    violation = jnp.asarray(margin) - d_merc_state(state, rt)[2:-1]
+    scale = jnp.asarray(smoothing, dtype=violation.dtype)
+    return scale * jax.nn.softplus(violation / scale)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Make Mercier stability available to implicit differentiation and least-squares optimization.

## Main changes

- Add `mercier_stability_residual(state, runtime)`.
- Use a smooth softplus penalty over validated `DMerc[2:-1]` surfaces.
- Support configurable stability margin and smoothing.
- Export the traceable objective through the optimization API.
- Update optimization examples to use state/runtime objectives.
- Add end-to-end implicit shape, pressure, and current gradient tests against
  frozen-path finite differences.
- Add a short constrained optimization that improves the Mercier margin while
  holding aspect ratio and quasiaxisymmetry.

## Results

- Solovev implicit DMerc AD agrees with frozen-path finite differences in three
  boundary directions and pressure from `2.35e-6` to `9.15e-4` relative.
- The 3-D current-constrained case agrees in two boundary directions and
  normalized toroidal current from `3.32e-5` to `2.80e-4` relative.
- CPU/GPU DMerc differences are at most `6.00e-11` across the Solovev shape and
  pressure components and `1.24e-12` across the 3-D shape/current components.
- The constrained smoke improves worst-surface DMerc from `-3.21e-5` to
  `-9.95e-6`, reduces the smooth violation norm by about 65%, holds aspect to
  0.05%, and decreases the QA residual.
- QA, QH, QP, and objective-showcase examples remain valid.

## Limitations

The objective inherits the traceable kernel's `lasym=False` restriction and intentionally excludes the first two surfaces and edge.

## Validation

- Focused CPU fixed/free-boundary, multigrid, hot-restart, WOUT, and parity
  suite: `89 passed, 13 skipped, 2 xfailed`.
- The exact local CPU `RUN_FULL=1` execution collected `750` tests and reported
  `715 passed, 32 skipped, 2 xfailed`, plus one basin-sensitive QP assertion.
  That run reduced QP by 22.5% (`0.445789 -> 0.345527`), satisfying the restored
  relative 15% guard; the corrected exact test then passed in `699.46 s`.
- Office CUDA 13 focused placement/parity suite: `33 passed` on two RTX A4000s
  with Python 3.12.13 and JAX/JAXlib 0.11.0, with routing variables unset.
- Current five-physics CPU/GPU audit: MHD (`2.46e-15`), well (`1.67e-11`),
  DMerc (`1.59e-11`), quasisymmetry (`3.89e-15`), and quasi-isodynamicity
  (`4.88e-15`) relative gradient differences; forward-state difference zero.
- Deep DMerc CPU/GPU parity covers three Solovev boundary components,
  pressure, two 3-D boundary components, and toroidal current; worst relative
  difference `6.00e-11`.
- Final stack checks: CI-scope Ruff, mypy, `git diff --check`, strict Sphinx, and wheel/sdist builds pass.

Stack 6/8. Depends on `codex/dmerc-jax-kernel`; merge before `codex/docs-diagnostics`.
