### PR TITLE
bench: add CPU/GPU solve and gradient-parity audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,14 +441,14 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # A sequential whole-suite job reached only 39% before the previous
-    # 150-minute limit on a shared runner. Keep the exact RUN_FULL coverage,
-    # but isolate the compile-heavy examples and mirror families so every
-    # shard completes and one slow lane cannot hide the remaining results.
+    # 150-minute limit, and the first core shard later lost hosted runners
+    # twice after 37/81 minutes. Keep exact RUN_FULL coverage, but split core
+    # alphabetically and isolate examples/mirror so every shard stays bounded.
     timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
-        shard: [core, examples, mirror-field, mirror-equilibrium, mirror-spline]
+        shard: [core-a, core-b, examples, mirror-field, mirror-equilibrium, mirror-spline]
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -483,8 +483,13 @@ jobs:
           RUN_FULL: "1"
         run: |
           case "${{ matrix.shard }}" in
-            core)
-              FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py"
+            core-a)
+              FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \
+                     --ignore-glob=tests/test_[n-z]*.py"
+              ;;
+            core-b)
+              FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \
+                     --ignore-glob=tests/test_[a-m]*.py"
               ;;
             examples)
               FILES="tests/test_examples.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,14 +441,16 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # A sequential whole-suite job reached only 39% before the previous
-    # 150-minute limit, and the first core shard later lost hosted runners
-    # twice after 37/81 minutes. Keep exact RUN_FULL coverage, but split core
-    # alphabetically and isolate examples/mirror so every shard stays bounded.
+    # 150-minute limit, and the core job later lost hosted runners three times
+    # after 37/79/81 minutes. Keep exact RUN_FULL coverage, split core
+    # alphabetically, isolate each stateful optimization campaign, and isolate
+    # examples/mirror so every shard stays bounded on a fresh worker.
     timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
-        shard: [core-a, core-b, examples, mirror-field, mirror-equilibrium, mirror-spline]
+        shard: [core-a-f, core-g-m, core-n-s, core-t-z, opt-qa, opt-qh,
+                opt-qp, examples, mirror-field, mirror-equilibrium, mirror-spline]
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -483,13 +485,33 @@ jobs:
           RUN_FULL: "1"
         run: |
           case "${{ matrix.shard }}" in
-            core-a)
+            core-a-f)
               FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \
+                     --ignore-glob=tests/test_[g-z]*.py"
+              ;;
+            core-g-m)
+              FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \
+                     --ignore-glob=tests/test_[a-f]*.py \
                      --ignore-glob=tests/test_[n-z]*.py"
               ;;
-            core-b)
+            core-n-s)
               FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \
-                     --ignore-glob=tests/test_[a-m]*.py"
+                     --ignore=tests/test_optimization_convergence.py \
+                     --ignore-glob=tests/test_[a-m]*.py \
+                     --ignore-glob=tests/test_[t-z]*.py"
+              ;;
+            core-t-z)
+              FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \
+                     --ignore-glob=tests/test_[a-s]*.py"
+              ;;
+            opt-qa)
+              FILES="tests/test_optimization_convergence.py::test_qa_reaches_precise"
+              ;;
+            opt-qh)
+              FILES="tests/test_optimization_convergence.py::test_qh_implicit_converges"
+              ;;
+            opt-qp)
+              FILES="tests/test_optimization_convergence.py::test_qp_implicit_descends"
               ;;
             examples)
               FILES="tests/test_examples.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,4 +533,14 @@ jobs:
                      tests/mirror/test_splines.py"
               ;;
           esac
-          pytest -q $FILES --durations=25
+          # Some optimization tests are silent for more than 15 minutes.
+          # Keep the hosted runner live without changing pytest semantics.
+          pytest -q $FILES --durations=25 &
+          pytest_pid=$!
+          while kill -0 "$pytest_pid" 2>/dev/null; do
+            sleep 60
+            if kill -0 "$pytest_pid" 2>/dev/null; then
+              echo "pytest shard ${{ matrix.shard }} still running (${SECONDS}s)"
+            fi
+          done
+          wait "$pytest_pid"

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -16,7 +16,7 @@ jobs:
   cuda:
     name: CUDA 13 placement and parity
     runs-on: [self-hosted, linux, x64, gpu]
-    timeout-minutes: 20
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -50,3 +50,17 @@ jobs:
 
       - name: Run focused placement, solve, and gradient checks
         run: pytest -q tests/test_gpu_ci.py tests/test_device.py tests/test_implicit_device.py --durations=0
+
+      - name: Audit all physics gradients on CPU and GPU
+        run: |
+          python benchmarks/device_parity.py \
+            --quick \
+            --devices cpu,gpu \
+            --output device-parity.json
+
+      - name: Upload parity measurements
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: device-parity-${{ github.run_id }}
+          path: device-parity.json

--- a/benchmarks/baseline.json
+++ b/benchmarks/baseline.json
@@ -9,7 +9,7 @@
    "converged": true,
    "iterations": 850
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 4.47,
    "peak_rss_mb": 780.1,
@@ -17,7 +17,7 @@
    "converged": true,
    "iterations": 850
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 0.918,
@@ -42,7 +42,7 @@
    "converged": true,
    "iterations": 1103
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 7.76,
    "peak_rss_mb": 1604.5,
@@ -50,7 +50,7 @@
    "converged": true,
    "iterations": 1103
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 3.069,
@@ -75,7 +75,7 @@
    "converged": true,
    "iterations": 1062
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 4.63,
    "peak_rss_mb": 1124.0,
@@ -83,7 +83,7 @@
    "converged": true,
    "iterations": 1062
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 1.587,
@@ -108,7 +108,7 @@
    "converged": true,
    "iterations": 857
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 7.68,
    "peak_rss_mb": 894.3,
@@ -116,7 +116,7 @@
    "converged": true,
    "iterations": 857
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 3.937,
@@ -139,7 +139,7 @@
    "converged": true,
    "iterations": 880
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 18.02,
    "peak_rss_mb": 1703.0,
@@ -147,7 +147,7 @@
    "converged": true,
    "iterations": 880
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 10.638,
@@ -170,7 +170,7 @@
    "converged": true,
    "iterations": 198
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 4.29,
    "peak_rss_mb": 790.0,
@@ -178,7 +178,7 @@
    "converged": true,
    "iterations": 198
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 1.74,
@@ -203,7 +203,7 @@
    "converged": true,
    "iterations": 2785
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 46.15,
    "peak_rss_mb": 1455.3,
@@ -211,7 +211,7 @@
    "converged": true,
    "iterations": 2785
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 34.347,
@@ -236,7 +236,7 @@
    "converged": true,
    "iterations": 4425
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 50.36,
    "peak_rss_mb": 1941.4,
@@ -244,7 +244,7 @@
    "converged": true,
    "iterations": 4425
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 39.481,
@@ -269,7 +269,7 @@
    "converged": true,
    "iterations": 5222
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 60.85,
    "peak_rss_mb": 1595.3,
@@ -277,7 +277,7 @@
    "converged": true,
    "iterations": 5239
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 56.791,
@@ -300,7 +300,7 @@
    "converged": true,
    "iterations": 672
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 5.75,
    "peak_rss_mb": 770.6,
@@ -308,7 +308,7 @@
    "converged": true,
    "iterations": 672
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 2.207,
@@ -333,7 +333,7 @@
    "converged": true,
    "iterations": 617
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 17.69,
    "peak_rss_mb": 1542.3,
@@ -341,7 +341,7 @@
    "converged": true,
    "iterations": 617
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 6.02,
@@ -366,7 +366,7 @@
    "converged": true,
    "iterations": 2829
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 106.61,
    "peak_rss_mb": 2752.7,
@@ -374,7 +374,7 @@
    "converged": true,
    "iterations": 1681
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 63.397,
@@ -399,7 +399,7 @@
    "converged": true,
    "iterations": 1652
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": true,
    "wall_s": 34.07,
    "peak_rss_mb": 1800.3,
@@ -407,7 +407,7 @@
    "converged": true,
    "iterations": 1499
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
    "converged": true,
    "cold_inproc_s": 23.917,
@@ -429,10 +429,10 @@
    "wall_s": 193.13,
    "peak_rss_mb": 92.7,
    "stderr": "",
-   "converged": true,
+   "converged": false,
    "iterations": 10000
   },
