### PR TITLE
Fix indexed INDATA parsing and localize non-finite forces

### DIFF
--- a/tests/test_freeboundary.py
+++ b/tests/test_freeboundary.py
@@ -28,6 +28,7 @@ structural + coarse:
 
 from __future__ import annotations
 
+import dataclasses
 import re
 from pathlib import Path
 
@@ -395,6 +396,23 @@ def test_missing_mgrid_raises(tmp_path):
     inp = VmecInput.from_file(DECK)
     with pytest.raises(MgridNotFoundError):
         FB.solve_free_boundary(inp, mgrid_path=tmp_path / "mgrid_missing.nc")
+
+
+def test_bad_supplied_axis_is_reguessed_before_fused_filament(capsys):
+    """Free boundary must share fixed boundary's first-bad-axis recovery."""
+    inp = VmecInput.from_file(DECK)
+    raxis_c = inp.raxis_c.copy()
+    raxis_c[0] = 2.0  # deliberately outside the CTH-like plasma boundary
+    inp = dataclasses.replace(inp, raxis_c=raxis_c, niter_array=[2], nstep=1)
+    result = FB.solve_free_boundary(
+        inp, mgrid_path=MGRID, max_iterations=2, verbose=True,
+        error_on_no_convergence=False,
+    )
+    output = capsys.readouterr().out
+    assert "TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS" in output
+    assert not result.converged
+    assert np.isfinite(result.fsqr)
+    assert result.r00 < 1.0
 
 
 def test_cli_missing_mgrid_fallback_warns(tmp_path):

--- a/tests/test_input_profiles.py
+++ b/tests/test_input_profiles.py
@@ -143,6 +143,38 @@ def test_indexed_aphi_overlays_dense_assignment() -> None:
     np.testing.assert_array_equal(inp.aphi[:3], [0.0, 1.0, 0.0])
 
 
+def test_indexed_aphi_starting_element_consumes_following_values() -> None:
+    """Fortran ``APHI(1)=0,1`` assigns two elements, not one scalar."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        MPOL = 3
+        NTOR = 0
+        APHI(1) = 0.0, 1.0
+        RBC(0,0) = 1.0
+        RBC(0,1) = 0.1
+        ZBS(0,1) = 0.1
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.aphi[:3], [0.0, 1.0, 0.0])
+
+
+def test_indexed_aphi_section_uses_fortran_inclusive_bounds() -> None:
+    """A non-leading array section retains VMEC's initialized first term."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        MPOL = 3
+        NTOR = 0
+        APHI(2:3) = 0.25, 0.5
+        RBC(0,0) = 1.0
+        RBC(0,1) = 0.1
+        ZBS(0,1) = 0.1
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.aphi[:4], [1.0, 0.25, 0.5, 0.0])
+
+
 def test_indexed_legacy_axis_overlays_vmec_axis() -> None:
     """Indexed obsolete RAXIS/ZAXIS entries retain VMEC2000 compatibility."""
     inp = VmecInput.from_indata_text(

--- a/tests/test_input_profiles.py
+++ b/tests/test_input_profiles.py
@@ -73,3 +73,91 @@ def test_vmecpp_json_example() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         assert VmecInput.from_file(new.to_json(Path(tmp) / "x.json")) == new
         assert VmecInput.from_file(new.to_indata(Path(tmp) / "input.x")) == new
+
+
+def test_indexed_indata_vectors_overlay_vmec_defaults() -> None:
+    """Indexed 1-D assignments follow VMEC2000 namelist lower bounds/defaults."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        MPOL = 3
+        NTOR = 0
+        APHI(2) = 0.25
+        AM(0) = 1000.0
+        AI(1) = -0.125
+        AC(2) = 0.5
+        NS_ARRAY(1) = 7
+        NS_ARRAY(2) = 15
+        FTOL_ARRAY(2) = 1e-12
+        NITER_ARRAY(2) = 400
+        EXTCUR(2) = -3.0
+        RBC(0,0) = 1.0
+        RBC(0,1) = 0.1
+        ZBS(0,1) = 0.1
+        /
+        """
+    )
+
+    # vmec_input.f initializes APHI(1)=1 before applying APHI(2).
+    np.testing.assert_array_equal(inp.aphi[:3], [1.0, 0.25, 0.0])
+    np.testing.assert_array_equal(inp.am[:3], [1000.0, 0.0, 0.0])
+    np.testing.assert_array_equal(inp.ai[:3], [0.0, -0.125, 0.0])
+    np.testing.assert_array_equal(inp.ac[:3], [0.0, 0.0, 0.5])
+    np.testing.assert_array_equal(inp.ns_array, [7, 15])
+    np.testing.assert_array_equal(inp.ftol_array, [1e-10, 1e-12])
+    # A partial NITER_ARRAY assignment prevents VMEC2000's all--1 fallback;
+    # unassigned active entries therefore remain -1.
+    np.testing.assert_array_equal(inp.niter_array, [-1, 400])
+    np.testing.assert_array_equal(inp.extcur, [0.0, -3.0])
+
+
+def test_indexed_aphi_can_override_identity_term() -> None:
+    """APHI(1) is one-based and may explicitly replace the VMEC default."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        MPOL = 3
+        NTOR = 0
+        APHI(1) = 0.5
+        RBC(0,0) = 1.0
+        RBC(0,1) = 0.1
+        ZBS(0,1) = 0.1
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.aphi[:3], [0.5, 0.0, 0.0])
+
+
+def test_indexed_aphi_overlays_dense_assignment() -> None:
+    """A sparse APHI term is not discarded after a dense leading zero."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        MPOL = 3
+        NTOR = 0
+        APHI = 0.0
+        APHI(2) = 1.0
+        RBC(0,0) = 1.0
+        RBC(0,1) = 0.1
+        ZBS(0,1) = 0.1
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.aphi[:3], [0.0, 1.0, 0.0])
+
+
+def test_indexed_legacy_axis_overlays_vmec_axis() -> None:
+    """Indexed obsolete RAXIS/ZAXIS entries retain VMEC2000 compatibility."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        MPOL = 3
+        NTOR = 1
+        RAXIS_CC(0) = 1.0
+        RAXIS(0) = 2.0
+        RAXIS(1) = 0.25
+        ZAXIS(1) = -0.5
+        RBC(0,0) = 1.0
+        RBC(0,1) = 0.1
+        ZBS(0,1) = 0.1
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.raxis_c, [2.0, 0.25])
+    np.testing.assert_array_equal(inp.zaxis_s, [0.0, -0.5])

--- a/tests/test_nonfinite_failfast.py
+++ b/tests/test_nonfinite_failfast.py
@@ -1,0 +1,40 @@
+"""Regression tests for first-iteration NaN/Inf handling."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from vmex.core.errors import VmecNumericalError
+from vmex.core.input import VmecInput
+from vmex.core.solver import solve
+from tools.diagnose_input import diagnose
+
+
+DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
+
+
+@pytest.mark.usefixtures("_module_jit_enabled")
+def test_zero_effective_toroidal_flux_fails_on_first_iteration() -> None:
+    """Zero PHIEDGE used to print NaNs until NITER was exhausted."""
+    inp = VmecInput.from_file(DATA / "input.nfp2_QI")
+    inp = dataclasses.replace(inp, phiedge=0.0, niter_array=[27])
+    with pytest.raises(VmecNumericalError, match="NON-FINITE") as caught:
+        solve(inp, max_iterations=27)
+    assert caught.value.iteration == 1
+    assert "PHIEDGE" in caught.value.hint
+
+
+def test_shareable_diagnostic_redacts_input_details(capsys) -> None:
+    """Default output must be safe to share for a confidential input deck."""
+    path = DATA / "input.nfp2_QI"
+    assert diagnose(path) == 0
+    output = capsys.readouterr().out
+    assert "input.nfp2_QI" not in output
+    assert "phiedge=" not in output.lower()
+    assert "nfp=" not in output.lower()
+    assert "R(0)=" not in output
+    assert "FSQR=" not in output
+    assert "OK_FIRST_FORCE_PASS_FINITE" in output

--- a/tests/test_nonfinite_failfast.py
+++ b/tests/test_nonfinite_failfast.py
@@ -38,3 +38,80 @@ def test_shareable_diagnostic_redacts_input_details(capsys) -> None:
     assert "R(0)=" not in output
     assert "FSQR=" not in output
     assert "OK_FIRST_FORCE_PASS_FINITE" in output
