### PR TITLE
docs: clarify accelerator installation and placement diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
 ## [Unreleased]
 
 ### Added
+- **Explicit device selection.** Forward, free-boundary, implicit, and CLI
+  solve paths accept public CPU/GPU/JAX placement controls: omitted or
+  `"auto"` retains VMEX's measured policy, `None` follows JAX, and explicit
+  platform names or `jax.Device` objects win without environment routing.
+- **Differentiable Mercier stability.** `d_merc_state` provides a traceable JAX
+  Mercier profile, and `mercier_stability_residual` exposes its validated
+  interior surfaces to implicit differentiation and optimization.
 - **GPU CI without environment routing.** A manual self-hosted CUDA 13 lane
   fails on CPU fallback and checks explicit CPU/GPU forward-solve and
   implicit-gradient parity without JAX platform environment variables.

--- a/README.md
+++ b/README.md
@@ -402,10 +402,12 @@ objective at a stiff weight:
 - lower the aspect ratio to 4.8 at fixed iota;
 - push the Mercier criterion `DMerc` toward stability at ⟨β⟩ ≈ 1.25%.
 
-The first four use the implicit adjoint (`jac="implicit"`). `DMerc` has no
-traceable lane yet (it is computed from host-side Mercier tables), so that
-campaign uses finite differences at `max_mode` 2. The self-consistent Redl
-bootstrap objective has its own section below.
+The first four use the implicit adjoint (`jac="implicit"`). The published
+`DMerc` showcase deliberately preserves its legacy host-side reporting lane
+and finite-difference baseline at `max_mode` 2. New campaigns can instead use
+the traceable `mercier_stability_residual` with `jac="implicit"`; see the
+optimization objectives documentation. The self-consistent Redl bootstrap
+objective has its own section below.
 
 ![Objectives showcase: five one-objective campaigns off the precise-QA seed](docs/_static/figures/readme_objectives.png)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ vmex --doctor
 
 VMEX does not require platform-selection environment variables for hardware
 detection. Its automatic policy keeps small solves and implicit gradients on
-CPU when that is faster; the fixed-boundary Python solve APIs also accept an
+CPU when that is faster; the public solve and implicit APIs also accept an
 explicit ``device=`` argument.
 
 Development install from source:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ Install from PyPI:
 pip install vmex
 ```
 
+For NVIDIA GPUs with a current JAX-supported Python and driver 580+, install
+the CUDA 13 wheel and verify the detected devices:
+
+```bash
+pip install -U "jax[cuda13]"
+vmex --doctor
+```
+
+VMEX does not require platform-selection environment variables for hardware
+detection. Its automatic policy keeps small solves and implicit gradients on
+CPU when that is faster; the fixed-boundary Python solve APIs also accept an
+explicit ``device=`` argument.
+
 Development install from source:
 
 ```bash