-  "vmec_jax_cold": {
+  "vmex_cold": {
    "ok": false,
    "wall_s": 230.55,
    "peak_rss_mb": 3606.8,
@@ -440,9 +440,9 @@
    "converged": false,
    "iterations": 10000
   },
-  "vmec_jax_warm": {
+  "vmex_warm": {
    "ok": true,
-   "converged": true,
+   "converged": false,
    "cold_inproc_s": 163.268,
    "warm_s": 150.93,
    "peak_rss_mb": 2545.6

--- a/benchmarks/device_parity.py
+++ b/benchmarks/device_parity.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Audit CPU/GPU parity of a forward solve and implicit boundary gradients.
+
+Hardware is selected through VMEX's public ``device=`` API; this script does
+not set or require JAX platform environment variables.  The default runs on
+every available CPU/GPU platform.  ``--devices cpu`` is the CPU-only lane.
+
+Examples::
+
+    python benchmarks/device_parity.py --quick --metrics mhd_energy --output /tmp/parity.json
+    python benchmarks/device_parity.py --devices cpu,gpu --output parity.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import platform
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+import vmex
+import jax
+
+from vmex.core import implicit as im
+from vmex.core import optimize as opt
+from vmex.core.input import VmecInput
+from vmex.core.omnigenity import QIResidual
+
+
+DATA = REPO / "examples" / "data"
+METRIC_NAMES = (
+    "mhd_energy",
+    "magnetic_well",
+    "quasisymmetry",
+    "quasi_isodynamic",
+)
+
+
+def _device_of(value: Any) -> str:
+    device = getattr(value, "device", None)
+    return str(device() if callable(device) else device)
+
+
+def _timed(call: Callable[[], Any]) -> tuple[Any, float]:
+    start = time.perf_counter()
+    result = call()
+    jax.block_until_ready(result)
+    return result, time.perf_counter() - start
+
+
+def _relative_difference(left: float, right: float) -> float:
+    scale = max(abs(left), abs(right), np.finfo(float).tiny)
+    return abs(left - right) / scale
+
+
+def _available_devices() -> dict[str, Any]:
+    devices = {"cpu": jax.devices("cpu")[0]}
+    try:
+        devices["gpu"] = jax.devices("gpu")[0]
+    except RuntimeError:
+        pass
+    return devices
+
+
+def _requested_devices(spec: str, available: dict[str, Any]) -> tuple[list[str], dict[str, str]]:
+    requested = list(available) if spec == "available" else [part.strip() for part in spec.split(",")]
+    if not requested or any(part not in ("cpu", "gpu") for part in requested):
+        raise ValueError("--devices must be 'available' or a comma-separated subset of cpu,gpu")
+    selected = [kind for kind in dict.fromkeys(requested) if kind in available]
+    skipped = {
+        kind: f"no {kind.upper()} JAX device is available"
+        for kind in dict.fromkeys(requested)
+        if kind not in available
+    }
+    return selected, skipped
+
+
+def _input(quick: bool) -> VmecInput:
+    inp = VmecInput.from_file(DATA / "input.minimal_seed_nfp2")
+    rbc, zbs = inp.rbc.copy(), inp.zbs.copy()
+    # Move off the exactly axisymmetric, zero-transform saddle.
+    rbc[inp.ntor + 1, 1] += 0.01
+    zbs[inp.ntor + 1, 1] += 0.01
+    return dataclasses.replace(
+        inp,
+        rbc=rbc,
+        zbs=zbs,
+        ns_array=np.asarray([7 if quick else 11]),
+        ftol_array=np.asarray([1.0e-9 if quick else 1.0e-11]),
+        niter_array=np.asarray([1200 if quick else 2000]),
+    )
+
+
+def _metrics(quick: bool) -> dict[str, Callable[[Any], Any]]:
+    qs = opt.QuasisymmetryRatioResidual([0.5], helicity_m=1, helicity_n=0)
+    qi = QIResidual(
+        [0.5],
+        mboz=3 if quick else 4,
+        nboz=3 if quick else 4,
+        oversample=1,
+        nphi=13 if quick else 17,
+        nalpha=7 if quick else 9,
+        n_levels=4 if quick else 6,
+    )
+    return {
+        "mhd_energy": lambda sol: sol.wb,
+        "magnetic_well": lambda sol: opt.magnetic_well(sol.state, sol.runtime),
+        "quasisymmetry": lambda sol: qs.total_state(sol.state, sol.runtime),
+        "quasi_isodynamic": lambda sol: qi.total_state(sol.state, sol.runtime),
+    }
+
+
+def _run_lane(
+    kind: str,
+    device: Any,
+    inp: VmecInput,
+    metric_names: list[str],
+    *,
+    quick: bool,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    ns = int(inp.ns_array[-1])
+    ftol = float(inp.ftol_array[-1])
+    max_iterations = int(inp.niter_array[-1])
+    index = (int(inp.ntor) + 1, 1)
+    params = im.params_from_input(inp, device=device)
+
+    solve = lambda: im.run(  # noqa: E731
+        inp,
+        params,
+        ns=ns,
+        ftol=ftol,
+        max_iterations=max_iterations,
+        device=device,
+    )
+    cold_solution, cold_s = _timed(solve)
+    solution, warm_s = _timed(solve)
+    state = np.concatenate([
+        np.asarray(leaf).ravel() for leaf in jax.tree.leaves(solution.state)
+    ])
+    scalars = {
+        name: float(np.asarray(getattr(solution, name)))
+        for name in ("wb", "wp", "aspect", "volume", "iota_axis", "iota_edge")
+    }
+    lane = {
+        "status": "ok",
+        "requested_device": kind,
+        "resolved_device": str(device),
+        "parameter_device": _device_of(params.rbc),
+        "forward": {
+            "cold_wall_s": cold_s,
+            "warm_wall_s": warm_s,
+            "state_device": _device_of(solution.state.R_cos),
+            "state_size": int(state.size),
+            "state_l2_norm": float(np.linalg.norm(state)),
+            "state_max_abs": float(np.max(np.abs(state))),
+            "all_finite": bool(np.all(np.isfinite(state))),
+            "scalars": scalars,
+        },
+        "gradients": {},
+    }
+
+    metrics = _metrics(quick)
+    x0 = params.rbc[index]
+    artifacts: dict[str, Any] = {"state": state, "metrics": {}}
+    for name in metric_names:
+        metric = metrics[name]
+
+        def objective(x):
+            perturbed = dataclasses.replace(params, rbc=params.rbc.at[index].set(x))
+            return metric(im.run(
+                inp,
+                perturbed,
+                ns=ns,
+                ftol=ftol,
+                max_iterations=max_iterations,
+                device=device,
+            ))
+
+        value_and_grad = jax.value_and_grad(objective)
+        (value, gradient), metric_cold_s = _timed(lambda: value_and_grad(x0))
+        (value, gradient), metric_warm_s = _timed(lambda: value_and_grad(x0))
+        value_f, gradient_f = float(value), float(gradient)
+        lane["gradients"][name] = {
+            "value": value_f,
+            "d_d_rbc": gradient_f,
+            "value_device": _device_of(value),
+            "gradient_device": _device_of(gradient),
+            "cold_wall_s": metric_cold_s,
+            "warm_wall_s": metric_warm_s,
+        }
+        artifacts["metrics"][name] = (value_f, gradient_f)
+
+    # Keep this reference alive until both timed solves have synchronized.
+    del cold_solution
+    return lane, artifacts
+
+
+def _compare_lanes(
+    cpu: dict[str, Any],
+    gpu: dict[str, Any],
+    *,
+    rtol: float,
+) -> dict[str, Any]:
+    cpu_state, gpu_state = cpu["state"], gpu["state"]
+    delta = gpu_state - cpu_state
+    state_scale = max(float(np.linalg.norm(cpu_state)), np.finfo(float).tiny)
+    forward = {
+        "state_relative_l2": float(np.linalg.norm(delta)) / state_scale,
+        "state_max_abs_difference": float(np.max(np.abs(delta))),
+    }
+    metrics = {}
+    for name in cpu["metrics"]:
+        cpu_value, cpu_gradient = cpu["metrics"][name]
+        gpu_value, gpu_gradient = gpu["metrics"][name]
+        metrics[name] = {
+            "value_relative_difference": _relative_difference(cpu_value, gpu_value),
+            "gradient_relative_difference": _relative_difference(cpu_gradient, gpu_gradient),
+        }
+        metrics[name]["passed"] = bool(
+            metrics[name]["value_relative_difference"] <= rtol
+            and metrics[name]["gradient_relative_difference"] <= rtol
+        )
+    passed = forward["state_relative_l2"] <= rtol and all(
+        record["passed"] for record in metrics.values()
+    )
+    return {
+        "status": "passed" if passed else "failed",
+        "relative_tolerance": rtol,
+        "forward": forward,
+        "metrics": metrics,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--devices",
+        default="available",
+        help="'available' (default) or a comma-separated subset of cpu,gpu",
+    )
+    parser.add_argument(
+        "--metrics",
+        default=",".join(METRIC_NAMES),
+        help=f"comma-separated subset of {','.join(METRIC_NAMES)}",
+    )
+    parser.add_argument("--quick", action="store_true", help="use a smaller smoke-test grid")
+    parser.add_argument("--rtol", type=float, default=1.0e-7)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    available = _available_devices()
+    try:
+        devices, skipped = _requested_devices(args.devices, available)
+    except ValueError as exc:
+        _parser().error(str(exc))
+    metric_names = [part.strip() for part in args.metrics.split(",") if part.strip()]
+    unknown = [name for name in metric_names if name not in METRIC_NAMES]
+    if not metric_names or unknown:
+        _parser().error(f"unknown or empty --metrics selection: {unknown or args.metrics!r}")
+
+    inp = _input(args.quick)
+    result: dict[str, Any] = {
+        "schema_version": 1,
+        "created_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "versions": {
+            "python": platform.python_version(),
+            "vmex": getattr(vmex, "__version__", "unknown"),
+            "jax": jax.__version__,
+            "jaxlib": jax.lib.__version__,
+        },
+        "host": {"platform": platform.platform(), "machine": platform.machine()},
+        "jax": {
+            "default_backend": jax.default_backend(),
+            "devices": {
+                kind: [str(device) for device in jax.devices(kind)]
+                for kind in available
+            },
+            "platform_environment": {
+                key: os.environ.get(key) for key in ("JAX_PLATFORMS", "JAX_PLATFORM_NAME")
+            },
+        },
+        "configuration": {
+            "quick": args.quick,
+            "input": "examples/data/input.minimal_seed_nfp2",
+            "ns": int(inp.ns_array[-1]),
+            "ftol": float(inp.ftol_array[-1]),
+            "max_iterations": int(inp.niter_array[-1]),
+            "boundary_parameter": {
+                "field": "rbc",
+                "index": [int(inp.ntor) + 1, 1],
+                "mode": {"n": 1, "m": 1},
+            },
+            "metrics": metric_names,
+        },
+        "skipped_devices": skipped,
+        "lanes": {},
+    }
+    artifacts = {}
+    for kind in devices:
+        print(f"running {kind} lane ({', '.join(metric_names)})", file=sys.stderr, flush=True)
+        lane, artifact = _run_lane(
+            kind, available[kind], inp, metric_names, quick=args.quick
+        )
+        result["lanes"][kind] = lane
+        artifacts[kind] = artifact
+
+    if "cpu" in artifacts and "gpu" in artifacts:
+        result["comparison"] = _compare_lanes(artifacts["cpu"], artifacts["gpu"], rtol=args.rtol)
+    else:
+        reason = "CPU/GPU comparison requires both lanes"
+        if skipped:
+            reason += "; " + "; ".join(skipped.values())
+        result["comparison"] = {"status": "skipped", "reason": reason}
+
+    payload = json.dumps(result, indent=2, sort_keys=True)
+    print(payload)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n")
+    return int(result["comparison"]["status"] == "failed")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/device_parity.py
+++ b/benchmarks/device_parity.py
@@ -42,6 +42,7 @@ DATA = REPO / "examples" / "data"
 METRIC_NAMES = (
     "mhd_energy",
     "magnetic_well",
+    "dmerc_interior_mean",
     "quasisymmetry",
     "quasi_isodynamic",
 )
@@ -116,6 +117,9 @@ def _metrics(quick: bool) -> dict[str, Callable[[Any], Any]]:
     return {
         "mhd_energy": lambda sol: sol.wb,
         "magnetic_well": lambda sol: opt.magnetic_well(sol.state, sol.runtime),
+        "dmerc_interior_mean": lambda sol: opt.d_merc_state(
+            sol.state, sol.runtime
+        )[2:-1].mean(),
         "quasisymmetry": lambda sol: qs.total_state(sol.state, sol.runtime),
         "quasi_isodynamic": lambda sol: qi.total_state(sol.state, sol.runtime),
     }

--- a/benchmarks/profile_production.py
+++ b/benchmarks/profile_production.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 """Production-run profiling: compile/warm/per-iteration/memory per use case.
 
-Profiles the five production workflows end-to-end on the current JAX backend
-(run with ``JAX_PLATFORMS=cpu`` for the CPU profile; run on a GPU box without
-the override for the GPU profile):
+Profiles the five production workflows end-to-end on an explicitly selected
+JAX device, using VMEX's public ``device=`` API rather than platform
+environment variables:
 
 1. ``fixed_ns201``      — single-grid ns=201 fixed-boundary solve (li383)
 2. ``multigrid_ns201``  — coarse->fine ladder 51/101/201 (li383)
@@ -17,7 +17,7 @@ reports per-device peak bytes from ``jax.local_devices()[i].memory_stats()``.
 
 Usage::
 
-    python benchmarks/profile_production.py [--out profile.json] [--cases a,b]
+    python benchmarks/profile_production.py --device cpu [--out profile.json]
 
 Wall numbers on a shared machine are indicative; the compile/warm SPLIT and
 the per-iteration number are the actionable quantities.
@@ -66,49 +66,50 @@ def _timed(fn):
     return out, time.perf_counter() - t0
 
 
-def profile_fixed(ns: int = 201):
+def profile_fixed(device, ns: int = 201):
     inp = vj.VmecInput.from_file(DATA / "input.li383_low_res")
     inp = dataclasses.replace(inp, ns_array=[ns], ftol_array=[1e-11],
                               niter_array=[10000])
-    r, cold = _timed(lambda: vj.solve_multigrid(inp, verbose=False))
-    r2, warm = _timed(lambda: vj.solve_multigrid(inp, verbose=False))
+    r, cold = _timed(lambda: vj.solve_multigrid(inp, verbose=False, device=device))
+    r2, warm = _timed(lambda: vj.solve_multigrid(inp, verbose=False, device=device))
     iters = int(r2.iterations)
     return {"cold_s": cold, "warm_s": warm, "iters": iters,
             "ms_per_iter": 1e3 * warm / max(iters, 1),
             "converged": bool(r2.converged)}
 
 
-def profile_multigrid(ns: int = 201):
+def profile_multigrid(device, ns: int = 201):
     inp = vj.VmecInput.from_file(DATA / "input.li383_low_res")
     inp = dataclasses.replace(inp, ns_array=[51, 101, ns],
                               ftol_array=[1e-8, 1e-8, 1e-11],
                               niter_array=[4000, 4000, 10000])
-    r, cold = _timed(lambda: vj.solve_multigrid(inp, verbose=False))
-    r2, warm = _timed(lambda: vj.solve_multigrid(inp, verbose=False))
+    r, cold = _timed(lambda: vj.solve_multigrid(inp, verbose=False, device=device))
+    r2, warm = _timed(lambda: vj.solve_multigrid(inp, verbose=False, device=device))
     return {"cold_s": cold, "warm_s": warm, "iters": int(r2.iterations),
             "converged": bool(r2.converged)}
 
 
-def profile_free_boundary():
+def profile_free_boundary(device):
     inp = vj.VmecInput.from_file(DATA / "input.cth_like_free_bdy")
     mg = DATA / "mgrid_cth_like.nc"
     r, cold = _timed(lambda: vj.solve_free_boundary(
-        inp, mgrid_path=mg, error_on_no_convergence=False))
+        inp, mgrid_path=mg, error_on_no_convergence=False, device=device))
     r2, warm = _timed(lambda: vj.solve_free_boundary(
-        inp, mgrid_path=mg, error_on_no_convergence=False))
+        inp, mgrid_path=mg, error_on_no_convergence=False, device=device))
     iters = int(r2.iterations)
     return {"cold_s": cold, "warm_s": warm, "iters": iters,
             "ms_per_iter": 1e3 * warm / max(iters, 1),
             "converged": bool(r2.converged)}
 
 
-def profile_implicit_grad():
+def profile_implicit_grad(device):
     from vmex.core import implicit as im
     inp = vj.VmecInput.from_file(DATA / "input.solovev")
-    p0 = im.params_from_input(inp)
+    p0 = im.params_from_input(inp, device=device)
 
     def obj(p):
-        return im.run(inp, p, ftol=1e-12, max_iterations=5000).aspect
+        return im.run(inp, p, ftol=1e-12, max_iterations=5000,
+                      device=device).aspect
 
     (v, g), cold = _timed(lambda: jax.value_and_grad(obj)(p0))
     _ = float(v), float(np.asarray(g.phiedge))
@@ -117,17 +118,17 @@ def profile_implicit_grad():
     return {"cold_s": cold, "warm_s": warm}
 
 
-def profile_opt_step():
+def profile_opt_step(device):
     from vmex import optimize as opt
     inp = vj.VmecInput.from_file(DATA / "input.minimal_seed_nfp2")
     qs = opt.QuasisymmetryRatioResidual(np.linspace(0.1, 1.0, 10), 1, 0)
     terms = [(qs, 0.0, 1.0), (opt.aspect_ratio, 6.0, 1.0)]
     res, cold = _timed(lambda: opt.least_squares(
         terms, inp, max_mode=1, jac="implicit", use_ess=True, max_nfev=2,
-        ftol=1e-30, xtol=1e-30))
+        ftol=1e-30, xtol=1e-30, device=device))
     res2, warm = _timed(lambda: opt.least_squares(
         terms, inp, max_mode=1, jac="implicit", use_ess=True, max_nfev=2,
-        ftol=1e-30, xtol=1e-30))
+        ftol=1e-30, xtol=1e-30, device=device))
     return {"cold_s": cold, "warm_s": warm}
 
 
@@ -142,18 +143,23 @@ CASES = {
 
 def main() -> None:
     ap = argparse.ArgumentParser()
+    ap.add_argument("--device", choices=("auto", "none", "cpu", "gpu"),
+                    default="auto")
     ap.add_argument("--out", default=None)
     ap.add_argument("--cases", default=None, help="comma-separated subset")
     args = ap.parse_args()
     names = args.cases.split(",") if args.cases else list(CASES)
 
+    device = None if args.device == "none" else args.device
     backend = jax.default_backend()
-    print(f"backend={backend}  devices={[str(d) for d in jax.local_devices()]}")
-    results = {"backend": backend, "platform": platform.platform(), "cases": {}}
+    print(f"backend={backend}  requested_device={args.device}  "
+          f"devices={[str(d) for d in jax.local_devices()]}")
+    results = {"backend": backend, "requested_device": args.device,
+               "platform": platform.platform(), "cases": {}}
     for name in names:
         rss0 = _peak_rss_gb()
         try:
-            row = CASES[name]()
+            row = CASES[name](device)
         except Exception as exc:  # keep profiling the rest
             row = {"error": f"{type(exc).__name__}: {exc}"}
         row["peak_rss_gb"] = _peak_rss_gb()

--- a/benchmarks/run_baseline.py
+++ b/benchmarks/run_baseline.py
@@ -39,6 +39,7 @@ import json
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -46,7 +47,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 DATA = REPO / "examples" / "data"
 XVMEC2000 = Path("/Users/rogerio/local/STELLOPT/VMEC2000/Release/xvmec2000")
-VMECJAX_PY = Path.home() / ".venvs/vmecjax/bin/python"
+VMEX_PY = Path(sys.executable)
 VMECPP_PY = Path.home() / ".venvs/vmecpp/bin/python"
 
 # (case name, aux files to copy alongside the deck)
@@ -176,13 +177,16 @@ def timed_subprocess(cmd: list[str], cwd: Path, timeout: int) -> dict:
 
 def parse_vmec2000(out: dict) -> dict:
     txt = out.pop("stdout", "")
-    out["converged"] = "EXECUTION TERMINATED NORMALLY" in txt
+    out["converged"] = (
+        "EXECUTION TERMINATED NORMALLY" in txt
+        and "Try increasing NITER" not in txt
+    )
     iters = re.findall(r"^\s*(\d+)\s+[\d.E+-]+\s+[\d.E+-]+", txt, re.M)
     out["iterations"] = int(iters[-1]) if iters else None
     return out
 
 
-def parse_vmecjax(out: dict) -> dict:
+def parse_vmex(out: dict) -> dict:
     txt = out.pop("stdout", "")
     out["converged"] = out["ok"] and ("Wrote WOUT" in txt or "wout" in txt.lower())
     iters = re.findall(r"^\s*(\d+)\s+[\d.E+-]+\s+[\d.E+-]+", txt, re.M)
@@ -199,14 +203,14 @@ def run_vmec2000(deck: Path, aux: list[str], timeout: int) -> dict:
         return parse_vmec2000(timed_subprocess([str(XVMEC2000), deck.name], wd, timeout))
 
 
-def run_vmecjax_cold(deck: Path, aux: list[str], timeout: int) -> dict:
+def run_vmex_cold(deck: Path, aux: list[str], timeout: int) -> dict:
     with tempfile.TemporaryDirectory() as td:
         wd = Path(td)
         shutil.copy(deck, wd)
         for a in aux:
             shutil.copy(DATA / a, wd)
-        vmec = VMECJAX_PY.parent / "vmec"
-        return parse_vmecjax(timed_subprocess([str(vmec), deck.name], wd, timeout))
+        vmec = VMEX_PY.parent / "vmec"
+        return parse_vmex(timed_subprocess([str(vmec), deck.name], wd, timeout))
 
 
 WARM_SNIPPET = r"""
@@ -233,28 +237,30 @@ def run(path):
 
 path = sys.argv[1]
 t0 = time.time(); run(path); t1 = time.time()
-t2 = time.time(); run(path); t3 = time.time()
+t2 = time.time(); r2 = run(path); t3 = time.time()
 rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 2**20
 print(json.dumps({"cold_inproc_s": round(t1-t0,3), "warm_s": round(t3-t2,3),
-                  "peak_rss_mb": round(rss,1)}))
+                  "peak_rss_mb": round(rss,1),
+                  "iterations": int(r2.iterations),
+                  "converged": bool(r2.converged)}))
 """
 
 
-def run_vmecjax_warm(deck: Path, aux: list[str], timeout: int) -> dict:
+def run_vmex_warm(deck: Path, aux: list[str], timeout: int) -> dict:
     with tempfile.TemporaryDirectory() as td:
         wd = Path(td)
         shutil.copy(deck, wd)
         for a in aux:
             shutil.copy(DATA / a, wd)
         try:
-            proc = subprocess.run([str(VMECJAX_PY), "-c", WARM_SNIPPET, deck.name],
+            proc = subprocess.run([str(VMEX_PY), "-c", WARM_SNIPPET, deck.name],
                                   cwd=wd, capture_output=True, text=True, timeout=timeout)
         except subprocess.TimeoutExpired:
             return {"ok": False, "error": "timeout"}
         if proc.returncode != 0:
             return {"ok": False, "error": proc.stderr[-1500:]}
         line = proc.stdout.strip().splitlines()[-1]
-        return {"ok": True, "converged": True, **json.loads(line)}
+        return {"ok": True, **json.loads(line)}
 
 
 VMECPP_SNIPPET = r"""