+
+
+def test_shareable_diagnostic_localizes_zero_energy_scale(
+    tmp_path: Path, capsys
+) -> None:
+    """The public code identifies normalization failure without leaking values."""
+    inp = VmecInput.from_file(DATA / "input.nfp2_QI")
+    private_path = dataclasses.replace(inp, phiedge=0.0).to_indata(
+        tmp_path / "input.confidential_name"
+    )
+
+    assert diagnose(private_path) == 1
+    output = capsys.readouterr().out
+    assert "D03C_ZERO_ENERGY_SCALE" in output
+    assert "unnormalized force sums finite: PASS" in output
+    assert "input.confidential_name" not in output
+    assert "phiedge=" not in output.lower()
+    assert "FSQR=" not in output
+
+
+def test_shareable_diagnostic_flags_unsupported_reconstruction(
+    tmp_path: Path, capsys
+) -> None:
+    """VMEC reconstruction inputs fail explicitly instead of being ignored."""
+    path = tmp_path / "input.private_reconstruction"
+    path.write_text(
+        """&INDATA
+        LRECON = T
+        IMSE = 1
+        MPOL = 3
+        NTOR = 0
+        RBC(0,0) = 1.0
+        RBC(0,1) = 0.1
+        ZBS(0,1) = 0.1
+        /
+        """
+    )
+
+    assert diagnose(path) == 1
+    output = capsys.readouterr().out
+    assert "D00A_RECONSTRUCTION_MODE_UNSUPPORTED" in output
+    assert "private_reconstruction" not in output
+    assert "RBC" not in output
+
+
+def test_inert_reconstruction_flag_matches_vmec2000_disable(
+    tmp_path: Path, capsys
+) -> None:
+    """read_indata.f disables LRECON when no MSE or Thomson data are active."""
+    inp = VmecInput.from_file(DATA / "input.nfp2_QI")
+    path = inp.to_indata(tmp_path / "input.inert_reconstruction")
+    text = path.read_text().replace("&INDATA", "&INDATA\n  LRECON = T")
+    path.write_text(text)
+
+    assert diagnose(path) == 0
+    output = capsys.readouterr().out
+    assert "input physics mode supported: PASS" in output
+    assert "OK_FIRST_FORCE_PASS_FINITE" in output
+
+
+def test_indexed_aphi_prevents_false_zero_flux_diagnosis(
+    tmp_path: Path, capsys
+) -> None:
+    """Dense APHI=0 plus APHI(2) is finite in VMEC2000 and must be in VMEX."""
+    inp = VmecInput.from_file(DATA / "input.nfp2_QI")
+    path = inp.to_indata(tmp_path / "input.indexed_aphi")
+    text = path.read_text().replace(
+        "  APHI = 1.0000000000000000E+00",
+        "  APHI = 0.0\n  APHI(2) = 1.0",
+    )
+    path.write_text(text)
+
+    assert diagnose(path) == 0
+    output = capsys.readouterr().out
+    assert "R/Z force normalization valid: PASS" in output
+    assert "lambda force normalization valid: PASS" in output
+    assert "OK_FIRST_FORCE_PASS_FINITE" in output