@@ -483,8 +496,11 @@ options:
 ```
 
 `vmec` detects the available JAX hardware without environment variables and
-uses CPU or GPU according to the measured per-stage policy. Use
-`--device cpu` or `--device gpu` to override it explicitly.
+uses CPU or GPU according to the measured per-stage policy. Use `--device
+cpu` or `--device gpu` to override it explicitly. Implicit-gradient work
+defaults to CPU because it is launch-bound on the tested GPUs; passing
+`device=None` to the Python API follows JAX placement. `vmex --doctor`
+reports the devices and both VMEX placement policies.
 
 ## Documentation
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 Requirements
 ------------
 
-- Python 3.10+
+- Python 3.10+ (Python 3.12+ recommended for current accelerator-enabled JAX)
 - ``numpy``, ``jax`` + ``jaxlib``, ``netCDF4``, ``matplotlib``,
   ``booz_xform_jax`` (all installed automatically)
 
@@ -71,12 +71,20 @@ e.g.:
 
 .. code-block:: bash
 
-   pip install -U "jax[cuda12]"
+   pip install -U "jax[cuda13]"
+
+CUDA 13 wheels currently require an NVIDIA driver version of at least 580
+and a Python version supported by the current JAX release. On older Python
+versions, package resolution can select an older JAX release whose accelerator
+extras differ; always confirm the result with ``vmex --doctor``. CUDA 12,
+ROCm, TPU, and platform-specific alternatives remain documented in JAX's
+installation matrix.
 
 ``vmex`` then picks CPU or GPU per solve using a measured device policy —
-small decks stay on the CPU, large ones move to the GPU. See
-:ref:`performance:GPU guidance` for the policy, how to pin a backend with
-``JAX_PLATFORMS``, and the persistent compilation cache.
+small decks stay on the CPU, large ones move to the GPU, and implicit-gradient
+work currently defaults to CPU because it is launch-bound on the tested GPUs.
+See :ref:`performance:GPU guidance` for the policy and persistent compilation
+cache. Environment variables are not required for ordinary hardware detection.
 
 Build the documentation locally
 -------------------------------

--- a/docs/mirror_geometry.rst
+++ b/docs/mirror_geometry.rst
@@ -873,10 +873,10 @@ deliberately unavailable because
 local Fourier-mode refinement failed; it will not be presented as a supported
 gradient.
 
-``device=None`` uses the shared measured device policy. On the office host,
-the corrected ``15x15`` case took 35.2 seconds on CPU and 44.2 seconds on one
-RTX A4000. Energy and force diagnostics agree to numerical precision. Explicit
-``device=`` arguments and JAX platform environment pins are always honored.
+This mirror derivative path does not expose the core solver's ``device=``
+contract. On the office host, the corrected ``15x15`` case took 35.2 seconds
+on CPU and 44.2 seconds on one RTX A4000; energy and force diagnostics agreed
+to numerical precision.
 
 Fixed- and free-boundary derivatives solve the linearized converged coefficient
 residual and never retain or differentiate the nonlinear iteration history. The

--- a/docs/objectives.rst
+++ b/docs/objectives.rst
@@ -340,6 +340,7 @@ Which objectives differentiate how
      - yes
      - yes
      - traceable Mercier profile / smooth interior instability hinge
+       (stellarator-symmetric states only)
    * - :func:`~vmex.core.optimize.d_merc`,
        :func:`~vmex.core.optimize.l_grad_b`
      - yes
@@ -357,9 +358,12 @@ Which objectives differentiate how
      - no
      - eigenvector weights have no nonsymmetric-eig derivative
 
-``jac="implicit"`` additionally requires a fixed-boundary,
-stellarator-symmetric problem (``LASYM = F``); see :doc:`optimization` for
-the gradient machinery itself and the measured cost of each piece.
+``jac="implicit"`` requires a fixed-boundary problem. Its boundary parameter
+map supports both symmetric and ``LASYM = T`` equilibria, but individual
+objectives can be symmetry-limited; in particular the traceable Mercier and
+quasisymmetry objectives currently require ``LASYM = F``. See
+:doc:`optimization` for the gradient machinery and measured cost of each
+piece.
 
 Writing your own objective
 --------------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -13,8 +13,9 @@ Verify the installation
    vmex --doctor
    vmex --test
 
-``vmex --doctor`` prints the active Python, package versions, and the JAX
-backend (CPU/GPU). ``vmex --test`` runs the bundled fixed-boundary QH case
+``vmex --doctor`` prints the active Python, package versions, JAX backend and
+devices, active JAX default device, and VMEX's forward/implicit placement
+policies. ``vmex --test`` runs the bundled fixed-boundary QH case
 end to end: it copies the packaged ``input.nfp4_QH_warm_start`` deck into
 ``./vmex_test/``, solves it (with ``FTOL_ARRAY = 1e-12`` for a fast first
 check), writes ``wout_nfp4_QH_warm_start.nc``, and renders diagnostic figures

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -32,6 +32,7 @@ def test_collect_report_reflects_interpreter():
     assert sys.version.split()[0] in report.python
     # this test suite runs with JAX importable
     assert report.jax_backend is not None
+    assert report.jax_default_device is None or isinstance(report.jax_default_device, str)
     assert len(report.jax_devices) >= 1
     assert set(doctor._CORE_PACKAGES) == set(report.versions)
     assert report.versions["numpy"] != "not installed"
@@ -45,6 +46,8 @@ def test_format_report_healthy_and_warning_paths():
     assert "vmex installation doctor" in text
     assert "Status: no obvious installation problems detected." in text
     assert "JAX backend:" in text
+    assert "JAX default device:" in text
+    assert "VMEX implicit default:" in text
     for name in doctor._CORE_PACKAGES:
         assert name in text
 

--- a/vmex/doctor.py
+++ b/vmex/doctor.py
@@ -44,6 +44,7 @@ class DoctorReport:
     pip_report: str
     versions: dict[str, str]
     jax_backend: str | None
+    jax_default_device: str | None
     jax_devices: tuple[str, ...]
     warnings: tuple[str, ...]
 
@@ -96,6 +97,16 @@ def _jax_info() -> tuple[str | None, tuple[str, ...], str | None]:
         return None, (), str(exc)
 
 
+def _jax_default_device() -> str | None:
+    try:
+        import jax
+
+        device = jax.config.jax_default_device
+        return None if device is None else str(device)
+    except Exception:  # pragma: no cover - defensive diagnostics only.
+        return None
+
+
 def collect_report() -> DoctorReport:
     """Collect installation diagnostics without modifying the environment."""
     versions = {name: _package_version(name) for name in _CORE_PACKAGES}
@@ -139,6 +150,7 @@ def collect_report() -> DoctorReport:
         pip_report=pip_text,
         versions=versions,
         jax_backend=backend,
+        jax_default_device=_jax_default_device(),
         jax_devices=devices,
         warnings=tuple(warnings),
     )
@@ -174,6 +186,7 @@ def format_report(report: DoctorReport) -> str:
         [
             "",
             f"JAX backend: {report.jax_backend or 'unavailable'}",
+            f"JAX default device: {report.jax_default_device or 'automatic'}",
             "JAX devices:",
         ]
     )
@@ -181,6 +194,12 @@ def format_report(report: DoctorReport) -> str:
         lines.extend(f"  - {device}" for device in report.jax_devices)
     else:
         lines.append("  - none detected")
+    lines.extend(
+        [
+            "VMEX forward default:  automatic size-based CPU/GPU policy",
+            "VMEX implicit default: CPU on accelerator hosts (optimizer device= overrides)",
+        ]
+    )
     lines.append("")
     if report.warnings:
         lines.append("Warnings:")


### PR DESCRIPTION
## Summary

Document the supported accelerator setup and make VMEX's placement policy visible through `vmex --doctor`.

## Main changes

- Add current CUDA 13 JAX installation guidance and driver requirements.
- Explain that ordinary hardware discovery does not require platform-selection environment variables.
- Document automatic, explicit, and JAX-controlled placement for public solve and implicit APIs.
- Report the JAX default device, available devices, and VMEX forward/implicit policies.
- Update README, installation, and quick-start guidance.
- Align the architecture, Mercier capability text, and Unreleased changelog with the implemented APIs.

## Results

- Doctor/package API tests pass.
- Strict Sphinx build passes with warnings treated as errors.
- README and docs match the implemented public APIs.

## Installation note

Python 3.12+ is recommended for current accelerator JAX wheels; VMEX continues to support Python 3.10+ where compatible dependencies are available.

## Validation

- Focused CPU fixed/free-boundary, multigrid, hot-restart, WOUT, and parity
  suite: `89 passed, 13 skipped, 2 xfailed`.
- The exact local CPU `RUN_FULL=1` execution collected `750` tests and reported
  `715 passed, 32 skipped, 2 xfailed`, plus one basin-sensitive QP assertion.
  That run reduced QP by 22.5% (`0.445789 -> 0.345527`), satisfying the restored
  relative 15% guard; the corrected exact test then passed in `699.46 s`.
- Office CUDA 13 focused placement/parity suite: `33 passed` on two RTX A4000s
  with Python 3.12.13 and JAX/JAXlib 0.11.0, with routing variables unset.
- Current five-physics CPU/GPU audit: MHD (`2.46e-15`), well (`1.67e-11`),
  DMerc (`1.59e-11`), quasisymmetry (`3.89e-15`), and quasi-isodynamicity
  (`4.88e-15`) relative gradient differences; forward-state difference zero.
- Deep DMerc CPU/GPU parity covers three Solovev boundary components,
  pressure, two 3-D boundary components, and toroidal current; worst relative
  difference `6.00e-11`.
- Final stack checks: CI-scope Ruff, mypy, `git diff --check`, strict Sphinx, and wheel/sdist builds pass.

Stack 7/8. Depends on `codex/dmerc-implicit`; merge before `codex/device-benchmarks`.