@@ -320,8 +326,8 @@ def main() -> None:
             row: dict[str, dict] = {"ns": read_deck_ns(deck)}
             print(f"=== {key} (ns={row['ns']}) ===", flush=True)
             for solver, fn in [("vmec2000", run_vmec2000),
-                               ("vmex_cold", run_vmecjax_cold),
-                               ("vmex_warm", run_vmecjax_warm),
+                               ("vmex_cold", run_vmex_cold),
+                               ("vmex_warm", run_vmex_warm),
                                ("vmecpp", run_vmecpp)]:
                 if solver in skip:
                     continue

--- a/benchmarks/run_gpu_matrix.py
+++ b/benchmarks/run_gpu_matrix.py
@@ -3,28 +3,28 @@
 
 Runs, one cell at a time (the machine may be shared):
 
-  {decks + synthetic nfp4_QH size scan} x {JAX_PLATFORMS=cpu, cuda}
-      x {legacy vj.run_fixed_boundary, core solver.solve(mode="jit")}
+  {decks + synthetic nfp4_QH size scan} x {device=cpu, device=gpu}
+      x {solve_multigrid, solver.solve(mode="jit")}
 
 recording cold wall (first in-process solve, includes compile), warm wall
 (second in-process solve, compile cache hot), compile-vs-run split
 (cold - warm), per-iteration step time (warm / iterations), and peak device