--- a/tests/test_nonfinite_failfast.py
+++ b/tests/test_nonfinite_failfast.py
@@ -115,3 +115,22 @@ def test_indexed_aphi_prevents_false_zero_flux_diagnosis(
     assert "R/Z force normalization valid: PASS" in output
     assert "lambda force normalization valid: PASS" in output
     assert "OK_FIRST_FORCE_PASS_FINITE" in output
+
+
+def test_indexed_aphi_multivalue_prevents_false_zero_flux_diagnosis(
+    tmp_path: Path, capsys
+) -> None:
+    """VMEC2000 treats APHI(1)=0,1 as two vector elements."""
+    inp = VmecInput.from_file(DATA / "input.nfp2_QI")
+    path = inp.to_indata(tmp_path / "input.indexed_aphi_multivalue")
+    text = path.read_text().replace(
+        "  APHI = 1.0000000000000000E+00",
+        "  APHI(1) = 0.0, 1.0",
+    )
+    path.write_text(text)
+
+    assert diagnose(path) == 0
+    output = capsys.readouterr().out
+    assert "R/Z force normalization valid: PASS" in output
+    assert "lambda force normalization valid: PASS" in output
+    assert "OK_FIRST_FORCE_PASS_FINITE" in output

--- a/tools/README.md
+++ b/tools/README.md
@@ -13,6 +13,13 @@ This directory contains developer-facing tools, not end-user examples.
 Hardware parity across forward solves and boundary gradients is audited by
 `benchmarks/device_parity.py`; use `--quick` for its reduced-grid smoke mode.
 
+- `diagnose_input.py`: runs the first VMEC force evaluation without entering
+  the nonlinear iteration. Its default shareable report contains only runtime
+  information, pass/fail checks, and a diagnostic code; it omits the input
+  path and all input-derived values. `--details` exposes parsed controls and
+  numerical values for local use with non-confidential decks only:
+  `python tools/diagnose_input.py path/to/input.case`.
+
 Tools may write to ignored `outputs/` or a user-selected scratch directory.
 They should not write tracked artifacts unless the command is explicitly a
 documentation or release-artifact promotion step.

--- a/tools/README.md
+++ b/tools/README.md
@@ -15,9 +15,10 @@ Hardware parity across forward solves and boundary gradients is audited by
 
 - `diagnose_input.py`: runs the first VMEC force evaluation without entering
   the nonlinear iteration. Its default shareable report contains only runtime
-  information, pass/fail checks, and a diagnostic code; it omits the input
-  path and all input-derived values. `--details` exposes parsed controls and
-  numerical values for local use with non-confidential decks only:
+  information, pass/fail checks for field assembly, force normalization,
+  Fourier projection, and preconditioning, plus a diagnostic code. It omits
+  the input path and all input-derived values. `--details` exposes parsed
+  controls and numerical values for local use with non-confidential decks only:
   `python tools/diagnose_input.py path/to/input.case`.
 
 Tools may write to ignored `outputs/` or a user-selected scratch directory.

--- a/tools/diagnose_input.py
+++ b/tools/diagnose_input.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+"""Print a privacy-preserving first-iteration diagnosis for one VMEC input deck.
+
+Usage::
+
+    python tools/diagnose_input.py path/to/input.case
+
+This intentionally stops before a full equilibrium solve or NESTOR call.  Its
+default output is safe to share: it omits the input path, every parsed input
+value, resolution, profile name, axis value, coefficient, and force magnitude.
+Use ``--details`` only for local diagnosis of a non-confidential deck.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import fields, is_dataclass
+import os
+from pathlib import Path
+from typing import Any
+
+import jax
+import numpy as np
+
+from vmex.core.geometry import half_mesh_jacobian
+from vmex.core.input import VmecInput
+from vmex.core.solver import _geometry, _initial_state, evaluate_forces, prepare_runtime
+
+
+def _named_arrays(value: Any, prefix: str = ""):
+    if is_dataclass(value):
+        for field in fields(value):
+            name = f"{prefix}.{field.name}" if prefix else field.name
+            yield from _named_arrays(getattr(value, field.name), name)
+        return
+    if isinstance(value, tuple) and hasattr(value, "_fields"):
+        for name in value._fields:
+            child = f"{prefix}.{name}" if prefix else name
+            yield from _named_arrays(getattr(value, name), child)
+        return
+    try:
+        array = np.asarray(value)
+    except Exception:
+        return
+    if np.issubdtype(array.dtype, np.number):
+        yield prefix, array
+
+
+def _nonfinite_names(value: Any, prefix: str) -> list[str]:
+    return [name for name, array in _named_arrays(value, prefix) if not np.isfinite(array).all()]
+
+
+def _range(value: Any) -> str:
+    array = np.asarray(value, dtype=float)
+    if not array.size:
+        return "empty"
+    if not np.isfinite(array).all():
+        return "non-finite"
+    return f"[{array.min():.6e}, {array.max():.6e}]"
+
+
+def diagnose(path: Path, *, details: bool = False) -> int:
+    inp = VmecInput.from_file(path)
+    rt = prepare_runtime(inp)
+    state = _initial_state(rt.setup)
+    _, geometry = _geometry(state, rt)
+    jacobian = half_mesh_jacobian(geometry, s=rt.setup.s_full)
+    gc, residuals, diagnostics = evaluate_forces(state, rt)
+
+    axis_supplied = any(
+        np.any(np.asarray(value) != 0.0)
+        for value in (inp.raxis_c, inp.raxis_s, inp.zaxis_c, inp.zaxis_s)
+    )
+    setup_bad = _nonfinite_names(rt.setup, "setup")
+    raw_bad = _nonfinite_names(residuals, "residual")
+    update_bad = (
+        _nonfinite_names(gc, "force")
+        + _nonfinite_names(diagnostics.preconditioned, "preconditioned")
+        + _nonfinite_names(diagnostics.cache, "preconditioner_cache")
+    )
+    diagnostic_bad = _nonfinite_names(
+        (diagnostics.wb, diagnostics.wp, diagnostics.r00, diagnostics.z00),
+        "diagnostics",
+    )
+    force_bad = raw_bad + update_bad + diagnostic_bad
+    fsq = (float(residuals.fsqr), float(residuals.fsqz), float(residuals.fsql))
+    pre = diagnostics.preconditioned
+
+    print("VMEX first-iteration diagnostic (shareable, input details redacted)")
+    print(
+        "runtime: "
+        f"jax={jax.__version__} backend={jax.default_backend()} "
+        f"x64={bool(jax.config.jax_enable_x64)} "
+        f"VMEX_FAST_COMPILE={os.environ.get('VMEX_FAST_COMPILE', '<default>')}"
+    )
+    sqrt_g = np.asarray(jacobian.sqrt_g)[1:]
+    jacobian_finite = np.isfinite(sqrt_g).all()
+    jacobian_good = jacobian_finite and not bool(jacobian.jacobian_sign_changed)
+    print(f"setup arrays finite: {'PASS' if not setup_bad else 'FAIL'}")
+    print(f"initial Jacobian valid: {'PASS' if jacobian_good else 'FAIL'}")
+    print(f"raw force residuals finite: {'PASS' if not raw_bad else 'FAIL'}")
+    print(f"preconditioned update finite: {'PASS' if not update_bad else 'FAIL'}")
+    print(f"other force diagnostics finite: {'PASS' if not diagnostic_bad else 'FAIL'}")
+
+    if details:
+        print("\nLOCAL DETAILS — do not share for a confidential deck")
+        print(f"input: {path.resolve()}")
+        print(
+            "resolution: "
+            f"nfp={inp.nfp} mpol={inp.mpol} ntor={inp.ntor} "
+            f"ntheta={rt.resolution.ntheta} nzeta={rt.resolution.nzeta} "
+            f"ns={rt.resolution.ns} lasym={inp.lasym} lfreeb={inp.lfreeb}"
+        )
+        print(
+            "controls: "
+            f"phiedge={inp.phiedge:.17g} delt={inp.delt:.17g} "
+            f"gamma={inp.gamma:.17g} ncurr={inp.ncurr} curtor={inp.curtor:.17g} "
+            f"precon_type={inp.precon_type!r} "
+            f"prec2d_threshold={inp.prec2d_threshold:.3e}"
+        )
+        print(
+            "profiles: "
+            f"pmass={inp.pmass_type!r} pcurr={inp.pcurr_type!r} "
+            f"piota={inp.piota_type!r} phips={_range(rt.setup.phips)} "
+            f"lamscale={float(rt.setup.lamscale):.6e} mass={_range(rt.setup.mass)}"
+        )
+        print(
+            "axis: "
+            f"input={'supplied' if axis_supplied else 'missing -> inferred'} "
+            f"R(0)={float(np.sum(np.asarray(rt.setup.raxis_c))):.6e} "
+            f"Z-coeff-max={float(np.max(np.abs(np.asarray(rt.setup.zaxis_s)))):.6e}"
+        )
+        print(
+            "jacobian: "
+            f"sign_changed={bool(jacobian.jacobian_sign_changed)} "
+            f"sqrt_g(interior)={_range(sqrt_g)} "
+            f"zero_count={int(np.count_nonzero(sqrt_g == 0.0))}"
+        )
+        print(
+            "residuals: "
+            f"FSQR={fsq[0]:.6e} FSQZ={fsq[1]:.6e} FSQL={fsq[2]:.6e}; "
+            f"pre=({float(pre.fsqr1):.6e}, {float(pre.fsqz1):.6e}, "
+            f"{float(pre.fsql1):.6e})"
+        )
+        bad = setup_bad + force_bad
+        print("nonfinite arrays: " + (", ".join(bad) if bad else "none"))
+
+    if details:
+        likely: list[str] = []
+        if inp.phiedge == 0.0 or float(rt.setup.lamscale) == 0.0:
+            likely.append(
+                "zero effective toroidal flux: check PHIEDGE and APHI; "
+                "the force/lambda normalizations are singular"
+            )
+        if bool(jacobian.jacobian_sign_changed):
+            likely.append(
+                "bad initial axis/boundary Jacobian: remove the supplied "
+                "RAXIS_*/ZAXIS_* to trigger inference, or seed them from the "
+                "VMEC2000 output"
+            )
+        if setup_bad:
+            likely.append(
+                "a parsed profile/setup array is already non-finite before iteration 1"
+            )
+        raw_finite = np.isfinite(np.asarray(fsq)).all()
+        pre_finite = np.isfinite(np.asarray([
+            pre.fsqr1, pre.fsqz1, pre.fsql1,
+        ], dtype=float)).all() and not _nonfinite_names(gc, "force")
+        if raw_finite and not pre_finite:
+            likely.append(
+                "raw force residuals are finite but the update is not: the 1D "
+                "radial/lambda preconditioner is the first failing stage"
+            )
+        if inp.gamma == 1.0:
+            likely.append("GAMMA=1 makes the printed MHD-energy expression singular")
+        if not likely and force_bad:
+            likely.append(
+                "non-finite values first appear inside the "
+                "geometry/field/preconditioner force pass"
+            )
+        assessment = "; ".join(likely) if likely else "first force pass is finite"
+    elif setup_bad:
+        assessment = "D01_SETUP_NONFINITE"
+    elif not jacobian_good:
+        assessment = "D02_INITIAL_JACOBIAN"
+    elif raw_bad:
+        assessment = "D03_RAW_FORCE_NONFINITE"
+    elif update_bad:
+        assessment = "D04_PRECONDITIONED_UPDATE_NONFINITE"
+    elif diagnostic_bad:
+        assessment = "D05_FORCE_DIAGNOSTIC_NONFINITE"
+    else:
+        assessment = "OK_FIRST_FORCE_PASS_FINITE"
+    print(f"assessment: {assessment}")
+    return 1 if setup_bad or force_bad or not jacobian_good else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="VMEC &INDATA or VMEC++ JSON deck")
+    parser.add_argument(
+        "--details", action="store_true",
+        help="print input-derived values for local use only; never share for a confidential deck",
+    )
+    args = parser.parse_args()
+    try:
+        return diagnose(args.input, details=args.details)
+    except Exception as exc:
+        print(f"diagnostic failed: {type(exc).__name__}")
+        if args.details:
+            print(f"local detail: {exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/diagnose_input.py
+++ b/tools/diagnose_input.py
@@ -23,7 +23,7 @@ import jax
 import numpy as np
 
 from vmex.core.geometry import half_mesh_jacobian
-from vmex.core.input import VmecInput
+from vmex.core.input import VmecInput, _read_indata_text
 from vmex.core.solver import _geometry, _initial_state, evaluate_forces, prepare_runtime
 
 
@@ -59,7 +59,54 @@ def _range(value: Any) -> str:
     return f"[{array.min():.6e}, {array.max():.6e}]"
 
 
+def _ok(value: Any) -> bool:
+    """Convert a scalar JAX/NumPy health flag to a host boolean."""
+    return bool(np.asarray(value))
+
+
+def _unsupported_mode_code(text: str) -> str | None:
+    """Return a value-free code for active VMEC modes VMEX does not solve."""
+    if text.lstrip()[:1] == "{":
+        return None
+    scalars, _indexed = _read_indata_text(text)
+
+    def first(name: str, default: Any = None) -> Any:
+        values = scalars.get(name)
+        return values[0] if values else default
+
+    # vsetup.f starts with LRECON=T, while read_indata.f disables it when
+    # neither diagnostic profile is active.  Reproduce that effective-mode
+    # decision so an inert explicit LRECON=T is not a false positive.
+    reconstruction_requested = bool(first("LRECON", True))
+    reconstruction_active = reconstruction_requested and (
+        int(first("ITSE", 0)) > 0 or int(first("IMSE", -1)) > 0
+    )
+    if reconstruction_active:
+        return "D00A_RECONSTRUCTION_MODE_UNSUPPORTED"
+    if bool(first("LRFP", False)):
+        return "D00B_RFP_MODE_UNSUPPORTED"
+    return None
+
+
+def _print_header() -> None:
+    print("VMEX first-iteration diagnostic (shareable, input details redacted)")
+    print(
+        "runtime: "
+        f"jax={jax.__version__} backend={jax.default_backend()} "
+        f"x64={bool(jax.config.jax_enable_x64)} "
+        f"VMEX_FAST_COMPILE={os.environ.get('VMEX_FAST_COMPILE', '<default>')}"
+    )
+
+
 def diagnose(path: Path, *, details: bool = False) -> int:
+    text = path.read_text()
+    unsupported = _unsupported_mode_code(text)
+    _print_header()
+    if unsupported is not None:
+        print("input physics mode supported: FAIL")
+        print(f"assessment: {unsupported}")
+        return 1
+
     inp = VmecInput.from_file(path)
     rt = prepare_runtime(inp)
     state = _initial_state(rt.setup)
@@ -85,19 +132,57 @@ def diagnose(path: Path, *, details: bool = False) -> int:
     force_bad = raw_bad + update_bad + diagnostic_bad
     fsq = (float(residuals.fsqr), float(residuals.fsqz), float(residuals.fsql))
     pre = diagnostics.preconditioned
+    health = diagnostics.health
 
-    print("VMEX first-iteration diagnostic (shareable, input details redacted)")
-    print(
-        "runtime: "
-        f"jax={jax.__version__} backend={jax.default_backend()} "
-        f"x64={bool(jax.config.jax_enable_x64)} "
-        f"VMEX_FAST_COMPILE={os.environ.get('VMEX_FAST_COMPILE', '<default>')}"
-    )
+    print("input physics mode supported: PASS")
     sqrt_g = np.asarray(jacobian.sqrt_g)[1:]
     jacobian_finite = np.isfinite(sqrt_g).all()
-    jacobian_good = jacobian_finite and not bool(jacobian.jacobian_sign_changed)
+    jacobian_nonzero = _ok(health.jacobian_nonzero)
+    jacobian_good = (
+        jacobian_finite
+        and jacobian_nonzero
+        and not bool(jacobian.jacobian_sign_changed)
+    )
+    rz_norm_good = (
+        _ok(health.volume_valid)
+        and _ok(health.energy_scale_valid)
+        and _ok(health.force_norm_finite)
+    )
+    lambda_norm_good = (
+        _ok(health.lambda_scale_valid) and _ok(health.lambda_norm_finite)
+    )
+    raw_sums_good = (
+        _ok(health.raw_r_sum_finite)
+        and _ok(health.raw_z_sum_finite)
+        and _ok(health.raw_lambda_sum_finite)
+    )
     print(f"setup arrays finite: {'PASS' if not setup_bad else 'FAIL'}")
     print(f"initial Jacobian valid: {'PASS' if jacobian_good else 'FAIL'}")
+    print(f"magnetic field assembly finite: {'PASS' if _ok(health.fields_finite) else 'FAIL'}")
+    print(f"R/Z force normalization valid: {'PASS' if rz_norm_good else 'FAIL'}")
+    print(f"lambda force normalization valid: {'PASS' if lambda_norm_good else 'FAIL'}")
+    print(
+        "real-space force kernels finite: "
+        f"{'PASS' if _ok(health.pipeline.real_space_finite) else 'FAIL'}"
+    )
+    print(
+        "spectral/scaled force finite: "
+        f"{'PASS' if (_ok(health.pipeline.spectral_finite) and _ok(health.pipeline.scaled_finite)) else 'FAIL'}"
+    )
+    print(f"unnormalized force sums finite: {'PASS' if raw_sums_good else 'FAIL'}")
+    print(
+        "normalized residual channels finite: "
+        f"R={'PASS' if _ok(health.raw_r_residual_finite) else 'FAIL'} "
+        f"Z={'PASS' if _ok(health.raw_z_residual_finite) else 'FAIL'} "
+        f"L={'PASS' if _ok(health.raw_lambda_residual_finite) else 'FAIL'}"
+    )
+    print(
+        "preconditioner stages finite: "
+        f"cache={'PASS' if _ok(health.cache_finite) else 'FAIL'} "
+        f"rhs={'PASS' if _ok(health.pipeline.rhs_finite) else 'FAIL'} "
+        f"radial={'PASS' if _ok(health.pipeline.radial_solve_finite) else 'FAIL'} "
+        f"lambda={'PASS' if _ok(health.pipeline.preconditioned_finite) else 'FAIL'}"
+    )
     print(f"raw force residuals finite: {'PASS' if not raw_bad else 'FAIL'}")
     print(f"preconditioned update finite: {'PASS' if not update_bad else 'FAIL'}")
     print(f"other force diagnostics finite: {'PASS' if not diagnostic_bad else 'FAIL'}")
@@ -183,8 +268,42 @@ def diagnose(path: Path, *, details: bool = False) -> int:
         assessment = "D01_SETUP_NONFINITE"
     elif not jacobian_good:
         assessment = "D02_INITIAL_JACOBIAN"
+    elif not _ok(health.fields_finite):
+        assessment = "D03A_MAGNETIC_FIELD_NONFINITE"
+    elif not _ok(health.volume_valid):
+        assessment = "D03B_DEGENERATE_VOLUME"
+    elif not _ok(health.energy_scale_valid):
+        assessment = "D03C_ZERO_ENERGY_SCALE"
+    elif not _ok(health.force_norm_finite):
+        assessment = "D03D_RZ_NORMALIZATION_NONFINITE"
+    elif not _ok(health.lambda_scale_valid):
+        assessment = "D03E_ZERO_LAMBDA_SCALE"
+    elif not _ok(health.lambda_norm_finite):
+        assessment = "D03F_LAMBDA_NORMALIZATION_NONFINITE"
+    elif not _ok(health.pipeline.real_space_finite):
+        assessment = "D03G_REAL_SPACE_FORCE_NONFINITE"
+    elif not _ok(health.pipeline.spectral_finite):
+        assessment = "D03H_SPECTRAL_FORCE_NONFINITE"
+    elif not _ok(health.pipeline.scaled_finite):
+        assessment = "D03I_SCALED_FORCE_NONFINITE"
+    elif not raw_sums_good:
+        assessment = "D03J_UNNORMALIZED_FORCE_SUM_NONFINITE"
+    elif not _ok(health.raw_r_residual_finite):
+        assessment = "D03K_R_RESIDUAL_NONFINITE"
+    elif not _ok(health.raw_z_residual_finite):
+        assessment = "D03L_Z_RESIDUAL_NONFINITE"
+    elif not _ok(health.raw_lambda_residual_finite):
+        assessment = "D03M_LAMBDA_RESIDUAL_NONFINITE"
     elif raw_bad:
         assessment = "D03_RAW_FORCE_NONFINITE"
+    elif not _ok(health.cache_finite):
+        assessment = "D04A_PRECONDITIONER_CACHE_NONFINITE"
+    elif not _ok(health.pipeline.rhs_finite):
+        assessment = "D04B_PRECONDITIONER_RHS_NONFINITE"
+    elif not _ok(health.pipeline.radial_solve_finite):
+        assessment = "D04C_RADIAL_PRECONDITIONER_NONFINITE"
+    elif not _ok(health.pipeline.preconditioned_finite):
+        assessment = "D04D_LAMBDA_PRECONDITIONER_NONFINITE"
     elif update_bad:
         assessment = "D04_PRECONDITIONED_UPDATE_NONFINITE"
     elif diagnostic_bad:

--- a/vmex/__init__.py
+++ b/vmex/__init__.py
@@ -103,6 +103,7 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
     "VmecInputError": (".core.errors", "VmecInputError"),
     "VmecJacobianError": (".core.errors", "VmecJacobianError"),
     "VmecConvergenceError": (".core.errors", "VmecConvergenceError"),
+    "VmecNumericalError": (".core.errors", "VmecNumericalError"),
     "MgridNotFoundError": (".core.errors", "MgridNotFoundError"),
     # modules
     "core": (".core", None),

--- a/vmex/core/errors.py
+++ b/vmex/core/errors.py
@@ -27,6 +27,12 @@ NS_ERROR_FLAG = 8
 MISC_ERROR_FLAG = 9
 SUCCESSFUL_TERM_FLAG = 11
 
+# Internal-only loop status.  VMEC2000 has no dedicated ``ier_flag`` for a
+# non-finite force evaluation; callers still receive ``MISC_ERROR_FLAG`` via
+# :class:`VmecNumericalError`, while this distinct carry value lets
+# ``solver._finalize`` distinguish NaN/Inf from a Jacobian-retry failure.
+NONFINITE_FLAG = 90
+
 #: VMEC2000 termination messages, keyed by ier_flag
 #: (Sources/Input_Output/fileout.f, ``werror`` table).
 WERROR_MESSAGES: dict[int, str] = {
@@ -104,6 +110,22 @@ class VmecConvergenceError(VmecError):
     iteration: int = 0
     fsq: tuple[float, float, float] | None = None
     ftol: float = 0.0
+
+
+@dataclass
+class VmecNumericalError(VmecError):
+    """A force evaluation produced NaN or infinity.
+
+    This is intentionally a fail-fast error: once a non-finite value reaches
+    the Richardson momentum state, later iterations cannot diagnose or repair
+    its source.  Common first-iteration causes are zero effective toroidal
+    flux (``PHIEDGE``/``APHI``), a singular or sign-changing initial geometry,
+    and non-finite profile values.
+    """
+
+    ier_flag: int = MISC_ERROR_FLAG
+    iteration: int = 0
+    fsq: tuple[float, float, float] | None = None
 
 
 @dataclass

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -66,6 +66,7 @@ from .solver import (
     SolveResult, SolverRuntime, SpectralState,
     _finalize, _geometry, _initial_carry, _initial_state, _make_body,
     _result_from_carry, _zero_cache, prepare_runtime, resolution_from_input,
+    reguess_initial_axis,
 )
 from .transforms import register_pytree_dataclass as _register
 from .vacuum import (
@@ -1022,6 +1023,32 @@ def _solve_free_boundary_impl(
     dtype = rt.setup.s_full.dtype
 
     _init_state = _initial_state(rt.setup)
+    _initial_ijacob = 0
+    # ``eqsolve.f`` retries a supplied axis when the first Jacobian changes
+    # sign.  The fixed-boundary driver already did this in ``_solve_stage``;
+    # free boundary must do it *before* constructing the fused axis-current
+    # filament, otherwise a recoverable bad axis can fail the static-topology
+    # guard before iteration 1.
+    _, _initial_geometry = _geometry(_init_state, rt)
+    _initial_jacobian = half_mesh_jacobian(_initial_geometry, s=rt.setup.s_full)
+    if bool(_initial_jacobian.jacobian_sign_changed) and ns >= 3:
+        if verbose:
+            emit(" INITIAL JACOBIAN CHANGED SIGN!")
+            emit(" TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS")
+        rt, _init_state, _axis = reguess_initial_axis(rt, _init_state)
+        _initial_ijacob = 1
+        _, _retry_geometry = _geometry(_init_state, rt)
+        _retry_jacobian = half_mesh_jacobian(_retry_geometry, s=rt.setup.s_full)
+        if bool(_retry_jacobian.jacobian_sign_changed):
+            # Preserve the normal typed solver failure and its remedy hint;
+            # do not let the later axis-filament topology guard obscure it.
+            from .errors import BAD_JACOBIAN_FLAG, VmecJacobianError, WERROR_MESSAGES
+            raise VmecJacobianError(
+                WERROR_MESSAGES[BAD_JACOBIAN_FLAG],
+                hint="decrease DELT or provide a better RAXIS_*/ZAXIS_* guess",
+                ier_flag=BAD_JACOBIAN_FLAG, iteration=1,
+                jacobian_resets=1, fsq=(1.0, 1.0, 1.0),
+            )
     _axis_r0, _axis_z0 = _vacuum_scalars(_init_state, rt)[2:4]
     basis, fused_vac, vacuum_lane = _vacuum_executables(
         resolution, mf=int(inp.mpol) + 1, nf=int(inp.ntor),
@@ -1048,7 +1075,7 @@ def _solve_free_boundary_impl(
         emit(FORCE_ITERATIONS_BANNER, end="")
         emit(screen_header(lasym=resolution.lasym, lfreeb=True), end="")
 
-    carry = _initial_carry(_init_state, rt_fixed, ijacob=0)
+    carry = _initial_carry(_init_state, rt_fixed, ijacob=_initial_ijacob)
     printed: set[int] = set()
     #: per-iteration DEL-BSQ recorded by the batched steady-state lane; rows
     #: not covered (pre-activation, turn-on pass) fall back to ``fb.delbsq``

--- a/vmex/core/input.py
+++ b/vmex/core/input.py
@@ -39,6 +39,7 @@ import numpy as np
 __all__ = ["VmecInput"]
 
 Scalar = Union[str, bool, int, float]
+IndexComponent = Union[int, slice]
 
 # ---------------------------------------------------------------------------
 # Tolerant Fortran-namelist tokenizer (targeted at VMEC &INDATA files)
@@ -110,16 +111,36 @@ def _parse_scalar(tok: str) -> Scalar:
         return tok
 
 
-def _parse_key(key: str) -> Tuple[str, Tuple[int, ...] | None]:
-    """Split ``KEY`` or ``KEY(i,j)`` into (name, indices); ``KEY(:)`` -> plain."""
+def _parse_key(key: str) -> Tuple[str, Tuple[IndexComponent, ...] | None]:
+    """Split a namelist key into its name and scalar/section designator.
+
+    A bare key and the whole-vector ``KEY(:)`` form return ``None``.  Fortran
+    triplets retain their inclusive upper bound in a :class:`slice`; they are
+    expanded after the assignment values have been tokenized.
+    """
     key = key.strip()
     if "(" not in key:
         return key.upper(), None
     base, rest = key.split("(", 1)
     rest = rest.rstrip(")")
-    if ":" in rest:
+    if rest.strip() == ":":
         return base.upper(), None
-    return base.upper(), tuple(int(x) for x in rest.split(",") if x.strip())
+    components: list[IndexComponent] = []
+    for component in rest.split(","):
+        component = component.strip()
+        if ":" not in component:
+            components.append(int(component))
+            continue
+        parts = component.split(":")
+        if len(parts) not in (2, 3):
+            raise ValueError(f"invalid namelist array section: {key}")
+        start = int(parts[0]) if parts[0].strip() else None
+        stop = int(parts[1]) if parts[1].strip() else None
+        step = int(parts[2]) if len(parts) == 3 and parts[2].strip() else 1
+        if step == 0:
+            raise ValueError(f"zero stride in namelist array section: {key}")
+        components.append(slice(start, stop, step))
+    return base.upper(), tuple(components)
 
 
 def _read_indata_text(text: str) -> tuple[Dict[str, List[Scalar]], Dict[str, Dict[Tuple[int, ...], Scalar]]]:
@@ -149,8 +170,35 @@ def _read_indata_text(text: str) -> tuple[Dict[str, List[Scalar]], Dict[str, Dic
             continue
         if idx is None:
             scalars[name] = values
+        elif len(idx) == 1:
+            # A one-dimensional namelist designator identifies the first
+            # destination element, not a scalar-only assignment.  Thus
+            # ``APHI(1)=0,1`` initializes APHI(1:2), exactly like VMEC2000.
+            # Array sections use inclusive Fortran bounds; an omitted upper
+            # bound consumes as many destinations as values supplied.
+            component = idx[0]
+            if isinstance(component, slice):
+                step = 1 if component.step is None else component.step
+                if component.start is None:
+                    # The only lower-bound-free form accepted here is a whole
+                    # vector, already handled as a dense assignment above.
+                    raise ValueError(f"array section needs a lower bound: {m.group('key')}")
+                if component.stop is None:
+                    positions = [component.start + step * j for j in range(len(values))]
+                else:
+                    end = component.stop + (1 if step > 0 else -1)
+                    positions = list(range(component.start, end, step))
+                if len(values) > len(positions):
+                    raise ValueError(f"too many values for namelist array section: {m.group('key')}")
+            else:
+                positions = [component + j for j in range(len(values))]
+            entries = indexed.setdefault(name, {})
+            for position, value in zip(positions, values):
+                entries[(position,)] = value
         else:
-            indexed.setdefault(name, {})[idx] = values[0]
+            if any(isinstance(component, slice) for component in idx):
+                raise ValueError(f"multidimensional array sections are unsupported: {m.group('key')}")
+            indexed.setdefault(name, {})[tuple(int(component) for component in idx)] = values[0]
     return scalars, indexed
 
 

--- a/vmex/core/input.py
+++ b/vmex/core/input.py
@@ -395,21 +395,68 @@ class VmecInput:
                 return None
             return list(values)
 
+        def vector(
+            name: str,
+            *,
+            lower: int,
+            default: list[float] | np.ndarray | None = None,
+            size: int | None = None,
+        ) -> np.ndarray:
+            """Apply dense and indexed namelist assignments to one vector.
+
+            Fortran namelist reads overlay assignments on the values initialized
+            by ``read_indata_namelist``.  In particular, ``APHI(2)=...`` must
+            retain VMEC's default ``APHI(1)=1``.  The old parser consumed only
+            unindexed vector assignments, silently ignoring indexed profile and
+            multigrid entries.
+            """
+            dense = get_list(name) or []
+            entries = indexed.get(name, {})
+            indexed_length = max(
+                (idx[0] - lower + 1 for idx in entries if len(idx) == 1),
+                default=0,
+            )
+            default_values = _float_array(default)
+            length = size if size is not None else max(
+                len(dense), indexed_length, int(default_values.size)
+            )
+            out = _fixed_length(default_values, length) if length else np.zeros((0,))
+            if dense:
+                count = min(len(dense), length)
+                out[:count] = np.asarray(dense[:count], dtype=float)
+            for idx, value in entries.items():
+                if len(idx) != 1:
+                    continue
+                position = idx[0] - lower
+                if 0 <= position < length:
+                    out[position] = float(value)
+            return out
+
         mpol = int(get("MPOL", 6))
         ntor = int(get("NTOR", 0))
 
         # ns_array: NS_ARRAY, or legacy NS, or the VMEC default 31.
-        ns_array = get_list("NS_ARRAY")
-        if ns_array is None:
-            ns_array = [int(get("NS", 31))]
+        ns_default = [int(get("NS", 31))]
+        ns_array = vector("NS_ARRAY", lower=1, default=ns_default)
+        ns_positive = np.asarray(ns_array, dtype=np.int64) > 0
+        n_stages = (
+            int(np.argmax(~ns_positive)) if np.any(~ns_positive) else len(ns_array)
+        )
+        n_stages = max(n_stages, 1)
+
         # ftol_array: FTOL_ARRAY, or scalar FTOL (vmec_input.f: ftol_array(1)=ftol).
-        ftol_array = get_list("FTOL_ARRAY")
-        if ftol_array is None:
-            ftol_array = [float(get("FTOL", 1e-10))]
-        # niter_array falls back to NITER when absent (read_indata_namelist).
-        niter_array = get_list("NITER_ARRAY")
-        if niter_array is None:
-            niter_array = [int(get("NITER", 100))]
+        ftol_default = np.zeros((n_stages,))
+        ftol_default[0] = float(get("FTOL", 1e-10))
+        ftol_array = vector(
+            "FTOL_ARRAY", lower=1, default=ftol_default
+        )
+        # vmec_input.f initializes every NITER_ARRAY entry to -1, and replaces
+        # the complete array with NITER only when no element was assigned.
+        niter_assigned = "NITER_ARRAY" in scalars or "NITER_ARRAY" in indexed
+        niter_default = np.full((n_stages,), -1 if niter_assigned else int(get("NITER", 100)))
+        niter_array = vector(
+            "NITER_ARRAY", lower=1, default=niter_default
+        )
 
         def axis(name: str, legacy: str | None = None) -> np.ndarray:
             out = _fixed_length(get_list(name) or [], ntor + 1)
@@ -420,6 +467,9 @@ class VmecInput:
                 # Backwards compatibility (read_indata_namelist):
                 # WHERE (raxis /= 0) raxis_cc = raxis (idem zaxis -> zaxis_cs).
                 old = _fixed_length(get_list(legacy) or [], ntor + 1)
+                for idx, value in indexed.get(legacy, {}).items():
+                    if len(idx) == 1 and 0 <= idx[0] <= ntor:
+                        old[idx[0]] = float(value)
                 out = np.where(old != 0.0, old, out)
             return out
 
@@ -433,15 +483,10 @@ class VmecInput:
                     grid[n + ntor, m] = float(value)
             return grid
 
-        extcur_indexed = indexed.get("EXTCUR", {})
-        if extcur_indexed:
-            size = max(idx[0] for idx in extcur_indexed if len(idx) == 1)
-            extcur = np.zeros((size,))
-            for idx, value in extcur_indexed.items():
-                if len(idx) == 1 and idx[0] >= 1:
-                    extcur[idx[0] - 1] = float(value)
-        else:
-            extcur = _float_array(get_list("EXTCUR") or [])
+        extcur = vector("EXTCUR", lower=1)
+
+        aphi_default = np.zeros((20,))
+        aphi_default[0] = 1.0
 
         return cls(
             lasym=bool(get("LASYM", False)),
@@ -455,26 +500,26 @@ class VmecInput:
             niter_array=niter_array,
             delt=float(get("DELT", 1.0)),
             tcon0=float(get("TCON0", 1.0)),
-            aphi=get_list("APHI"),
+            aphi=vector("APHI", lower=1, default=aphi_default, size=20),
             phiedge=float(get("PHIEDGE", 1.0)),
             nstep=int(get("NSTEP", 10)),
             pmass_type=str(get("PMASS_TYPE", "power_series")),
-            am=get_list("AM") or [],
-            am_aux_s=get_list("AM_AUX_S") or [],
-            am_aux_f=get_list("AM_AUX_F") or [],
+            am=vector("AM", lower=0, default=np.zeros((21,)), size=21),
+            am_aux_s=vector("AM_AUX_S", lower=1),
+            am_aux_f=vector("AM_AUX_F", lower=1),
             pres_scale=float(get("PRES_SCALE", 1.0)),
             gamma=float(get("GAMMA", 0.0)),
             spres_ped=float(get("SPRES_PED", 1.0)),
             ncurr=int(get("NCURR", 0)),
             pcurr_type=str(get("PCURR_TYPE", "power_series")),
-            ac=get_list("AC") or [],
-            ac_aux_s=get_list("AC_AUX_S") or [],
-            ac_aux_f=get_list("AC_AUX_F") or [],
+            ac=vector("AC", lower=0, default=np.zeros((21,)), size=21),
+            ac_aux_s=vector("AC_AUX_S", lower=1),
+            ac_aux_f=vector("AC_AUX_F", lower=1),
             curtor=float(get("CURTOR", 0.0)),
             piota_type=str(get("PIOTA_TYPE", "power_series")),
-            ai=get_list("AI") or [],
-            ai_aux_s=get_list("AI_AUX_S") or [],
-            ai_aux_f=get_list("AI_AUX_F") or [],
+            ai=vector("AI", lower=0, default=np.zeros((21,)), size=21),
+            ai_aux_s=vector("AI_AUX_S", lower=1),
+            ai_aux_f=vector("AI_AUX_F", lower=1),
             bloat=float(get("BLOAT", 1.0)),
             raxis_c=axis("RAXIS_CC", legacy="RAXIS"),
             zaxis_s=axis("ZAXIS_CS", legacy="ZAXIS"),

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -128,8 +128,9 @@ from jax import lax
 from .device import AUTO, device_context
 from .errors import (
     BAD_JACOBIAN_FLAG, JAC75_FLAG, MISC_ERROR_FLAG, MORE_ITER_FLAG,
-    NORM_TERM_FLAG, SUCCESSFUL_TERM_FLAG, VmecConvergenceError,
-    VmecJacobianError, WERROR_MESSAGES,
+    NONFINITE_FLAG, NORM_TERM_FLAG, SUCCESSFUL_TERM_FLAG,
+    VmecConvergenceError, VmecJacobianError, VmecNumericalError,
+    WERROR_MESSAGES,
 )
 from .fields import (
     constraint_scaling, energies_and_force_norms, magnetic_fields,
@@ -1012,6 +1013,54 @@ def evaluate_forces(
     return result.gc, result.residuals, diagnostics
 
 
+def _evaluation_is_finite(result: _EvalResult) -> Array:
+    """Whether every iteration-driving output of one ``funct3d`` pass is finite."""
+    leaves = jax.tree.leaves((
+        result.gc, result.residuals, result.pre, result.wb, result.wp,
+        result.r00, result.z00, result.cache,
+    ))
+    finite = jnp.asarray(True)
+    for leaf in leaves:
+        finite = finite & jnp.all(jnp.isfinite(jnp.asarray(leaf)))
+    return finite
+
+
+def reguess_initial_axis(
+    rt: SolverRuntime, state: SpectralState
+) -> tuple[SolverRuntime, SpectralState, tuple[Array, Array, Array, Array]]:
+    """Apply the VMEC2000 first-bad-Jacobian magnetic-axis retry.
+
+    Shared by fixed- and free-boundary drivers.  Besides rebuilding the
+    ``profil3d`` state, this updates the setup's axis arrays and rebinds the
+    constraint baselines to that state (``funct3d.f: iter2 == iter1``).
+    """
+    setup = rt.setup
+    _, geometry = _geometry(state, rt)
+    axis = guess_axis(
+        geometry, s=setup.s_full, trig=rt.trig, signgs=setup.signgs
+    )
+    arrays = interior_guess(
+        boundary_R_cos=setup.boundary_R_cos,
+        boundary_R_sin=setup.boundary_R_sin,
+        boundary_Z_cos=setup.boundary_Z_cos,
+        boundary_Z_sin=setup.boundary_Z_sin,
+        raxis_c=axis[0], raxis_s=axis[1], zaxis_c=axis[2], zaxis_s=axis[3],
+        modes=rt.modes, trig=rt.trig, s=setup.s_full,
+    )
+    new_setup = replace(
+        setup,
+        raxis_c=axis[0], raxis_s=axis[1], zaxis_c=axis[2], zaxis_s=axis[3],
+        R_cos=arrays[0], R_sin=arrays[1], Z_cos=arrays[2], Z_sin=arrays[3],
+        lambda_cos=arrays[4], lambda_sin=arrays[5],
+    )
+    state = SpectralState(
+        R_cos=arrays[0], R_sin=arrays[1], Z_cos=arrays[2], Z_sin=arrays[3],
+        L_cos=arrays[4], L_sin=arrays[5],
+    )
+    rt = runtime_with_baselines(replace(rt, setup=new_setup), state)
+    return rt, state, axis
+
+
 # -- Iteration body (evolve.f + TimeStepControl + the eqsolve.f checks) ----------------------------------------------
 
 
@@ -1029,6 +1078,7 @@ def _make_body(rt: SolverRuntime) -> Callable[[_LoopCarry], _LoopCarry]:
         e1 = _evaluate(carry.state, carry.cache, it, carry.iter1, carry.fsqz, rt,
                        carry.fsqr + carry.fsqz)
         jac1 = e1.jacobian_sign_changed
+        nonfinite1 = (~jac1) & (~_evaluation_is_finite(e1))
         # On irst=2 funct3d skips residue: the module residuals stay stale.
         fsqr_c = jnp.where(jac1, carry.fsqr, e1.residuals.fsqr)
         fsqz_c = jnp.where(jac1, carry.fsqz, e1.residuals.fsqz)
@@ -1037,7 +1087,7 @@ def _make_body(rt: SolverRuntime) -> Callable[[_LoopCarry], _LoopCarry]:
 
         converged = (~jac1) & (fsqr_c <= ftol) & (fsqz_c <= ftol) & (fsql_c <= ftol)
         bad_init = jac1 & (it == 1)
-        stepping = running & (~converged) & (~bad_init)
+        stepping = running & (~converged) & (~bad_init) & (~nonfinite1)
 
         # ---- TimeStepControl (evolve.f) ------------------------------------
         first = it == carry.iter1
@@ -1077,6 +1127,8 @@ def _make_body(rt: SolverRuntime) -> Callable[[_LoopCarry], _LoopCarry]:
             (state_r, e1.cache, fsqz_c, fsqr_c + fsqz_c),
         )
         reeval_bad = restart & e2.jacobian_sign_changed
+        nonfinite2 = restart & (~e2.jacobian_sign_changed) & (~_evaluation_is_finite(e2))
+        numerical_bad = nonfinite1 | nonfinite2
 
         fsqr_f = jnp.where(restart, e2.residuals.fsqr, fsqr_c)
         fsqz_f = jnp.where(restart, e2.residuals.fsqz, fsqz_c)
@@ -1134,18 +1186,19 @@ def _make_body(rt: SolverRuntime) -> Callable[[_LoopCarry], _LoopCarry]:
         jac75 = stepping & (ijacob_n >= 75)
         maxed = stepping & (~eq_reset) & (~jac75) & (it >= max_iter)
 
-        stop_now = running & (converged | bad_init) | jac75 | maxed | reeval_bad
+        stop_now = running & (converged | bad_init | numerical_bad) | jac75 | maxed | reeval_bad
         done_n = carry.done | stop_now
         ier_n = jnp.where(
             carry.done, carry.ier,
             jnp.where(running & converged, SUCCESSFUL_TERM_FLAG,
             jnp.where(running & bad_init, BAD_JACOBIAN_FLAG,
+            jnp.where(running & numerical_bad, NONFINITE_FLAG,
             jnp.where(jac75, JAC75_FLAG,
             jnp.where(reeval_bad, MISC_ERROR_FLAG,
-            jnp.where(maxed, MORE_ITER_FLAG, carry.ier))))),
+            jnp.where(maxed, MORE_ITER_FLAG, carry.ier)))))),
         ).astype(carry.ier.dtype)
 
-        advance = stepping & (~eq_reset) & (~jac75) & (~maxed) & (~reeval_bad)
+        advance = stepping & (~eq_reset) & (~jac75) & (~maxed) & (~reeval_bad) & (~numerical_bad)
         iteration_n = jnp.where(advance, it + 1, it)
 
         # ---- trajectory row (printout.f values) ----------------------------
@@ -1402,18 +1455,7 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
         if verbose:
             emit(" INITIAL JACOBIAN CHANGED SIGN!")
             emit(" TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS")
-        _, geometry = _geometry(state0, rt)
-        axis = guess_axis(geometry, s=setup.s_full, trig=rt.trig, signgs=setup.signgs)
-        new_state = interior_guess(
-            boundary_R_cos=setup.boundary_R_cos, boundary_R_sin=setup.boundary_R_sin,
-            boundary_Z_cos=setup.boundary_Z_cos, boundary_Z_sin=setup.boundary_Z_sin,
-            raxis_c=axis[0], raxis_s=axis[1], zaxis_c=axis[2], zaxis_s=axis[3],
-            modes=rt.modes, trig=rt.trig, s=setup.s_full,
-        )
-        state0 = SpectralState(
-            R_cos=new_state[0], R_sin=new_state[1], Z_cos=new_state[2],
-            Z_sin=new_state[3], L_cos=new_state[4], L_sin=new_state[5],
-        )
+        rt, state0, _axis = reguess_initial_axis(rt, state0)
         carry = _run_loop(state0, rt, mode=mode, ijacob=1, verbose=verbose,
                           emit=emit)
     return carry
@@ -1430,6 +1472,16 @@ def _finalize(carry: _LoopCarry, rt: SolverRuntime) -> SolveResult:
             WERROR_MESSAGES[MORE_ITER_FLAG],
             hint="increase NITER or loosen FTOL",
             iteration=int(carry.iteration), fsq=fsq, ftol=rt.ftol,
+        )
+    if ier == NONFINITE_FLAG:
+        raise VmecNumericalError(
+            "NON-FINITE FORCE EVALUATION (NaN OR Inf)",
+            hint=(
+                "check parsed PHIEDGE/APHI, profile values, and the initial "
+                "axis/boundary; a zero effective toroidal flux makes the "
+                "VMEC force normalizations singular"
+            ),
+            iteration=int(carry.iteration), fsq=fsq,
         )
     raise VmecJacobianError(
         WERROR_MESSAGES.get(ier, WERROR_MESSAGES[JAC75_FLAG]),

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -57,7 +57,7 @@ restart), and the stage machinery is factored into :func:`_solve_stage`/
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, fields as dataclass_fields, is_dataclass, replace
 from typing import Any, Callable
 
 import functools
@@ -234,6 +234,45 @@ class PreconditionerCache:
 
 
 @dataclass(frozen=True)
+class ForcePipelineHealth:
+    """Finite-stage flags for the ``forces -> residue`` pipeline.
+
+    These booleans deliberately retain no equilibrium values.  They let the
+    privacy-preserving diagnostic distinguish real-space force assembly,
+    Fourier projection, residual scaling, and preconditioning failures.
+    """
+
+    real_space_finite: Array
+    spectral_finite: Array
+    scaled_finite: Array
+    rhs_finite: Array
+    radial_solve_finite: Array
+    preconditioned_finite: Array
+
+
+@dataclass(frozen=True)
+class NumericalHealth:
+    """Privacy-safe first-force-pass health flags (no input-derived values)."""
+
+    geometry_finite: Array
+    jacobian_nonzero: Array
+    fields_finite: Array
+    volume_valid: Array
+    energy_scale_valid: Array
+    force_norm_finite: Array
+    lambda_scale_valid: Array
+    lambda_norm_finite: Array
+    pipeline: ForcePipelineHealth
+    raw_r_sum_finite: Array
+    raw_z_sum_finite: Array
+    raw_lambda_sum_finite: Array
+    raw_r_residual_finite: Array
+    raw_z_residual_finite: Array
+    raw_lambda_residual_finite: Array
+    cache_finite: Array
+
+
+@dataclass(frozen=True)
 class FunctDiagnostics:
     """Per-evaluation diagnostics returned by :func:`evaluate_forces`.
 
@@ -251,6 +290,7 @@ class FunctDiagnostics:
     z00: Array
     jacobian_sign_changed: Array
     cache: PreconditionerCache
+    health: NumericalHealth
 
 
 @dataclass(frozen=True)
@@ -266,6 +306,7 @@ class _EvalResult:
     z00: Array
     jacobian_sign_changed: Array
     cache: PreconditionerCache
+    health: NumericalHealth
 
 
 @dataclass(frozen=True)
@@ -290,8 +331,10 @@ class _LoopCarry:
     trajectory: Array
 
 
-for _cls in (SpectralState, PreconditionerCache, FunctDiagnostics, _EvalResult,
-             _LoopCarry):
+for _cls in (
+    SpectralState, PreconditionerCache, ForcePipelineHealth, NumericalHealth,
+    FunctDiagnostics, _EvalResult, _LoopCarry,
+):
     _register(_cls)
 
 
@@ -696,13 +739,40 @@ def _zero_cache(rt: SolverRuntime) -> PreconditionerCache:
 # -- One funct3d pass ------------------------------------------------------------------------------------------------
 
 
+def _all_finite(value) -> Array:
+    """Return one traced boolean for all numeric leaves in ``value``."""
+    finite = jnp.asarray(True)
+
+    def visit(item):
+        nonlocal finite
+        if item is None:
+            return
+        if is_dataclass(item):
+            for field in dataclass_fields(item):
+                visit(getattr(item, field.name))
+            return
+        if isinstance(item, dict):
+            for child in item.values():
+                visit(child)
+            return
+        if isinstance(item, (tuple, list)):
+            for child in item:
+                visit(child)
+            return
+        finite = finite & jnp.all(jnp.isfinite(jnp.asarray(item)))
+
+    visit(value)
+    return finite
+
+
 def _force_pipeline(
     *,
     geometry, jacobian, metrics, fields,
     R_cos: Array, R_sin: Array, Z_cos: Array, Z_sin: Array,
     cache: PreconditionerCache, rt: SolverRuntime,
     iteration: Array, fsqz_previous: Array,
-) -> tuple[Any, Any]:
+    collect_health: bool = False,
+) -> tuple[Any, Any, ForcePipelineHealth]:
     """MHD forces -> residue.f90 chain -> scalfor/faclam preconditioning.
 
     The ``funct3d.f`` -> ``forces.f`` -> ``tomnsps`` -> ``residue.f90`` segment
@@ -712,7 +782,8 @@ def _force_pipeline(
     preconditioned)``: the ``scalxc``-scaled force (input to the invariant
     residuals ``getfsq``) and the 1D-preconditioned force (input to
     ``fsqr1/fsqz1`` and the update direction ``gc``).  All preconditioner
-    matrices come from the frozen ``cache`` (``ns4`` cadence).
+    matrices come from the frozen ``cache`` (``ns4`` cadence).  The third
+    return value contains finite/not-finite stage flags only.
     """
     setup = rt.setup
     res = rt.resolution