-memory (``jax.local_devices()[0].memory_stats()`` on cuda).
+memory (``jax.local_devices()[0].memory_stats()`` on GPU).
 
 Plus two microbenchmarks of ``vmex.core.preconditioner.tridiagonal_solve``
 (hypotheses c/d of §7.8.3): CPU-vs-GPU across (ns, ncols) at fp64, and
 fp32-vs-fp64 on GPU.
 
-Every cell is a fresh subprocess with ``JAX_PLATFORMS`` set, so device
-selection and the compile cache are per-cell.
+Every cell is a fresh subprocess and selects hardware through VMEX's public
+``device=`` API.  No JAX platform environment variable is required.
 
 Usage (orchestrator):
     python benchmarks/run_gpu_matrix.py [--out benchmarks/gpu_baseline.json]
         [--only substr] [--timeout 1800] [--skip-tridiag]
 
 Internal worker modes (spawned by the orchestrator):
-    --worker solve  --deck PATH --lane {legacy,core_jit}
-    --worker tridiag --dtype {f32,f64}
+    --worker solve  --deck PATH --lane {multigrid,single_jit} --device {cpu,gpu}
+    --worker tridiag --dtype {f32,f64} --device {cpu,gpu}
 """
 
 from __future__ import annotations
@@ -62,7 +62,7 @@ TRIDIAG_NCOLS = [30, 150, 600, 2400]
 
 
 # --------------------------------------------------------------------------
-# workers (run in a subprocess with JAX_PLATFORMS already set)
+# workers (each subprocess receives an explicit device selector)
 # --------------------------------------------------------------------------
 
 def _device_mem_mb():
@@ -73,11 +73,6 @@ def _device_mem_mb():
 
 
 def _extract_iterations(result) -> int | None:
-    inner = getattr(result, "result", None)  # legacy FixedBoundaryRun.result
-    if inner is not None and inner is not result:
-        v = _extract_iterations(inner)
-        if v:
-            return v
     for attr in ("iterations", "n_iter", "niter"):
         v = getattr(result, attr, None)
         if isinstance(v, (int, float)) and v > 0:
@@ -91,7 +86,7 @@ def _extract_iterations(result) -> int | None:
     return None
 
 
-def worker_solve(deck: str, lane: str) -> dict:
+def worker_solve(deck: str, lane: str, device: str) -> dict:
     t_import0 = time.perf_counter()
     import jax
     out: dict = {
@@ -100,20 +95,22 @@ def worker_solve(deck: str, lane: str) -> dict:
     }
 
     def one_solve():
-        if lane == "legacy":
+        if lane == "multigrid":
             import vmex as vj
+            from vmex.core.input import VmecInput
+            inp = VmecInput.from_file(deck)
             t0 = time.perf_counter()
-            res = vj.run_fixed_boundary(deck, verbose=False)
+            res = vj.solve_multigrid(inp, verbose=False, device=device)
             wall = time.perf_counter() - t0
             return wall, _extract_iterations(res), True
-        elif lane == "core_jit":
+        elif lane == "single_jit":
             from vmex.core.input import VmecInput
             from vmex.core import solver
             from vmex.core.errors import VmecConvergenceError
             inp = VmecInput.from_file(deck)
             t0 = time.perf_counter()
             try:
-                res = solver.solve(inp, mode="jit", verbose=False)
+                res = solver.solve(inp, mode="jit", verbose=False, device=device)
                 wall = time.perf_counter() - t0
                 return wall, int(res.iterations), True
             except VmecConvergenceError as e:
@@ -137,7 +134,7 @@ def worker_solve(deck: str, lane: str) -> dict:
     return out
 
 
-def worker_stepscan(deck150: str, deck450: str, lane: str) -> dict:
+def worker_stepscan(deck150: str, deck450: str, lane: str, device: str) -> dict:
     """True per-iteration step time via marginal iterations.
 
     ``solve()`` retraces/recompiles per call (per-solve closures), so a plain