@@ -743,6 +814,8 @@ def _force_pipeline(
             force_Z_even=jnp.asarray(forces.force_Z_even).at[-1].add(-ru0[-1] * rbsq),
             force_Z_odd=jnp.asarray(forces.force_Z_odd).at[-1].add(-ru0[-1] * rbsq),
         )
+    passing = jnp.asarray(True)
+    real_space_finite = _all_finite(forces) if collect_health else passing
     spectral = spectral_mhd_forces(
         forces, mpol=res.mpol, ntor=res.ntor, trig=rt.trig, include_edge=bool(rt.lfreeb)
     )
@@ -751,7 +824,11 @@ def _force_pipeline(
     rotated = m1_residue_rotation(spectral, lconm1=setup.lconm1)
     zero_gate = m1_zero_condition(fsqz_previous=fsqz_previous, iterations_since_restart=iteration)
     released = zero_m1_z_force(rotated, zero_gate)
+    spectral_finite = (
+        _all_finite((spectral, rotated, released)) if collect_health else passing
+    )
     scaled = scalxc_scale_force(released, s=s)
+    scaled_finite = _all_finite(scaled) if collect_health else passing
     if setup.lthreed or setup.lasym:
         rhs = scale_m1_preconditioner_rhs(
             scaled, coefficients_R=cache.coefficients_R,
@@ -759,9 +836,21 @@ def _force_pipeline(
         )
     else:
         rhs = scaled
+    rhs_finite = _all_finite(rhs) if collect_health else passing
     solved = apply_radial_preconditioner(rhs, matrices_R=cache.matrices_R, matrices_Z=cache.matrices_Z, jmax=rt.jmax)
+    radial_solve_finite = _all_finite(solved) if collect_health else passing
     preconditioned = apply_lambda_preconditioner(solved, cache.faclam)
-    return scaled, preconditioned
+    health = ForcePipelineHealth(
+        real_space_finite=real_space_finite,
+        spectral_finite=spectral_finite,
+        scaled_finite=scaled_finite,
+        rhs_finite=rhs_finite,
+        radial_solve_finite=radial_solve_finite,
+        preconditioned_finite=(
+            _all_finite(preconditioned) if collect_health else passing
+        ),
+    )
+    return scaled, preconditioned, health
 
 
 def _preconditioned_force_signed(
@@ -791,7 +880,7 @@ def _preconditioned_force_signed(
         signgs=setup.signgs, gamma=rt.gamma, mass=setup.mass,
         ncurr=setup.ncurr, enclosed_current=setup.icurv,
     )
-    _, preconditioned = _force_pipeline(
+    _, preconditioned, _health = _force_pipeline(
         geometry=geometry, jacobian=jacobian, metrics=metrics, fields=fields,
         R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
         cache=cache, rt=rt, iteration=iteration, fsqz_previous=fsqz_previous,
@@ -860,6 +949,7 @@ def _evaluate(
     state: SpectralState, cache: PreconditionerCache, iteration: Array,
     iter_last_reset: Array, fsqz_previous: Array, rt: SolverRuntime,
     fsq_rz_previous: Array | None = None,
+    *, collect_health: bool = False,
 ) -> _EvalResult:
     """One funct3d.f pass (fixed boundary), pure and jit-friendly.
 
@@ -946,10 +1036,11 @@ def _evaluate(
     # verbatim with the 2D-preconditioner force map (:func:`_force_pipeline`)
     # so the two can never drift; ``scaled`` feeds the invariant residuals,
     # ``preconditioned`` the fsqr1/fsqz1 residuals and the update force ``gc``.
-    scaled, preconditioned = _force_pipeline(
+    scaled, preconditioned, pipeline_health = _force_pipeline(
         geometry=geometry, jacobian=jacobian, metrics=metrics, fields=fields,
         R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
         cache=cache, rt=rt, iteration=iteration, fsqz_previous=fsqz_previous,
+        collect_health=collect_health,
     )
     if rt.lfreeb:
         # residue.f90 medge rule: the edge rows join fsqr/fsqz only when
@@ -971,6 +1062,47 @@ def _evaluate(
         residuals = force_residuals(scaled, fnorm=cache.fnorm, fnormL=cache.fnormL, r1=energies.r1, include_edge=False)
     pre = preconditioned_residuals(preconditioned, fnorm1=cache.fnorm1, delta_s=hs)
 
+    passing = jnp.asarray(True)
+    if collect_health:
+        sqrt_g_inner = jnp.asarray(jacobian.sqrt_g)[1:]
+        volume = jnp.asarray(energies.volume)
+        energy_scale = jnp.maximum(
+            jnp.asarray(energies.wb), jnp.asarray(energies.wp)
+        )
+        lamscale = jnp.asarray(fields.lamscale)
+        health = NumericalHealth(
+            geometry_finite=_all_finite((geometry, jacobian, metrics)),
+            jacobian_nonzero=jnp.all(sqrt_g_inner != 0.0),
+            fields_finite=_all_finite(fields),
+            volume_valid=jnp.isfinite(volume) & (volume != 0.0),
+            energy_scale_valid=(
+                jnp.isfinite(energy_scale) & (energy_scale != 0.0)
+            ),
+            force_norm_finite=jnp.isfinite(jnp.asarray(energies.fnorm)),
+            lambda_scale_valid=jnp.isfinite(lamscale) & (lamscale != 0.0),
+            lambda_norm_finite=jnp.isfinite(jnp.asarray(energies.fnormL)),
+            pipeline=pipeline_health,
+            raw_r_sum_finite=jnp.isfinite(jnp.asarray(residuals.gcr2)),
+            raw_z_sum_finite=jnp.isfinite(jnp.asarray(residuals.gcz2)),
+            raw_lambda_sum_finite=jnp.isfinite(jnp.asarray(residuals.gcl2)),
+            raw_r_residual_finite=jnp.isfinite(jnp.asarray(residuals.fsqr)),
+            raw_z_residual_finite=jnp.isfinite(jnp.asarray(residuals.fsqz)),
+            raw_lambda_residual_finite=jnp.isfinite(jnp.asarray(residuals.fsql)),
+            cache_finite=_all_finite(cache),
+        )
+    else:
+        health = NumericalHealth(
+            geometry_finite=passing, jacobian_nonzero=passing,
+            fields_finite=passing, volume_valid=passing,
+            energy_scale_valid=passing, force_norm_finite=passing,
+            lambda_scale_valid=passing, lambda_norm_finite=passing,
+            pipeline=pipeline_health,
+            raw_r_sum_finite=passing, raw_z_sum_finite=passing,
+            raw_lambda_sum_finite=passing, raw_r_residual_finite=passing,
+            raw_z_residual_finite=passing, raw_lambda_residual_finite=passing,
+            cache_finite=passing,
+        )
+
     sqrt_s0 = jnp.sqrt(jnp.maximum(s[0], 0.0))
     r00 = geometry.R_even[0, 0, 0] + sqrt_s0 * geometry.R_odd[0, 0, 0]
     z00 = geometry.Z_even[0, 0, 0] + sqrt_s0 * geometry.Z_odd[0, 0, 0]
@@ -979,6 +1111,7 @@ def _evaluate(
         gc=_force_to_state(preconditioned, rt),
         residuals=residuals, pre=pre, wb=energies.wb, wp=energies.wp,
         r00=r00, z00=z00, jacobian_sign_changed=jac_changed, cache=cache,
+        health=health,
     )
 
 
@@ -1003,12 +1136,13 @@ def evaluate_forces(
         iter_last_reset = iteration  # force refresh
     result = _evaluate(
         state, cache, jnp.asarray(iteration), jnp.asarray(iter_last_reset),
-        jnp.asarray(fsqz_previous), runtime,
+        jnp.asarray(fsqz_previous), runtime, collect_health=True,
     )
     diagnostics = FunctDiagnostics(
         preconditioned=result.pre,
         wb=result.wb, wp=result.wp, r00=result.r00, z00=result.z00,
         jacobian_sign_changed=result.jacobian_sign_changed, cache=result.cache,
+        health=result.health,
     )
     return result.gc, result.residuals, diagnostics
 


### PR DESCRIPTION
## Summary

This PR is now stacked directly on #68 so the full sequence can be reviewed and tested before merge; its own diff remains limited to the parser/non-finite/axis-recovery changes below.

This PR fixes and diagnoses the fixed- and free-boundary iteration-1 NaN reported by a collaborator, without using or exposing the collaborator's input:

- parse indexed one-dimensional VMEC namelist arrays with Fortran lower bounds, multivalue starts, array sections, and overlay semantics;
- stop on the first non-finite force evaluation instead of printing NaN through `NITER`;
- identify the first failing field, normalization, force, Fourier, residual, or preconditioner stage with shareable value-free codes;
- apply VMEC2000's initial-axis recovery before free-boundary vacuum/axis-current construction.

## What the collaborator's report proves

The private case fails identically with `LFREEB=T` and `LFREEB=F`, with and without `PRECON_TYPE='NONE'`, and with supplied, omitted, or VMEC2000-derived axis coefficients. The old diagnostic reported finite setup arrays and a valid initial Jacobian, but non-finite raw residuals on iteration 1.

That rules out NESTOR/vacuum activation, the optional 2-D preconditioner, and the supplied axis as the common cause. They all occur after (or outside) the fixed-boundary raw-force failure. The probable common cause is the normalization input to the raw force residuals.

## Reproduced VMEC2000/VMEX split and root cause

VMEX's namelist parser handled indexed 2-D boundary coefficients, but silently ignored indexed 1-D assignments such as:

```fortran
APHI = 0.0
APHI(2) = 1.0
```

VMEC2000 overlays `APHI(2)` on the initialized array. Old VMEX retained only the dense leading zero, so the effective toroidal-flux derivative, magnetic energy scale, and lambda scale became zero. The unnormalized forces remained finite, but multiplication by singular force norms made `FSQR`, `FSQZ`, and `FSQL` NaN on the first pass. This mechanism is fully consistent with the collaborator's value-free `D03_RAW_FORCE_NONFINITE` report, although the private deck must be rerun to confirm that it is the exact case there.

A follow-up audit found a second legal Fortran form with the same failure:

```fortran
APHI(1) = 0.0, 1.0
```

VMEC2000 assigns both `APHI(1:2)` elements. VMEX had retained only the first zero. On the same public deck that interpretation reproduces finite setup and Jacobian, `WMHD=0`, and NaN in all three iteration-1 residuals. The parser now consumes consecutive values from an indexed starting element and handles one-dimensional Fortran array sections with inclusive bounds.

I reproduced the split with a public circular-tokamak deck. Local VMEC2000 and patched VMEX print the same first iteration to displayed precision:

```text
FSQR=2.00E+00  FSQZ=1.73E+00  FSQL=3.56E-02
RAX=6.000E+00  DELT=9.00E-01  WMHD=9.3751E+03
```

Simulating the pre-fix VMEX interpretation (`APHI=[0,0,...]`) on the same deck gives a zero energy scale and non-finite residuals. Both indexed forms now reproduce VMEC2000's displayed first iteration exactly. A second indexed-array VMEC2000 comparison reached machine-precision parity in `rmnc`, `zmns`, magnetic energy, and the `add_fluxes.f90` half-to-full iota reconstruction.

The parser now overlays indexed assignments for:

- `APHI`, `AM`, `AI`, and `AC` (including their different Fortran lower bounds);
- auxiliary profile arrays;
- `NS_ARRAY`, `FTOL_ARRAY`, and `NITER_ARRAY`, including VMEC2000's initialized gap values;
- `EXTCUR`;
- modern and obsolete indexed axis arrays.

## Privacy-safe diagnosis

`python tools/diagnose_input.py INPUT` evaluates one force pass and emits only runtime metadata, PASS/FAIL stages, and an assessment code. It never emits the input path/name, resolution, coefficients, profiles, flux/current values, axis values, force magnitudes, logs, or wout content unless the explicitly local-only `--details` flag is used.

The former broad `D03` is now localized to:

- magnetic-field assembly;
- volume, R/Z energy normalization, lambda scale, or lambda normalization;
- real-space force kernels, Fourier projection, or residual scaling;
- unnormalized force sums and individual normalized R/Z/lambda channels;
- preconditioner cache, RHS, radial solve, or lambda preconditioner.

Active reconstruction and RFP inputs are reported as unsupported before VMEX silently applies ordinary-equilibrium semantics. The reconstruction check follows `vsetup.f`/`read_indata.f`: an inert `LRECON=T` with no active MSE/Thomson data is not falsely rejected.

The stage checks are collected only by the diagnostic API; production solver iterations retain the existing finite-result guard without paying for all intermediate diagnostic reductions.

## Other behavioral fixes

- Every iteration-driving output is checked for NaN/Inf. A non-finite pass raises `VmecNumericalError` at iteration 1 with public `ier_flag=9`.
- VMEC2000 `eqsolve.f` retries a sign-changing initial Jacobian using `guess_axis`. VMEX now shares that recovery between fixed and free boundary and rebuilds the free-boundary axis-current/vacuum topology only after the retry.
- If the regenerated axis is still invalid, the normal typed Jacobian error is raised.

## Validation

Local checks after the new commit:

- parser/diagnostic/force focused suite: **108 passed**;
- fixed boundary, multigrid, free boundary, CLI, and solver suite: **157 passed, 12 skipped, 2 expected xfailed**;
- full implicit AD/FD suite with JIT: **19 passed**;
- Ruff over `vmex tests examples benchmarks tools`: clean;
- mypy over `vmex`: clean;
- `git diff --check`: clean.

After rebasing onto #68, the focused parser/non-finite/free-boundary group passes **98 tests with 1 expected missing-asset skip**; Ruff, mypy, and `git diff --check` remain clean. All **17** ordinary hosted checks pass on the rebased head, and GitHub reports the PR mergeable/clean.

After the multivalue/section follow-up, **111 parser, diagnostic, and validation tests pass** locally. The broader collaborator-path audit passes **186 tests with 9 optional skips**. Ruff and mypy remain clean.

All hosted CI shards pass, including the combined >=95% coverage gate.

## Confidentiality

No private input, filename, path, log, wout, coefficient, equilibrium value, mgrid, or coil data was received, copied, printed, or committed. All reproduction and parity work uses synthetic/public inputs. The requested collaborator rerun remains value-free and explicitly forbids `--details`.