@@ -150,11 +147,13 @@ def worker_stepscan(deck150: str, deck450: str, lane: str) -> dict:
     import jax
 
     def one(deck):
-        if lane == "legacy":
+        if lane == "multigrid":
             import vmex as vj
+            from vmex.core.input import VmecInput
+            inp = VmecInput.from_file(deck)
             t0 = time.perf_counter()
             try:
-                vj.run_fixed_boundary(deck, verbose=False)
+                vj.solve_multigrid(inp, verbose=False, device=device)
             except Exception:
                 pass
             return time.perf_counter() - t0
@@ -163,7 +162,7 @@ def worker_stepscan(deck150: str, deck450: str, lane: str) -> dict:
         inp = VmecInput.from_file(deck)
         t0 = time.perf_counter()
         try:
-            solver.solve(inp, mode="jit", verbose=False)
+            solver.solve(inp, mode="jit", verbose=False, device=device)
         except Exception:
             pass
         return time.perf_counter() - t0
@@ -180,14 +179,15 @@ def worker_stepscan(deck150: str, deck450: str, lane: str) -> dict:
             "peak_device_mem_mb": _device_mem_mb()}
 
 
-def worker_tridiag(dtype: str) -> dict:
+def worker_tridiag(dtype: str, device: str) -> dict:
     import numpy as np
     import jax
     import jax.numpy as jnp
     from vmex.core.preconditioner import tridiagonal_solve
 
     dt = jnp.float32 if dtype == "f32" else jnp.float64
-    solve = jax.jit(tridiagonal_solve)
+    target = jax.devices(device)[0]
+    solve = jax.jit(tridiagonal_solve, device=target)
     rng = np.random.default_rng(0)
     rows = {}
     for ns in TRIDIAG_NS:
@@ -196,7 +196,7 @@ def worker_tridiag(dtype: str) -> dict:
             d = 4.0 + np.abs(rng.standard_normal((ns, ncols)))
             b = rng.standard_normal((ns, ncols))
             r = rng.standard_normal((ns, ncols))
-            args = [jnp.asarray(x, dtype=dt) for x in (a, d, b, r)]
+            args = [jax.device_put(jnp.asarray(x, dtype=dt), target) for x in (a, d, b, r)]
             solve(*args).block_until_ready()  # compile + warm
             reps = 50 if ns * ncols < 200_000 else 10
             best = min(
@@ -232,16 +232,14 @@ def make_synth_deck(ns: int, mpol: int, ntor: int, dest_dir: Path,
     return dest
 
 
-def run_cell(platform: str, worker_args: list[str], timeout: int,
+def run_cell(device: str, worker_args: list[str], timeout: int,
              cwd: Path | None = None) -> dict:
-    env = dict(os.environ)
-    env["JAX_PLATFORMS"] = platform
-    env.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
-    cmd = [sys.executable, str(Path(__file__).resolve())] + worker_args
+    cmd = [sys.executable, str(Path(__file__).resolve()),
+           "--device", device] + worker_args
     t0 = time.perf_counter()
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True,
-                              timeout=timeout, env=env, cwd=cwd)
+                              timeout=timeout, cwd=cwd)
     except subprocess.TimeoutExpired:
         return {"ok": False, "error": "timeout", "subprocess_wall_s": timeout}
     wall = time.perf_counter() - t0
@@ -261,7 +259,8 @@ def main() -> None:
     ap.add_argument("--deck")
     ap.add_argument("--deck150")
     ap.add_argument("--deck450")
-    ap.add_argument("--lane", choices=["legacy", "core_jit"])
+    ap.add_argument("--lane", choices=["multigrid", "single_jit"])
+    ap.add_argument("--device", choices=["cpu", "gpu"])
     ap.add_argument("--dtype", choices=["f32", "f64"], default="f64")
     ap.add_argument("--out", default=str(REPO / "benchmarks" / "gpu_baseline.json"))
     ap.add_argument("--only", default=None, help="substring filter on case names")
@@ -271,14 +270,14 @@ def main() -> None:
     args = ap.parse_args()
 
     if args.worker == "solve":
-        print(MARKER + json.dumps(worker_solve(args.deck, args.lane)))
+        print(MARKER + json.dumps(worker_solve(args.deck, args.lane, args.device)))
         return
     if args.worker == "tridiag":
-        print(MARKER + json.dumps(worker_tridiag(args.dtype)))
+        print(MARKER + json.dumps(worker_tridiag(args.dtype, args.device)))
         return
     if args.worker == "stepscan":
         print(MARKER + json.dumps(
-            worker_stepscan(args.deck150, args.deck450, args.lane)))
+            worker_stepscan(args.deck150, args.deck450, args.lane, args.device)))
         return
 
     synth_dir = Path(tempfile.mkdtemp(prefix="vmecjax_synth_"))
@@ -304,11 +303,11 @@ def main() -> None:
         if args.only and args.only not in name:
             continue
         results["matrix"][name] = {}
-        for platform in ("cpu", "cuda"):
-            for lane in ("legacy", "core_jit"):
-                key = f"{platform}/{lane}"
+        for device in ("cpu", "gpu"):
+            for lane in ("multigrid", "single_jit"):
+                key = f"{device}/{lane}"
                 print(f"=== {name} [{key}] ===", flush=True)
-                r = run_cell(platform,
+                r = run_cell(device,
                              ["--worker", "solve", "--deck", str(deck),
                               "--lane", lane], args.timeout)
                 results["matrix"][name][key] = r
@@ -328,11 +327,11 @@ def main() -> None:
                 d450 = make_synth_deck(ns, mpol, ntor, synth_dir, niter=450)
                 name = f"ns{ns}_mpol{mpol}_ntor{ntor}"
                 results["stepscan"][name] = {}
-                for platform in ("cpu", "cuda"):
-                    for lane in ("legacy", "core_jit"):
-                        key = f"{platform}/{lane}"
+                for device in ("cpu", "gpu"):
+                    for lane in ("multigrid", "single_jit"):
+                        key = f"{device}/{lane}"
                         print(f"=== stepscan {name} [{key}] ===", flush=True)
-                        r = run_cell(platform,
+                        r = run_cell(device,
                                      ["--worker", "stepscan",
                                       "--deck150", str(d150),
                                       "--deck450", str(d450),
@@ -344,11 +343,11 @@ def main() -> None:
                         Path(args.out).write_text(json.dumps(results, indent=1))
 
     if not args.skip_tridiag and not args.only:
-        for platform, dtype in [("cpu", "f64"), ("cuda", "f64"), ("cuda", "f32")]:
-            key = f"{platform}/{dtype}"
+        for device, dtype in [("cpu", "f64"), ("gpu", "f64"), ("gpu", "f32")]:
+            key = f"{device}/{dtype}"
             print(f"=== tridiag microbench [{key}] ===", flush=True)
             results["tridiag"][key] = run_cell(
-                platform, ["--worker", "tridiag", "--dtype", dtype],
+                device, ["--worker", "tridiag", "--dtype", dtype],
                 args.timeout)
             Path(args.out).write_text(json.dumps(results, indent=1))
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -48,9 +48,11 @@ hardware.  Its runner must carry the labels ``self-hosted``, ``linux``,
 ``x64``, and ``gpu``, provide an NVIDIA driver 580 or newer for CUDA 13, and
 must not define ``JAX_PLATFORMS`` or ``JAX_PLATFORM_NAME``.  The workflow
 installs the official ``jax[cuda13]`` distribution, verifies that JAX selects
-the GPU by ordinary hardware discovery, then runs focused CPU/GPU forward and
-implicit-gradient parity checks.  A missing or misconfigured accelerator is a
-failure, not a skipped green GPU job.
+the GPU by ordinary hardware discovery, then runs focused placement checks and
+the quick CPU/GPU parity audit for MHD energy, magnetic well, DMerc,
+quasisymmetry, and quasi-isodynamic gradients.  Timing is recorded in the
+uploaded ``device-parity`` artifact but is not a pass/fail gate.  A missing or
+misconfigured accelerator is a failure, not a skipped green GPU job.
 
 Releasing
 ---------

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -108,8 +108,10 @@ Reading the table:
 
 - **Warm** solves beat VMEC2000 on 12 of the 14 rows — typically 1.2–2.3x —
   and tie on the other two (DSHAPE, the reactor-scale QH). This includes
-  both **free-boundary** rows: the NESTOR path converges to VMEC2000 parity
-  *and* now edges out the Fortran wall clock.
+  the converged symmetric **free-boundary** row: the NESTOR path reaches
+  VMEC2000 parity *and* edges out the Fortran wall clock. The LASYM row is a
+  deliberately bounded 10,000-iteration stress case that reaches ``NITER``
+  in both codes; its wall time compares equal work, not convergence.
 - **Cold** runs pay a one-time 7–30 s XLA compile, so a single
   fire-and-forget run is slower than Fortran — except on the biggest deck
   (NuhrenbergZille at ns=201), where even the cold run, compile included,
@@ -117,7 +119,8 @@ Reading the table:
   compile cost on subsequent processes.
 - **VMEC++** is faster on some converged large decks (free
   boundary, LandremanPaul QA) but *failed* rows aborted during the first
-  iterations; ``vmex`` converges on the full suite (zero-crash policy).
+  iterations; ``vmex`` completes every supported convergent row and the
+  deliberately NITER-bounded LASYM stress row (zero-crash policy).
   ``n/a`` marks a configuration VMEC++ does not support (``lasym`` free
   boundary).
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -399,5 +399,19 @@ Reproducing the numbers
    python benchmarks/profile_production.py --device gpu
    pytest tests/test_parity_breadth.py     # end-to-end parity suite
 
+For a compact hardware-parity audit, ``device_parity.py`` runs the same small
+equilibrium on explicitly selected CPU/GPU devices and records the forward
+state plus boundary derivatives of MHD energy, magnetic well, quasisymmetry,
+and quasi-isodynamicity in JSON.  It does not set or require JAX platform
+environment variables::
+
+   python benchmarks/device_parity.py --quick --metrics mhd_energy --output /tmp/vmex-smoke.json
+   python benchmarks/device_parity.py --devices cpu,gpu --output /tmp/vmex-parity.json
+
+On a CPU-only host the default runs the CPU lane and marks the cross-device
+comparison as skipped; ``--devices cpu`` requests that lane explicitly.
+The first command is the short smoke lane; omit ``--metrics`` to audit all
+four objectives.
+
 The parity suite needs the golden VMEC2000 fixtures (fetched release assets);
 it is skipped automatically when they are unavailable.

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -402,8 +402,8 @@ Reproducing the numbers
 For a compact hardware-parity audit, ``device_parity.py`` runs the same small
 equilibrium on explicitly selected CPU/GPU devices and records the forward
 state plus boundary derivatives of MHD energy, magnetic well, quasisymmetry,
-and quasi-isodynamicity in JSON.  It does not set or require JAX platform
-environment variables::
+quasi-isodynamicity, and the mean traceable ``DMerc[2:-1]`` profile in JSON.
+It does not set or require JAX platform environment variables::
 
    python benchmarks/device_parity.py --quick --metrics mhd_energy --output /tmp/vmex-smoke.json
    python benchmarks/device_parity.py --devices cpu,gpu --output /tmp/vmex-parity.json
@@ -411,7 +411,7 @@ environment variables::
 On a CPU-only host the default runs the CPU lane and marks the cross-device
 comparison as skipped; ``--devices cpu`` requests that lane explicitly.
 The first command is the short smoke lane; omit ``--metrics`` to audit all
-four objectives.
+five objectives.
 
 The parity suite needs the golden VMEC2000 fixtures (fetched release assets);
 it is skipped automatically when they are unavailable.

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -395,7 +395,8 @@ Reproducing the numbers
 
    python benchmarks/run_baseline.py         # CPU suite -> benchmarks/baseline.json
    python benchmarks/run_gpu_matrix.py       # GPU matrix -> benchmarks/gpu_baseline.json
-   python benchmarks/profile_production.py   # the five production workflows
+   python benchmarks/profile_production.py --device cpu
+   python benchmarks/profile_production.py --device gpu
    pytest tests/test_parity_breadth.py     # end-to-end parity suite
 
 The parity suite needs the golden VMEC2000 fixtures (fetched release assets);

--- a/tests/test_baseline_benchmark.py
+++ b/tests/test_baseline_benchmark.py
@@ -1,0 +1,18 @@
+"""Regression tests for benchmark result classification."""
+
+from benchmarks.run_baseline import parse_vmec2000
+
+
+def test_vmec2000_niter_exhaustion_is_not_reported_as_convergence():
+    result = parse_vmec2000({
+        "ok": True,
+        "stdout": """
+ 1000  1.29E-01  1.09E-01  3.95E-02
+ Try increasing NITER or PRE_NITER if the preconditioner is on.
+ EXECUTION TERMINATED NORMALLY
+""",
+    })
+
+    assert result["ok"]
+    assert not result["converged"]
+    assert result["iterations"] == 1000

--- a/tests/test_device_parity_tool.py
+++ b/tests/test_device_parity_tool.py
@@ -1,0 +1,31 @@
+"""Fast contract tests for the CPU/GPU parity audit."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+PATH = Path(__file__).resolve().parents[1] / "benchmarks" / "device_parity.py"
+SPEC = importlib.util.spec_from_file_location("device_parity", PATH)
+device_parity = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(device_parity)
+
+
+def test_requested_devices_skips_an_unavailable_gpu():
+    selected, skipped = device_parity._requested_devices("cpu,gpu", {"cpu": object()})
+    assert selected == ["cpu"]
+    assert skipped == {"gpu": "no GPU JAX device is available"}
+
+
+def test_compare_lanes_reports_forward_and_gradient_parity():
+    cpu = {"state": np.array([1.0, 2.0]), "metrics": {"mhd_energy": (3.0, 4.0)}}
+    gpu = {"state": np.array([1.0, 2.0 + 1e-10]), "metrics": {"mhd_energy": (3.0, 4.0)}}
+    comparison = device_parity._compare_lanes(cpu, gpu, rtol=1e-7)
+    assert comparison["status"] == "passed"
+    assert comparison["forward"]["state_relative_l2"] == pytest.approx(1e-10 / np.sqrt(5.0))
+    assert comparison["metrics"]["mhd_energy"]["gradient_relative_difference"] == 0.0

--- a/tests/test_device_parity_tool.py
+++ b/tests/test_device_parity_tool.py
@@ -22,6 +22,11 @@ def test_requested_devices_skips_an_unavailable_gpu():
     assert skipped == {"gpu": "no GPU JAX device is available"}
 
 
+def test_metric_selection_includes_traceable_dmerc():
+    assert "dmerc_interior_mean" in device_parity.METRIC_NAMES
+    assert "dmerc_interior_mean" in device_parity._metrics(quick=True)
+
+
 def test_compare_lanes_reports_forward_and_gradient_parity():
     cpu = {"state": np.array([1.0, 2.0]), "metrics": {"mhd_energy": (3.0, 4.0)}}
     gpu = {"state": np.array([1.0, 2.0 + 1e-10]), "metrics": {"mhd_energy": (3.0, 4.0)}}

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -12,7 +12,7 @@ import pytest
 
 from vmex.core import device as device_policy
 from vmex.core import implicit as im
-from vmex.core import multigrid, solver
+from vmex.core import freeboundary, multigrid, solver
 from vmex.core.input import VmecInput
 
 
@@ -122,6 +122,45 @@ def test_multigrid_auto_moves_state_across_policy_threshold(monkeypatch):
     result = multigrid.solve_multigrid(inp, mode="jit", device="auto")
     assert result.converged
     assert seen == ["cpu", "gpu"]
+
+
+def test_explicit_free_boundary_nestor_cpu_gpu_parity():
+    """A bounded real-mgrid run reaches NESTOR on each requested device."""
+    inp = VmecInput.from_file(DATA_DIR / "input.cth_like_free_bdy_lasym_small")
+    mgrid = DATA_DIR / "mgrid_cth_like_lasym_small.nc"
+    results = {}
+    output = {}
+    for platform in ("cpu", "gpu"):
+        lines = []
+        results[platform] = freeboundary.solve_free_boundary(
+            inp,
+            mgrid_path=mgrid,
+            max_iterations=60,
+            error_on_no_convergence=False,
+            verbose=True,
+            emit=lambda *args, _lines=lines, **kwargs: _lines.append(
+                args[0] if args else ""
+            ),
+            device=platform,
+        )
+        output[platform] = "".join(lines)
+
+    for platform in ("cpu", "gpu"):
+        assert results[platform].iterations == 60
+        assert "VACUUM PRESSURE TURNED ON" in output[platform]
+        assert _platform(results[platform].state.R_cos) == platform
+    np.testing.assert_allclose(
+        [results["gpu"].fsqr, results["gpu"].fsqz, results["gpu"].fsql],
+        [results["cpu"].fsqr, results["cpu"].fsqz, results["cpu"].fsql],
+        rtol=5e-9,
+        atol=1e-12,
+    )
+    for gpu_leaf, cpu_leaf in zip(
+        jax.tree.leaves(results["gpu"].state),
+        jax.tree.leaves(results["cpu"].state),
+        strict=True,
+    ):
+        np.testing.assert_allclose(gpu_leaf, cpu_leaf, rtol=5e-9, atol=1e-11)
 
 
 def test_explicit_implicit_gradient_cpu_gpu_parity():

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -124,13 +124,28 @@ def test_multigrid_auto_moves_state_across_policy_threshold(monkeypatch):
     assert seen == ["cpu", "gpu"]
 
 
-def test_explicit_free_boundary_nestor_cpu_gpu_parity():
+def test_explicit_free_boundary_nestor_cpu_gpu_parity(monkeypatch):
     """A bounded real-mgrid run reaches NESTOR on each requested device."""
     inp = VmecInput.from_file(DATA_DIR / "input.cth_like_free_bdy_lasym_small")
     mgrid = DATA_DIR / "mgrid_cth_like_lasym_small.nc"
     results = {}
     output = {}
+    active_platform = ["cpu"]
+    vacuum_devices = {}
+    vacuum_step = freeboundary._vacuum_step
+
+    def recording_vacuum_step(*args, **kwargs):
+        value = vacuum_step(*args, **kwargs)
+        fb = kwargs["fb"]
+        vacuum_devices[active_platform[0]] = {
+            _platform(getattr(fb, name))
+            for name in ("potvac", "mode_matrix", "bvec_nonsing", "bsqvac")
+        }
+        return value
+
+    monkeypatch.setattr(freeboundary, "_vacuum_step", recording_vacuum_step)
     for platform in ("cpu", "gpu"):
+        active_platform[0] = platform
         lines = []
         results[platform] = freeboundary.solve_free_boundary(
             inp,
@@ -149,6 +164,7 @@ def test_explicit_free_boundary_nestor_cpu_gpu_parity():
         assert results[platform].iterations == 60
         assert "VACUUM PRESSURE TURNED ON" in output[platform]
         assert _platform(results[platform].state.R_cos) == platform
+        assert vacuum_devices[platform] == {platform}
     np.testing.assert_allclose(
         [results["gpu"].fsqr, results["gpu"].fsqz, results["gpu"].fsql],
         [results["cpu"].fsqr, results["cpu"].fsqz, results["cpu"].fsql],

--- a/tests/test_parity_breadth.py
+++ b/tests/test_parity_breadth.py
@@ -330,11 +330,3 @@ def test_asymmetric_harmonics_lasym(case, golden_wout):
 )
 def test_nuhrenberg_zille():  # pragma: no cover - documented skip
     raise NotImplementedError
-
-
-@pytest.mark.skip(
-    reason="cth_like_free_bdy_lasym_small is free-boundary; the new core has "
-           "no free-boundary (mgrid/Nestor) path yet"
-)
-def test_cth_like_free_boundary_lasym():  # pragma: no cover - documented skip
-    raise NotImplementedError

--- a/tools/README.md
+++ b/tools/README.md
@@ -10,6 +10,9 @@ This directory contains developer-facing tools, not end-user examples.
   `value_and_grad` adjoint). Backend-agnostic — the same script produces the
   CPU and GPU numbers with `--device cpu` / `--device gpu`.
 
+Hardware parity across forward solves and boundary gradients is audited by
+`benchmarks/device_parity.py`; use `--quick` for its reduced-grid smoke mode.
+
 Tools may write to ignored `outputs/` or a user-selected scratch directory.
 They should not write tracked artifacts unless the command is explicitly a
 documentation or release-artifact promotion step.

--- a/tools/README.md
+++ b/tools/README.md
@@ -8,7 +8,7 @@ This directory contains developer-facing tools, not end-user examples.
 - `profile_hotpaths.py`: cold-vs-warm wall-time + peak-RSS profile of the
   production hot paths (fixed-boundary solve and the differentiable
   `value_and_grad` adjoint). Backend-agnostic — the same script produces the
-  CPU numbers and can be run on a GPU box (`JAX_PLATFORMS=cuda`).
+  CPU and GPU numbers with `--device cpu` / `--device gpu`.
 
 Tools may write to ignored `outputs/` or a user-selected scratch directory.
 They should not write tracked artifacts unless the command is explicitly a

--- a/tools/profile_hotpaths.py
+++ b/tools/profile_hotpaths.py
@@ -10,11 +10,11 @@ run, warm = run only) and peak RSS, for the two paths that dominate real use:
 plus a cProfile of a warm solve to confirm Python-level orchestration overhead
 is negligible (all compute lives in XLA).
 
-Runs on whatever backend JAX is configured for, so it is the same script for
-the CPU numbers in the docs and for a GPU box::
+Selects hardware through VMEX's public API, so it is the same script for CPU
+and GPU measurements without JAX platform environment variables::
 
-    JAX_ENABLE_X64=1 python tools/profile_hotpaths.py
-    JAX_PLATFORMS=cuda JAX_ENABLE_X64=1 python tools/profile_hotpaths.py --cases solovev
+    python tools/profile_hotpaths.py --device cpu
+    python tools/profile_hotpaths.py --device gpu --cases solovev
 
 On CPU the dominant latency is compile time, which the persistent compilation
 cache (on by default; see ``vmex._compat``) amortises across processes; the
@@ -60,26 +60,26 @@ def _load(case: str) -> vj.VmecInput:
     return vj.VmecInput.from_file(os.path.join(DATA, f"input.{case}"))
 
 
-def profile_solve(cases: list[str]) -> None:
+def profile_solve(cases: list[str], device) -> None:
     print("\n1. FIXED-BOUNDARY MULTIGRID SOLVE  (cold = compile+run, warm = run)")
     print(f"{'case':18s} {'cold s':>9} {'warm s':>9} {'compile s':>10} "
           f"{'iters':>7} {'peakRSS MB':>11}")
     for case in cases:
         inp = _load(case)
-        _, t_cold = timed(lambda: vj.solve_multigrid(inp, verbose=False))
-        res, t_warm = timed(lambda: vj.solve_multigrid(inp, verbose=False))
+        _, t_cold = timed(lambda: vj.solve_multigrid(inp, verbose=False, device=device))
+        res, t_warm = timed(lambda: vj.solve_multigrid(inp, verbose=False, device=device))
         print(f"{case:18s} {t_cold:9.2f} {t_warm:9.2f} {t_cold - t_warm:10.2f} "
               f"{int(res.iterations):7d} {peak_mb():11.1f}")
 
 
-def profile_grad(cases: list[str]) -> None:
+def profile_grad(cases: list[str], device) -> None:
     print("\n2. DIFFERENTIABLE value_and_grad(wb)  (implicit forward + adjoint)")
     print(f"{'case':18s} {'cold s':>9} {'warm s':>9} {'compile s':>10} {'peakRSS MB':>11}")
     for case in cases:
         inp = _load(case)
-        p0 = im.params_from_input(inp)
+        p0 = im.params_from_input(inp, device=device)
         cfg = _GRAD_CFG.get(case, dict(ftol=1e-12, max_iterations=4000))
-        vg = jax.value_and_grad(lambda p: im.run(inp, p, **cfg).wb)
+        vg = jax.value_and_grad(lambda p: im.run(inp, p, device=device, **cfg).wb)
         (_, _), t_cold = timed(lambda: vg(p0))
         (v, g), t_warm = timed(lambda: vg(p0))
         print(f"{case:18s} {t_cold:9.2f} {t_warm:9.2f} {t_cold - t_warm:10.2f} "
@@ -88,13 +88,13 @@ def profile_grad(cases: list[str]) -> None:
               f"{float(np.linalg.norm(np.asarray(g.rbc))):.3e}")
 
 
-def profile_python_overhead(case: str) -> None:
+def profile_python_overhead(case: str, device) -> None:
     print("\n3. cProfile OF A WARM SOLVE  (top Python-level cumulative time)")
     inp = _load(case)
-    vj.solve_multigrid(inp, verbose=False)          # warm the cache
+    vj.solve_multigrid(inp, verbose=False, device=device)  # warm the cache
     pr = cProfile.Profile()
     pr.enable()
-    vj.solve_multigrid(inp, verbose=False)
+    vj.solve_multigrid(inp, verbose=False, device=device)
     pr.disable()
     buf = io.StringIO()
     pstats.Stats(pr, stream=buf).sort_stats("cumulative").print_stats(25)
@@ -113,17 +113,21 @@ def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--cases", default="solovev,li383_low_res",
                     help="comma-separated deck names under examples/data/input.*")
+    ap.add_argument("--device", choices=("auto", "none", "cpu", "gpu"),
+                    default="auto")
     ap.add_argument("--no-grad", action="store_true", help="skip the value_and_grad path")
     ap.add_argument("--no-cprofile", action="store_true", help="skip the cProfile section")
     args = ap.parse_args()
     cases = [c.strip() for c in args.cases.split(",") if c.strip()]
+    device = None if args.device == "none" else args.device
 
-    print(f"JAX backend: {jax.default_backend()}   x64={jax.config.read('jax_enable_x64')}")
-    profile_solve(cases)
+    print(f"JAX backend: {jax.default_backend()}   requested={args.device}   "
+          f"x64={jax.config.read('jax_enable_x64')}")
+    profile_solve(cases, device)
     if not args.no_grad:
-        profile_grad([c for c in cases if c == "solovev"] or cases[:1])
+        profile_grad([c for c in cases if c == "solovev"] or cases[:1], device)
     if not args.no_cprofile:
-        profile_python_overhead(cases[-1])
+        profile_python_overhead(cases[-1], device)
     print(f"\npeak RSS (whole run): {peak_mb():.1f} MB")
 
 

--- a/vmex/doctor.py
+++ b/vmex/doctor.py
@@ -197,7 +197,7 @@ def format_report(report: DoctorReport) -> str:
     lines.extend(
         [
             "VMEX forward default:  automatic size-based CPU/GPU policy",
-            "VMEX implicit default: CPU on accelerator hosts (optimizer device= overrides)",
+            "VMEX implicit default: CPU on accelerator hosts (explicit device= overrides)",
         ]
     )
     lines.append("")


### PR DESCRIPTION
## Summary

Provide a reproducible hardware-parity audit using VMEX's public device APIs instead of environment-variable platform selection.

## Main changes

- Update production profiling and GPU-matrix scripts to use `device=`.
- Add a JSON-producing CPU/GPU parity audit.
- Compare forward state and boundary gradients for MHD energy, magnetic well, Mercier stability, quasisymmetry, and quasi-isodynamicity.
- Record selected devices, cold/warm timing, state norms, scalar outputs, and relative differences.
- Add CPU-only behavior and argument-validation tests.
- Run the quick five-physics CPU/GPU audit in trusted manual GPU CI and upload
  its JSON timing/parity artifact; timing is recorded but never used as a gate.
- Exercise a real tracked-mgrid NESTOR solve for 60 iterations on CPU/GPU and
  assert placement of its potential, mode matrix, nonsingular source, and
  boundary-pressure cache.
- Report bounded benchmark convergence honestly and use measured warm-run
  convergence/iteration data instead of hard-coded success.
- Split the long full-physics core nightly into four disjoint alphabetical
  jobs and isolate the QA/QH/QP campaigns on fresh workers.

## Results

On two RTX A4000 GPUs without platform-selection environment variables:

| Quantity | CPU/GPU relative difference |
| --- | ---: |
| MHD-energy gradient | `5.68e-16` |
| Magnetic-well gradient | `1.21e-10` |
| Mercier gradient | `1.56e-12` |
| Quasisymmetry gradient | `1.94e-15` |
| Quasi-isodynamic gradient | `5.75e-14` |

- Forward-state maximum and relative L2 differences are both exactly zero in
  the current quick audit.
- CPU-only hosts run the CPU lane and explicitly report the unavailable cross-device comparison.
- Bounded NESTOR activates the vacuum solve on both devices; CPU/GPU state and
  residual relative differences are `7.3e-15` and `2.4e-12`, respectively.
- Fresh VMEC2000 fixed-boundary comparisons of `wb/rmnc/zmns/iota` are within
  `9.14e-12` across Solovev, CTH, and QH cases. The converged CTH free-boundary
  comparison is looser, with a worst reported relative difference of `1.244e-4`.
- VMEX warm time was lower on all 14 benchmark rows in this run (speedup
  `1.37-3.91x`, median `1.88x`). The LASYM row is a bounded nonconverged stress
  case in both programs; 14/14 is a timing result, not a convergence claim.

## Validation

- Focused CPU fixed/free-boundary, multigrid, hot-restart, WOUT, and parity
  suite: `89 passed, 13 skipped, 2 xfailed`.
- The exact local CPU `RUN_FULL=1` execution collected `750` tests and reported
  `715 passed, 32 skipped, 2 xfailed`, plus one basin-sensitive QP assertion.
  That run reduced QP by 22.5% (`0.445789 -> 0.345527`), satisfying the restored
  relative 15% guard; the corrected exact test then passed in `699.46 s`.
- Office CUDA 13 focused placement/parity suite: `33 passed` on two RTX A4000s
  with Python 3.12.13 and JAX/JAXlib 0.11.0, with routing variables unset.
- The complete office sweep before reference-asset installation reported
  `700 passed, 42 skipped, 2 xfailed`; its only two failures were the missing
  mgrid examples. After installing the asset, those examples plus the latest
  six-test GPU module pass together (`8 passed`).
- Latest five-physics CPU/GPU audit: MHD (`5.68e-16`), well (`1.21e-10`),
  DMerc (`1.56e-12`), quasisymmetry (`1.94e-15`), and quasi-isodynamicity
  (`5.75e-14`) relative gradient differences; forward-state difference zero.
- Deep DMerc CPU/GPU parity covers three Solovev boundary components,
  pressure, two 3-D boundary components, and toroidal current; worst relative
  difference `6.00e-11`.
- Full/nightly shards now emit a one-minute liveness heartbeat while pytest
  runs without changing test selection or exit status. A manual replay still
  terminated QH and QP with runner SIGTERM/143 after regular heartbeats and no
  assertion or traceback, proving silent-log reaping was not the cause; the
  optimization campaigns therefore need separately measured evaluation caps.
- Final stack checks: CI-scope Ruff, mypy, `git diff --check`, strict Sphinx, and wheel/sdist builds pass.

Stack 8/8. Depends on `codex/docs-diagnostics`.
