### PR TITLE
Complete VMEC2000 parity for free-boundary multigrid and solver recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ env:
 permissions:
   contents: read
 
-# Sharded CI (plan.md Phase-2 review item 1): five parallel test jobs, each
-# well under the 10-minute wall-time budget, plus a fast lint gate (ruff +
-# mypy) and a coverage gate that combines the parity + gradient shards and
-# enforces >= 95% on vmex.
+# Sharded CI (plan.md Phase-2 review item 1): bounded parallel test jobs, plus
+# a fast lint gate (ruff + mypy) and a coverage gate that combines the parity
+# and gradient shards and enforces >= 95% on vmex.  The explicit job limits
+# include dependency setup, coverage handling, and hosted-runner variance.
 jobs:
   lint:
     # Fast fail-first gate (plan Item I.3): ruff + mypy over the whole tree,
@@ -181,8 +181,8 @@ jobs:
           print("golden dir:", mod.resolve_golden_dir())
           EOF
 
-      # Four shards, each well under the 10-min budget.  The xdist dist MODE is
-      # chosen PER SHARD by whether its modules share an expensive fixture:
+      # Four bounded shards.  The xdist dist MODE is chosen PER SHARD by
+      # whether its modules share an expensive fixture:
       #   * loadscope groups a whole module onto ONE worker, so module-scoped
       #     equilibrium fixtures (omnigenity qi_eq/tok_eq, bootstrap eq,
       #     stability vacuum/highbeta/shaped) are solved ONCE, not once-per-
@@ -251,12 +251,14 @@ jobs:
   gradient:
     name: Implicit-gradient suite ${{ matrix.shard }} (JIT on, coverage)
     runs-on: ubuntu-latest
-    # Sharded so no single job exceeds the timeout even with a COLD finite-
-    # difference cache (first run after the test file changes recomputes every
-    # FD reference). The two dominant FD tests (lasym-adjoint, lasym-3d) each get
-    # their own shard; shard "c" is the 17 remaining, lighter tests. Each shard
-    # keeps its own FD reference cache. Warm-cache runs finish in ~4 min.
-    timeout-minutes: 15
+    # Sharded so a COLD finite-difference cache remains bounded (first run
+    # after the test file changes recomputes every FD reference).  The two
+    # dominant FD tests (lasym-adjoint, lasym-3d) each get their own shard;
+    # shard "c" owns the remaining tests.  A slow hosted runner measured
+    # 14m19s for those tests alone, so include installation, coverage upload,
+    # and runner variance rather than canceling a fully passing test process
+    # during post-processing.  Warm-cache runs remain much faster.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [a, b, c, d]
+        shard: [a, b, c1, c2, d]
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -181,7 +181,7 @@ jobs:
           print("golden dir:", mod.resolve_golden_dir())
           EOF
 
-      # Four bounded shards.  The xdist dist MODE is chosen PER SHARD by
+      # Five bounded shards.  The xdist dist MODE is chosen PER SHARD by
       # whether its modules share an expensive fixture:
       #   * loadscope groups a whole module onto ONE worker, so module-scoped
       #     equilibrium fixtures (omnigenity qi_eq/tok_eq, bootstrap eq,
@@ -201,7 +201,9 @@ jobs:
       #   a = heaviest solver-golden modules, including all free-boundary
       #       modules so their JAX caches leave with this bounded shard instead
       #       of accumulating in the catch-all worker processes;
-      #   c = everything else, incl. omnigenity/turbulence/bootstrap/stability.
+      #   c1/c2 = the former catch-all, split explicitly after two hosted
+      #           runners were externally shut down above 84% despite no test
+      #           failure.  Explicit file ownership keeps coverage disjoint.
       # Together they cover the whole non-gradient, non-example core suite once;
       # the separate mirror matrix owns tests/mirror. Therefore
       # every test file appears in exactly one shard (coverage gate combines
@@ -221,21 +223,58 @@ jobs:
           B_FILES="tests/test_golden_digests.py \
                    tests/test_bootstrap.py \
                    tests/test_wout_golden.py"
+          C1_FILES="tests/test_baseline_benchmark.py \
+                    tests/test_boozer_tables.py \
+                    tests/test_cli.py \
+                    tests/test_cli_device.py \
+                    tests/test_compat.py \
+                    tests/test_coverage_margin.py \
+                    tests/test_device.py \
+                    tests/test_device_parity_tool.py \
+                    tests/test_doctor.py \
+                    tests/test_fetch_assets.py \
+                    tests/test_forces_residuals.py \
+                    tests/test_fourier_transforms.py \
+                    tests/test_geometry_fields.py \
+                    tests/test_gpu_ci.py \
+                    tests/test_implicit_device.py \
+                    tests/test_implicit_multi_rhs.py \
+                    tests/test_input_profiles.py \
+                    tests/test_lgradb.py \
+                    tests/test_mgrid.py \
+                    tests/test_multigrid_interp.py \
+                    tests/test_nonfinite_failfast.py"
+          C2_FILES="tests/test_omnigenity.py \
+                    tests/test_optimization_convergence.py \
+                    tests/test_optimize_penalty.py \
+                    tests/test_package_api.py \
+                    tests/test_packaging_metadata.py \
+                    tests/test_parallel.py \
+                    tests/test_plotting_boozer.py \
+                    tests/test_preconditioner.py \
+                    tests/test_preconditioner_2d.py \
+                    tests/test_printing.py \
+                    tests/test_profiles.py \
+                    tests/test_setup.py \
+                    tests/test_setup_extras.py \
+                    tests/test_single_stage_simultaneous.py \
+                    tests/test_solver_axis_initialization.py \
+                    tests/test_stability.py \
+                    tests/test_step_control.py \
+                    tests/test_turbulence.py \
+                    tests/test_validation_guards.py \
+                    tests/test_vmec2000_feature_stress.py"
           D_FILES="tests/test_optimize.py"
           if [ "${{ matrix.shard }}" = "a" ]; then
             pytest -q -n 4 --dist loadscope $A_FILES --durations=15 --cov=vmex --cov-report=term
           elif [ "${{ matrix.shard }}" = "b" ]; then
             pytest -q -n 4 --dist load $B_FILES --durations=15 --cov=vmex --cov-report=term
+          elif [ "${{ matrix.shard }}" = "c1" ]; then
+            pytest -q -n 4 --dist loadscope $C1_FILES --durations=15 --cov=vmex --cov-report=term
+          elif [ "${{ matrix.shard }}" = "c2" ]; then
+            pytest -q -n 4 --dist loadscope $C2_FILES --durations=15 --cov=vmex --cov-report=term
           elif [ "${{ matrix.shard }}" = "d" ]; then
             pytest -q -n 4 --dist load $D_FILES --durations=15 --cov=vmex --cov-report=term
-          else
-            IGNORES=$(for f in $A_FILES $B_FILES $D_FILES; do echo "--ignore=$f"; done)
-            pytest -q -n 4 --dist loadscope tests \
-              --ignore=tests/mirror \
-              --ignore=tests/test_implicit_grad.py \
-              --ignore=tests/test_examples.py \
-              $IGNORES \
-              --durations=15 --cov=vmex --cov-report=term
           fi
 
       - name: Stash coverage data
@@ -376,7 +415,7 @@ jobs:
 
       - name: Combine shards and enforce the gate
         run: |
-          coverage combine coverage.parity-a coverage.parity-b coverage.parity-c coverage.parity-d coverage.gradient-a coverage.gradient-b coverage.gradient-c coverage.examples
+          coverage combine coverage.parity-a coverage.parity-b coverage.parity-c1 coverage.parity-c2 coverage.parity-d coverage.gradient-a coverage.gradient-b coverage.gradient-c coverage.examples
           # The mirror release audit reaches 95% only after appending nightly
           # fixed/free adjoint tests. The fast core artifacts intentionally
           # exclude those tests, so do not mix a partial mirror number into

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,9 @@ jobs:
       #                         cheap + /tmp-cached, so per-worker re-solve is
       #                         negligible; loadscope serialised 383 s)
       # The fixture-sharing modules stay on loadscope:
-      #   a = heaviest solver-golden modules;
+      #   a = heaviest solver-golden modules, including all free-boundary
+      #       modules so their JAX caches leave with this bounded shard instead
+      #       of accumulating in the catch-all worker processes;
       #   c = everything else, incl. omnigenity/turbulence/bootstrap/stability.
       # Together they cover the whole non-gradient, non-example core suite once;
       # the separate mirror matrix owns tests/mirror. Therefore
@@ -212,6 +214,8 @@ jobs:
                    tests/test_multigrid_ladder.py \
                    tests/test_optimize_traceable_qs.py \
                    tests/test_freeboundary.py \
+                   tests/test_freeboundary_multigrid.py \
+                   tests/test_freeboundary_diff.py \
                    tests/test_cli_freeboundary.py \
                    tests/test_solver_end_to_end.py"
           B_FILES="tests/test_golden_digests.py \

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ CPU, single thread; `benchmarks/baseline.json`; reproduce with
 |---|:---:|:---:|:---:|
 | Fixed-boundary equilibria | ✅ | ✅ | ✅ |
 | Free boundary from an mgrid file | ✅ | ✅ | ✅ |
+| Free-boundary radial multigrid + hot restart | ✅ | ✅ | ❌ |
 | Free boundary directly from coils (no mgrid) | ✅ | ❌ | ❌ |
 | Free-boundary tokamaks (`ntor = 0`) | ✅ | ✅ | ❌ |
 | Non-stellarator-symmetric (`LASYM = T`) | ✅ | ✅ | ✅ |
@@ -310,8 +311,10 @@ plot_wout(eq.wout, "figures/")
 ```
 
 Choosing an entry point: `optimize.solve_equilibrium` for Python analysis and
-objectives (state + runtime + lazy `.wout`); `multigrid.solve_multigrid` when
-you only need the converged state (the CLI's engine); `implicit.run` for
+objectives (state + runtime + lazy `.wout`); `multigrid.solve_multigrid` for a
+fixed-boundary ladder; `multigrid.solve_free_boundary_multigrid` for a
+free-boundary ladder (including vacuum continuation and hot starts);
+`implicit.run` for
 gradients (`jax.grad`-able `ImplicitSolution`); `solver.solve` as the
 low-level single-grid building block.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@
 **VMEX** is a clean-room, JAX-native reimplementation of the
 [VMEC2000](https://princetonuniversity.github.io/STELLOPT/VMEC) ideal-MHD
 equilibrium code for stellarators and tokamaks. It reproduces VMEC2000
-iteration-for-iteration on benchmark decks — and, unlike the Fortran
-original, it is differentiable and runs on GPUs.
+iteration-for-iteration on representative benchmark decks — and, unlike the
+Fortran original, provides differentiable research paths and runs on GPUs.
+The exact support and validation matrix is documented in
+[VMEC2000 compatibility and research scope](https://vmex.readthedocs.io/en/latest/vmec2000_compatibility.html).
 
 - **VMEC2000 parity.** The solver ports VMEC2000's algorithms
   constant-for-constant (steepest-descent moment method, radial
@@ -28,15 +30,17 @@ original, it is differentiable and runs on GPUs.
   respect to boundary shape and profile parameters by implicit
   differentiation of the converged fixed point — no finite differences, no
   unrolling — validated against central finite differences to ~1e-6 relative
-  (see the gradient table in the docs), with an O(1)-memory adjoint. **Free
-  boundary** is differentiable end-to-end through the virtual-casing vacuum
-  field (coil / `extcur` derivatives), finite-difference-validated.
+  (see the gradient table in the docs), with an O(1)-memory adjoint. The
+  **free-boundary virtual-casing residual** is differentiable in coil /
+  `extcur` parameters on a specified plasma boundary and is
+  finite-difference-validated. The host-driven NESTOR equilibrium solve itself
+  is not differentiated.
 - **Drop-in.** Reads VMEC2000 `input.*` namelists and VMEC++-style JSON,
   prints VMEC2000-format iteration output, and writes `wout_*.nc` files
   that load unchanged in simsopt and booz_xform.
 - **Batteries included.** Plotting (`vmex --plot`), Boozer transform
   (`vmex --booz`), spline profiles, multigrid, hot restart, free boundary
-  from mgrid files *or* directly from coils,
+  from mgrid files or fields tabulated from coils,
   typed zero-crash errors — with the shared linear/adjoint solver layer
   factored out into [SOLVAX](https://pypi.org/project/solvax/).
 
@@ -173,7 +177,7 @@ CPU, single thread; `benchmarks/baseline.json`; reproduce with
 | Fixed-boundary equilibria | ✅ | ✅ | ✅ |
 | Free boundary from an mgrid file | ✅ | ✅ | ✅ |
 | Free-boundary radial multigrid + hot restart | ✅ | ✅ | ❌ |
-| Free boundary directly from coils (no mgrid) | ✅ | ❌ | ❌ |
+| Free boundary from an in-memory coil-field table | ✅ | ❌ | ❌ |
 | Free-boundary tokamaks (`ntor = 0`) | ✅ | ✅ | ❌ |
 | Non-stellarator-symmetric (`LASYM = T`) | ✅ | ✅ | ✅ |
 | Fixed-boundary fallback on missing mgrid | ✅ | ✅ | ❌ |
@@ -185,19 +189,19 @@ CPU, single thread; `benchmarks/baseline.json`; reproduce with
 | Plotting built in (`--plot`) | ✅ | ❌ | ❌ |
 | GPU execution | ✅ | ❌ | ❌ |
 | Differentiable fixed boundary (implicit diff, O(1) memory) | ✅ | ❌ | ❌ |
-| Differentiable free boundary (virtual casing) | ✅ | ❌ | ❌ |
+| Differentiable virtual-casing residual on a specified boundary | ✅ | ❌ | ❌ |
 | 2D block preconditioner (stiff-case speedup) | ✅ | ❌ | ❌ |
 
-### Free boundary straight from coils
+### Free boundary from coil-field tabulation
 
-Free-boundary solves can run directly from a coil set: tabulate an
+Free-boundary solves can use a coil set by tabulating an
 [ESSOS](https://github.com/uwplasma/ESSOS) coil set onto the solver grid in
 memory (`essos.coils.Coils.to_mgrid`) and pass it as `external_field=`,
-with no MAKEGRID file involved. For gradients, the differentiable free
-boundary evaluates a JAX Biot-Savart (a plain `xyz→B` callable) at the
-boundary points of each iteration, keeping the coil degrees of freedom
-differentiable end-to-end. All coil geometry lives in ESSOS; vmex has no
-coil code of its own.
+without a persistent MAKEGRID file. This forward route still uses mgrid
+interpolation. Separately, the virtual-casing residual can evaluate a JAX
+Biot-Savart callable directly on a specified boundary, retaining coil
+derivatives for that residual; it is not an adjoint of the reconverged NESTOR
+solve. All coil geometry lives in ESSOS; vmex has no coil code of its own.
 
 ![Free-boundary Landreman-Paul QA pressure scan directly from ESSOS coils](docs/_static/figures/readme_essos_beta_scan.png)
 

--- a/benchmarks/freeboundary_multigrid.json
+++ b/benchmarks/freeboundary_multigrid.json
@@ -1,0 +1,131 @@
+{
+  "schema": 1,
+  "case": "input.cth_like_free_bdy",
+  "input_data_embedded": false,
+  "ladder": {
+    "ns": [
+      7,
+      15
+    ],
+    "ftol": [
+      1e-08,
+      1e-10
+    ],
+    "niter": [
+      1000,
+      2500
+    ]
+  },
+  "environment": {
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "jax_backend": "cpu",
+    "jax_version": "0.11.0",
+    "x64": true
+  },
+  "vmec2000": {
+    "wall_s": 0.8787723330315202,
+    "converged": true,
+    "vacuum_turnons": 1,
+    "stages": [
+      {
+        "ns": 7,
+        "ftol": 1e-08,
+        "niter_cap": 1000,
+        "first_iteration": 1,
+        "first_fsqr": 0.208,
+        "first_fsqz": 0.0147,
+        "first_fsql": 0.0486,
+        "iterations": 239,
+        "fsqr": 9.56e-09,
+        "fsqz": 2.07e-09,
+        "fsql": 5.1e-09
+      },
+      {
+        "ns": 15,
+        "ftol": 1e-10,
+        "niter_cap": 2500,
+        "first_iteration": 1,
+        "first_fsqr": 1.73,
+        "first_fsqz": 0.887,
+        "first_fsql": 1.51e-05,
+        "iterations": 340,
+        "fsqr": 9.78e-11,
+        "fsqz": 2.3e-11,
+        "fsql": 2.51e-11
+      }
+    ]
+  },
+  "vmex_cold": {
+    "wall_s": 7.601543041877449,
+    "converged": true,
+    "vacuum_turnons": 1,
+    "stages": [
+      {
+        "ns": 7,
+        "ftol": 1e-08,
+        "niter_cap": 1000,
+        "first_iteration": 1,
+        "first_fsqr": 0.208,
+        "first_fsqz": 0.0147,
+        "first_fsql": 0.0486,
+        "iterations": 250,
+        "fsqr": 1e-08,
+        "fsqz": 2.43e-09,
+        "fsql": 5.09e-09
+      },
+      {
+        "ns": 15,
+        "ftol": 1e-10,
+        "niter_cap": 2500,
+        "first_iteration": 1,
+        "first_fsqr": 0.00201,
+        "first_fsqz": 0.00125,
+        "first_fsql": 1.52e-05,
+        "iterations": 340,
+        "fsqr": 9.72e-11,
+        "fsqz": 2.28e-11,
+        "fsql": 2.44e-11
+      }
+    ]
+  },
+  "vmex_warm": {
+    "wall_s": 1.220268583158031,
+    "converged": true,
+    "vacuum_turnons": 1,
+    "stages": [
+      {
+        "ns": 7,
+        "ftol": 1e-08,
+        "niter_cap": 1000,
+        "first_iteration": 1,
+        "first_fsqr": 0.208,
+        "first_fsqz": 0.0147,
+        "first_fsql": 0.0486,
+        "iterations": 250,
+        "fsqr": 1e-08,
+        "fsqz": 2.43e-09,
+        "fsql": 5.09e-09
+      },
+      {
+        "ns": 15,
+        "ftol": 1e-10,
+        "niter_cap": 2500,
+        "first_iteration": 1,
+        "first_fsqr": 0.00201,
+        "first_fsqz": 0.00125,
+        "first_fsql": 1.52e-05,
+        "iterations": 340,
+        "fsqr": 9.72e-11,
+        "fsqz": 2.28e-11,
+        "fsql": 2.44e-11
+      }
+    ],
+    "peak_rss_mb": 3464.167424
+  },
+  "final_wout_parity": {
+    "rmnc_scale_relative_max": 6.101819389044875e-05,
+    "zmns_scale_relative_max": 0.0003593757378372186,
+    "iotaf_scale_relative_max": 1.52135512200139e-06,
+    "wb_relative": 5.9358469873606814e-08
+  }
+}

--- a/benchmarks/freeboundary_multigrid.json
+++ b/benchmarks/freeboundary_multigrid.json
@@ -23,7 +23,7 @@
     "x64": true
   },
   "vmec2000": {
-    "wall_s": 0.8787723330315202,
+    "wall_s": 0.9823904170189053,
     "converged": true,
     "vacuum_turnons": 1,
     "stages": [
@@ -56,7 +56,7 @@
     ]
   },
   "vmex_cold": {
-    "wall_s": 7.601543041877449,
+    "wall_s": 10.065343208843842,
     "converged": true,
     "vacuum_turnons": 1,
     "stages": [
@@ -89,7 +89,7 @@
     ]
   },
   "vmex_warm": {
-    "wall_s": 1.220268583158031,
+    "wall_s": 1.9825521658640355,
     "converged": true,
     "vacuum_turnons": 1,
     "stages": [
@@ -120,7 +120,7 @@
         "fsql": 2.44e-11
       }
     ],
-    "peak_rss_mb": 3464.167424
+    "peak_rss_mb": 3421.749248
   },
   "final_wout_parity": {
     "rmnc_scale_relative_max": 6.101819389044875e-05,

--- a/benchmarks/freeboundary_multigrid.json
+++ b/benchmarks/freeboundary_multigrid.json
@@ -17,13 +17,13 @@
     ]
   },
   "environment": {
-    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "platform": "macOS-26.5.1-arm64-arm-64bit-Mach-O",
     "jax_backend": "cpu",
     "jax_version": "0.11.0",
     "x64": true
   },
   "vmec2000": {
-    "wall_s": 0.9823904170189053,
+    "wall_s": 0.9156720000319183,
     "converged": true,
     "vacuum_turnons": 1,
     "stages": [
@@ -56,7 +56,7 @@
     ]
   },
   "vmex_cold": {
-    "wall_s": 10.065343208843842,
+    "wall_s": 8.61459045810625,
     "converged": true,
     "vacuum_turnons": 1,
     "stages": [
@@ -78,18 +78,18 @@
         "ftol": 1e-10,
         "niter_cap": 2500,
         "first_iteration": 1,
-        "first_fsqr": 0.00201,
-        "first_fsqz": 0.00125,
-        "first_fsql": 1.52e-05,
+        "first_fsqr": 1.73,
+        "first_fsqz": 0.887,
+        "first_fsql": 1.53e-05,
         "iterations": 340,
-        "fsqr": 9.72e-11,
+        "fsqr": 9.69e-11,
         "fsqz": 2.28e-11,
-        "fsql": 2.44e-11
+        "fsql": 2.45e-11
       }
     ]
   },
   "vmex_warm": {
-    "wall_s": 1.9825521658640355,
+    "wall_s": 1.1960331248119473,
     "converged": true,
     "vacuum_turnons": 1,
     "stages": [
@@ -111,21 +111,21 @@
         "ftol": 1e-10,
         "niter_cap": 2500,
         "first_iteration": 1,
-        "first_fsqr": 0.00201,
-        "first_fsqz": 0.00125,
-        "first_fsql": 1.52e-05,
+        "first_fsqr": 1.73,
+        "first_fsqz": 0.887,
+        "first_fsql": 1.53e-05,
         "iterations": 340,
-        "fsqr": 9.72e-11,
+        "fsqr": 9.69e-11,
         "fsqz": 2.28e-11,
-        "fsql": 2.44e-11
+        "fsql": 2.45e-11
       }
     ],
-    "peak_rss_mb": 3421.749248
+    "peak_rss_mb": 3982.753792
   },
   "final_wout_parity": {
-    "rmnc_scale_relative_max": 6.101819389044875e-05,
-    "zmns_scale_relative_max": 0.0003593757378372186,
-    "iotaf_scale_relative_max": 1.52135512200139e-06,
-    "wb_relative": 5.9358469873606814e-08
+    "rmnc_scale_relative_max": 6.079271399094438e-05,
+    "zmns_scale_relative_max": 0.00035877512680282587,
+    "iotaf_scale_relative_max": 1.994041086342155e-06,
+    "wb_relative": 6.065743061267379e-08
   }
 }

--- a/benchmarks/run_baseline.py
+++ b/benchmarks/run_baseline.py
@@ -221,17 +221,13 @@ from vmex.core.input import VmecInput
 from vmex.core.multigrid import solve_multigrid
 
 def run(path):
-    # Same route as the ``vmec`` CLI (core/cli.py): fixed-boundary decks run
-    # the full NS_ARRAY ladder; free-boundary decks run the final stage.
+    # Same route as the ``vmec`` CLI (core/cli.py): both fixed- and
+    # free-boundary decks run the full NS_ARRAY ladder.
     inp = VmecInput.from_file(path)
     if bool(getattr(inp, "lfreeb", False)):
-        from vmex.core.freeboundary import solve_free_boundary
-        from vmex.core.solver import resolution_from_input
-
-        ns = int(np.atleast_1d(np.asarray(inp.ns_array))[-1])
-        return solve_free_boundary(
-            inp, resolution=resolution_from_input(inp, ns=ns),
-            error_on_no_convergence=False,
+        from vmex.core.multigrid import solve_free_boundary_multigrid
+        return solve_free_boundary_multigrid(
+            inp, raise_on_max_iterations=False,
         )
     return solve_multigrid(inp)
 

--- a/benchmarks/run_freeboundary_multigrid.py
+++ b/benchmarks/run_freeboundary_multigrid.py
@@ -83,6 +83,13 @@ def _stage_iterations(stdout: str) -> list[dict]:
     return stages
 
 
+def _vmec_converged(stdout: str) -> bool:
+    return (
+        "EXECUTION TERMINATED NORMALLY" in stdout
+        and "Try increasing NITER" not in stdout
+    )
+
+
 def _normalized_max_error(mine: np.ndarray, reference: np.ndarray) -> float:
     scale = max(float(np.max(np.abs(reference))), np.finfo(float).tiny)
     return float(np.max(np.abs(mine - reference)) / scale)
@@ -186,7 +193,7 @@ def main() -> None:
         },
         "vmec2000": {
             "wall_s": vmec_wall,
-            "converged": "EXECUTION TERMINATED NORMALLY" in vmec.stdout,
+            "converged": _vmec_converged(vmec.stdout),
             "vacuum_turnons": vmec.stdout.count("VACUUM PRESSURE TURNED ON"),
             "stages": _stage_iterations(vmec.stdout),
         },

--- a/benchmarks/run_freeboundary_multigrid.py
+++ b/benchmarks/run_freeboundary_multigrid.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Benchmark and parity-check free-boundary radial multigrid against VMEC2000.
+
+The default case is the public, converged CTH-like fixture.  The report stores
+only aggregate timings, residuals, iteration counts, and normalized output
+errors; it never copies input-deck text or coil/mgrid data into the JSON.  This
+makes the harness safe to use with confidential collaborator cases too::
+
+    python benchmarks/run_freeboundary_multigrid.py \
+      --deck /private/path/input.case --mgrid /private/path/mgrid.nc \
+      --ns 7,15 --ftol 1e-8,1e-10 --niter 1000,2500 \
+      --out /private/path/result.json
+
+VMEC2000 runs in a temporary directory.  VMEX is measured cold and warm in
+one process so the warm row excludes JAX compilation and mgrid loading caches.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import resource
+import subprocess
+import tempfile
+import time
+from dataclasses import replace
+from pathlib import Path
+
+import jax
+import numpy as np
+
+from vmex.core.input import VmecInput
+from vmex.core.multigrid import solve_free_boundary_multigrid
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_DECK = REPO / "examples" / "data" / "input.cth_like_free_bdy"
+DEFAULT_MGRID = REPO / "examples" / "data" / "mgrid_cth_like.nc"
+DEFAULT_XVMEC = Path("/Users/rogerio/local/STELLOPT/VMEC2000/Release/xvmec2000")
+
+
+def _numbers(value: str, cast):
+    return [cast(x) for x in value.replace(",", " ").split()]
+
+
+def _replace_array(text: str, name: str, values: list) -> str:
+    replacement = f"  {name} = " + ", ".join(str(v) for v in values) + ","
+    pattern = rf"(?im)^\s*{re.escape(name)}\s*=.*$"
+    out, count = re.subn(pattern, replacement, text, count=1)
+    if count != 1:
+        raise ValueError(f"input deck has no active {name} assignment")
+    return out
+
+
+def _stage_iterations(stdout: str) -> list[dict]:
+    stages = []
+    matches = list(re.finditer(
+        r"NS\s*=\s*(\d+).*?FTOLV\s*=\s*([\d.E+\-]+).*?NITER\s*=\s*(\d+)",
+        stdout,
+    ))
+    for i, match in enumerate(matches):
+        block = stdout[match.end(): matches[i + 1].start() if i + 1 < len(matches) else None]
+        rows = re.findall(
+            r"(?m)^\s*(\d+)\s+([\d.E+\-]+)\s+([\d.E+\-]+)\s+([\d.E+\-]+)",
+            block,
+        )
+        first = rows[0] if rows else (None, None, None, None)
+        last = rows[-1] if rows else (None, None, None, None)
+        stages.append({
+            "ns": int(match.group(1)), "ftol": float(match.group(2)),
+            "niter_cap": int(match.group(3)),
+            "first_iteration": None if first[0] is None else int(first[0]),
+            "first_fsqr": None if first[1] is None else float(first[1]),
+            "first_fsqz": None if first[2] is None else float(first[2]),
+            "first_fsql": None if first[3] is None else float(first[3]),
+            "iterations": None if last[0] is None else int(last[0]),
+            "fsqr": None if last[1] is None else float(last[1]),
+            "fsqz": None if last[2] is None else float(last[2]),
+            "fsql": None if last[3] is None else float(last[3]),
+        })
+    return stages
+
+
+def _normalized_max_error(mine: np.ndarray, reference: np.ndarray) -> float:
+    scale = max(float(np.max(np.abs(reference))), np.finfo(float).tiny)
+    return float(np.max(np.abs(mine - reference)) / scale)
+
+
+def _peak_rss_mb() -> float:
+    raw = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return float(raw / 1e6 if platform.system() == "Darwin" else raw / 1024.0)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--deck", type=Path, default=DEFAULT_DECK)
+    parser.add_argument("--mgrid", type=Path, default=DEFAULT_MGRID)
+    parser.add_argument("--xvmec", type=Path, default=DEFAULT_XVMEC)
+    parser.add_argument("--ns", default="7,15")
+    parser.add_argument("--ftol", default="1e-8,1e-10")
+    parser.add_argument("--niter", default="1000,2500")
+    parser.add_argument("--out", type=Path,
+                        default=REPO / "benchmarks" / "freeboundary_multigrid.json")
+    args = parser.parse_args()
+
+    ns = _numbers(args.ns, int)
+    ftol = _numbers(args.ftol, float)
+    niter = _numbers(args.niter, int)
+    if not (len(ns) == len(ftol) == len(niter)):
+        raise ValueError("--ns, --ftol, and --niter must have equal lengths")
+    for path in (args.deck, args.mgrid, args.xvmec):
+        if not path.is_file():
+            raise FileNotFoundError(path)
+
+    text = args.deck.read_text()
+    text = _replace_array(text, "NS_ARRAY", ns)
+    text = _replace_array(text, "FTOL_ARRAY", ftol)
+    text = _replace_array(text, "NITER_ARRAY", niter)
+    case = "vmex_fbmg_benchmark"
+
+    with tempfile.TemporaryDirectory(prefix="vmex-fbmg-") as td:
+        work = Path(td)
+        deck = work / f"input.{case}"
+        deck.write_text(text)
+        os.symlink(args.mgrid.resolve(), work / Path(args.mgrid).name)
+
+        t0 = time.perf_counter()
+        vmec = subprocess.run(
+            [str(args.xvmec.resolve()), deck.name], cwd=work,
+            capture_output=True, text=True, check=False,
+        )
+        vmec_wall = time.perf_counter() - t0
+        if vmec.returncode != 0:
+            raise RuntimeError(
+                f"VMEC2000 failed with {vmec.returncode}:\n{vmec.stdout[-2000:]}\n"
+                f"{vmec.stderr[-2000:]}"
+            )
+
+        inp = replace(
+            VmecInput.from_file(deck), ns_array=np.asarray(ns),
+            ftol_array=np.asarray(ftol), niter_array=np.asarray(niter),
+        )
+
+        def vmex_run():
+            lines: list[str] = []
+            start = time.perf_counter()
+            result = solve_free_boundary_multigrid(
+                inp, mgrid_path=args.mgrid.resolve(), verbose=True,
+                emit=lambda value="", end="\n": lines.append(str(value) + end),
+                raise_on_max_iterations=False,
+            )
+            jax.block_until_ready(result.state.R_cos)
+            return result, "".join(lines), time.perf_counter() - start
+
+        cold, cold_stdout, cold_wall = vmex_run()
+        warm, warm_stdout, warm_wall = vmex_run()
+
+        from vmex.core.wout import read_wout
+
+        reference = read_wout(work / f"wout_{case}.nc")
+        mine = {(int(m), int(n)): i for i, (m, n) in enumerate(zip(warm.xm, warm.xn))}
+        indices = np.asarray([
+            mine[(int(m), int(n))] for m, n in zip(reference.xm, reference.xn)
+        ])
+        parity = {
+            "rmnc_scale_relative_max": _normalized_max_error(
+                warm.rmnc[:, indices], np.asarray(reference.rmnc)),
+            "zmns_scale_relative_max": _normalized_max_error(
+                warm.zmns[:, indices], np.asarray(reference.zmns)),
+            "iotaf_scale_relative_max": _normalized_max_error(
+                warm.iotaf, np.asarray(reference.iotaf)),
+            "wb_relative": abs(float(warm.wb) - float(reference.wb))
+            / max(abs(float(reference.wb)), np.finfo(float).tiny),
+        }
+
+    report = {
+        "schema": 1,
+        "case": args.deck.name,
+        "input_data_embedded": False,
+        "ladder": {"ns": ns, "ftol": ftol, "niter": niter},
+        "environment": {
+            "platform": platform.platform(), "jax_backend": jax.default_backend(),
+            "jax_version": jax.__version__, "x64": bool(jax.config.jax_enable_x64),
+        },
+        "vmec2000": {
+            "wall_s": vmec_wall,
+            "converged": "EXECUTION TERMINATED NORMALLY" in vmec.stdout,
+            "vacuum_turnons": vmec.stdout.count("VACUUM PRESSURE TURNED ON"),
+            "stages": _stage_iterations(vmec.stdout),
+        },
+        "vmex_cold": {
+            "wall_s": cold_wall, "converged": bool(cold.converged),
+            "vacuum_turnons": cold_stdout.count("VACUUM PRESSURE TURNED ON"),
+            "stages": _stage_iterations(cold_stdout),
+        },
+        "vmex_warm": {
+            "wall_s": warm_wall, "converged": bool(warm.converged),
+            "vacuum_turnons": warm_stdout.count("VACUUM PRESSURE TURNED ON"),
+            "stages": _stage_iterations(warm_stdout),
+            "peak_rss_mb": _peak_rss_mb(),
+        },
+        "final_wout_parity": parity,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_freeboundary_multigrid.py
+++ b/benchmarks/run_freeboundary_multigrid.py
@@ -4,7 +4,7 @@
 The default case is the public, converged CTH-like fixture.  The report stores
 only aggregate timings, residuals, iteration counts, and normalized output
 errors; it never copies input-deck text or coil/mgrid data into the JSON.  This
-makes the harness safe to use with confidential collaborator cases too::
+makes the harness safe to use with private validation cases too::
 
     python benchmarks/run_freeboundary_multigrid.py \
       --deck /private/path/input.case --mgrid /private/path/mgrid.nc \

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -193,11 +193,14 @@ jogs, no assembled blocks — and the system is solved with matrix-free
 restarted GMRES from SOLVAX (``solvax.gmres``) in
 :func:`~vmex.core.preconditioner_2d.newton_direction`. A loose GMRES
 tolerance yields an inexact Newton step; peak memory stays at one force
-graph. Activation mirrors ``evolve.f``
+graph. Activation mirrors the main ``evolve.f`` gates
 (:class:`~vmex.core.preconditioner_2d.Prec2DConfig`): finest grid only,
 ``iter2 >= 10``, and ``fsqr + fsqz + fsql < prec2d_threshold``; the wiring in
 :mod:`vmex.core.solver` swaps the Newton direction for the 1D force
 direction under a ``lax.cond``, leaving the default 1D-only path untouched.
+It does **not** reproduce VMEC2000's distinct CG/GMRESR/TFQMR evolution
+algorithms or its ``PRE_NITER`` budget mutation; see
+:doc:`vmec2000_compatibility`.
 
 Spectral condensation (``alias.f``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -252,9 +255,10 @@ interpolated in :math:`\sqrt{s}`-internal form to the next finer grid
 the scaled array, interpolate linearly in :math:`s`, unscale, and zero the
 odd-m axis row (:func:`~vmex.core.multigrid.interpolate_coefficients` /
 :func:`~vmex.core.multigrid.interpolate_state`; the equations are in
-:doc:`equations`). Mode and radial arrays are padded to the maximum
-resolution so all stages share one compiled executable — the ladder pays a
-single JIT compile. The same interpolation seam provides hot restart
+:doc:`equations`). Each distinct stage structure may compile once; repeated
+ladders with the same structures reuse those executables. A single
+maximum-resolution masked executable is future work, not current behavior.
+The same interpolation seam provides hot restart
 (:func:`vmex.core.solver.hot_restart_state`): a previous solution (e.g.
 the previous point of a parameter scan) can seed the solve directly, at the
 same or a different radial resolution.

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -109,7 +109,14 @@ the velocity and rescales ``delt``):
 - **bad Jacobian** (``irst = 2``): restore the checkpoint, zero the velocity,
   ``delt *= 0.90``; on the first bad Jacobian the axis guess is recomputed
   (``guess_axis``), and ``delt`` is reset at ``ijacob = 25, 50`` with a hard
-  stop at 75 (``jac75_flag``);
+  stop at 75 (``jac75_flag``).  VMEX then offers a bounded driver-level
+  recovery (two attempts by default): restart the best finite checkpoint with
+  zero velocity and half the preceding initial ``DELT`` (capped at 0.5).
+  The force equations and stopping tolerance do not change.  Set
+  ``jacobian_retries=0`` (Python) or ``--jacobian-retries 0`` (CLI) for the
+  exact VMEC2000 fatal-stop policy.  Free-boundary recovery rebuilds the
+  axis-current filament and all resolution/geometry-dependent NESTOR
+  structures before continuing;
 - **residual blow-up** (``irst = 3``): if after more than 10 steps the
   residual exceeds :math:`10^4\times` the checkpoint value, restore and
   ``delt /= 1.03``.

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -322,12 +322,25 @@ with the VMEC2000 cadence (``funct3d.f``):
   ``rbsq = bsqvac + presf(ns)`` at ``js = ns``, and the constraint reference
   surfaces ``rcon0, zcon0`` ramp by 0.9 per iteration.
 
-The external field comes either from an ``mgrid`` file
-(:mod:`vmex.core.mgrid`, trilinear interpolation weighted by ``EXTCUR``)
-or from any ``xyz -> B`` callable — e.g. an ESSOS ``essos.coils.Coils``
-Biot-Savart field (``lambda pts: coils.B(pts)``), interpolation-free and
-differentiable through the coil parameters. vmex itself carries no coil
-code; coils live in ESSOS.
+:func:`vmex.core.multigrid.solve_free_boundary_multigrid` implements
+``runvmec.f``'s radial ladder.  Increasing grids interpolate ``xstore`` using
+the same odd-m :math:`\sqrt{s}` scaling as fixed boundary; equal grids rerun
+the current state and decreasing entries are skipped.  ``ivac``, adaptive
+``nvacskip``, and the last ``bsqvac`` are carried.  Because the free-boundary
+block is guarded by ``iter2 > 1``, a new stage uses that carried pressure on
+iteration 1 and performs its first full update on iteration 2.  The
+resolution-specific NESTOR basis, Green-function program, axis-current
+filament program, cached potential matrix, and traced cadence loop are selected
+or rebuilt for the new stage.  Vacuum activates only once across the ladder.
+
+The forward NESTOR solver consumes a :class:`~vmex.core.mgrid.MgridField`.
+It may be loaded from an ``mgrid`` file (trilinear interpolation weighted by
+``EXTCUR``) or built once with
+:meth:`~vmex.core.mgrid.MgridField.from_cartesian_field`, which tabulates an
+ESSOS/SIMSOPT Biot--Savart object or any ``xyz -> B`` callable.  The resulting
+table and its current scale remain JAX-differentiable; tabulation itself does
+not retain coil-geometry derivatives.  Direct, interpolation-free ESSOS coil
+derivatives use the virtual-casing residual below. vmex carries no coil code.
 
 Differentiable free boundary (virtual casing)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -112,6 +112,10 @@ the velocity and rescales ``delt``):
   stop at 75 (``jac75_flag``).  VMEX then offers a bounded driver-level
   recovery (two attempts by default): restart the best finite checkpoint with
   zero velocity and half the preceding initial ``DELT`` (capped at 0.5).
+  This is a continuation, not a fresh ``profil3d`` initialization: the
+  first-pass ``LMOVE_AXIS`` transfer is disabled on the driver-level retry, so
+  a still-large force cannot replace the checkpoint with a cold axis-derived
+  state.
   The force equations and stopping tolerance do not change.  Set
   ``jacobian_retries=0`` (Python) or ``--jacobian-retries 0`` (CLI) for the
   exact VMEC2000 fatal-stop policy.  Free-boundary recovery rebuilds the
@@ -149,7 +153,12 @@ system with the :math:`m^2` and :math:`(n\,\mathrm{NFP})^2` weights, the
 algorithm vectorized over all spectral columns simultaneously
 (:func:`vmex.core.preconditioner.tridiagonal_solve`, a thin arg-order
 adapter over ``solvax.tridiagonal_solve`` — the shared SOLVAX linear-solver
-package). :math:`\lambda` uses the diagonal ``faclam`` factors from
+package). Production application uses ``solvax.tridiagonal_solve_checked``:
+the unregularized Thomas pivots must pass VMEC2000's
+``abs(pivot) > 1e-8*abs(diagonal)`` condition and a backward-residual check.
+Rejected columns receive an identity preconditioner action and a typed
+diagnostic instead of an amplified finite or NaN/Inf update. :math:`\lambda`
+uses the diagonal ``faclam`` factors from
 ``lamcal.f90`` (:func:`~vmex.core.preconditioner.lamcal`):
 
 .. math::
@@ -270,6 +279,16 @@ The same interpolation seam provides hot restart
 the previous point of a parameter scan) can seed the solve directly, at the
 same or a different radial resolution.
 
+The transfer includes VMEC2000's non-geometric module state.  In particular,
+``initialize_radial.f`` resets ``fsq``, ``iter1``, ``iter2``, ``ijacob``,
+and the time-step controller, but it does **not** reset
+``fsqr/fsqz/fsql``.  VMEX therefore passes the previous stage's three
+invariant residuals into the first force evaluation on the next grid.  This
+matters in free boundary: ``residue.f90`` uses the retained
+``fsqr + fsqz`` to decide whether the carried edge-force row belongs in the
+first fine-grid norm.  Axis re-guess transfers and bounded JAC75 retries
+retain the same residual state instead of silently becoming cold starts.
+
 Free boundary (NESTOR)
 ----------------------
 
@@ -330,16 +349,17 @@ with the VMEC2000 cadence (``funct3d.f``):
      \frac{1}{\max(0.1,\; 10^{11}\,(\mathrm{fsqr}+\mathrm{fsqz}))}\right);
 
 - the vacuum pressure enters the edge force through
-  ``rbsq = bsqvac + presf(ns)`` at ``js = ns``, and the constraint reference
-  surfaces ``rcon0, zcon0`` ramp by 0.9 per iteration.
+  ``rbsq = (bsqvac + presf_ns) * R(edge) / hs`` at ``js = ns``, and the
+  constraint reference surfaces ``rcon0, zcon0`` ramp by 0.9 per iteration.
 
 :func:`vmex.core.multigrid.solve_free_boundary_multigrid` implements
 ``runvmec.f``'s radial ladder.  Increasing grids interpolate ``xstore`` using
 the same odd-m :math:`\sqrt{s}` scaling as fixed boundary; equal grids rerun
-the current state and decreasing entries are skipped.  ``ivac``, adaptive
-``nvacskip``, and the last ``bsqvac`` are carried.  Because the free-boundary
-block is guarded by ``iter2 > 1``, a new stage uses that carried pressure on
-iteration 1 and performs its first full update on iteration 2.  The
+the current state and the ladder stops at the first decreasing entry.
+``ivac``, adaptive ``nvacskip``, the exact ``rbsq`` edge product, and the
+three invariant residual channels are carried.  Because the free-boundary
+block is guarded by ``iter2 > 1``, a new stage uses that carried edge product
+on iteration 1 and performs its first full update on iteration 2.  The
 resolution-specific NESTOR basis, Green-function program, axis-current
 filament program, cached potential matrix, and traced cadence loop are selected
 or rebuilt for the new stage.  Vacuum activates only once across the ladder.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -63,7 +63,8 @@ Module map
      - single-grid solve loop: ``lax.while_loop`` core + host-blocked CLI lane
      - ``funct3d.f``, ``eqsolve.f``
    * - :mod:`~vmex.core.multigrid`
-     - ``NS_ARRAY`` ladder, coarse-to-fine interpolation, hot restart
+     - fixed- and free-boundary ``NS_ARRAY`` ladders, coarse-to-fine
+       interpolation, hot restart, vacuum continuation/rebuild
      - ``runvmec.f``, ``interp.f``
    * - :mod:`~vmex.core.vacuum`
      - NESTOR: Green's function, ``analyt``/``scalpot``, ``potvac`` solve
@@ -77,9 +78,8 @@ Module map
      - differentiable free-boundary residual via virtual casing
      - (no VMEC2000 equivalent)
    * - :mod:`~vmex.core.mgrid`
-     - mgrid netCDF read/write, differentiable interpolated field; external
-       coils live in ESSOS (``essos.coils.Coils``), consumed as an mgrid or
-       ``xyz -> B`` callable
+     - mgrid netCDF read/write, differentiable interpolated field, and
+       ESSOS/SIMSOPT/``xyz -> B`` host-side Biot--Savart tabulation
      - MAKEGRID file format, ``mgrid_mod.f90``
    * - :mod:`~vmex.core.implicit`
      - implicit differentiation of the equilibrium (``custom_vjp`` + adjoint

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -62,6 +62,10 @@ Options
      - Override the final-stage ``FTOL_ARRAY`` tolerance.
    * - ``--max-iter N``
      - Override the final-stage ``NITER_ARRAY`` iteration cap.
+   * - ``--jacobian-retries N``
+     - Retry a stage from its best finite checkpoint after the VMEC2000
+       75-Jacobian-reset condition, using a reduced ``DELT`` (default 2).
+       Use 0 to preserve VMEC2000's immediate fatal-stop behavior.
    * - ``--coils PATH``
      - ESSOS-style coils file (``.json`` or ``.npz`` with ``dofs_curves``,
        ``dofs_currents``, ``n_segments``, ``nfp``, ``stellsym``) supplying

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -94,16 +94,16 @@ For ``LFREEB = T`` decks:
   ``Coils.to_mgrid``; currently branch ``feature/mgrid-from-coils``).
 
 The free-boundary path runs the complete ``NS_ARRAY`` ladder.  It interpolates
-the stored best plasma state, carries VMEC2000's active-vacuum and adaptive
+the preceding stage's final plasma state, carries VMEC2000's active-vacuum and adaptive
 ``NVACSKIP`` state, and selects fresh resolution-specific NESTOR programs at
 each new grid.  A user-provided ``initial_state`` is also supported by the
 Python API for hot restarts.
 
-The remaining known divergence is that the NESTOR potential is not yet
+A WOUT-specific divergence on the base of PR #70 is that the NESTOR potential is not yet
 exported to the wout ``potsin``/``xmpot``/
 ``xnpot``/``*_sur`` variables (written as netCDF fill). An NITER-exhausted
-free-boundary run still writes the wout (VMEC2000 behavior) and exits with
-``ier_flag = 2``.
+fixed- or free-boundary run writes a WOUT only when ``LFULL3D1OUT=T`` and exits
+with ``ier_flag = 2``; with the default ``F`` no WOUT is produced.
 
 Exit codes (zero-crash policy)
 ------------------------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -93,9 +93,14 @@ For ``LFREEB = T`` decks:
   :class:`vmex.core.mgrid.MgridField` (requires an ESSOS build providing
   ``Coils.to_mgrid``; currently branch ``feature/mgrid-from-coils``).
 
-Known divergences of the current free-boundary lane: it is single-grid (only
-the final ``NS_ARRAY`` stage runs; multi-stage decks print a note), and the
-NESTOR potential is not yet exported to the wout ``potsin``/``xmpot``/
+The free-boundary path runs the complete ``NS_ARRAY`` ladder.  It interpolates
+the stored best plasma state, carries VMEC2000's active-vacuum and adaptive
+``NVACSKIP`` state, and selects fresh resolution-specific NESTOR programs at
+each new grid.  A user-provided ``initial_state`` is also supported by the
+Python API for hot restarts.
+
+The remaining known divergence is that the NESTOR potential is not yet
+exported to the wout ``potsin``/``xmpot``/
 ``xnpot``/``*_sur`` variables (written as netCDF fill). An NITER-exhausted
 free-boundary run still writes the wout (VMEC2000 behavior) and exits with
 ``ier_flag = 2``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ if _ENABLE_VIEWCODE:
 
 _FAST = _truthy(os.environ.get("SPHINX_FAST"))
 if _FAST:
-    tags.add("fast")
+    tags.add("fast")  # noqa: F821 - provided by the Sphinx configuration runtime
     # In fast mode build only a minimal landing page to keep CI under minutes.
     master_doc = "index_fast"
     include_patterns = ["index_fast.rst"]

--- a/docs/equations.rst
+++ b/docs/equations.rst
@@ -580,7 +580,11 @@ VMEC’s ``TimeStepControl`` tracks the minimum of the preconditioned residual
 (``res0``) and the physical residual (``res1``). If either grows by a factor of
 ``1e4`` after 10 steps, VMEC restores the last good state and reduces
 ``DELT`` by a factor of 1.03. ``vmex`` mirrors this logic to reproduce the
-VMEC2000 iteration trace.
+VMEC2000 iteration trace.  If that trace reaches VMEC2000's fatal limit of 75
+Jacobian resets, VMEX may perform the documented driver-level best-checkpoint
+retry with a reduced initial ``DELT``.  This is a solver globalization
+extension, not a change to the equilibrium residual; it is disabled with
+``jacobian_retries=0``.
 
 Multigrid interpolation (``interp.f``)
 --------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,10 +3,12 @@ VMEX
 
 **VMEX** is a clean-room, JAX-native reimplementation of the **VMEC2000**
 ideal-MHD equilibrium code for stellarators and tokamaks. It solves fixed- and
-free-boundary equilibria with VMEC2000-parity numerics, writes standard
-``wout_*.nc`` output, and — unlike the Fortran original — is differentiable
-(fixed boundary by implicit differentiation, free boundary through the
-virtual-casing vacuum field) and runs on CPUs and GPUs.
+free-boundary equilibria with VMEC2000-derived numerics, writes standard
+``wout_*.nc`` output, and — unlike the Fortran original — provides
+differentiable fixed-boundary equilibria plus differentiable virtual-casing
+external-field residuals on a specified free boundary. It runs on CPUs and
+GPUs. Exact support and validation scope is in
+:doc:`vmec2000_compatibility`.
 
 Why VMEX?
 ---------
@@ -14,8 +16,9 @@ Why VMEX?
 - **VMEC2000 parity.** The solver ports the VMEC2000 algorithms
   (steepest-descent moment method, 1D radial preconditioner, Richardson time
   stepping, spectral condensation, NESTOR vacuum solve) constant-for-constant.
-  Benchmark decks converge in the *same* iteration counts as VMEC2000 and the
-  ``wout`` files agree per-variable (see :doc:`performance`). An optional 2D
+  Representative benchmark decks converge in the same iteration counts as
+  VMEC2000 and tested ``wout`` variables agree within their stated tolerances
+  (see :doc:`performance`). An optional 2D
   block preconditioner cuts iterations 2.5–11x on stiff decks while leaving
   the default path byte-identical.
 - **Differentiable.** Gradients of fixed-boundary equilibrium properties
@@ -23,10 +26,11 @@ Why VMEX?
   differentiation of the converged fixed point
   (:mod:`vmex.core.implicit`) — no finite differences, no iteration
   unrolling — validated against central finite differences (see
-  :doc:`optimization`), with an O(1)-memory adjoint. Free-boundary
-  equilibria are differentiable end-to-end through the virtual-casing vacuum
-  field (coil / ``extcur`` derivatives), finite-difference-validated
-  (:mod:`vmex.core.freeboundary_diff`). A growing :doc:`objectives
+  :doc:`optimization`), with an O(1)-memory adjoint. Virtual-casing residuals
+  are differentiable in coil / ``extcur`` parameters on a specified boundary
+  and finite-difference-validated; the host-driven NESTOR equilibrium solve
+  itself is not differentiated (:mod:`vmex.core.freeboundary_diff`). A
+  growing :doc:`objectives
   library <objectives>` — quasisymmetry, omnigenity, Redl bootstrap,
   ballooning stability, gyrokinetic turbulence proxies — plugs straight
   into a least-squares driver with those exact gradients, reaching precise
@@ -37,8 +41,8 @@ Why VMEX?
   booz_xform.
 - **Batteries included.** Built-in plotting (``vmex --plot``), Boozer
   transform (``vmex --booz`` via ``booz_xform_jax``), spline profiles,
-  multigrid with hot restart, free boundary from mgrid files *or* directly
-  from coils, and typed
+  multigrid with hot restart, free boundary from mgrid files or fields
+  tabulated from coils, and typed
   zero-crash error handling. The shared linear/adjoint solver layer is
   factored out into `SOLVAX <https://pypi.org/project/solvax/>`_.
 
@@ -100,6 +104,7 @@ Documentation
       api/index
       cli
       input_reference
+      vmec2000_compatibility
       wout_reference
 
    .. toctree::

--- a/docs/input_reference.rst
+++ b/docs/input_reference.rst
@@ -9,9 +9,12 @@ Input file reference
   names.
 
 Both round-trip: ``VmecInput.to_json`` writes a VMEC++-schema JSON deck that
-parses back to the same input. All VMEC2000 defaults and ``readin.f``
+parses back to the same input. Implemented VMEC2000 defaults and ``readin.f``
 normalizations are applied on construction (see the
-:mod:`vmex.core.input` docstring for the exact rules).
+:mod:`vmex.core.input` docstring for the exact rules). Parsing does not imply
+solver support: the complete supported/rejected/no-op classification is in
+:doc:`vmec2000_compatibility`. Unknown names and active unsupported physics
+fail before setup.
 
 INDATA variables
 ----------------
@@ -55,7 +58,8 @@ Multigrid ladder and stepping
      - Meaning
    * - ``NS_ARRAY``
      - ``[31]``
-     - radial surfaces per multigrid stage
+     - radial surfaces per multigrid stage; explicit ``NS_ARRAY(1)=0`` uses
+       the VMEC2000 ``NSIN -> 31`` legacy expansion
    * - ``FTOL_ARRAY``
      - ``[1e-10]``
      - force tolerance per stage (converged when ``fsqr, fsqz, fsql`` are all
@@ -78,6 +82,20 @@ Multigrid ladder and stepping
    * - ``NSTEP``
      - 10
      - iterations between progress prints
+   * - ``TIME_SLICE``
+     - 0
+     - informational value preserved in the VMEC-style run header
+   * - ``LFORBAL``
+     - ``F``
+     - use VMEC2000's non-variational average-force replacement for the
+       ``m=1,n=0`` R/Z channels
+   * - ``LMOVE_AXIS``
+     - ``T``
+     - permit automatic first-pass axis recovery for a large finite force
+   * - ``LFULL3D1OUT``
+     - ``F``
+     - write an unconverged WOUT after NITER exhaustion (fixed or free
+       boundary); fatal numerical/Jacobian failures never write one
 
 Pressure profile
 ~~~~~~~~~~~~~~~~
@@ -181,8 +199,8 @@ Free boundary
      - free-boundary mode; forced ``F`` when ``MGRID_FILE = 'NONE'``
    * - ``MGRID_FILE``
      - ``'NONE'``
-     - MAKEGRID vacuum-field file, or ``'DIRECT_COILS'`` for direct
-       Biot-Savart coil fields (with ``vmex --coils``)
+     - MAKEGRID vacuum-field file, or ``'DIRECT_COILS'`` to ask ESSOS to
+       tabulate a temporary mgrid (with ``vmex --coils``)
    * - ``EXTCUR``
      - —
      - external coil-group currents [A]
@@ -194,12 +212,15 @@ Free boundary
      - boundary spectral filtering
    * - ``PRECON_TYPE`` / ``PREC2D_THRESHOLD``
      - ``NONE`` / 1e-30
-     - 2D preconditioner selection (accepted for compatibility)
+     - ``NONE``/``DEFAULT`` use the 1-D VMEC path; ``GMRES`` selects VMEX's
+       exact-JVP matrix-free Newton--GMRES path. VMEC2000 ``CG``, ``GMRESR``,
+       and ``TFQMR`` are distinct and are rejected, not aliased.
 
 VMEC++-style JSON
 -----------------
 
-The JSON schema follows ``vmecpp.VmecInput`` verbatim: the keys are the
+The JSON schema follows the implemented ``vmecpp.VmecInput`` subset: the keys
+are the
 lower-case INDATA names (``lasym, nfp, mpol, ntor, ntheta, nzeta, ns_array,
 ftol_array, niter_array, delt, tcon0, aphi, phiedge, nstep, pmass_type, am,
 am_aux_s, am_aux_f, pres_scale, adiabatic_index, spres_ped, ncurr,
@@ -235,3 +256,15 @@ length ``ntor + 1``:
 
 Extensions beyond VMEC++ (ignored by VMEC++ but accepted here): the spline
 and pedestal profile types listed above, with the same key names as INDATA.
+``free_boundary_method="nestor"`` is accepted explicitly. ``only_coils`` and
+``biest`` select different models and are rejected. Unknown JSON keys are
+errors rather than silent no-ops.
+
+Unsupported and output-only INDATA controls
+-------------------------------------------
+
+Active reconstruction, RFP, TRIP3D, ANIMEC, target-volume rescaling, and
+unsupported continuation/preconditioner modes fail with a typed error.
+Neutral legacy defaults remain accepted. Legacy output-only switches are
+listed individually in :doc:`vmec2000_compatibility`; they do not alter the
+equilibrium and VMEX does not imply that their auxiliary files are produced.

--- a/docs/input_reference.rst
+++ b/docs/input_reference.rst
@@ -44,7 +44,10 @@ Symmetry and resolution
      - toroidal modes ``n = -ntor .. ntor``
    * - ``NTHETA`` / ``NZETA``
      - 0
-     - angular grid points (0 selects the VMEC default)
+     - angular grid points (0 selects the VMEC default).  Explicit values
+       below ``2*MPOL+6`` / ``2*NTOR+4`` remain legal for VMEC2000 parity but
+       can alias nonlinear force products; the privacy-safe diagnostic reports
+       ``W01_ANGULAR_GRID_BELOW_VMEC_DEFAULT`` without printing the values.
 
 Multigrid ladder and stepping
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/input_reference.rst
+++ b/docs/input_reference.rst
@@ -16,6 +16,30 @@ solver support: the complete supported/rejected/no-op classification is in
 :doc:`vmec2000_compatibility`. Unknown names and active unsupported physics
 fail before setup.
 
+Fortran namelist assignment semantics
+--------------------------------------
+
+INDATA assignments are replayed in source order, as a Fortran namelist reader
+writes into the already initialized ``vmec_input.f`` arrays.  A later short
+dense assignment replaces only the elements it supplies; it does not clear an
+earlier tail.  Indexed writes and dense writes override one another according
+to their textual order.  For example,
+
+.. code-block:: fortran
+
+   FTOL_ARRAY = 1e-6, 1e-11, 1e-30, 1e-30
+   FTOL_ARRAY = 1e-7, 1e-7
+
+leaves entries 3 and 4 at ``1e-30``.
+
+An indexed designator followed by several values is a *starting-element*
+assignment, so ``APHI(1)=1,0`` writes elements 1 and 2.  Array sections use
+inclusive Fortran bounds, and the first subscript varies fastest.  Thus compact
+boundary syntax such as ``RBC(-6:6,0)=...`` is equivalent to the corresponding
+13 scalar assignments.  Omitted section limits (``RBC(:,0)`` or
+``RBC(-6:,0)``) are resolved from the declared VMEC2000 array bounds.  Bounds,
+rank, and value count are checked before setup.
+
 INDATA variables
 ----------------
 
@@ -62,14 +86,19 @@ Multigrid ladder and stepping
    * - ``NS_ARRAY``
      - ``[31]``
      - radial surfaces per multigrid stage; explicit ``NS_ARRAY(1)=0`` uses
-       the VMEC2000 ``NSIN -> 31`` legacy expansion
+       the VMEC2000 ``NSIN -> 31`` legacy expansion.  The active ladder ends
+       at the first nonpositive or decreasing entry; equal entries rerun.
    * - ``FTOL_ARRAY``
      - ``[1e-10]``
      - force tolerance per stage (converged when ``fsqr, fsqz, fsql`` are all
-       below it)
+       below it).  If its first element is explicitly zero, ``readin.f``'s
+       geometric ladder from ``1e-8`` to scalar ``FTOL`` is generated.
    * - ``NITER_ARRAY`` (or ``NITER``)
      - ``[100]``
-     - iteration cap per stage
+     - iteration cap per stage.  Scalar ``NITER`` fills the complete array
+       only when every initialized ``NITER_ARRAY`` entry remains ``-1``.
+       A preserved ``-1`` in a partially assigned array still executes the
+       first ``eqsolve`` pass before the iteration-limit check, as in VMEC2000.
    * - ``DELT``
      - 1.0
      - initial time step
@@ -218,6 +247,8 @@ Free boundary
      - ``NONE``/``DEFAULT`` use the 1-D VMEC path; ``GMRES`` selects VMEX's
        exact-JVP matrix-free Newton--GMRES path. VMEC2000 ``CG``, ``GMRESR``,
        and ``TFQMR`` are distinct and are rejected, not aliased.
+       ``NONE`` does **not** disable ``scalfor`` or lambda scaling; it disables
+       only the optional 2-D block preconditioner, as in VMEC2000.
 
 VMEC++-style JSON
 -----------------

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -245,18 +245,28 @@ default:
 The end-to-end effect on the profiled production ``opt_step`` and the CPU
 versus GPU placement question are quantified in :doc:`performance`.
 
+For implicit Jacobians, ``jac_chunk_size=None`` means one full-width
+``lax.map`` batch rather than a bare ``vmap``.  This is a correctness
+workaround for JAX 0.6.2: the bare transform produced an incorrect nested
+iterative-solve column, while the full-width batch, smaller chunks, and
+independent central finite differences agree.  The memory meaning remains
+“unchunked”; ``"auto"`` or an integer supplies the research-grade bounded
+path.
+
 Free-boundary gradients (virtual casing)
 ----------------------------------------
 
-**Free boundary** is differentiable through a different route
+External-field optimization on a specified plasma boundary is differentiable
+through a different route
 (:mod:`vmex.core.freeboundary_diff`): rather than differentiating the
 NESTOR vacuum solve, the plasma-boundary contribution to the vacuum field
 is computed by **virtual casing**, which is a smooth function of the coil /
 ``extcur`` parameters and the plasma surface.  Coil-parameter derivatives
-of free-boundary outputs are obtained end-to-end this way and are
-finite-difference-validated.  (The two scopes are complementary: the
+of this boundary residual are finite-difference-validated.  They are not the
+derivative of a fully reconverged NESTOR equilibrium.  (The two scopes are
+complementary: the
 fixed-boundary implicit adjoint is validated to ~1e-6 relative; the
-free-boundary virtual-casing path is FD-validated.)  See the
+virtual-casing residual path is FD-validated.)  See the
 *Differentiable free boundary* section of :doc:`algorithms`.
 
 True single-stage (plasma boundary **and** coils at once)

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -181,14 +181,14 @@ Parity with VMEC2000
 Free-boundary multigrid has a dedicated reproducible artifact,
 ``benchmarks/freeboundary_multigrid.json``.  On the public converged CTH-like
 ``NS_ARRAY = 7, 15`` ladder (Apple Silicon CPU, 2026-07-21), VMEC2000 takes
-239 + 340 iterations in 0.88 s; vmex takes 250 + 340 iterations, 7.60 s cold
-and 1.22 s warm.  Both activate vacuum exactly once.  Against an ns=15
+239 + 340 iterations in 0.98 s; vmex takes 250 + 340 iterations, 10.07 s cold
+and 1.98 s warm.  Both activate vacuum exactly once.  Against an ns=15
 VMEC2000 wout, vmex's final scale-relative maximum errors are
 ``6.10e-5`` (R), ``3.59e-4`` (Z), ``1.52e-6`` (iota), and ``5.94e-8``
 (relative ``wb``).  The first fine-grid raw residual remains a transient
 ordering difference (``FSQR=2.01e-3`` versus VMEC2000's ``1.73``), but both
 then take exactly 340 fine-grid iterations to the same fixed point.  Warm
-execution is within 1.4x of Fortran on this small case; the one-time XLA
+execution is within 2.1x of Fortran on this small case; the one-time XLA
 compile dominates the cold result.
 
 Per-iteration algorithmic parity (same step control, preconditioner cadence,

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -178,6 +178,19 @@ phase) and the perturbation warm start (3.7x fewer trial-solve iterations)
 Parity with VMEC2000
 --------------------
 
+Free-boundary multigrid has a dedicated reproducible artifact,
+``benchmarks/freeboundary_multigrid.json``.  On the public converged CTH-like
+``NS_ARRAY = 7, 15`` ladder (Apple Silicon CPU, 2026-07-21), VMEC2000 takes
+239 + 340 iterations in 0.88 s; vmex takes 250 + 340 iterations, 7.60 s cold
+and 1.22 s warm.  Both activate vacuum exactly once.  Against an ns=15
+VMEC2000 wout, vmex's final scale-relative maximum errors are
+``6.10e-5`` (R), ``3.59e-4`` (Z), ``1.52e-6`` (iota), and ``5.94e-8``
+(relative ``wb``).  The first fine-grid raw residual remains a transient
+ordering difference (``FSQR=2.01e-3`` versus VMEC2000's ``1.73``), but both
+then take exactly 340 fine-grid iterations to the same fixed point.  Warm
+execution is within 1.4x of Fortran on this small case; the one-time XLA
+compile dominates the cold result.
+
 Per-iteration algorithmic parity (same step control, preconditioner cadence,
 constants) means the solver does not just reach the same answer — it takes
 the *same number of iterations* as VMEC2000 on the benchmark decks:
@@ -397,6 +410,7 @@ Reproducing the numbers
 .. code-block:: bash
 
    python benchmarks/run_baseline.py         # CPU suite -> benchmarks/baseline.json
+   python benchmarks/run_freeboundary_multigrid.py  # free-bdy ladder + VMEC2000 parity
    python benchmarks/run_gpu_matrix.py       # GPU matrix -> benchmarks/gpu_baseline.json
    python benchmarks/profile_production.py --device cpu
    python benchmarks/profile_production.py --device gpu

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -48,9 +48,11 @@ writes ``wout_circular_tokamak.nc`` next to the input file. Useful flags:
 Free-boundary decks (``LFREEB = T``) route automatically: a readable
 ``MGRID_FILE`` runs the free-boundary solver; a missing mgrid file falls back
 to a fixed-boundary solve with a warning (VMEC2000 behavior); and
-``MGRID_FILE = 'DIRECT_COILS'`` together with ``--coils coils.json`` evaluates
-the external field directly from an ESSOS-style coil set via Biot-Savart —
-no mgrid interpolation at all. See :doc:`cli` for the complete reference.
+``MGRID_FILE = 'DIRECT_COILS'`` together with ``--coils coils.json`` asks ESSOS
+to tabulate the coil field into a temporary mgrid used by NESTOR.  The separate
+virtual-casing residual can evaluate a JAX Biot--Savart callable directly, but
+is not the derivative of the NESTOR equilibrium solve. See :doc:`cli` and
+:doc:`vmec2000_compatibility` for the complete contract.
 
 Plotting
 --------

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -153,6 +153,11 @@ set, tabulates its Biot–Savart field once into an in-memory
 against it — calibrating ``PRES_SCALE`` per step so the converged wout
 ``betatotal`` lands on 0/1/2/3 %.
 
+The same adapter is available independently of the example as
+``MgridField.from_cartesian_field``.  It accepts ESSOS' ``B(points)`` protocol,
+SIMSOPT's ``set_points(points); B()`` protocol, or a plain Cartesian callable;
+the tabulated field can be reused across every radial stage and hot restart.
+
 .. literalinclude:: ../examples/free_boundary_essos_coils.py
    :language: python
 

--- a/docs/vmec2000_compatibility.rst
+++ b/docs/vmec2000_compatibility.rst
@@ -1,0 +1,593 @@
+VMEC2000 compatibility and research scope
+=========================================
+
+Purpose
+-------
+
+This page is the normative disclosure of what VMEX does with VMEC2000 input,
+solver, output, and differentiation features.  It is deliberately more
+conservative than a feature list: a control is called *supported* only when it
+reaches the production path, and validation evidence is stated separately.
+
+The source of truth used for this audit is the STELLOPT VMEC2000 tree:
+
+* ``LIBSTELL/Sources/Modules/vmec_input.f`` for the complete ``&INDATA``
+  namelist and defaults;
+* ``VMEC2000/Sources/Input_Output/readin.f`` for post-read normalization and
+  preconditioner selection;
+* ``VMEC2000/Sources/TimeStep/runvmec.f``, ``evolve.f`` and ``vmec.f`` for
+  multigrid, convergence, continuation, and WOUT policy;
+* ``VMEC2000/Sources/General`` for force, restart, RFP, and axis behavior;
+* ``VMEC2000/Sources/NESTOR_vacuum`` for the vacuum solve; and
+* ``VMEC2000/Sources/Input_Output/wrout.f`` and ``jxbforce.f`` for WOUT
+  variables and derived diagnostics.
+
+Status vocabulary
+-----------------
+
+``implemented``
+   The production VMEX path consumes the control or implements the method.
+   This does not by itself claim numerical parity for every equilibrium.
+
+``parity-regressed``
+   Tests compare the relevant trajectory, state, or WOUT quantity with
+   VMEC2000 for at least one representative case.
+
+``deliberate divergence``
+   VMEX implements the same mathematical purpose with a disclosed different
+   algorithm or extends VMEC2000 behavior.
+
+``partial``
+   A documented subset is implemented.  The omitted subset fails explicitly
+   where silently dropping it could change a result.
+
+``accepted no-op``
+   The value cannot change equilibrium physics and is retained only so legacy
+   decks parse.  VMEX does not produce the requested legacy artifact.
+
+``accepted with warning``
+   The equilibrium equations are unaffected, so the deck can run, but VMEX
+   warns that a requested auxiliary artifact is not produced.
+
+``rejected when active``
+   The parser recognizes the VMEC2000 control but raises
+   :class:`~vmex.core.input.UnsupportedInputModeError` before setup.  It never
+   substitutes an ordinary equilibrium for the requested model.
+
+``not implemented``
+   No production implementation or parity claim exists.
+
+No-silent-physics policy
+------------------------
+
+Input passes through four distinct gates:
+
+``tokenize -> classify -> construct/normalize -> setup/solve -> output``.
+
+Parsing a name is not evidence that the solver uses it.  VMEX therefore
+applies these rules:
+
+1. Unknown INDATA variables and unknown VMEC++ JSON keys are input errors.
+2. Active controls which change the mathematical problem, iteration contract,
+   or requested WOUT convention are either implemented or rejected before
+   iteration 1.
+3. Neutral spellings such as ``AH=0``, ``AT=[1,0,...]``,
+   ``TRIP3D_FILE='NONE'``, and an inactive reconstruction block remain
+   accepted.
+4. Active legacy output requests which do not change the equilibrium are
+   accepted with a warning when the artifact is unavailable; truly obsolete
+   controls with no VMEC2000 production behavior are listed as no-ops.
+5. Symmetry-limited derived methods raise on ``LASYM=T`` instead of omitting
+   Fourier partners.
+
+The privacy-preserving ``tools/diagnose_input.py`` reports the same
+classification as the production parser.  Its stable ``D00*`` code contains
+no filename, coefficient, input value, or equilibrium result.
+
+Equilibrium capability matrix
+-----------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 19 57
+
+   * - Capability
+     - Status
+     - Scope and evidence
+   * - Fixed boundary, stellarator symmetric
+     - parity-regressed
+     - VMEC force iteration, multigrid, restart logic, profiles, and WOUT
+       variables have representative VMEC2000 golden tests.
+   * - Fixed boundary, ``LASYM=T``
+     - parity-regressed
+     - Full asymmetric solve and WOUT partner channels are implemented.
+       Symmetry-limited *derived objectives* are a separate row below.
+   * - Free boundary, NESTOR, symmetric
+     - implemented; parity-regressed on representative cases
+     - Mgrid external field, plasma-current filament, full/incremental vacuum
+       cadence, pressure coupling, and WOUT equilibrium channels.
+   * - Free boundary, NESTOR, ``LASYM=T``
+     - implemented; limited regression envelope
+     - A CTH-like asymmetric case exercises the solve.  Symmetric and
+       asymmetric vacuum-potential WOUT completeness are tracked separately.
+   * - Fixed-boundary ``NS_ARRAY``
+     - parity-regressed
+     - Increasing stages interpolate the final state, equal stages rerun, and
+       decreasing stages are skipped as in ``runvmec.f``.
+   * - Free-boundary ``NS_ARRAY``
+     - implemented by PR #70
+     - Plasma state, ``ivac``, adaptive ``nvacskip``, boundary pressure, and
+       vacuum continuation are carried.  Resolution-specific NESTOR basis,
+       Green-function, filament, matrix, and cache structures are rebuilt or
+       selected at every executed resolution.
+   * - Hot restart
+     - implemented
+     - Fixed and free boundary accept ``initial_state``.  A user free-boundary
+       restart repeats activation (reset-file semantics); continuation between
+       radial stages carries the active vacuum state.
+   * - Mgrid
+     - implemented
+     - MAKEGRID netCDF field and coil-group currents are interpolated in
+       :class:`~vmex.core.mgrid.MgridField`.
+   * - ESSOS/SIMSOPT field callable
+     - deliberate VMEX extension
+     - A Cartesian ``xyz -> B`` callable can be tabulated once into an
+       ``MgridField``.  The table/current scale remains differentiable; coil
+       geometry derivatives are not retained by tabulation.
+   * - CLI ``--coils`` / ``DIRECT_COILS``
+     - deliberate VMEX extension
+     - ESSOS exports an mgrid representation which then follows the same
+       NESTOR path.  This is not an interpolation-free coil solve.
+   * - VMEC++ ``free_boundary_method='only_coils'``
+     - rejected when active
+     - This is a different boundary model, not an alias for choosing a coil
+       input source.
+   * - BIEST vacuum method
+     - not implemented
+     - VMEC++'s ``biest`` selector is rejected rather than mapped to NESTOR.
+   * - TRIP3D coupling
+     - rejected when active
+     - A non-``NONE`` ``TRIP3D_FILE`` receives
+       ``D00E_TRIP3D_MODE_UNSUPPORTED``.
+   * - Reconstruction
+     - rejected when active
+     - Effective ``LRECON`` with ``IMSE>0`` or ``ITSE>0`` receives
+       ``D00A_RECONSTRUCTION_MODE_UNSUPPORTED``.  An inert ``LRECON=T`` with no
+       reconstruction signals remains inert, matching VMEC2000.
+   * - Reversed-field pinch
+     - rejected when active
+     - ``LRFP=T`` receives ``D00B_RFP_MODE_UNSUPPORTED``.  VMEX does not claim
+       the reciprocal-q profile, force, residue, or vacuum sign semantics.
+   * - ANIMEC anisotropy/flow
+     - rejected when active
+     - Nonzero ``AH`` or non-default ``AT`` receives
+       ``D00F_ANIMEC_MODE_UNSUPPORTED``.
+   * - Boundary target-volume rescaling
+     - rejected when active
+     - ``TVOLUME>0`` / ``LVOLUME_RFIX`` geometry rescaling from
+       ``vmec_input.f:RESCALE_BOUNDARY`` is not yet ported.
+
+Complete INDATA disposition
+---------------------------
+
+Core grid, profiles, and geometry
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 18 50
+
+   * - VMEC2000 variables
+     - Status
+     - Effective VMEX behavior
+   * - ``LASYM, NFP, MPOL, NTOR, NTHETA, NZETA``
+     - implemented
+     - Select symmetry, Fourier resolution, and angular quadrature.
+   * - ``NS_ARRAY``
+     - implemented
+     - Radial resolution-continuation ladder.  The explicit old-style
+       ``NS_ARRAY(1)=0`` form expands through ``NSIN`` to ``[NSIN,31]``.
+   * - ``FTOL_ARRAY``
+     - implemented
+     - Per-stage physical-force stopping tolerance.
+   * - ``FTOL``
+     - deliberate divergence
+     - Accepted as a useful scalar fallback.  In the audited VMEC2000 source,
+       the initialized nonzero ``FTOL_ARRAY(1)`` can make scalar ``FTOL``
+       ineffective unless the array sentinel is also changed.
+   * - ``NITER_ARRAY, NITER``
+     - implemented
+     - VMEC2000's ``ALL(NITER_ARRAY==-1) -> NITER`` fallback is reproduced.
+   * - ``DELT, TCON0, NSTEP``
+     - implemented
+     - Initial time step, spectral-condensation multiplier, and print cadence.
+   * - ``APHI, PHIEDGE``
+     - implemented
+     - Toroidal-flux map and edge flux.  Indexed and section assignments use
+       Fortran lower bounds and column-major order.
+   * - ``GAMMA, BLOAT, SPRES_PED, PRES_SCALE``
+     - implemented
+     - Profile/equation-of-state controls used by setup.
+   * - ``PMASS_TYPE, AM, AM_AUX_S, AM_AUX_F``
+     - implemented
+     - Pressure profile types listed in :mod:`vmex.core.profiles`.
+   * - ``PIOTA_TYPE, AI, AI_AUX_S, AI_AUX_F``
+     - implemented, excluding RFP interpretation
+     - Prescribed-iota profile for ``NCURR=0``.
+   * - ``PCURR_TYPE, AC, AC_AUX_S, AC_AUX_F, CURTOR, NCURR``
+     - implemented
+     - Prescribed-current lane for ``NCURR=1`` and ordinary current data.
+   * - ``RAXIS_CC, ZAXIS_CS, RAXIS_CS, ZAXIS_CC``
+     - implemented
+     - Initial axis Fourier coefficients.
+   * - obsolete ``RAXIS, ZAXIS``
+     - implemented compatibility
+     - Nonzero legacy entries override their modern partners as in
+       ``read_indata_namelist``.
+   * - ``RBC, ZBS, RBS, ZBC``
+     - implemented
+     - Scalar, one-dimensional section, and multidimensional Fortran namelist
+       assignments are supported.
+   * - ``TVOLUME, LVOLUME_RFIX``
+     - rejected when active
+     - Positive target-volume rescaling is not silently omitted.
+
+Force, axis, and iteration controls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 31 18 51
+
+   * - VMEC2000 variables
+     - Status
+     - Effective VMEX behavior
+   * - ``LFORBAL``
+     - implemented by PR #70
+     - Selects VMEC2000's non-variational average-force replacement for the
+       ``m=1,n=0`` R/Z channels.
+   * - ``LMOVE_AXIS``
+     - implemented by PR #70
+     - Enables the first-pass ``irst=4`` axis re-guess when the finite force sum
+       exceeds the VMEC2000 threshold.  The value is preserved in WOUT.
+   * - ``LFULL3D1OUT``
+     - implemented
+     - On fixed or free NITER exhaustion, ``T`` writes the unconverged WOUT and
+       ``F`` does not.  Numerical/Jacobian failures never write one.
+   * - ``PRE_NITER``
+     - rejected when active with 2-D GMRES
+     - VMEC2000 changes the total post-activation iteration cap.  VMEX does not
+       yet implement that budget mutation.
+   * - ``MAX_MAIN_ITERATIONS``
+     - rejected above 1
+     - VMEC2000 can request additional ``NITER`` blocks after
+       ``more_iter_flag``.  VMEX instead exposes explicit hot restart.
+   * - ``LGIVEUP, FGIVEUP``
+     - rejected when ``LGIVEUP=T``
+     - VMEC2000's early stop between poorly converged radial stages is not yet
+       implemented.
+   * - ``TIME_SLICE``
+     - implemented
+     - Preserved in the VMEC-style run header.  It does not change the
+       equilibrium equations.
+   * - ``OMP_NUM_THREADS``
+     - accepted no-op
+     - JAX/XLA owns CPU threading; see :doc:`parallelization`.
+
+Free-boundary controls
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 18 52
+
+   * - VMEC2000 variables
+     - Status
+     - Effective VMEX behavior
+   * - ``LFREEB, MGRID_FILE, EXTCUR``
+     - implemented
+     - Select NESTOR and the external coil-group field.  ``MGRID_FILE='NONE'``
+       selects fixed boundary.  An unreadable requested mgrid follows
+       VMEC2000's warning/fixed-boundary fallback, including fixed WOUT
+       metadata.
+   * - ``NVACSKIP``
+     - implemented
+     - Full-vacuum cadence and adaptive lower bound; nonpositive input falls
+       back to ``NFP``.
+   * - ``MFILTER_FBDY, NFILTER_FBDY``
+     - implemented
+     - Suppress selected high boundary modes in setup and implicit boundary
+       degrees of freedom.
+   * - ``TRIP3D_FILE``
+     - rejected when non-``NONE``
+     - No external-field substitution occurs.
+
+Preconditioner controls
+~~~~~~~~~~~~~~~~~~~~~~~
+
+VMEC2000's strings do not denote one interchangeable implementation.
+``readin.f`` selects a 2-D block operator with four distinct evolution/Krylov
+algorithms: ``CG`` (type 1), ``GMRES`` (type 2), ``GMRESR`` (type 3), and
+``TFQMR`` (type 4).  ``NONE``, ``DEFAULT``, and unrecognized strings leave the
+ordinary 1-D radial preconditioner in the audited source.
+
+VMEX uses this explicit contract:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 22 54
+
+   * - ``PRECON_TYPE``
+     - VMEX status
+     - Meaning
+   * - ``NONE`` or ``DEFAULT``
+     - implemented
+     - VMEC-parity 1-D radial tridiagonal preconditioner only.
+   * - ``GMRES``
+     - deliberate divergence
+     - Exact JAX JVP of the preconditioned force, solved matrix-free by
+       restarted SOLVAX GMRES.  VMEC2000 instead finite-difference assembles a
+       block-tridiagonal operator.
+   * - ``CG``, ``GMRESR``, ``TFQMR``
+     - rejected when active
+     - These are not aliases for VMEX GMRES.
+   * - any other string
+     - rejected
+     - Prevents typographical selection of unintended solver behavior.
+
+``PREC2D_THRESHOLD`` is consumed by VMEX GMRES on the finest radial stage
+after the minimum-iteration gate.  An explicit Python
+:class:`~vmex.core.preconditioner_2d.Prec2DConfig` remains the VMEX-native
+advanced interface.
+
+Reconstruction, anisotropy, and legacy output controls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The complete VMEC2000 reconstruction family is classified together because
+its arrays have no ordinary-equilibrium meaning:
+
+``LRECON, IMSE, ITSE, PSA, PFA, ISA, IFA, IMATCH_PHIEDGE, IOPT_RAXIS,
+TENSI, TENSP, TENSI2, FPOLYI, MSEANGLE_OFFSET, MSEANGLE_OFFSETM, ISNODES,
+IPNODES, RSTARK, DATASTARK, SIGMA_STARK, RTHOM, DATATHOM, SIGMA_THOM,
+PRESFAC, PRES_OFFSET, PHIDIAM, SIGMA_DELPHID, NFLXS, INDXFLX, DSIOBT,
+SIGMA_FLUX, NBFLD, INDXBFLD, BBC, SIGMA_B, SIGMA_CURRENT, LPOFR``.
+
+They are accepted only while the effective reconstruction mode is inactive;
+active reconstruction is rejected as a unit.
+
+The ANIMEC family ``AH, AT, BCRIT, PH_TYPE, PT_TYPE, AH_AUX_S, AH_AUX_F,
+AT_AUX_S, AT_AUX_F`` is similarly accepted at its isotropic defaults and
+rejected when ``AH`` or ``AT`` activates anisotropic physics.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 20 48
+
+   * - Output/legacy variables
+     - Status
+     - Disclosure
+   * - ``LBSUBS=T``
+     - rejected when active
+     - Requests a different ``B_s`` diagnostic in ``jxbforce.f``.
+   * - ``LNYQUIST=F``
+     - rejected when active
+     - VMEX currently writes its Nyquist WOUT contract.
+   * - ``LMAC, LEDGE_DUMP, LOLDOUT, LWOUTTXT, LDIAGNO``
+     - accepted with warning
+     - These request auxiliary VMEC2000 monitor, edge, legacy, text-WOUT, or
+       DIAGNO artifacts which VMEX does not produce.  The netCDF WOUT and
+       equilibrium solve remain available.
+   * - ``LMOVIE, LSPECTRUM_DUMP, LOPTIM``
+     - accepted no-op
+     - These are obsolete and have no production behavior in the audited
+       VMEC2000 source.  They do not change the equilibrium force solve.
+   * - ``LBOOZ, MBOOZ, NBOOZ, BOOZ_SURFACES``
+     - VMEX extension; ``LBOOZ=T`` rejected
+     - Use ``vmex --booz --mbooz ... --nbooz ... --booz-surfaces ...``.
+
+WOUT contract and limitations
+-----------------------------
+
+VMEX writes a VMEC2000-shaped netCDF WOUT; :doc:`wout_reference` lists every
+variable.  The following distinctions are important:
+
+* ``lrecon`` and ``lrfp`` are false because active modes are rejected.
+* ``lmove_axis`` records the actual input value.
+* ``lfreeb`` records the *effective* solve.  A missing-mgrid fixed-boundary
+  fallback is not labeled free-boundary.
+* ``ier_flag=2`` WOUT output requires ``LFULL3D1OUT=T`` for either boundary
+  mode.
+* On the base of PR #70, NESTOR potential/surface variables are present as
+  netCDF fill because the solver result does not expose them.  PR #73 adds the
+  symmetric potential/surface export; its asymmetric extension remains a
+  separate requirement and must not be lost during merge.
+* PR #72 adds ``curlabel`` schema preservation.  It is complementary to, not a
+  replacement for, the free-boundary solve changes.
+
+Differentiation and derived-method matrix
+-----------------------------------------
+
+``AD`` below means algorithmic/automatic differentiation of the stated VMEX
+map.  ``FD-validated`` means a test compares that derivative with a finite
+difference; it does not mean the method itself uses FD.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 27 20 53
+
+   * - Method
+     - Status
+     - Exact scope
+   * - Fixed-boundary implicit equilibrium derivative
+     - implemented; FD-validated
+     - Boundary/profile/current/flux parameters at a converged fixed point.
+       Multigrid and adaptive iteration history are initializers, not
+       differentiated.
+   * - NESTOR forward solve derivative
+     - not implemented
+     - The host-driven full/incremental NESTOR fixed point has no adjoint or
+       custom derivative.
+   * - Virtual-casing external-field residual
+     - implemented; FD-validated
+     - Coil/current derivatives on a specified plasma boundary.  This is not
+       the derivative of a fully reconverged NESTOR equilibrium.
+   * - Simultaneous boundary + coil surface-field construction
+     - partial
+     - Traceable state-to-surface data exists for ``LASYM=F`` with the optional
+       ``virtual_casing_jax`` dependency.  ``LASYM=T`` is rejected as
+       unvalidated.
+   * - Mgrid tabulation
+     - partial derivative contract
+     - Differentiable in table values/current scale, not in the coil geometry
+       used to generate a frozen table.
+   * - Mercier WOUT diagnostic
+     - implemented; host/FD-only
+     - VMEC2000-style WOUT engine.  The traceable Mercier objective is
+       stellarator-symmetric.
+   * - Ballooning, traceable Boozer/QI/omnigenity, turbulence geometry
+     - partial
+     - Current traceable implementations require ``LASYM=F`` and raise
+       otherwise.
+   * - ``L_grad_B`` WOUT and state objectives
+     - partial
+     - ``LASYM=F`` only.  Both public lanes now raise on asymmetric input;
+       asymmetric partners are never discarded.
+   * - Quasilinear/nonlinear-window turbulence proxies
+     - value-level
+     - Eigenvector-weighted objectives use finite-difference optimization;
+       the documented growth-rate lane is AD-capable.
+
+Terms and design decisions
+--------------------------
+
+Fixed boundary
+   The last radial surface is prescribed by ``RBC/ZBS/RBS/ZBC`` and is not
+   evolved by the plasma force iteration.
+
+Free boundary
+   The plasma edge evolves and is coupled to exterior magnetic pressure.
+   ``LFREEB`` is a physics selection, not merely an output flag.
+
+NESTOR
+   VMEC2000's boundary-integral vacuum solver.  It solves for a harmonic
+   scalar potential so the total exterior field is tangent to the plasma
+   boundary.
+
+Mgrid
+   A cylindrical grid of external magnetic-field components, partitioned by
+   coil group and weighted by ``EXTCUR``.
+
+Multigrid
+   In VMEC terminology, a radial *resolution-continuation ladder*
+   (``NS_ARRAY``), not a V-cycle correction method.  Each stage performs a
+   nonlinear equilibrium solve and transfers the state to the next stage.
+
+Hot restart
+   Seeding a solve with an existing spectral state.  Fixed-boundary hot restart
+   adapts the edge smoothly to a changed boundary; free-boundary restart
+   distinguishes user reset semantics from within-ladder vacuum continuation.
+
+Raw/physical force residual
+   ``FSQR``, ``FSQZ``, and ``FSQL`` are normalized physical force channels and
+   determine convergence.
+
+Preconditioned update residual
+   Lower-case/internal force norms measure the update after the radial or
+   optional 2-D preconditioner.  Changing a preconditioner must not change the
+   equilibrium root.
+
+``LFORBAL``
+   Replaces selected R/Z force coefficients with a non-variational
+   flux-averaged force-balance form.  It changes the force operator and must be
+   propagated through setup, solve, diagnostics, and differentiation.
+
+``LMOVE_AXIS``
+   Enables the VMEC2000 first-force axis-recovery control transfer.  It is not
+   equivalent to supplying an axis and is independent of the preconditioner.
+
+``LFULL3D1OUT``
+   Controls output after iteration-budget exhaustion; it does not declare the
+   unconverged state converged.
+
+CLI lane / JIT lane
+   Two controllers around the same force and update kernels.  The CLI lane
+   prints/checks between compiled blocks; the JIT lane is a traced loop.
+   ``VMEX_FAST_COMPILE`` and device policy may change compilation/execution
+   strategy, never the intended physics mode.
+
+AD / FD
+   Automatic differentiation computes derivatives of a coded map.  Finite
+   differences perturb inputs and rerun that map.  An AD result is
+   research-grade only for the exact map disclosed and independently checked
+   over a stated parameter/regime envelope.
+
+Open-PR ownership and merge preservation
+----------------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 13 33 54
+
+   * - PR
+     - Primary scope
+     - Relationship to this audit
+   * - #61--#64
+     - Device contract and accelerator selection/CI
+     - Performance/placement only; they do not repair ignored VMEC2000 physics
+       controls.
+   * - #65--#66
+     - Traceable Mercier method/objective
+     - Adds an explicitly symmetry-limited derived method; does not change the
+       equilibrium parser.
+   * - #67--#68
+     - Accelerator documentation, doctor, and benchmarks
+     - Complement the device design disclosure.
+   * - #69
+     - Nonfinite/axis diagnostics and parser hardening
+     - Originally detected active reconstruction/RFP only in the diagnostic.
+       Production enforcement and the complete no-silent-mode policy belong to
+       the revised #70 stack and must survive merge.
+   * - #70
+     - Free-boundary multigrid plus collaborator fixes
+     - Owns multidimensional namelist sections, APHI/profile parsing, finite
+       first-force diagnosis, axis recovery, LFORBAL, free-boundary vacuum
+       continuation/rebuild, effective fallback metadata, preconditioner
+       semantics, and this compatibility ledger.
+   * - #71
+     - Hot-restart example/documentation
+     - Depends on #70's free-boundary multigrid behavior; keep after #70.
+   * - #72
+     - ``curlabel`` WOUT schema
+     - Complementary output parity; retain when resolving WOUT conflicts.
+   * - #73
+     - Symmetric NESTOR potential/surface WOUT export
+     - Closes part of the documented fill-value gap; asymmetric export remains
+       explicit follow-up work.
+   * - #74
+     - Bounded nightly validation
+     - CI scheduling/limits only; no solver semantics.
+
+Research-grade completion criteria
+----------------------------------
+
+A remaining row is complete only when all applicable evidence exists:
+
+1. a production implementation, not a diagnostic-only branch;
+2. unit tests that prove the control reaches the intended kernel/controller;
+3. VMEC2000 comparison of trajectory and converged state where parity is the
+   goal;
+4. fixed/free and symmetric/asymmetric coverage where the method claims those
+   modes;
+5. multigrid and hot-restart coverage where state is transferred;
+6. WOUT schema/value comparison where outputs are claimed;
+7. AD-versus-FD checks for every differentiability claim, with the exact
+   differentiated map identified; and
+8. benchmarks that report hardware, precision, cold/warm compilation, solver
+   tolerance, iteration count, and failure policy.
+
+The highest-priority unimplemented parity work exposed by this audit is:
+VMEC2000 continuation controls (``PRE_NITER``, ``MAX_MAIN_ITERATIONS``,
+``LGIVEUP``), target-volume rescaling, the non-GMRES 2-D preconditioner modes,
+TRIP3D/reconstruction/RFP/ANIMEC physics where required by collaborators, a
+true NESTOR equilibrium derivative, and complete asymmetric NESTOR WOUT
+structures.

--- a/docs/vmec2000_compatibility.rst
+++ b/docs/vmec2000_compatibility.rst
@@ -82,7 +82,10 @@ applies these rules:
 
 The privacy-preserving ``tools/diagnose_input.py`` reports the same
 classification as the production parser.  Its stable ``D00*`` code contains
-no filename, coefficient, input value, or equilibrium result.
+no filename, coefficient, input value, or equilibrium result.  It also reports
+whether explicit angular grids meet VMEC2000's automatic-resolution floor;
+``W01_ANGULAR_GRID_BELOW_VMEC_DEFAULT`` is a convergence-risk warning, not a
+parser or physics-mode rejection.
 
 Equilibrium capability matrix
 -----------------------------
@@ -201,6 +204,10 @@ Core grid, profiles, and geometry
    * - ``DELT, TCON0, NSTEP``
      - implemented
      - Initial time step, spectral-condensation multiplier, and print cadence.
+       VMEX's driver retries a fatal 75-reset stage from its best finite
+       checkpoint with reduced ``DELT`` (two attempts by default); set
+       ``jacobian_retries=0``/``--jacobian-retries 0`` for exact VMEC2000
+       termination behavior.
    * - ``APHI, PHIEDGE``
      - implemented
      - Toroidal-flux map and edge flux.  Indexed and section assignments use
@@ -249,7 +256,10 @@ Force, axis, and iteration controls
    * - ``LMOVE_AXIS``
      - implemented by PR #70
      - Enables the first-pass ``irst=4`` axis re-guess when the finite force sum
-       exceeds the VMEC2000 threshold.  The value is preserved in WOUT.
+       exceeds the VMEC2000 threshold.  Missing/all-zero axis coefficients are
+       not pre-inferred in production: VMEX now follows VMEC2000's supplied
+       zero-axis first pass and exactly one ``eqsolve.f`` recovery transfer.
+       The value is preserved in WOUT.
    * - ``LFULL3D1OUT``
      - implemented
      - On fixed or free NITER exhaustion, ``T`` writes the unconverged WOUT and
@@ -550,9 +560,10 @@ Open-PR ownership and merge preservation
    * - #70
      - Free-boundary multigrid plus collaborator fixes
      - Owns multidimensional namelist sections, APHI/profile parsing, finite
-       first-force diagnosis, axis recovery, LFORBAL, free-boundary vacuum
-       continuation/rebuild, effective fallback metadata, preconditioner
-       semantics, and this compatibility ledger.
+       first-force diagnosis, exact single-transfer axis recovery, LFORBAL,
+       bounded JAC75 best-checkpoint recovery, angular-grid risk diagnostics,
+       free-boundary vacuum continuation/rebuild, effective fallback metadata,
+       preconditioner semantics, and this compatibility ledger.
    * - #71
      - Hot-restart example/documentation
      - Depends on #70's free-boundary multigrid behavior; keep after #70.

--- a/docs/vmec2000_compatibility.rst
+++ b/docs/vmec2000_compatibility.rst
@@ -116,7 +116,8 @@ Equilibrium capability matrix
    * - Fixed-boundary ``NS_ARRAY``
      - parity-regressed
      - Increasing stages interpolate the final state, equal stages rerun, and
-       decreasing stages are skipped as in ``runvmec.f``.
+       ``readin.f`` ends the active ladder at the first decreasing or
+       nonpositive entry.
    * - Free-boundary ``NS_ARRAY``
      - implemented by PR #70
      - Plasma state, ``ivac``, adaptive ``nvacskip``, boundary pressure, and
@@ -190,17 +191,23 @@ Core grid, profiles, and geometry
      - implemented
      - Radial resolution-continuation ladder.  The explicit old-style
        ``NS_ARRAY(1)=0`` form expands through ``NSIN`` to ``[NSIN,31]``.
+       ``readin.f`` accepts a positive nondecreasing prefix (equal grids
+       rerun) and excludes the first decreasing/nonpositive value and its tail.
    * - ``FTOL_ARRAY``
      - implemented
-     - Per-stage physical-force stopping tolerance.
+     - Per-stage physical-force stopping tolerance.  Repeated dense/indexed
+       namelist assignments overlay in source order.  An explicit zero first
+       entry generates VMEC2000's geometric ``1e-8 -> FTOL`` ladder.
    * - ``FTOL``
-     - deliberate divergence
-     - Accepted as a useful scalar fallback.  In the audited VMEC2000 source,
-       the initialized nonzero ``FTOL_ARRAY(1)`` can make scalar ``FTOL``
-       ineffective unless the array sentinel is also changed.
+     - implemented
+     - Used directly for a single grid when ``FTOL_ARRAY(1)=0`` and as the
+       final target of the generated multigrid tolerance ladder.
    * - ``NITER_ARRAY, NITER``
      - implemented
-     - VMEC2000's ``ALL(NITER_ARRAY==-1) -> NITER`` fallback is reproduced.
+     - VMEC2000's ``ALL(NITER_ARRAY==-1) -> NITER`` fallback is reproduced;
+       any explicit array write preserves unassigned ``-1`` elements.  Such a
+       stage executes one force/evolution pass before the ``iter2 >= niter``
+       limit is observed.
    * - ``DELT, TCON0, NSTEP``
      - implemented
      - Initial time step, spectral-condensation multiplier, and print cadence.
@@ -233,8 +240,9 @@ Core grid, profiles, and geometry
        ``read_indata_namelist``.
    * - ``RBC, ZBS, RBS, ZBC``
      - implemented
-     - Scalar, one-dimensional section, and multidimensional Fortran namelist
-       assignments are supported.
+     - Scalar, starting-element, and multidimensional Fortran namelist
+       sections are supported with declared bounds, inclusive section limits,
+       first-subscript-fastest order, and source-ordered overlay.
    * - ``TVOLUME, LVOLUME_RFIX``
      - rejected when active
      - Positive target-volume rescaling is not silently omitted.
@@ -252,7 +260,10 @@ Force, axis, and iteration controls
    * - ``LFORBAL``
      - implemented by PR #70
      - Selects VMEC2000's non-variational average-force replacement for the
-       ``m=1,n=0`` R/Z channels.
+       ``m=1,n=0`` R/Z channels.  ``calc_fbal`` consumes full-mesh ``chipf``
+       reconstructed from the effective half-mesh ``chips`` by the
+       ``add_fluxes.f90`` formulas for both ``NCURR`` modes; WOUT uses the
+       same reconstruction.
    * - ``LMOVE_AXIS``
      - implemented by PR #70
      - Enables the first-pass ``irst=4`` axis re-guess when the finite force sum
@@ -332,7 +343,8 @@ VMEX uses this explicit contract:
      - Meaning
    * - ``NONE`` or ``DEFAULT``
      - implemented
-     - VMEC-parity 1-D radial tridiagonal preconditioner only.
+     - VMEC-parity 1-D radial tridiagonal plus lambda preconditioner.  These
+       spellings disable only the optional 2-D block preconditioner.
    * - ``GMRES``
      - deliberate divergence
      - Exact JAX JVP of the preconditioned force, solved matrix-free by
@@ -349,6 +361,15 @@ VMEX uses this explicit contract:
 after the minimum-iteration gate.  An explicit Python
 :class:`~vmex.core.preconditioner_2d.Prec2DConfig` remains the VMEX-native
 advanced interface.
+
+The production radial solve uses SOLVAX's checked tridiagonal interface.  It
+replays VMEC2000 ``serial_tridslv``'s unregularized modified-pivot test at the
+same ``1e-8`` relative threshold and additionally verifies a normwise backward
+residual.  VMEC2000 executes a process-wide ``STOP`` on a rejected pivot;
+VMEX instead applies the identity action only to rejected coefficient columns,
+keeps the update finite, and reports
+``D04E_RADIAL_PRECONDITIONER_REJECTED``.  Well-conditioned columns retain the
+ordinary platform-selected Thomas/fused solve and its existing parity tests.
 
 Reconstruction, anisotropy, and legacy output controls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -491,6 +512,7 @@ Multigrid
    In VMEC terminology, a radial *resolution-continuation ladder*
    (``NS_ARRAY``), not a V-cycle correction method.  Each stage performs a
    nonlinear equilibrium solve and transfers the state to the next stage.
+   Fixed and free boundary use the same normalized nondecreasing prefix.
 
 Hot restart
    Seeding a solve with an existing spectral state.  Fixed-boundary hot restart
@@ -508,8 +530,10 @@ Preconditioned update residual
 
 ``LFORBAL``
    Replaces selected R/Z force coefficients with a non-variational
-   flux-averaged force-balance form.  It changes the force operator and must be
-   propagated through setup, solve, diagnostics, and differentiation.
+   flux-averaged force-balance form.  Its radial force uses full-mesh
+   ``phipf/chipf`` and half-mesh current/pressure differences exactly as
+   ``fbal.f``/``add_fluxes.f90`` specify.  It changes the force operator and
+   must be propagated through setup, solve, diagnostics, and differentiation.
 
 ``LMOVE_AXIS``
    Enables the VMEC2000 first-force axis-recovery control transfer.  It is not
@@ -558,12 +582,13 @@ Open-PR ownership and merge preservation
        Production enforcement and the complete no-silent-mode policy belong to
        the revised #70 stack and must survive merge.
    * - #70
-     - Free-boundary multigrid plus collaborator fixes
+     - Free-boundary multigrid and VMEC2000 parity hardening
      - Owns multidimensional namelist sections, APHI/profile parsing, finite
        first-force diagnosis, exact single-transfer axis recovery, LFORBAL,
-       bounded JAC75 best-checkpoint recovery, angular-grid risk diagnostics,
-       free-boundary vacuum continuation/rebuild, effective fallback metadata,
-       preconditioner semantics, and this compatibility ledger.
+       full-mesh force-balance profiles, bounded JAC75 best-checkpoint recovery,
+       angular-grid risk diagnostics, free-boundary vacuum
+       continuation/rebuild, guarded radial solves, effective fallback
+       metadata, preconditioner semantics, and this compatibility ledger.
    * - #71
      - Hot-restart example/documentation
      - Depends on #70's free-boundary multigrid behavior; keep after #70.
@@ -577,6 +602,32 @@ Open-PR ownership and merge preservation
    * - #74
      - Bounded nightly validation
      - CI scheduling/limits only; no solver semantics.
+
+Public integrated stress gate
+-----------------------------
+
+``tests/test_vmec2000_feature_stress.py`` constructs a reproducible difficult
+case solely from the tracked public
+``input.serial2500170_surface_points_mpol12_ntor12`` boundary.  The stress
+header combines ``MPOL=13``, ``NTOR=9`` (238 modes), no supplied axis,
+``LFORBAL=T``, ``PRECON_TYPE='NONE'``, compact multidimensional boundary
+sections, repeated dense array overlays, an ``APHI`` starting-element write,
+and a four-stage ``21,34,55,89`` ladder.  The mandatory gate parses the exact
+combination and reaches a finite first force with automatic axis recovery and
+an accepted radial solve.  The full gate runs the 21-surface fixed-boundary
+problem to the VMEC2000 equilibrium and pins its residual channels, energy,
+axis, iteration count, and reset count.
+
+The same PR's public free-boundary matrix uses the bundled CTH-like mgrid
+fixtures to cover one-time vacuum activation, increasing/equal radial grids,
+NESTOR structure rebuild/reuse, carried ``ivac/nvacskip/rbsq`` and invariant
+residuals, first-fine-grid edge-force norms, evolved-edge hot restart,
+``LFORBAL``, ``PRECON_TYPE='NONE'``, active VMEX GMRES, JAC75 checkpoint
+recovery, and WOUT comparison.  Its ``7 -> 15`` converged trajectory pins the
+same first fine-grid ``FSQR/FSQZ/FSQL`` screen row as local VMEC2000 before
+comparing the final WOUT.  The ESSOS/SIMSOPT adapters and free-boundary
+AD-versus-FD tests remain separate so an optional external package cannot
+weaken the mandatory mgrid/NESTOR gates.
 
 Research-grade completion criteria
 ----------------------------------
@@ -599,6 +650,6 @@ A remaining row is complete only when all applicable evidence exists:
 The highest-priority unimplemented parity work exposed by this audit is:
 VMEC2000 continuation controls (``PRE_NITER``, ``MAX_MAIN_ITERATIONS``,
 ``LGIVEUP``), target-volume rescaling, the non-GMRES 2-D preconditioner modes,
-TRIP3D/reconstruction/RFP/ANIMEC physics where required by collaborators, a
+TRIP3D/reconstruction/RFP/ANIMEC physics where required by research programs, a
 true NESTOR equilibrium derivative, and complete asymmetric NESTOR WOUT
 structures.

--- a/docs/wout_reference.rst
+++ b/docs/wout_reference.rst
@@ -1,10 +1,11 @@
 wout file reference
 ===================
 
-:mod:`vmex.core.wout` implements the complete variable set written by
-VMEC2000's ``wrout.f``, with the exact netCDF names, dimensions, dtypes and
-unit conventions of the reference implementation, so the files load unchanged
-in simsopt, booz_xform, and other VMEC-ecosystem tools. Use
+:mod:`vmex.core.wout` implements a VMEC2000-compatible netCDF schema with the
+names, dimensions, dtypes, and unit conventions required by simsopt,
+booz_xform, and other VMEC-ecosystem tools.  A declared variable may still be
+fill-valued where its producer is not implemented; those cases are disclosed
+below and in :doc:`vmec2000_compatibility`. Use
 :func:`vmex.core.wout.read_wout` / :func:`~vmex.core.wout.write_wout`
 for IO and :func:`~vmex.core.wout.wout_from_state` to build the dataset
 from a converged solver state.
@@ -23,7 +24,8 @@ Scalars
 ``pmass_type``, ``piota_type``, ``wb``, ``wp``, ``gamma``, ``rmax_surf``,
 ``rmin_surf``, ``zmax_surf``, ``nfp``, ``ns``, ``mpol``, ``ntor``, ``mnmax``,
 ``mnmax_nyq``, ``niter``, ``itfsq``, ``lasym``, ``lrecon``, ``lfreeb``,
-``lrfp``, ``ier_flag``, ``aspect``, ``betatotal``, ``betapol``, ``betator``,
+``lmove_axis``, ``lrfp``, ``ier_flag``, ``aspect``, ``betatotal``,
+``betapol``, ``betator``,
 ``betaxis``, ``b0``, ``rbtor0``, ``rbtor``, ``signgs``, ``IonLarmor``,
 ``volavgB``, ``ctor``, ``Aminor_p``, ``Rmajor_p``, ``volume_p``, ``ftolv``,
 ``fsql``, ``fsqr``, ``fsqz``, ``nextcur``, ``extcur(:)``, ``mgrid_mode``.
@@ -77,7 +79,9 @@ the free-boundary solver does not yet return the vacuum potential (see
 Parity with VMEC2000
 --------------------
 
-wout parity against VMEC2000 golden runs is asserted per-variable with
+WOUT parity against representative VMEC2000 golden runs is asserted
+per-variable with
 combined relative + absolute tolerances (CompareWOut-style methodology from
 VMEC++ validation), with a documented looser bound for ``currumnc/currvmnc``.
-See :doc:`performance` for the case-by-case parity results.
+This is not a claim that fill-valued or untested modes have parity. See
+:doc:`performance` and :doc:`vmec2000_compatibility`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ Issues = "https://github.com/uwplasma/vmex/issues"
 Changelog = "https://github.com/uwplasma/vmex/releases"
 
 [project.optional-dependencies]
-# Differentiable free boundary via virtual casing (plan.md R15.3 + R19).
+# Differentiable virtual-casing residual on a specified boundary
+# (plan.md R15.3 + R19); this is not a NESTOR equilibrium adjoint.
 # ``virtual_casing_jax`` is a uwplasma package (https://github.com/uwplasma/
 # virtual_casing_jax); it is NOT yet on PyPI, so ``pip install vmex[freeb]``
 # will not resolve it from an index — install it editable alongside vmex:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "matplotlib",
   "packaging",
   "booz_xform_jax",
-  "solvax",
+  "solvax>=0.8.8",
   "tomli; python_version < '3.11'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,10 @@ omit = ["*/freeboundary_diff.py", "*/turbulence.py"]
 line-length = 120
 
 [tool.ruff.lint]
+# Ruff 0.16 changed its implicit default from the classic Pyflakes/pycodestyle
+# baseline to every stable rule.  Keep VMEX's existing lint contract explicit
+# so an unpinned developer-tool upgrade cannot reclassify the whole repository.
+select = ["E4", "E7", "E9", "F"]
 # E402: module-level import not at top-of-file.  Deferred imports (after env
 #        setup / jax.config calls) are deliberate to control JAX initialisation.
 # E501: line too long.  Handled by the line-length setting above; long lines in

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,4 +261,6 @@ def test_lforbal_iteration_exhaustion_writes_wout(tmp_path):
     ]
     wout_path = tmp_path / "wout_lforbal.nc"
     assert wout_path.exists()
-    assert int(read_wout(wout_path).ier_flag) == MORE_ITER_FLAG
+    wout = read_wout(wout_path)
+    assert int(wout.ier_flag) == MORE_ITER_FLAG
+    assert bool(wout.lmove_axis) is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ Covered here (plan.md Phase 2 STATUS item 4 — first vertical slice):
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import io
 import re
 from pathlib import Path
@@ -236,3 +237,28 @@ def test_iteration_exhaustion_exits_with_more_iter(tmp_path):
     )
     assert rc == MORE_ITER_FLAG
     assert WERROR_MESSAGES[MORE_ITER_FLAG] in stdout
+
+
+def test_lforbal_iteration_exhaustion_writes_wout(tmp_path):
+    """LFORBAL=T is solved, not ignored, and keeps VMEC's NITER WOUT policy."""
+    inp = dataclasses.replace(
+        VmecInput.from_file(SOLOVEV_DECK),
+        lforbal=True,
+        lfull3d1out=True,
+        lmove_axis=False,
+        nstep=1,
+        niter_array=np.asarray([3]),
+        ftol_array=np.asarray([1.0e-30]),
+    )
+    deck = inp.to_indata(tmp_path / "input.lforbal")
+    rc, stdout = _run_cli([str(deck), "--outdir", str(tmp_path)])
+    assert rc == MORE_ITER_FLAG
+    rows = _iteration_rows(stdout)
+    assert [row[1][:3] for row in rows] == [
+        [8.33e-2, 4.94e-4, 3.21e-2],
+        [6.82e-3, 1.41e-3, 4.37e-3],
+        [1.52e-2, 9.15e-4, 6.98e-3],
+    ]
+    wout_path = tmp_path / "wout_lforbal.nc"
+    assert wout_path.exists()
+    assert int(read_wout(wout_path).ier_flag) == MORE_ITER_FLAG

--- a/tests/test_cli_device.py
+++ b/tests/test_cli_device.py
@@ -42,7 +42,7 @@ def test_free_boundary_cli_forwards_device(monkeypatch, tmp_path):
     args = cli.build_parser().parse_args(
         ["input.case", "--quiet", "--device", "gpu"]
     )
-    inp = SimpleNamespace(ns_array=[11])
+    inp = SimpleNamespace(ns_array=[11], lfull3d1out=False)
     plan = SimpleNamespace(solver_kwargs={})
     seen = {}
     ftol_array, niter_array = [1e-8], [3]
@@ -63,4 +63,4 @@ def test_free_boundary_cli_forwards_device(monkeypatch, tmp_path):
     assert seen["device"] == "gpu"
     assert seen["ftol_array"] is ftol_array
     assert seen["niter_array"] is niter_array
-    assert seen["raise_on_max_iterations"] is False
+    assert seen["raise_on_max_iterations"] is True

--- a/tests/test_cli_device.py
+++ b/tests/test_cli_device.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from vmex.core import cli, freeboundary, multigrid, solver
+from vmex.core import cli, multigrid
 
 
 def test_device_option_parses_supported_choices():
@@ -44,20 +44,23 @@ def test_free_boundary_cli_forwards_device(monkeypatch, tmp_path):
     )
     inp = SimpleNamespace(ns_array=[11])
     plan = SimpleNamespace(solver_kwargs={})
-    resolution = object()
     seen = {}
+    ftol_array, niter_array = [1e-8], [3]
 
     monkeypatch.setattr(cli, "_read_input", lambda _: inp)
     monkeypatch.setattr(cli, "_free_boundary_plan", lambda *a, **k: plan)
-    monkeypatch.setattr(cli, "_final_stage_params", lambda *a, **k: (11, 1e-8, 3))
+    monkeypatch.setattr(
+        cli, "_stage_overrides", lambda *a, **k: (ftol_array, niter_array),
+    )
     monkeypatch.setattr(cli, "_write_wout_from_result", lambda *a, **k: object())
-    monkeypatch.setattr(solver, "resolution_from_input", lambda *a, **k: resolution)
 
     def fake_solve(source, **kwargs):
         seen.update(kwargs)
         return SimpleNamespace(converged=True, ier_flag=0)
 
-    monkeypatch.setattr(freeboundary, "solve_free_boundary", fake_solve)
+    monkeypatch.setattr(multigrid, "solve_free_boundary_multigrid", fake_solve)
     assert cli._solve_input_file(args, tmp_path / "input.case", tmp_path, emit=print) == 0
     assert seen["device"] == "gpu"
-    assert seen["resolution"] is resolution
+    assert seen["ftol_array"] is ftol_array
+    assert seen["niter_array"] is niter_array
+    assert seen["raise_on_max_iterations"] is False

--- a/tests/test_cli_freeboundary.py
+++ b/tests/test_cli_freeboundary.py
@@ -8,8 +8,8 @@ Covered:
    ``In VACUUM`` block and ``VACUUM PRESSURE TURNED ON`` banner appear, the
    wout is written and readable with ``lfreeb = True`` and the mgrid's
    ``nextcur``/``extcur``, and the exit code is 2 (MORE ITERATIONS
-   REQUIRED — the capped run cannot converge but VMEC2000 still writes the
-   wout);
+   REQUIRED — the fixture explicitly sets ``LFULL3D1OUT=T`` so VMEC2000 and
+   VMEX write the capped state);
 2. missing mgrid file: warning + fixed-boundary fallback (VMEC2000 policy);
 3. direct-coil conventions: ``MGRID_FILE = 'DIRECT_COILS'`` without
    ``--coils`` and ``--coils`` on a fixed-boundary deck are typed input
@@ -69,6 +69,11 @@ def freeb_cli(tmp_path_factory) -> tuple[int, str, Path]:
     workdir = tmp_path_factory.mktemp("cli_freeb")
     deck = workdir / DECK.name
     shutil.copyfile(DECK, deck)
+    text, count = re.subn(
+        r"(?m)^\s*/\s*$", "  LFULL3D1OUT = T,\n/", deck.read_text(), count=1
+    )
+    assert count == 1
+    deck.write_text(text)
     shutil.copyfile(MGRID, workdir / MGRID.name)
     outdir = workdir / "out"
     rc, stdout = _run_cli([str(deck), "--max-iter", "80", "--outdir", str(outdir)])
@@ -100,7 +105,7 @@ def test_exit_code_reflects_more_iter(freeb_cli):
 
 def test_wout_written_with_free_boundary_fields(freeb_cli):
     _, _, wout_path = freeb_cli
-    assert wout_path.exists(), "capped free-boundary run must still write the wout"
+    assert wout_path.exists(), "LFULL3D1OUT must retain the capped free-boundary state"
     # wrout.f dimensions extcur by the mgrid's nextcur (the bundled synthetic
     # mgrid holds a single summed coil group), truncating the deck's EXTCUR.
     mgrid = read_mgrid(MGRID)
@@ -139,6 +144,26 @@ def test_missing_mgrid_falls_back_to_fixed_boundary(tmp_path):
     assert "In VACUUM" not in stdout
     # the capped fixed-boundary fallback exhausts NITER -> exit code 2.
     assert rc == MORE_ITER_FLAG
+    assert not (tmp_path / f"wout_{CASE}.nc").exists()
+
+
+def test_missing_mgrid_forced_wout_has_effective_fixed_metadata(tmp_path):
+    """LFULL3D1OUT retains the fallback state but must not label it free."""
+    deck = tmp_path / DECK.name
+    text, count = re.subn(
+        r"(?m)^\s*/\s*$", "  LFULL3D1OUT = T,\n/", DECK.read_text(), count=1
+    )
+    assert count == 1
+    deck.write_text(text)  # mgrid deliberately absent
+    rc, stdout = _run_cli(
+        [str(deck), "--max-iter", "5", "--outdir", str(tmp_path)]
+    )
+    assert rc == MORE_ITER_FLAG
+    assert "FIXED-BOUNDARY" in stdout
+    wout = read_wout(tmp_path / f"wout_{CASE}.nc")
+    assert bool(wout.lfreeb) is False
+    with netCDF4.Dataset(str(tmp_path / f"wout_{CASE}.nc")) as ds:
+        assert int(ds["lfreeb__logical__"][()]) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -8,12 +8,14 @@ decision, not the presence of an accelerator.
 from __future__ import annotations
 
 import contextlib
+from types import SimpleNamespace
 
 import jax
+import numpy as np
 import pytest
 
 from vmex.core import device as dev
-from vmex.core import freeboundary
+from vmex.core import freeboundary, multigrid
 from vmex.core.fourier import Resolution
 
 
@@ -159,6 +161,17 @@ def test_device_context_wraps_default_device_for_explicit_cpu():
         pass
 
 
+def test_put_numeric_leaves_preserves_metadata_and_none_contract():
+    resolution = _res(ns=11, mpol=6, ntor=0)
+    assert dev._placement_device(None, resolution) is None
+    cpu = jax.devices("cpu")[0]
+    moved = dev._put_numeric_leaves(
+        {"array": np.ones(2), "metadata": "kept"}, cpu,
+    )
+    assert moved["array"].device.platform == "cpu"
+    assert moved["metadata"] == "kept"
+
+
 def test_free_boundary_uses_shared_device_context(monkeypatch):
     resolution = _res(ns=11, mpol=6, ntor=0)
     seen = {}
@@ -170,10 +183,10 @@ def test_free_boundary_uses_shared_device_context(monkeypatch):
 
     def fake_solve(inp, **kwargs):
         seen["solve"] = (inp, kwargs)
-        return "result"
+        return SimpleNamespace(result="result")
 
     monkeypatch.setattr(freeboundary, "device_context", fake_context)
-    monkeypatch.setattr(freeboundary, "_solve_free_boundary_impl", fake_solve)
+    monkeypatch.setattr(freeboundary, "_solve_free_boundary_stage", fake_solve)
     inp = object()
     result = freeboundary.solve_free_boundary(
         inp, resolution=resolution, device="cpu", max_iterations=3
@@ -184,3 +197,5 @@ def test_free_boundary_uses_shared_device_context(monkeypatch):
     assert seen["solve"][0] is inp
     assert seen["solve"][1]["resolution"] is resolution
     assert seen["solve"][1]["max_iterations"] == 3
+    assert freeboundary.solve_free_boundary.__kwdefaults__["device"] == dev.AUTO
+    assert multigrid.solve_free_boundary_multigrid.__kwdefaults__["device"] == dev.AUTO

--- a/tests/test_forces_residuals.py
+++ b/tests/test_forces_residuals.py
@@ -28,6 +28,7 @@ import pytest
 from vmex.core import residuals as newr
 from vmex.core.forces import apply_m1_force_balance
 from vmex.core.input import VmecInput
+from vmex.core.setup import run_setup
 from vmex.core.solver import (
     _initial_state,
     evaluate_forces,
@@ -59,7 +60,12 @@ def _allclose(new, old, name, rtol=RTOL, atol=ATOL):
 def case(request):
     name = request.param
     inp = VmecInput.from_file(DATA_DIR / f"input.{name}")
-    rt = prepare_runtime(inp, resolution_from_input(inp))
+    resolution = resolution_from_input(inp)
+    # These are pure force-kernel tests, so request a regular inferred axis
+    # for all-zero-axis decks.  Production keeps the supplied zero axis and
+    # performs its one VMEC2000-compatible recovery in the solve driver.
+    setup = run_setup(inp, resolution, infer_axis_if_missing=True)
+    rt = prepare_runtime(inp, resolution, setup=setup)
     state = _initial_state(rt.setup)
     return SimpleNamespace(name=name, inp=inp, rt=rt, state=state)
 

--- a/tests/test_forces_residuals.py
+++ b/tests/test_forces_residuals.py
@@ -26,6 +26,7 @@ import numpy as np
 import pytest
 
 from vmex.core import residuals as newr
+from vmex.core.forces import apply_m1_force_balance
 from vmex.core.input import VmecInput
 from vmex.core.solver import (
     _initial_state,
@@ -33,6 +34,7 @@ from vmex.core.solver import (
     prepare_runtime,
     resolution_from_input,
 )
+from vmex.core.transforms import SpectralForce
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "examples" / "data"
 
@@ -128,6 +130,48 @@ def test_release_conditions_are_traced_values():
         jax.jit(lambda f, i: newr.m1_zero_condition(fsqz_previous=f, iterations_since_restart=i))(
             jnp.asarray(1e-7), jnp.asarray(100)
         )
+    )
+
+
+def test_lforbal_replaces_only_symmetric_m1_n0_interior() -> None:
+    """tomnsp_mod.f leaves every block except frcc/fzsc(m=1,n=0) alone."""
+    shape = (5, 3, 2)
+    frcc = jnp.arange(np.prod(shape), dtype=jnp.float64).reshape(shape)
+    fzsc = 100.0 + frcc
+    untouched = -frcc
+    force = SpectralForce(
+        force_R_cc=frcc,
+        force_Z_sc=fzsc,
+        force_R_ss=untouched,
+        force_Z_cs=2.0 * untouched,
+    )
+    equif = jnp.asarray([0.0, 2.0, 4.0, 6.0, 0.0])
+    factor_R = jnp.asarray([0.0, 10.0, 20.0, 30.0, 0.0])
+    factor_Z = jnp.asarray([0.0, 5.0, 10.0, 15.0, 0.0])
+    got = apply_m1_force_balance(
+        force, equif=equif, factor_R=factor_R, factor_Z=factor_Z
+    )
+
+    expected_R = np.asarray(frcc).copy()
+    expected_Z = np.asarray(fzsc).copy()
+    old_R = expected_R[:, 1, 0].copy()
+    old_Z = expected_Z[:, 1, 0].copy()
+    work = old_R[1:-1] / np.asarray(factor_R)[1:-1] - (
+        old_Z[1:-1] / np.asarray(factor_Z)[1:-1]
+    )
+    expected_R[1:-1, 1, 0] = (
+        0.5 * np.asarray(factor_R)[1:-1]
+        * (np.asarray(equif)[1:-1] + work)
+    )
+    expected_Z[1:-1, 1, 0] = (
+        0.5 * np.asarray(factor_Z)[1:-1]
+        * (np.asarray(equif)[1:-1] - work)
+    )
+    np.testing.assert_allclose(np.asarray(got.force_R_cc), expected_R)
+    np.testing.assert_allclose(np.asarray(got.force_Z_sc), expected_Z)
+    np.testing.assert_array_equal(np.asarray(got.force_R_ss), np.asarray(untouched))
+    np.testing.assert_array_equal(
+        np.asarray(got.force_Z_cs), np.asarray(2.0 * untouched)
     )
 
 

--- a/tests/test_freeboundary.py
+++ b/tests/test_freeboundary.py
@@ -415,6 +415,26 @@ def test_bad_supplied_axis_is_reguessed_before_fused_filament(capsys):
     assert result.r00 < 1.0
 
 
+def test_cached_vacuum_executable_rechecks_dynamic_axis(monkeypatch):
+    """A structural cache hit must still validate the current magnetic axis."""
+    resolution = object()
+    cached = (object(), object(), object())
+    monkeypatch.setitem(
+        FB._VACUUM_EXECUTABLE_CACHE, (resolution, 1, 2, 3), cached,
+    )
+    seen = []
+    monkeypatch.setattr(
+        FB, "_assert_static_filament_topology", lambda *args: seen.append(args),
+    )
+    result = FB._vacuum_executables(
+        resolution, mf=2, nf=3, signgs=1, wint=None, modes=None,
+        axis_r0="r", axis_z0="z",
+    )
+
+    assert result is cached
+    assert seen == [(cached[0], "r", "z")]
+
+
 def test_cli_missing_mgrid_fallback_warns(tmp_path):
     """CLI policy: missing mgrid -> fixed-boundary fallback warning (VMEC2000)."""
     import types

--- a/tests/test_freeboundary.py
+++ b/tests/test_freeboundary.py
@@ -40,7 +40,7 @@ import jax.numpy as jnp  # noqa: E402
 
 from vmex.core import freeboundary as FB  # noqa: E402
 from vmex.core import vacuum as V  # noqa: E402
-from vmex.core.errors import MgridNotFoundError  # noqa: E402
+from vmex.core.errors import MgridNotFoundError, VmecJacobianError  # noqa: E402
 from vmex.core.input import VmecInput  # noqa: E402
 from vmex.core.mgrid import MgridField, read_mgrid  # noqa: E402
 from vmex.core.solver import (  # noqa: E402
@@ -396,6 +396,34 @@ def test_missing_mgrid_raises(tmp_path):
     inp = VmecInput.from_file(DECK)
     with pytest.raises(MgridNotFoundError):
         FB.solve_free_boundary(inp, mgrid_path=tmp_path / "mgrid_missing.nc")
+
+
+def test_jac75_retry_rebuilds_vacuum_and_converges(capsys):
+    """A recovered free-boundary stage rebuilds NESTOR at its checkpoint."""
+    inp = dataclasses.replace(
+        VmecInput.from_file(CONV_DECK), delt=1.0e4,
+    )
+    with pytest.raises(VmecJacobianError) as exc:
+        FB.solve_free_boundary(
+            inp,
+            mgrid_path=CONV_MGRID,
+            max_iterations=2500,
+            jacobian_retries=0,
+        )
+    assert exc.value.jacobian_resets == 75
+
+    result = FB.solve_free_boundary(
+        inp,
+        mgrid_path=CONV_MGRID,
+        max_iterations=2500,
+        jacobian_retries=2,
+        verbose=True,
+    )
+    output = capsys.readouterr().out
+    assert "JACOBIAN RECOVERY RETRY" in output
+    assert "VACUUM PRESSURE TURNED ON" in output
+    assert result.converged
+    assert max(result.fsqr, result.fsqz, result.fsql) <= 1.0e-10
 
 
 def test_bad_supplied_axis_is_reguessed_before_fused_filament(capsys):

--- a/tests/test_freeboundary.py
+++ b/tests/test_freeboundary.py
@@ -415,6 +415,23 @@ def test_bad_supplied_axis_is_reguessed_before_fused_filament(capsys):
     assert result.r00 < 1.0
 
 
+def test_high_first_force_reguesses_valid_axis_before_vacuum(capsys):
+    """LMOVE_AXIS also retries a valid-Jacobian axis when FSQ(1) > 1e2."""
+    inp = VmecInput.from_file(DECK)
+    raxis_c = inp.raxis_c.copy()
+    raxis_c[0] = 0.81  # valid Jacobian, but raw first-force sum is ~2.8e2
+    inp = dataclasses.replace(inp, raxis_c=raxis_c, niter_array=[2], nstep=1)
+    result = FB.solve_free_boundary(
+        inp, mgrid_path=MGRID, max_iterations=2, verbose=True,
+        error_on_no_convergence=False,
+    )
+    output = capsys.readouterr().out
+    assert "INITIAL JACOBIAN CHANGED SIGN" not in output
+    assert "TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS" in output
+    assert result.fsq_history[0, :3].sum() < 1.0e2
+    assert np.isfinite(result.fsqr)
+
+
 def test_cached_vacuum_executable_rechecks_dynamic_axis(monkeypatch):
     """A structural cache hit must still validate the current magnetic axis."""
     resolution = object()

--- a/tests/test_freeboundary.py
+++ b/tests/test_freeboundary.py
@@ -400,6 +400,11 @@ def test_missing_mgrid_raises(tmp_path):
 
 def test_jac75_retry_rebuilds_vacuum_and_converges(capsys):
     """A recovered free-boundary stage rebuilds NESTOR at its checkpoint."""
+    if not CONV_MGRID.exists():
+        pytest.skip(
+            "converged public CTH mgrid asset unavailable; run "
+            "examples/data/fetch_assets.py"
+        )
     inp = dataclasses.replace(
         VmecInput.from_file(CONV_DECK), delt=1.0e4,
     )

--- a/tests/test_freeboundary_multigrid.py
+++ b/tests/test_freeboundary_multigrid.py
@@ -37,8 +37,10 @@ def _state(ns: int, mnmax: int, value: float) -> SpectralState:
 
 
 def test_stage_transfer_carries_vacuum_and_interpolates_xstore(monkeypatch) -> None:
-    """Increasing grids use xstore; equal grids use the current xc state."""
+    """User seeds and increasing grids interpolate; equal grids reuse xc."""
     inp = VmecInput.from_file(DECK)
+    modes = mode_table(int(inp.mpol), int(inp.ntor))
+    seed = _state(5, modes.mnmax, 3.0)
     calls = []
     vacua = []
 
@@ -79,19 +81,22 @@ def test_stage_transfer_carries_vacuum_and_interpolates_xstore(monkeypatch) -> N
     field = object()
     result = solve_free_boundary_multigrid(
         inp, ns_array=[7, 15, 15], ftol_array=[1e-4], niter_array=[2],
-        external_field=field, raise_on_max_iterations=False,
+        external_field=field, initial_state=seed,
+        raise_on_max_iterations=False,
         time_step=0.25, tcon0=1.2, gamma=0.1, nstep=17, lconm1=False,
         precon_type="NONE", prec2d_threshold=3e-7,
     )
 
     assert result.marker == 15
     assert [c[0] for c in calls] == [7, 15, 15]
-    assert calls[0][1] is None and calls[0][2] is None
+    expected_seed = interpolate_state(seed, ns_fine=7, modes=modes)
+    np.testing.assert_allclose(
+        np.asarray(calls[0][1].R_cos), np.asarray(expected_seed.R_cos))
+    assert calls[0][2] is None
     assert calls[1][1].R_cos.shape[0] == 15
     # The increasing-grid interpolation came from stage 1 xstore (=21), not
     # its current xc (=11).  Odd-m sqrt(s) scaling makes the expected radial
     # profile non-constant, so compare with the actual interp.f operator.
-    modes = mode_table(int(inp.mpol), int(inp.ntor))
     expected = interpolate_state(
         _state(7, modes.mnmax, 21.0), ns_fine=15, modes=modes)
     np.testing.assert_allclose(
@@ -101,6 +106,16 @@ def test_stage_transfer_carries_vacuum_and_interpolates_xstore(monkeypatch) -> N
     np.testing.assert_allclose(np.asarray(calls[2][1].R_cos), 12.0)
     assert calls[2][2] is vacua[1]
     assert calls[2][1].R_cos.shape[0] == 15
+
+
+def test_vmec2000_niter_exhaustion_is_not_converged() -> None:
+    from benchmarks.run_freeboundary_multigrid import _vmec_converged
+
+    stdout = """\
+ Try increasing NITER or PRE_NITER if the preconditioner is on.
+ EXECUTION TERMINATED NORMALLY
+"""
+    assert not _vmec_converged(stdout)
 
 
 def test_public_two_stage_free_boundary_rebuilds_and_stays_finite() -> None:

--- a/tests/test_freeboundary_multigrid.py
+++ b/tests/test_freeboundary_multigrid.py
@@ -1,0 +1,207 @@
+"""Free-boundary radial-ladder, continuation, and hot-restart regressions."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+import jax.numpy as jnp  # noqa: E402
+
+from vmex.core import freeboundary as FB  # noqa: E402
+from vmex.core.input import VmecInput  # noqa: E402
+from vmex.core.fourier import mode_table  # noqa: E402
+from vmex.core.multigrid import (  # noqa: E402
+    interpolate_state, solve_free_boundary_multigrid,
+)
+from vmex.core.preconditioner_2d import Prec2DConfig  # noqa: E402
+from vmex.core.solver import SpectralState, resolution_from_input  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("_module_jit_enabled")
+
+REPO = Path(__file__).resolve().parents[1]
+DECK = REPO / "examples" / "data" / "input.cth_like_free_bdy_lasym_small"
+MGRID = REPO / "examples" / "data" / "mgrid_cth_like_lasym_small.nc"
+CONV_DECK = REPO / "examples" / "data" / "input.cth_like_free_bdy"
+CONV_MGRID = REPO / "examples" / "data" / "mgrid_cth_like.nc"
+CONV_WOUT = REPO / "examples" / "data" / "single_grid" / "wout_cth_like_free_bdy.nc"
+
+
+def _state(ns: int, mnmax: int, value: float) -> SpectralState:
+    a = jnp.full((ns, mnmax), value, dtype=jnp.float64)
+    return SpectralState(a, a, a, a, a, a)
+
+
+def test_stage_transfer_carries_vacuum_and_interpolates_xstore(monkeypatch) -> None:
+    """Increasing grids use xstore; equal grids use the current xc state."""
+    inp = VmecInput.from_file(DECK)
+    calls = []
+    vacua = []
+
+    def fake_stage(_inp, **kwargs):
+        assert kwargs["time_step"] == 0.25
+        assert kwargs["tcon0"] == 1.2
+        assert kwargs["gamma"] == 0.1
+        assert kwargs["nstep"] == 17
+        assert kwargs["lconm1"] is False
+        assert kwargs["precon_type"] == "NONE"
+        assert kwargs["prec2d_threshold"] == 3e-7
+        if len(calls) < 2:
+            assert kwargs["reuse_vacuum_cache"] is False
+        else:
+            assert kwargs["reuse_vacuum_cache"] is True
+            np.testing.assert_array_equal(
+                np.asarray(kwargs["constraint_continuation"][0]), [2.0])
+        ns = kwargs["resolution"].ns
+        incoming = kwargs["initial_state"]
+        continuation = kwargs["vacuum_continuation"]
+        calls.append((ns, incoming, continuation))
+        vacuum = FB.FreeBoundaryState(
+            ivac=5 + len(calls), nvacskip=11 + len(calls), nvskip0=9,
+            turned_on=True, delbsq=0.1 * len(calls),
+        )
+        vacua.append(vacuum)
+        # Deliberately make current xc and xstore distinguishable.
+        current = _state(ns, kwargs["resolution"].mnmax, 10.0 + len(calls))
+        xstore = _state(ns, kwargs["resolution"].mnmax, 20.0 + len(calls))
+        result = SimpleNamespace(state=current, marker=ns)
+        return SimpleNamespace(
+            result=result, continuation_state=xstore, vacuum=vacuum,
+            rcon0=jnp.asarray([len(calls)], dtype=float),
+            zcon0=jnp.asarray([-len(calls)], dtype=float),
+        )
+
+    monkeypatch.setattr(FB, "_solve_free_boundary_stage", fake_stage)
+    field = object()
+    result = solve_free_boundary_multigrid(
+        inp, ns_array=[7, 15, 15], ftol_array=[1e-4], niter_array=[2],
+        external_field=field, raise_on_max_iterations=False,
+        time_step=0.25, tcon0=1.2, gamma=0.1, nstep=17, lconm1=False,
+        precon_type="NONE", prec2d_threshold=3e-7,
+    )
+
+    assert result.marker == 15
+    assert [c[0] for c in calls] == [7, 15, 15]
+    assert calls[0][1] is None and calls[0][2] is None
+    assert calls[1][1].R_cos.shape[0] == 15
+    # The increasing-grid interpolation came from stage 1 xstore (=21), not
+    # its current xc (=11).  Odd-m sqrt(s) scaling makes the expected radial
+    # profile non-constant, so compare with the actual interp.f operator.
+    modes = mode_table(int(inp.mpol), int(inp.ntor))
+    expected = interpolate_state(
+        _state(7, modes.mnmax, 21.0), ns_fine=15, modes=modes)
+    np.testing.assert_allclose(
+        np.asarray(calls[1][1].R_cos), np.asarray(expected.R_cos))
+    assert calls[1][2] is vacua[0]
+    # Equal NS returns early in initialize_radial.f and keeps current xc (=12).
+    np.testing.assert_allclose(np.asarray(calls[2][1].R_cos), 12.0)
+    assert calls[2][2] is vacua[1]
+    assert calls[2][1].R_cos.shape[0] == 15
+
+
+def test_public_two_stage_free_boundary_rebuilds_and_stays_finite() -> None:
+    """The bundled non-confidential LASYM case crosses vacuum turn-on."""
+    inp = VmecInput.from_file(DECK)
+    lines: list[str] = []
+
+    def emit(value="", end="\n"):
+        lines.append(str(value) + end)
+
+    result = solve_free_boundary_multigrid(
+        inp, ns_array=[7, 15], ftol_array=[1e-10, 1e-10],
+        niter_array=[60, 5], mgrid_path=MGRID, verbose=True, emit=emit,
+        raise_on_max_iterations=False,
+    )
+    output = "".join(lines)
+    assert output.count("VACUUM PRESSURE TURNED ON") == 1
+    assert "NS =    7" in output and "NS =   15" in output
+    assert result.state.R_cos.shape[0] == 15
+    assert np.all(np.isfinite(result.fsq_history))
+    assert np.all(np.isfinite(np.asarray(result.state.R_cos)))
+    # Regression for the old turn-on-ordering blow-up (~5 km major radius).
+    assert 0.5 < result.r00 < 1.0
+
+
+def test_single_grid_hot_restart_preserves_free_edge() -> None:
+    inp = VmecInput.from_file(DECK)
+    first = FB.solve_free_boundary(
+        inp, mgrid_path=MGRID, max_iterations=1,
+        error_on_no_convergence=False,
+    )
+    seed = replace(
+        first.state,
+        R_cos=first.state.R_cos.at[-1, 0].add(1.0e-5),
+        Z_sin=first.state.Z_sin.at[-1, 1].add(-1.0e-5),
+    )
+    restarted = FB.solve_free_boundary(
+        inp, mgrid_path=MGRID, max_iterations=1, initial_state=seed,
+        error_on_no_convergence=False,
+    )
+    # Vacuum activation repeats on a reset-style user hot restart, but the
+    # evolved free boundary is not replaced by the deck's original edge.
+    np.testing.assert_allclose(
+        np.asarray(restarted.state.R_cos[-1]),
+        np.asarray(seed.R_cos[-1]), rtol=0.0, atol=0.0,
+    )
+    np.testing.assert_allclose(
+        np.asarray(restarted.state.Z_sin[-1]),
+        np.asarray(seed.Z_sin[-1]), rtol=0.0, atol=0.0,
+    )
+
+
+def test_rejects_fixed_boundary_input() -> None:
+    inp = replace(VmecInput.from_file(DECK), lfreeb=False)
+    with pytest.raises(ValueError, match="LFREEB"):
+        solve_free_boundary_multigrid(inp, external_field=object())
+
+
+@pytest.mark.full
+def test_free_boundary_accepts_active_2d_preconditioner() -> None:
+    """The fixed-boundary preconditioner controls remain live in free mode."""
+    inp = VmecInput.from_file(DECK)
+    cfg = Prec2DConfig(
+        threshold=1e-2, start_iteration=45, step=0.05,
+        gmres_restart=2, gmres_max_restarts=1, gmres_rtol=0.1,
+    )
+    result = FB.solve_free_boundary(
+        inp, mgrid_path=MGRID, resolution=resolution_from_input(inp, ns=7),
+        max_iterations=55, error_on_no_convergence=False, prec2d=cfg,
+    )
+    assert result.iterations == 55
+    assert np.all(np.isfinite([result.fsqr, result.fsqz, result.fsql]))
+
+
+@pytest.mark.full
+def test_converged_multigrid_final_state_matches_vmec2000_wout() -> None:
+    if not CONV_MGRID.exists() or not CONV_WOUT.exists():
+        pytest.skip("converged CTH mgrid/wout assets unavailable")
+    from vmex.core.wout import read_wout
+
+    inp = VmecInput.from_file(CONV_DECK)
+    result = solve_free_boundary_multigrid(
+        inp, ns_array=[7, 15], ftol_array=[1e-8, 1e-10],
+        niter_array=[1000, 2500], mgrid_path=CONV_MGRID,
+    )
+    reference = read_wout(CONV_WOUT)
+    mine = {(int(m), int(n)): i for i, (m, n) in enumerate(zip(result.xm, result.xn))}
+    idx = np.asarray([
+        mine[(int(m), int(n))] for m, n in zip(reference.xm, reference.xn)
+    ])
+    rerr = np.max(np.abs(result.rmnc[-1, idx] - reference.rmnc[-1])) / np.max(np.abs(reference.rmnc[-1]))
+    zerr = np.max(np.abs(result.zmns[-1, idx] - reference.zmns[-1])) / np.max(np.abs(reference.zmns[-1]))
+    s_mine = np.linspace(0.0, 1.0, result.iotaf.size)
+    s_ref = np.linspace(0.0, 1.0, reference.iotaf.size)
+    iota_ref = np.interp(s_mine, s_ref, reference.iotaf)
+    ierr = np.max(np.abs(result.iotaf - iota_ref)) / np.max(np.abs(iota_ref))
+    assert result.converged
+    # This packaged reference is ns=151, while the fast CI ladder ends at
+    # ns=15; compare the common boundary and interpolated iota at the expected
+    # radial-discretization scale.  The exact ns=15 VMEC2000 comparison is
+    # recorded by benchmarks/run_freeboundary_multigrid.py (<1e-3 here).
+    assert rerr < 1e-2
+    assert zerr < 1e-2
+    assert ierr < 1.5e-2

--- a/tests/test_freeboundary_multigrid.py
+++ b/tests/test_freeboundary_multigrid.py
@@ -36,8 +36,8 @@ def _state(ns: int, mnmax: int, value: float) -> SpectralState:
     return SpectralState(a, a, a, a, a, a)
 
 
-def test_stage_transfer_carries_vacuum_and_interpolates_xstore(monkeypatch) -> None:
-    """User seeds and increasing grids interpolate; equal grids reuse xc."""
+def test_stage_transfer_carries_vacuum_and_interpolates_final_xc(monkeypatch) -> None:
+    """User seeds and increasing/equal grids continue from final xc."""
     inp = VmecInput.from_file(DECK)
     modes = mode_table(int(inp.mpol), int(inp.ntor))
     seed = _state(5, modes.mnmax, 3.0)
@@ -94,11 +94,11 @@ def test_stage_transfer_carries_vacuum_and_interpolates_xstore(monkeypatch) -> N
         np.asarray(calls[0][1].R_cos), np.asarray(expected_seed.R_cos))
     assert calls[0][2] is None
     assert calls[1][1].R_cos.shape[0] == 15
-    # The increasing-grid interpolation came from stage 1 xstore (=21), not
-    # its current xc (=11).  Odd-m sqrt(s) scaling makes the expected radial
-    # profile non-constant, so compare with the actual interp.f operator.
+    # allocate_ns.f overwrites newly allocated xstore from old xc before
+    # initialize_radial.f calls interp.f.  The source is therefore stage 1's
+    # final xc (=11), not its best-residual restart checkpoint (=21).
     expected = interpolate_state(
-        _state(7, modes.mnmax, 21.0), ns_fine=15, modes=modes)
+        _state(7, modes.mnmax, 11.0), ns_fine=15, modes=modes)
     np.testing.assert_allclose(
         np.asarray(calls[1][1].R_cos), np.asarray(expected.R_cos))
     assert calls[1][2] is vacua[0]
@@ -139,6 +139,24 @@ def test_public_two_stage_free_boundary_rebuilds_and_stays_finite() -> None:
     assert np.all(np.isfinite(np.asarray(result.state.R_cos)))
     # Regression for the old turn-on-ordering blow-up (~5 km major radius).
     assert 0.5 < result.r00 < 1.0
+
+
+def test_niter_exhausted_free_stage_transfers_final_xc_vmec2000_parity() -> None:
+    """The pre-vacuum free ladder continues from final xc after coarse NITER."""
+    inp = VmecInput.from_file(DECK)
+    result = solve_free_boundary_multigrid(
+        inp, ns_array=[7, 15], ftol_array=[1e-30, 1e-30],
+        niter_array=[2, 1], mgrid_path=MGRID,
+        raise_on_max_iterations=False,
+    )
+    # Local xvmec2000/PARVMEC 9.0 on these public assets gives the same first
+    # ns=15 row (vacuum is deliberately not yet active).
+    np.testing.assert_allclose(
+        result.fsq_history[0, :3],
+        [0.03192713, 0.00284142, 0.00899460],
+        rtol=2e-6,
+    )
+    assert result.r00 == pytest.approx(0.7430588672, rel=2e-10)
 
 
 def test_single_grid_hot_restart_preserves_free_edge() -> None:

--- a/tests/test_freeboundary_multigrid.py
+++ b/tests/test_freeboundary_multigrid.py
@@ -159,6 +159,58 @@ def test_niter_exhausted_free_stage_transfers_final_xc_vmec2000_parity() -> None
     assert result.r00 == pytest.approx(0.7430588672, rel=2e-10)
 
 
+def test_lforbal_free_ladder_matches_vmec2000_before_vacuum_activation() -> None:
+    """The shared LFORBAL force map survives free coarse-to-fine transfer."""
+    inp = replace(
+        VmecInput.from_file(DECK), lforbal=True, lmove_axis=False
+    )
+    result = solve_free_boundary_multigrid(
+        inp,
+        ns_array=[7, 15],
+        ftol_array=[1e-30, 1e-30],
+        niter_array=[2, 1],
+        mgrid_path=MGRID,
+        raise_on_max_iterations=False,
+        device="cpu",
+    )
+    # Fresh local xvmec2000/PARVMEC 9.0 prints on the ns=15 pass:
+    #   1  1.89E-02  3.61E-03  8.96E-03 ... WMHD 5.0791E-02
+    # Vacuum is deliberately not active yet (DEL-BSQ remains 1).
+    np.testing.assert_allclose(
+        result.fsq_history[0, :3],
+        [1.89e-2, 3.61e-3, 8.96e-3],
+        rtol=7e-3,
+    )
+    assert result.r00 == pytest.approx(0.7430400635, rel=2e-10)
+    assert result.wmhd == pytest.approx(0.0507912723, rel=2e-9)
+
+
+@pytest.mark.full
+def test_lforbal_free_ladder_crosses_vacuum_activation() -> None:
+    """The non-variational force remains finite after a real NESTOR update."""
+    inp = replace(VmecInput.from_file(DECK), lforbal=True)
+    lines: list[str] = []
+
+    def emit(value="", end="\n"):
+        lines.append(str(value) + end)
+
+    result = solve_free_boundary_multigrid(
+        inp,
+        ns_array=[7, 15],
+        ftol_array=[1e-10, 1e-10],
+        niter_array=[60, 5],
+        mgrid_path=MGRID,
+        verbose=True,
+        emit=emit,
+        raise_on_max_iterations=False,
+        device="cpu",
+    )
+    assert "".join(lines).count("VACUUM PRESSURE TURNED ON") == 1
+    assert np.all(np.isfinite(result.fsq_history))
+    assert np.all(np.isfinite(np.asarray(result.state.R_cos)))
+    assert 0.5 < result.r00 < 1.0
+
+
 def test_single_grid_hot_restart_preserves_free_edge() -> None:
     inp = VmecInput.from_file(DECK)
     first = FB.solve_free_boundary(

--- a/tests/test_freeboundary_multigrid.py
+++ b/tests/test_freeboundary_multigrid.py
@@ -61,6 +61,14 @@ def test_stage_transfer_carries_vacuum_and_interpolates_final_xc(monkeypatch) ->
         ns = kwargs["resolution"].ns
         incoming = kwargs["initial_state"]
         continuation = kwargs["vacuum_continuation"]
+        if calls:
+            assert kwargs["residual_continuation"] == (
+                float(len(calls)),
+                float(len(calls)) + 0.1,
+                float(len(calls)) + 0.2,
+            )
+        else:
+            assert kwargs["residual_continuation"] is None
         calls.append((ns, incoming, continuation))
         vacuum = FB.FreeBoundaryState(
             ivac=5 + len(calls), nvacskip=11 + len(calls), nvskip0=9,
@@ -70,7 +78,13 @@ def test_stage_transfer_carries_vacuum_and_interpolates_final_xc(monkeypatch) ->
         # Deliberately make current xc and xstore distinguishable.
         current = _state(ns, kwargs["resolution"].mnmax, 10.0 + len(calls))
         xstore = _state(ns, kwargs["resolution"].mnmax, 20.0 + len(calls))
-        result = SimpleNamespace(state=current, marker=ns)
+        result = SimpleNamespace(
+            state=current,
+            marker=ns,
+            fsqr=float(len(calls)),
+            fsqz=float(len(calls)) + 0.1,
+            fsql=float(len(calls)) + 0.2,
+        )
         return SimpleNamespace(
             result=result, continuation_state=xstore, vacuum=vacuum,
             rcon0=jnp.asarray([len(calls)], dtype=float),
@@ -181,8 +195,11 @@ def test_lforbal_free_ladder_matches_vmec2000_before_vacuum_activation() -> None
         [1.89e-2, 3.61e-3, 8.96e-3],
         rtol=7e-3,
     )
-    assert result.r00 == pytest.approx(0.7430400635, rel=2e-10)
-    assert result.wmhd == pytest.approx(0.0507912723, rel=2e-9)
+    # The full-mesh chipf reconstruction used by calc_fbal/add_fluxes also
+    # restores the VMEC2000 energy row (5.079117E-02) rather than the former
+    # half-mesh-substitution value.
+    assert result.r00 == pytest.approx(0.7430400335, rel=2e-10)
+    assert result.wmhd == pytest.approx(0.05079117051, rel=2e-9)
 
 
 @pytest.mark.full
@@ -265,11 +282,30 @@ def test_converged_multigrid_final_state_matches_vmec2000_wout() -> None:
     if not CONV_MGRID.exists() or not CONV_WOUT.exists():
         pytest.skip("converged CTH mgrid/wout assets unavailable")
     from vmex.core.wout import read_wout
+    from benchmarks.run_freeboundary_multigrid import _stage_iterations
 
     inp = VmecInput.from_file(CONV_DECK)
+    lines: list[str] = []
     result = solve_free_boundary_multigrid(
         inp, ns_array=[7, 15], ftol_array=[1e-8, 1e-10],
         niter_array=[1000, 2500], mgrid_path=CONV_MGRID,
+        verbose=True,
+        emit=lambda value="", end="\n": lines.append(str(value) + end),
+    )
+    stages = _stage_iterations("".join(lines))
+    assert len(stages) == 2
+    # initialize_radial.f retains the coarse-grid residual module variables.
+    # On the first fine-grid pass they activate residue.f90's medge=1 gate,
+    # so the carried vacuum edge force is included immediately.  These are
+    # the local VMEC2000/PARVMEC screen values for the same public assets.
+    np.testing.assert_allclose(
+        [
+            stages[1]["first_fsqr"],
+            stages[1]["first_fsqz"],
+            stages[1]["first_fsql"],
+        ],
+        [1.73, 0.887, 1.51e-5],
+        rtol=1.5e-2,
     )
     reference = read_wout(CONV_WOUT)
     mine = {(int(m), int(n)): i for i, (m, n) in enumerate(zip(result.xm, result.xn))}

--- a/tests/test_geometry_fields.py
+++ b/tests/test_geometry_fields.py
@@ -38,6 +38,7 @@ from vmex.core.geometry import (
     real_space_geometry,
 )
 from vmex.core.input import VmecInput
+from vmex.core.setup import run_setup
 from vmex.core.solver import (
     _geometry,
     _initial_state,
@@ -63,7 +64,13 @@ def case(request):
     """Initial state + a pure new-core pipeline closure for one deck."""
     name = request.param
     inp = VmecInput.from_file(DATA_DIR / f"input.{name}")
-    rt = prepare_runtime(inp, resolution_from_input(inp))
+    resolution = resolution_from_input(inp)
+    # These are kernel tests, not production-driver tests: construct a
+    # regular geometry even when a public deck supplies an all-zero axis.
+    # Production intentionally starts from that supplied axis and lets
+    # eqsolve perform its single VMEC2000-compatible recovery transfer.
+    setup = run_setup(inp, resolution, infer_axis_if_missing=True)
+    rt = prepare_runtime(inp, resolution, setup=setup)
     setup = rt.setup
     state = _initial_state(setup)
     s = setup.s_full

--- a/tests/test_geometry_fields.py
+++ b/tests/test_geometry_fields.py
@@ -30,6 +30,7 @@ from vmex.core.fields import (
     energies_and_force_norms,
     magnetic_fields,
     metric_elements,
+    radial_force_balance_error,
     surface_currents,
 )
 from vmex.core.geometry import (
@@ -172,6 +173,57 @@ def test_surface_currents_finite(case):
         assert np.isfinite(float(getattr(cur, name))), name
     # The toroidal-field profile bvco must be nonzero away from the axis.
     assert np.max(np.abs(np.asarray(cur.bvco)[1:])) > 0.0
+
+
+def test_lforbal_uses_add_fluxes_full_mesh_chipf(case):
+    """calc_fbal consumes full-mesh chipf reconstructed from effective chips."""
+    currents = surface_currents(
+        bsubu=case.mf.bsubu,
+        bsubv=case.mf.bsubv,
+        trig=case.rt.trig,
+        s=case.s,
+        signgs=int(case.setup.signgs),
+    )
+    s = np.asarray(case.s)
+    hs = s[1] - s[0]
+    signgs = float(case.setup.signgs)
+    buco = np.asarray(currents.buco)
+    bvco = np.asarray(currents.bvco)
+    jcurv = signgs * (buco[2:] - buco[1:-1]) / hs
+    jcuru = -signgs * (bvco[2:] - bvco[1:-1]) / hs
+    vp = np.asarray(case.mf.vp)
+    pressure = np.asarray(case.mf.pressure)
+    vpphi = 0.5 * (vp[2:] + vp[1:-1])
+    presgrad = (pressure[2:] - pressure[1:-1]) / hs
+    chips = np.asarray(case.mf.chips)
+    chipf = np.empty_like(chips)
+    chipf[0] = 1.5 * chips[1] - 0.5 * chips[2]
+    chipf[1:-1] = 0.5 * (chips[1:-1] + chips[2:])
+    chipf[-1] = 1.5 * chips[-1] - 0.5 * chips[-2]
+    expected = np.zeros_like(chips)
+    expected[1:-1] = (
+        -np.asarray(case.setup.phipf)[1:-1] * jcuru
+        + chipf[1:-1] * jcurv
+    ) / vpphi + presgrad
+
+    actual = radial_force_balance_error(
+        fields=case.mf,
+        phipf=case.setup.phipf,
+        trig=case.rt.trig,
+        s=case.s,
+        signgs=int(case.setup.signgs),
+    )
+    np.testing.assert_allclose(actual, expected, rtol=2e-13, atol=2e-14)
+
+    if case.name == "cth_like_fixed_bdy":
+        half_mesh_substitution = np.zeros_like(chips)
+        half_mesh_substitution[1:-1] = (
+            -np.asarray(case.setup.phipf)[1:-1] * jcuru
+            + chips[1:-1] * jcurv
+        ) / vpphi + presgrad
+        assert not np.allclose(
+            actual, half_mesh_substitution, rtol=1e-8, atol=1e-12
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -14,6 +14,7 @@ from vmex.core import device as device_policy
 from vmex.core import implicit as im
 from vmex.core import freeboundary, multigrid, solver
 from vmex.core.input import VmecInput
+from vmex.core.mgrid import MgridField
 
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "examples" / "data"
@@ -124,15 +125,17 @@ def test_multigrid_auto_moves_state_across_policy_threshold(monkeypatch):
     assert seen == ["cpu", "gpu"]
 
 
-def test_explicit_free_boundary_nestor_cpu_gpu_parity(monkeypatch):
-    """A bounded real-mgrid run reaches NESTOR on each requested device."""
+def test_explicit_free_boundary_multigrid_cpu_gpu_parity(monkeypatch):
+    """A bounded real-mgrid ladder reaches NESTOR on each requested device."""
     inp = VmecInput.from_file(DATA_DIR / "input.cth_like_free_bdy_lasym_small")
     mgrid = DATA_DIR / "mgrid_cth_like_lasym_small.nc"
     results = {}
     output = {}
     active_platform = ["cpu"]
     vacuum_devices = {}
+    stage_devices = {"cpu": [], "gpu": []}
     vacuum_step = freeboundary._vacuum_step
+    solve_stage = freeboundary._solve_free_boundary_stage
 
     def recording_vacuum_step(*args, **kwargs):
         value = vacuum_step(*args, **kwargs)
@@ -144,14 +147,37 @@ def test_explicit_free_boundary_nestor_cpu_gpu_parity(monkeypatch):
         return value
 
     monkeypatch.setattr(freeboundary, "_vacuum_step", recording_vacuum_step)
+
+    def recording_solve_stage(*args, **kwargs):
+        record = {
+            "field": {_platform(x) for x in jax.tree.leaves(
+                kwargs["external_field"])},
+        }
+        state = kwargs["initial_state"]
+        if state is not None:
+            record["state"] = {_platform(x) for x in jax.tree.leaves(state)}
+        vacuum = kwargs["vacuum_continuation"]
+        if vacuum is not None:
+            record["vacuum"] = {
+                _platform(getattr(vacuum, name))
+                for name in ("bsqvac", "rbsq", "mode_matrix", "bvec_nonsing", "potvac")
+            }
+        stage_devices[active_platform[0]].append(record)
+        return solve_stage(*args, **kwargs)
+
+    monkeypatch.setattr(
+        freeboundary, "_solve_free_boundary_stage", recording_solve_stage,
+    )
     for platform in ("cpu", "gpu"):
         active_platform[0] = platform
         lines = []
-        results[platform] = freeboundary.solve_free_boundary(
+        results[platform] = multigrid.solve_free_boundary_multigrid(
             inp,
             mgrid_path=mgrid,
-            max_iterations=60,
-            error_on_no_convergence=False,
+            ns_array=[7, 15],
+            ftol_array=[1e-10, 1e-10],
+            niter_array=[60, 5],
+            raise_on_max_iterations=False,
             verbose=True,
             emit=lambda *args, _lines=lines, **kwargs: _lines.append(
                 args[0] if args else ""
@@ -161,22 +187,104 @@ def test_explicit_free_boundary_nestor_cpu_gpu_parity(monkeypatch):
         output[platform] = "".join(lines)
 
     for platform in ("cpu", "gpu"):
-        assert results[platform].iterations == 60
+        assert results[platform].iterations == 5
         assert "VACUUM PRESSURE TURNED ON" in output[platform]
         assert _platform(results[platform].state.R_cos) == platform
         assert vacuum_devices[platform] == {platform}
+        assert stage_devices[platform][0]["field"] == {platform}
+        assert stage_devices[platform][1] == {
+            "field": {platform}, "state": {platform}, "vacuum": {platform},
+        }
     np.testing.assert_allclose(
         [results["gpu"].fsqr, results["gpu"].fsqz, results["gpu"].fsql],
         [results["cpu"].fsqr, results["cpu"].fsqz, results["cpu"].fsql],
         rtol=5e-9,
         atol=1e-12,
     )
-    for gpu_leaf, cpu_leaf in zip(
-        jax.tree.leaves(results["gpu"].state),
-        jax.tree.leaves(results["cpu"].state),
-        strict=True,
-    ):
-        np.testing.assert_allclose(gpu_leaf, cpu_leaf, rtol=5e-9, atol=1e-11)
+    gpu_state = np.concatenate([
+        np.asarray(x).ravel() for x in jax.tree.leaves(results["gpu"].state)
+    ])
+    cpu_state = np.concatenate([
+        np.asarray(x).ravel() for x in jax.tree.leaves(results["cpu"].state)
+    ])
+    delta = gpu_state - cpu_state
+    assert np.linalg.norm(delta) / np.linalg.norm(cpu_state) < 5e-6
+    assert np.max(np.abs(delta)) < 1e-6
+
+    resolution = solver.resolution_from_input(inp, ns=15)
+    restart_inputs = []
+
+    def recording_restart(*args, **kwargs):
+        restart_inputs.append(kwargs["initial_state"])
+        return solve_stage(*args, **kwargs)
+
+    monkeypatch.setattr(freeboundary, "_solve_free_boundary_stage", recording_restart)
+    for target, source in (("gpu", "cpu"), ("cpu", "gpu")):
+        seed = results[source].state
+        restarted = freeboundary.solve_free_boundary(
+            inp, mgrid_path=mgrid, resolution=resolution, max_iterations=1,
+            error_on_no_convergence=False, initial_state=seed, device=target,
+        )
+        assert _platform(restarted.state.R_cos) == target
+        assert _platform(restart_inputs[-1].R_cos) == target
+        np.testing.assert_array_equal(restart_inputs[-1].R_cos[-1], seed.R_cos[-1])
+        np.testing.assert_array_equal(restart_inputs[-1].Z_sin[-1], seed.Z_sin[-1])
+
+
+def test_free_boundary_multigrid_auto_relocates_every_carry(monkeypatch):
+    """AUTO may cross CPU/GPU between stages without retaining committed leaves."""
+    inp = VmecInput.from_file(DATA_DIR / "input.cth_like_free_bdy_lasym_small")
+    resolutions = [solver.resolution_from_input(inp, ns=ns) for ns in (7, 15)]
+    work = [device_policy.iteration_work(resolution) for resolution in resolutions]
+    monkeypatch.setattr(device_policy, "GPU_MIN_ITERATION_WORK", sum(work) // 2)
+    field = MgridField(
+        *(jax.numpy.ones((1, 1, 2, 2)) for _ in range(3)),
+        extcur=jax.numpy.ones(1), rmin=0.0, rmax=1.0,
+        zmin=-1.0, zmax=1.0, nfp=1,
+    )
+    seen = []
+
+    def fake_stage(_inp, **kwargs):
+        state = kwargs["initial_state"]
+        vacuum = kwargs["vacuum_continuation"]
+        seen.append({
+            "field": {_platform(x) for x in jax.tree.leaves(kwargs["external_field"])},
+            "state": None if state is None else {
+                _platform(x) for x in jax.tree.leaves(state)},
+            "vacuum": None if vacuum is None else {
+                _platform(getattr(vacuum, name))
+                for name in ("bsqvac", "rbsq", "mode_matrix", "bvec_nonsing", "potvac")
+            },
+            "constraint": None if kwargs["constraint_continuation"] is None else {
+                _platform(x) for x in kwargs["constraint_continuation"]},
+        })
+        ns, mnmax = kwargs["resolution"].ns, kwargs["resolution"].mnmax
+        arrays = [jax.numpy.zeros((ns, mnmax)) for _ in range(6)]
+        state = solver.SpectralState(*arrays)
+        cache = jax.numpy.zeros(1)
+        vacuum = freeboundary.FreeBoundaryState(
+            turned_on=True, bsqvac=cache, rbsq=cache, mode_matrix=cache,
+            bvec_nonsing=cache, potvac=cache,
+        )
+        result = type("Result", (), {"state": state})()
+        return freeboundary._FreeBoundaryStageResult(
+            result, vacuum, state, cache, cache,
+        )
+
+    monkeypatch.setattr(freeboundary, "_solve_free_boundary_stage", fake_stage)
+    result = multigrid.solve_free_boundary_multigrid(
+        inp, ns_array=[7, 15, 15], ftol_array=[1e-8], niter_array=[1],
+        external_field=field, raise_on_max_iterations=False, device="auto",
+    )
+
+    assert seen == [
+        {"field": {"cpu"}, "state": None, "vacuum": None, "constraint": None},
+        {"field": {"gpu"}, "state": {"gpu"}, "vacuum": {"gpu"},
+         "constraint": None},
+        {"field": {"gpu"}, "state": {"gpu"}, "vacuum": {"gpu"},
+         "constraint": {"gpu"}},
+    ]
+    assert _platform(result.state.R_cos) == "gpu"
 
 
 def test_explicit_implicit_gradient_cpu_gpu_parity():

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -852,13 +852,21 @@ def test_lasym_adjoint_vs_frozen_path_fd(lasym):
     zero = jax.tree.map(jnp.zeros_like, p0)
     print(f"\n[{name}] lasym adjoint vs frozen-path FD at refined fixed point "
           f"(base |F| = {base_res:.1e}):")
-    for field, idx in (("rbs", (ntor, 2)), ("zbc", (ntor, 2)), ("zbs", (ntor, 1))):
+    directions = (
+        # The zbc direction has the largest O(h^2) truncation coefficient on
+        # JAX 0.6.2.  h=5e-6 keeps that error below the adjoint tolerance while
+        # the other directions retain the less cancellation-sensitive 1e-5.
+        ("zbc", (ntor, 2), 5e-6),
+        ("rbs", (ntor, 2), 1e-5),
+        ("zbs", (ntor, 1), 1e-5),
+    )
+    for field, idx, h in directions:
         tangent = dataclasses.replace(
             zero, **{field: getattr(zero, field).at[idx].set(1.0)})
         an = analytic_dir(tangent)
-        fd = frozen_fd(tangent)
+        fd = frozen_fd(tangent, h=h)
         rel = abs(an / fd - 1.0) if fd else abs(an - fd)
-        print(f"  d(wb)/d({field}{idx}): analytic={an:+.9e} "
+        print(f"  d(wb)/d({field}{idx}), h={h:.0e}: analytic={an:+.9e} "
               f"frozen-FD={fd:+.9e} rel={rel:.2e}")
         assert rel <= 5e-5, f"{field}{idx}: adjoint vs frozen-path FD rel {rel:.2e}"
 

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -410,7 +410,7 @@ def test_gradient_independent_of_iteration_policy(solovev):
 
 def test_iota_edge_gradient_vs_frozen_path_fd():
     """``d(iota_edge)/d(boundary)`` on the 3D ``ncurr=1`` case — the hard case
-    from the collaborator AD-vs-FD feedback.  ``iota`` is derived from the
+    from the solver-sensitive AD-vs-FD regression.  ``iota`` is derived from the
     current-constrained ``chips``, so the metric reads the converged solver
     state and is *solver-sensitive*: a naive re-solve FD at ``p ± h`` lets the
     convergence logic re-form and gives the wrong answer (measured, ``h=1e-4``):

--- a/tests/test_input_profiles.py
+++ b/tests/test_input_profiles.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from vmex.core.input import VmecInput
+from vmex.core.input import UnsupportedInputModeError, VmecInput
 
 REPO = Path(__file__).resolve().parents[1]
 DATA = REPO / "examples" / "data"
@@ -110,6 +110,113 @@ def test_lfull3d1out_default_explicit_true_and_indata_round_trip(
     assert VmecInput.from_file(
         inp.to_indata(tmp_path / "input.lfull3d1out")
     ).lfull3d1out is True
+
+
+def test_legacy_ns_array_zero_expands_via_nsin() -> None:
+    """VMEC2000's explicit old-style sentinel builds the NSIN -> 31 ladder."""
+    inp = VmecInput.from_indata_text(
+        "&INDATA\nNS_ARRAY(1) = 0\nNSIN = 7\n/\n"
+    )
+    np.testing.assert_array_equal(inp.ns_array, [7, 31])
+
+
+def test_legacy_niter_scalar_fills_the_multigrid_ladder() -> None:
+    """NITER is the VMEC2000 fallback only when NITER_ARRAY is unassigned."""
+    inp = VmecInput.from_indata_text(
+        "&INDATA\nNS_ARRAY = 7, 15\nNITER = 321\n/\n"
+    )
+    np.testing.assert_array_equal(inp.niter_array, [321, 321])
+
+
+@pytest.mark.parametrize(
+    ("body", "code"),
+    [
+        ("LRECON=T\nIMSE=1", "D00A_RECONSTRUCTION_MODE_UNSUPPORTED"),
+        ("LRFP=T", "D00B_RFP_MODE_UNSUPPORTED"),
+        ("TRIP3D_FILE='field.nc'", "D00E_TRIP3D_MODE_UNSUPPORTED"),
+        ("AH(0)=0.1", "D00F_ANIMEC_MODE_UNSUPPORTED"),
+        ("AT=0.9", "D00F_ANIMEC_MODE_UNSUPPORTED"),
+        ("TVOLUME=10.0", "D00G_VOLUME_RESCALE_UNSUPPORTED"),
+        ("PRECON_TYPE='CG'", "D00H_PRECONDITIONER_MODE_UNSUPPORTED"),
+        (
+            "PRECON_TYPE='GMRES'\nPRE_NITER=20",
+            "D00I_ITERATION_CONTROL_UNSUPPORTED",
+        ),
+        ("MAX_MAIN_ITERATIONS=2", "D00I_ITERATION_CONTROL_UNSUPPORTED"),
+        ("LGIVEUP=T", "D00I_ITERATION_CONTROL_UNSUPPORTED"),
+        ("LBSUBS=T", "D00J_OUTPUT_MODE_UNSUPPORTED"),
+        ("LNYQUIST=F", "D00J_OUTPUT_MODE_UNSUPPORTED"),
+        ("LBOOZ=T", "D00J_OUTPUT_MODE_UNSUPPORTED"),
+    ],
+)
+def test_active_unsupported_indata_modes_fail_in_production_parser(
+    body: str, code: str,
+) -> None:
+    """A parsed control must never silently select an ordinary VMEX solve."""
+    with pytest.raises(UnsupportedInputModeError) as caught:
+        VmecInput.from_indata_text(f"&INDATA\n{body}\n/\n")
+    assert caught.value.code == code
+
+
+def test_neutral_legacy_modes_remain_accepted() -> None:
+    """Default-valued legacy controls do not require deck surgery."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        LRECON = T
+        IMSE = -1
+        ITSE = 0
+        LRFP = F
+        TRIP3D_FILE = 'NONE'
+        AH = 0.0
+        AT = 1.0, 0.0
+        TVOLUME = -1.0
+        PRECON_TYPE = 'DEFAULT'
+        PRE_NITER = -1
+        MAX_MAIN_ITERATIONS = 1
+        LGIVEUP = F
+        LBSUBS = F
+        LNYQUIST = T
+        LBOOZ = F
+        LDIAGNO = F
+        /
+        """
+    )
+    assert inp.precon_type == "DEFAULT"
+
+
+def test_time_slice_reaches_vmec_style_run_header() -> None:
+    """The informational VMEC header field must not be parsed and discarded."""
+    from vmex.core.cli import _preamble
+
+    inp = VmecInput.from_indata_text("&INDATA\nTIME_SLICE=1.25\n/\n")
+    assert "TIME SLICE  1.2500E+00" in _preamble(
+        "case", time_slice=inp.time_slice
+    )
+
+
+def test_unimplemented_legacy_artifact_request_warns() -> None:
+    """An output-only compatibility flag is allowed but never silently ignored."""
+    with pytest.warns(RuntimeWarning, match="LDIAGNO.*not implemented"):
+        VmecInput.from_indata_text("&INDATA\nLDIAGNO=T\n/\n")
+
+
+def test_vmecpp_json_modes_and_unknown_keys_are_not_ignored() -> None:
+    """VMEC++ model selection and misspelled keys fail before setup."""
+    with pytest.raises(
+        UnsupportedInputModeError,
+        match="free_boundary_method",
+    ) as caught:
+        VmecInput.from_json_text('{"free_boundary_method": "only_coils"}')
+    assert caught.value.code == "D00K_FREE_BOUNDARY_METHOD_UNSUPPORTED"
+
+    with pytest.raises(ValueError, match="unknown VMEC\\+\\+ JSON input key"):
+        VmecInput.from_json_text('{"free_boundary_method": "nestor", "mpoll": 6}')
+
+
+def test_unknown_indata_name_is_not_ignored() -> None:
+    """A misspelled physics control cannot become an accidental default."""
+    with pytest.raises(ValueError, match="unknown INDATA variable.*PHIEDG"):
+        VmecInput.from_indata_text("&INDATA\nPHIEDG = 0.5\n/\n")
 
 
 def test_indexed_indata_vectors_overlay_vmec_defaults() -> None:

--- a/tests/test_input_profiles.py
+++ b/tests/test_input_profiles.py
@@ -175,6 +175,48 @@ def test_indexed_aphi_section_uses_fortran_inclusive_bounds() -> None:
     np.testing.assert_array_equal(inp.aphi[:4], [1.0, 0.25, 0.5, 0.0])
 
 
+def test_boundary_section_accepts_toroidal_mode_range() -> None:
+    """VMEC boundary rows accept compact ``RBC(nlo:nhi,m)`` assignments."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        MPOL = 2
+        NTOR = 2
+        RBC(-2:2,0) = 1.0, 2.0, 3.0, 4.0, 5.0
+        ZBS(-2:2,1) = -1.0, -2.0, -3.0, -4.0, -5.0
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.rbc[:, 0], [1.0, 2.0, 3.0, 4.0, 5.0])
+    np.testing.assert_array_equal(inp.zbs[:, 1], [-1.0, -2.0, -3.0, -4.0, -5.0])
+
+
+def test_boundary_section_uses_fortran_column_major_order() -> None:
+    """The first boundary subscript varies fastest, as in Fortran namelists."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        MPOL = 2
+        NTOR = 1
+        RBC(-1:1,0:1) = 1.0, 2.0, 3.0, 4.0, 5.0, 6.0
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.rbc[:, 0], [1.0, 2.0, 3.0])
+    np.testing.assert_array_equal(inp.rbc[:, 1], [4.0, 5.0, 6.0])
+
+
+def test_boundary_section_accepts_negative_stride() -> None:
+    """Inclusive section bounds and negative strides follow Fortran syntax."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        MPOL = 2
+        NTOR = 2
+        RBC(2:-2:-2,0) = 1.0, 2.0, 3.0
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.rbc[:, 0], [3.0, 0.0, 2.0, 0.0, 1.0])
+
+
 def test_indexed_legacy_axis_overlays_vmec_axis() -> None:
     """Indexed obsolete RAXIS/ZAXIS entries retain VMEC2000 compatibility."""
     inp = VmecInput.from_indata_text(

--- a/tests/test_input_profiles.py
+++ b/tests/test_input_profiles.py
@@ -66,6 +66,7 @@ def test_vmecpp_json_example() -> None:
     assert new.lfreeb is False  # VMEC++ default
     assert new.gamma == 0.0  # default (JSON alias: adiabatic_index)
     assert new.mgrid_file == "NONE"
+    assert new.lmove_axis is True
 
     # And it survives both writers.
     import tempfile
@@ -73,6 +74,18 @@ def test_vmecpp_json_example() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         assert VmecInput.from_file(new.to_json(Path(tmp) / "x.json")) == new
         assert VmecInput.from_file(new.to_indata(Path(tmp) / "input.x")) == new
+
+
+def test_lmove_axis_default_explicit_false_and_indata_round_trip(
+    tmp_path: Path,
+) -> None:
+    """VMEC2000 defaults LMOVE_AXIS=T and permits an explicit opt-out."""
+    assert VmecInput.from_indata_text("&INDATA\n/\n").lmove_axis is True
+    inp = VmecInput.from_indata_text("&INDATA\nLMOVE_AXIS = F\n/\n")
+    assert inp.lmove_axis is False
+    assert VmecInput.from_file(
+        inp.to_indata(tmp_path / "input.lmove_axis")
+    ).lmove_axis is False
 
 
 def test_indexed_indata_vectors_overlay_vmec_defaults() -> None:

--- a/tests/test_input_profiles.py
+++ b/tests/test_input_profiles.py
@@ -66,6 +66,7 @@ def test_vmecpp_json_example() -> None:
     assert new.lfreeb is False  # VMEC++ default
     assert new.gamma == 0.0  # default (JSON alias: adiabatic_index)
     assert new.mgrid_file == "NONE"
+    assert new.precon_type == "NONE"
     assert new.lmove_axis is True
 
     # And it survives both writers.
@@ -126,6 +127,65 @@ def test_legacy_niter_scalar_fills_the_multigrid_ladder() -> None:
         "&INDATA\nNS_ARRAY = 7, 15\nNITER = 321\n/\n"
     )
     np.testing.assert_array_equal(inp.niter_array, [321, 321])
+
+
+def test_readin_stops_at_first_decreasing_ns_entry() -> None:
+    """Later resolutions do not resume after readin.f closes multi_ns_grid."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        NS_ARRAY = 21, 34, 20, 55
+        FTOL_ARRAY = 1e-7, 1e-8, 1e-9, 1e-10
+        NITER_ARRAY = 100, 200, 300, 400
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.ns_array, [21, 34])
+    np.testing.assert_array_equal(inp.ftol_array, [1e-7, 1e-8])
+    np.testing.assert_array_equal(inp.niter_array, [100, 200])
+
+
+def test_zero_first_ftol_builds_vmec2000_geometric_ladder() -> None:
+    """readin.f interpolates from 1e-8 to scalar FTOL across the ladder."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        NS_ARRAY = 21, 34, 55, 89
+        FTOL = 1e-14
+        FTOL_ARRAY(1) = 0.0
+        /
+        """
+    )
+    expected = 1.0e-8 * (1.0e-6 ** (np.arange(4) / 3.0))
+    np.testing.assert_allclose(inp.ftol_array, expected, rtol=1e-15)
+    assert inp.ftol_array[-1] == pytest.approx(1e-14)
+
+
+def test_partial_niter_array_preserves_unassigned_minus_one_entries() -> None:
+    """Any explicit NITER_ARRAY write disables the all--1 scalar fallback."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        NS_ARRAY = 21, 34, 55
+        NITER = 999
+        NITER_ARRAY(2) = 400
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.niter_array, [-1, 400, -1])
+
+
+def test_partial_niter_minus_one_executes_one_vmec_pass() -> None:
+    """eqsolve evaluates once before its ``iter2 >= niter`` termination."""
+    from vmex.core.solver import prepare_runtime, resolution_from_input
+
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        NS_ARRAY = 7, 11
+        NITER_ARRAY(2) = 400
+        /
+        """
+    )
+    runtime = prepare_runtime(inp, resolution_from_input(inp, ns=7))
+    assert inp.niter_array[0] == -1
+    assert runtime.max_iterations == 1
 
 
 @pytest.mark.parametrize(
@@ -359,6 +419,75 @@ def test_boundary_section_accepts_negative_stride() -> None:
         """
     )
     np.testing.assert_array_equal(inp.rbc[:, 0], [3.0, 0.0, 2.0, 0.0, 1.0])
+
+
+def test_negative_stride_section_uses_fortran_default_bounds() -> None:
+    """Omitted bounds reverse the declared extent when the stride is negative."""
+    values = ", ".join(str(value) for value in range(1, 21))
+    inp = VmecInput.from_indata_text(
+        f"""&INDATA
+        APHI(::-1) = {values}
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.aphi[:3], [20.0, 19.0, 18.0])
+
+
+def test_repeated_dense_assignments_overlay_in_source_order() -> None:
+    """A short later assignment preserves the earlier Fortran array tail."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        NS_ARRAY = 11, 25, 49, 75
+        FTOL_ARRAY = 1e-7, 1e-8, 1e-9, 1e-10
+        FTOL_ARRAY = 1e-6, 1e-11
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.ns_array, [11, 25, 49, 75])
+    np.testing.assert_array_equal(inp.ftol_array, [1e-6, 1e-11, 1e-9, 1e-10])
+
+
+def test_dense_and_indexed_assignments_honor_source_order() -> None:
+    """Later dense writes override earlier indexed elements, not vice versa."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        APHI(2) = 0.25
+        APHI = 0.0, 1.0
+        APHI(3) = 0.5
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.aphi[:4], [0.0, 1.0, 0.5, 0.0])
+
+
+def test_multidimensional_starting_element_continues_in_fortran_order() -> None:
+    """Multiple values after ``RBC(n,m)`` continue with n varying fastest."""
+    inp = VmecInput.from_indata_text(
+        """&INDATA
+        MPOL = 2
+        NTOR = 2
+        RBC(-1,0) = 1.0, 2.0, 3.0, 4.0
+        /
+        """
+    )
+    np.testing.assert_array_equal(inp.rbc[:, 0], [0.0, 1.0, 2.0, 3.0, 4.0])
+
+
+@pytest.mark.parametrize("designator", ["RBC", "RBC(:,0)", "RBC(-101:,0)"])
+def test_dense_and_open_boundary_sections_use_declared_fortran_bounds(
+    designator: str,
+) -> None:
+    """Whole/open sections are resolved from VMEC2000's allocated bounds."""
+    inp = VmecInput.from_indata_text(
+        f"""&INDATA
+        MPOL = 2
+        NTOR = 1
+        {designator} = 101*0.0, 2.5
+        /
+        """
+    )
+    assert inp.rbc[1, 0] == 2.5  # physical n=0 at row ntor
+    assert np.count_nonzero(inp.rbc) == 1
 
 
 def test_indexed_legacy_axis_overlays_vmec_axis() -> None:

--- a/tests/test_input_profiles.py
+++ b/tests/test_input_profiles.py
@@ -88,6 +88,30 @@ def test_lmove_axis_default_explicit_false_and_indata_round_trip(
     ).lmove_axis is False
 
 
+def test_lforbal_default_explicit_true_and_indata_round_trip(
+    tmp_path: Path,
+) -> None:
+    """VMEC2000 defaults LFORBAL=F and supports the active replacement."""
+    assert VmecInput.from_indata_text("&INDATA\n/\n").lforbal is False
+    inp = VmecInput.from_indata_text("&INDATA\nLFORBAL = T\n/\n")
+    assert inp.lforbal is True
+    assert VmecInput.from_file(
+        inp.to_indata(tmp_path / "input.lforbal")
+    ).lforbal is True
+
+
+def test_lfull3d1out_default_explicit_true_and_indata_round_trip(
+    tmp_path: Path,
+) -> None:
+    """VMEC2000 defaults LFULL3D1OUT=F and permits an explicit WOUT request."""
+    assert VmecInput.from_indata_text("&INDATA\n/\n").lfull3d1out is False
+    inp = VmecInput.from_indata_text("&INDATA\nLFULL3D1OUT = T\n/\n")
+    assert inp.lfull3d1out is True
+    assert VmecInput.from_file(
+        inp.to_indata(tmp_path / "input.lfull3d1out")
+    ).lfull3d1out is True
+
+
 def test_indexed_indata_vectors_overlay_vmec_defaults() -> None:
     """Indexed 1-D assignments follow VMEC2000 namelist lower bounds/defaults."""
     inp = VmecInput.from_indata_text(

--- a/tests/test_mgrid.py
+++ b/tests/test_mgrid.py
@@ -20,7 +20,9 @@ jax = pytest.importorskip("jax")
 import jax.numpy as jnp  # noqa: E402
 
 from vmex.core.errors import MgridNotFoundError  # noqa: E402
-from vmex.core.mgrid import MgridData, MgridField, read_mgrid, write_mgrid  # noqa: E402
+from vmex.core.mgrid import (  # noqa: E402
+    MgridData, MgridField, read_mgrid, tabulate_cartesian_field, write_mgrid,
+)
 
 REPO = Path(__file__).resolve().parents[1]
 MGRID_PATH = REPO / "examples" / "data" / "mgrid_cth_like_lasym_small.nc"
@@ -121,6 +123,82 @@ def test_grad_wrt_extcur_finite_nonzero(data: MgridData) -> None:
     assert g_np.shape == (data.nextcur,)
     assert np.all(np.isfinite(g_np))
     assert np.max(np.abs(g_np)) > 0.0
+
+
+def test_tabulate_cartesian_callable_and_cylindrical_conversion() -> None:
+    def field(points):
+        p = np.asarray(points)
+        return np.stack((2.0 + 0.1 * p[:, 0], -3.0 + 0.2 * p[:, 1],
+                         4.0 + 0.3 * p[:, 2]), axis=-1)
+
+    data = tabulate_cartesian_field(
+        field, rmin=0.5, rmax=1.5, zmin=-0.4, zmax=0.4,
+        ir=5, jz=4, kp=12, nfp=2,
+    )
+    sampled = MgridField.from_mgrid_data(data, extcur=[1.7])
+    # Test exact grid points: no interpolation error obscures the Cartesian
+    # -> cylindrical convention.
+    phi = np.arange(data.kp) * 2.0 * np.pi / (data.nfp * data.kp)
+    r = np.full_like(phi, 1.0)
+    z = np.zeros_like(phi)
+    xyz = np.stack((r * np.cos(phi), r * np.sin(phi), z), axis=-1)
+    direct = 1.7 * field(xyz)
+    br, bp, bz = (np.asarray(v) for v in sampled.b_cyl(r, phi, z))
+    np.testing.assert_allclose(br, direct[:, 0] * np.cos(phi) + direct[:, 1] * np.sin(phi))
+    np.testing.assert_allclose(bp, -direct[:, 0] * np.sin(phi) + direct[:, 1] * np.cos(phi))
+    np.testing.assert_allclose(bz, direct[:, 2])
+
+
+def test_tabulate_simsopt_set_points_protocol() -> None:
+    class FakeSimsoptField:
+        def set_points(self, points):
+            self.points = np.asarray(points)
+
+        def B(self):
+            return np.column_stack((self.points[:, 0] * 0 + 1.0,
+                                    self.points[:, 1] * 0 + 2.0,
+                                    self.points[:, 2] * 0 + 3.0))
+
+    data = tabulate_cartesian_field(
+        FakeSimsoptField(), rmin=0.4, rmax=1.0, zmin=-0.2, zmax=0.2,
+        ir=3, jz=3, kp=5, nfp=1,
+    )
+    assert data.br.shape == (1, 5, 3, 3)
+    assert np.all(np.isfinite(data.br))
+    assert np.all(np.isfinite(data.bp))
+    np.testing.assert_allclose(data.bz, 3.0)
+
+
+def test_tabulate_actual_essos_biot_savart() -> None:
+    pytest.importorskip("essos")
+    from essos.coils import Coils, Curves
+    from essos.fields import BiotSavart
+
+    dofs = np.zeros((2, 3, 3))
+    for i, phi0 in enumerate((0.2, 0.8)):
+        dofs[i, 0, 0], dofs[i, 0, 2] = 0.8 * np.cos(phi0), 0.25 * np.cos(phi0)
+        dofs[i, 1, 0], dofs[i, 1, 2] = 0.8 * np.sin(phi0), 0.25 * np.sin(phi0)
+        dofs[i, 2, 1] = 0.25
+    bs = BiotSavart(Coils(Curves(jnp.asarray(dofs), 32, 1, False),
+                          jnp.asarray([1.0e5, -0.7e5])))
+    data = tabulate_cartesian_field(
+        bs, rmin=0.25, rmax=0.55, zmin=-0.15, zmax=0.15,
+        ir=3, jz=3, kp=4, nfp=1,
+    )
+    assert np.all(np.isfinite(data.br))
+    # At table nodes, cylindrical components must reconstruct ESSOS' direct
+    # Cartesian field to roundoff.
+    k, j, i = 1, 1, 1
+    phi = k * 2.0 * np.pi / data.kp
+    r = np.linspace(data.rmin, data.rmax, data.ir)[i]
+    z = np.linspace(data.zmin, data.zmax, data.jz)[j]
+    direct = np.asarray(bs.B(jnp.asarray([r * np.cos(phi), r * np.sin(phi), z])))
+    reconstructed = np.asarray([
+        data.br[0, k, j, i] * np.cos(phi) - data.bp[0, k, j, i] * np.sin(phi),
+        data.br[0, k, j, i] * np.sin(phi) + data.bp[0, k, j, i] * np.cos(phi),
+        data.bz[0, k, j, i],
+    ])
+    np.testing.assert_allclose(reconstructed, direct, rtol=1e-13, atol=1e-15)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_multigrid_ladder.py
+++ b/tests/test_multigrid_ladder.py
@@ -63,6 +63,7 @@ import jax
 jax.config.update("jax_enable_x64", True)
 
 from vmex.core import multigrid, solver
+from vmex.core.errors import VmecJacobianError
 from vmex.core.input import VmecInput
 
 pytestmark = pytest.mark.usefixtures("_module_jit_enabled")  # full solves: run jitted
@@ -305,6 +306,45 @@ def test_lmove_axis_high_first_force_retry_and_opt_out(capsys) -> None:
     output = capsys.readouterr().out
     assert "TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS" not in output
     assert not_retried.fsq_history[0, :3].sum() > 1.0e2
+
+
+def test_jac75_best_checkpoint_retry_converges_to_same_equilibrium(
+    capsys,
+) -> None:
+    """VMEX's bounded recovery replaces VMEC's manual change-DELT rerun."""
+    import dataclasses
+
+    base = dataclasses.replace(
+        _load_input("solovev"),
+        lforbal=True,
+        ns_array=np.asarray([11]),
+        ftol_array=np.asarray([1.0e-7]),
+        niter_array=np.asarray([500]),
+        delt=0.5,
+    )
+    reference = multigrid.solve_multigrid(
+        base, device="cpu", jacobian_retries=0,
+    )
+
+    unstable = dataclasses.replace(base, delt=1.0e4)
+    with pytest.raises(VmecJacobianError) as exc:
+        multigrid.solve_multigrid(
+            unstable, device="cpu", jacobian_retries=0,
+        )
+    assert exc.value.jacobian_resets == 75
+
+    recovered = multigrid.solve_multigrid(
+        unstable, device="cpu", jacobian_retries=2, verbose=True,
+    )
+    output = capsys.readouterr().out
+    assert "JACOBIAN RECOVERY RETRY 1/2" in output
+    assert recovered.converged
+    np.testing.assert_allclose(
+        [recovered.wb, recovered.wp, recovered.r00],
+        [reference.wb, reference.wp, reference.r00],
+        rtol=2.0e-12,
+        atol=2.0e-14,
+    )
 
 
 def test_lforbal_thirty_rows_and_cache_refresh_match_vmec2000() -> None:

--- a/tests/test_multigrid_ladder.py
+++ b/tests/test_multigrid_ladder.py
@@ -253,6 +253,25 @@ def test_ladder_skips_decreasing_stages():
                                rtol=5e-12)
 
 
+def test_ladder_forwards_explicit_2d_preconditioner(monkeypatch):
+    seen = []
+    marker = object()
+
+    def stop_after_prepare(*args, **kwargs):
+        seen.append(kwargs)
+        raise RuntimeError("stop")
+
+    monkeypatch.setattr(multigrid, "prepare_runtime", stop_after_prepare)
+    with pytest.raises(RuntimeError, match="stop"):
+        multigrid.solve_multigrid(
+            _load_input("cth_like_fixed_bdy"), ns_array=[5],
+            precon_type="NONE", prec2d_threshold=3e-7, prec2d=marker,
+        )
+    assert seen[0]["precon_type"] == "NONE"
+    assert seen[0]["prec2d_threshold"] == 3e-7
+    assert seen[0]["prec2d"] is marker
+
+
 # ---------------------------------------------------------------------------
 # TASK B: compile counts + wall time (cold subprocesses)
 # ---------------------------------------------------------------------------

--- a/tests/test_multigrid_ladder.py
+++ b/tests/test_multigrid_ladder.py
@@ -243,15 +243,23 @@ def test_qh_ladder_wb_matches_direct_1e10_target():
     assert abs(ladder.wb / direct.wb - 1.0) < 1e-10
 
 
-def test_ladder_skips_decreasing_stages():
-    """runvmec.f: decreasing NS_ARRAY entries are skipped, equal re-run."""
-    result = multigrid.solve_multigrid(
+def test_ladder_stops_at_first_decreasing_stage():
+    """readin.f excludes the first decreasing entry and every later value."""
+    stopped = multigrid.solve_multigrid(
         _load_input("cth_like_fixed_bdy"), ns_array=[5, 9, 5, 15],
         ftol_array=[1e-8, 1e-10, 1e-10, 1e-14], niter_array=[25000],
     )
-    assert result.converged
-    np.testing.assert_allclose(result.wb, VMEC2000_LADDER_WB["cth_like_fixed_bdy"],
-                               rtol=5e-12)
+    reference = multigrid.solve_multigrid(
+        _load_input("cth_like_fixed_bdy"), ns_array=[5, 9],
+        ftol_array=[1e-8, 1e-10], niter_array=[25000],
+    )
+    assert stopped.converged and reference.converged
+    np.testing.assert_allclose(
+        [stopped.wb, stopped.wp, stopped.r00],
+        [reference.wb, reference.wp, reference.r00],
+        rtol=2e-13,
+        atol=2e-14,
+    )
 
 
 def test_ladder_forwards_explicit_2d_preconditioner(monkeypatch):
@@ -338,6 +346,7 @@ def test_jac75_best_checkpoint_retry_converges_to_same_equilibrium(
     )
     output = capsys.readouterr().out
     assert "JACOBIAN RECOVERY RETRY 1/2" in output
+    assert "TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS" not in output
     assert recovered.converged
     np.testing.assert_allclose(
         [recovered.wb, recovered.wp, recovered.r00],
@@ -391,7 +400,7 @@ def test_lforbal_thirty_rows_and_cache_refresh_match_vmec2000() -> None:
     assert result.r00 == pytest.approx(3.9897106225, rel=2e-10)
     assert result.wmhd == pytest.approx(2.5489005543, rel=2e-10)
 
-    # Collaborator regression: before this port, deleting LFORBAL produced
+    # Regression coverage: before this port, deleting LFORBAL produced
     # the same trajectory because the normal solver silently ignored the
     # flag.  The supported default-F formulation remains the established
     # VMEC2000 row and is now detectably distinct from the T formulation.

--- a/tests/test_multigrid_ladder.py
+++ b/tests/test_multigrid_ladder.py
@@ -307,6 +307,71 @@ def test_lmove_axis_high_first_force_retry_and_opt_out(capsys) -> None:
     assert not_retried.fsq_history[0, :3].sum() > 1.0e2
 
 
+def test_lforbal_thirty_rows_and_cache_refresh_match_vmec2000() -> None:
+    """Non-variational m=1 balance matches across the ns4=25 refresh."""
+    import dataclasses
+
+    inp = dataclasses.replace(
+        _load_input("solovev"),
+        lforbal=True,
+        lmove_axis=False,
+        nstep=25,
+        niter_array=np.asarray([30]),
+        ftol_array=np.asarray([1.0e-30]),
+    )
+    result = multigrid.solve_multigrid(
+        inp, raise_on_max_iterations=False, device="cpu"
+    )
+    # Fresh local xvmec2000/PARVMEC 9.0 run of this public deck prints:
+    #   1  8.33E-02  4.94E-04  3.21E-02
+    #   2  6.82E-03  1.41E-03  4.37E-03
+    #   3  1.52E-02  9.15E-04  6.98E-03
+    expected_first = [
+        ["8.33E-02", "4.94E-04", "3.21E-02"],
+        ["6.82E-03", "1.41E-03", "4.37E-03"],
+        ["1.52E-02", "9.15E-04", "6.98E-03"],
+    ]
+    got_first = [
+        [f"{value:.2E}" for value in row[:3]]
+        for row in result.fsq_history[:3]
+    ]
+    assert got_first == expected_first
+    # A fresh local xvmec2000/PARVMEC 9.0 run also prints
+    #  25  4.24E-03  8.46E-04  1.39E-03
+    #  30  6.47E-04  4.25E-04  4.89E-04
+    # so the row after VMEC's iteration-26 cache refresh is covered, not
+    # merely the initial frozen force-balance factors.
+    assert [
+        [f"{value:.2E}" for value in result.fsq_history[i, :3]]
+        for i in (24, 29)
+    ] == [
+        ["4.24E-03", "8.46E-04", "1.39E-03"],
+        ["6.47E-04", "4.25E-04", "4.89E-04"],
+    ]
+    assert result.r00 == pytest.approx(3.9897106225, rel=2e-10)
+    assert result.wmhd == pytest.approx(2.5489005543, rel=2e-10)
+
+    # Collaborator regression: before this port, deleting LFORBAL produced
+    # the same trajectory because the normal solver silently ignored the
+    # flag.  The supported default-F formulation remains the established
+    # VMEC2000 row and is now detectably distinct from the T formulation.
+    variational = multigrid.solve_multigrid(
+        dataclasses.replace(
+            inp,
+            lforbal=False,
+            niter_array=np.asarray([1]),
+        ),
+        raise_on_max_iterations=False,
+        device="cpu",
+    )
+    assert [f"{value:.2E}" for value in variational.fsq_history[0, :3]] == [
+        "9.41E-02", "2.76E-03", "3.21E-02",
+    ]
+    assert not np.allclose(
+        variational.fsq_history[0, :2], result.fsq_history[0, :2]
+    )
+
+
 def test_niter_exhausted_stage_transfers_final_xc_like_vmec2000() -> None:
     """allocate_ns.f overwrites xstore from old final xc before interp.f."""
     inp = _load_input("solovev")

--- a/tests/test_multigrid_ladder.py
+++ b/tests/test_multigrid_ladder.py
@@ -272,6 +272,60 @@ def test_ladder_forwards_explicit_2d_preconditioner(monkeypatch):
     assert seen[0]["prec2d"] is marker
 
 
+def test_lmove_axis_high_first_force_retry_and_opt_out(capsys) -> None:
+    """funct3d.f irst=4: finite first force >1e2 retries the axis once."""
+    import dataclasses
+
+    inp = _load_input("solovev")
+    bad_axis = np.asarray([4.4])
+    enabled = dataclasses.replace(
+        inp, raxis_c=bad_axis, niter_array=np.asarray([2]), nstep=1,
+        lmove_axis=True,
+    )
+    retried = multigrid.solve_multigrid(
+        enabled, raise_on_max_iterations=False, verbose=True,
+    )
+    output = capsys.readouterr().out
+    assert "TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS" in output
+    # Local xvmec2000/PARVMEC 9.0 gives these same first two post-retry rows.
+    np.testing.assert_allclose(
+        retried.fsq_history[:, :3],
+        [
+            [0.03502655, 0.00397168, 0.01427437],
+            [0.09080383, 0.08646060, 0.11152927],
+        ],
+        rtol=2e-6,
+    )
+    assert retried.r00 == pytest.approx(3.8237007872, rel=2e-10)
+
+    disabled = dataclasses.replace(enabled, lmove_axis=False)
+    not_retried = multigrid.solve_multigrid(
+        disabled, raise_on_max_iterations=False, verbose=True,
+    )
+    output = capsys.readouterr().out
+    assert "TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS" not in output
+    assert not_retried.fsq_history[0, :3].sum() > 1.0e2
+
+
+def test_niter_exhausted_stage_transfers_final_xc_like_vmec2000() -> None:
+    """allocate_ns.f overwrites xstore from old final xc before interp.f."""
+    inp = _load_input("solovev")
+    result = multigrid.solve_multigrid(
+        inp, ns_array=[7, 11], ftol_array=[1e-30, 1e-30],
+        niter_array=[2, 1], raise_on_max_iterations=False,
+    )
+    # Local xvmec2000/PARVMEC 9.0 on this public ladder prints, at the first
+    # ns=11 pass: 1.86E-02, 1.09E-03, 7.46E-03, RAX=3.864.  Interpolating the
+    # best-residual checkpoint instead gives the detectably different
+    # 8.29E-03, 8.16E-04, 4.68E-03, RAX=3.936.
+    np.testing.assert_allclose(
+        result.fsq_history[0, :3],
+        [0.01861506, 0.00108547, 0.00745712],
+        rtol=2e-6,
+    )
+    assert result.r00 == pytest.approx(3.8635255062, rel=2e-10)
+
+
 # ---------------------------------------------------------------------------
 # TASK B: compile counts + wall time (cold subprocesses)
 # ---------------------------------------------------------------------------

--- a/tests/test_nonfinite_failfast.py
+++ b/tests/test_nonfinite_failfast.py
@@ -84,6 +84,20 @@ def test_shareable_diagnostic_flags_unsupported_reconstruction(
     assert "RBC" not in output
 
 
+def test_shareable_diagnostic_uses_production_mode_classification(
+    tmp_path: Path, capsys,
+) -> None:
+    """A production-rejected model gets a stable value-free diagnostic code."""
+    path = tmp_path / "input.private_trip3d"
+    path.write_text("&INDATA\nTRIP3D_FILE='private_field_name.nc'\n/\n")
+    assert diagnose(path) == 1
+    output = capsys.readouterr().out
+    assert "input parsing: PASS" in output
+    assert "D00E_TRIP3D_MODE_UNSUPPORTED" in output
+    assert "private_trip3d" not in output
+    assert "private_field_name" not in output
+
+
 def test_shareable_diagnostic_supports_lforbal(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_nonfinite_failfast.py
+++ b/tests/test_nonfinite_failfast.py
@@ -83,6 +83,28 @@ def test_shareable_diagnostic_flags_unsupported_reconstruction(
     assert "RBC" not in output
 
 
+def test_shareable_diagnostic_redacts_input_parse_error(
+    tmp_path: Path, capsys
+) -> None:
+    """A parser failure gets a useful code without echoing private syntax."""
+    path = tmp_path / "input.private_parse_error"
+    path.write_text(
+        """&INDATA
+        MPOL = 3
+        NTOR = 1
+        RBC(:,0) = 1.0
+        /
+        """
+    )
+
+    assert diagnose(path) == 1
+    output = capsys.readouterr().out
+    assert "D00C_INPUT_PARSE_ERROR" in output
+    assert "private_parse_error" not in output
+    assert "RBC" not in output
+    assert "ValueError" not in output
+
+
 def test_inert_reconstruction_flag_matches_vmec2000_disable(
     tmp_path: Path, capsys
 ) -> None:
@@ -133,4 +155,48 @@ def test_indexed_aphi_multivalue_prevents_false_zero_flux_diagnosis(
     output = capsys.readouterr().out
     assert "R/Z force normalization valid: PASS" in output
     assert "lambda force normalization valid: PASS" in output
+    assert "OK_FIRST_FORCE_PASS_FINITE" in output
+
+
+def test_shareable_diagnostic_accepts_compact_boundary_section(
+    tmp_path: Path, capsys
+) -> None:
+    """A legal ``RBC(nlo:nhi,m)`` section reaches the first force pass."""
+    inp = VmecInput.from_file(DATA / "input.nfp2_QI")
+    path = inp.to_indata(tmp_path / "input.private_boundary_section")
+    text = path.read_text().replace(
+        "&INDATA",
+        "&INDATA\n  RBC(-6:6,0) = 13*0.0",
+    )
+    path.write_text(text)
+
+    assert diagnose(path) == 0
+    output = capsys.readouterr().out
+    assert "private_boundary_section" not in output
+    assert "RBC" not in output
+    assert "OK_FIRST_FORCE_PASS_FINITE" in output
+
+
+def test_first_force_uses_values_from_compact_boundary_sections(
+    tmp_path: Path, capsys
+) -> None:
+    """Section-only boundary coefficients produce a finite equilibrium state."""
+    path = tmp_path / "input.private_section_only"
+    path.write_text(
+        """&INDATA
+        NFP = 1
+        MPOL = 3
+        NTOR = 1
+        NS_ARRAY = 7
+        RBC(-1:1,0) = 0.0, 1.0, 0.0
+        RBC(-1:1,1) = 0.0, 0.1, 0.0
+        ZBS(-1:1,1) = 0.0, 0.1, 0.0
+        /
+        """
+    )
+
+    assert diagnose(path) == 0
+    output = capsys.readouterr().out
+    assert "private_section_only" not in output
+    assert "RBC" not in output
     assert "OK_FIRST_FORCE_PASS_FINITE" in output

--- a/tests/test_nonfinite_failfast.py
+++ b/tests/test_nonfinite_failfast.py
@@ -41,6 +41,24 @@ def test_shareable_diagnostic_redacts_input_details(capsys) -> None:
     assert "OK_FIRST_FORCE_PASS_FINITE" in output
 
 
+def test_shareable_diagnostic_warns_on_undersampled_angular_grid(
+    tmp_path: Path, capsys
+) -> None:
+    """The aliasing warning discloses no resolution or coefficient values."""
+    inp = VmecInput.from_file(DATA / "input.nfp2_QI")
+    path = dataclasses.replace(inp, ntheta=16, nzeta=14).to_indata(
+        tmp_path / "input.private_undersampled"
+    )
+
+    assert diagnose(path) == 0
+    output = capsys.readouterr().out
+    assert "angular grid meets VMEC automatic-resolution floor: FAIL" in output
+    assert "assessment: W01_ANGULAR_GRID_BELOW_VMEC_DEFAULT" in output
+    assert "private_undersampled" not in output
+    assert "ntheta=" not in output.lower()
+    assert "nzeta=" not in output.lower()
+
+
 def test_shareable_diagnostic_localizes_zero_energy_scale(
     tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_nonfinite_failfast.py
+++ b/tests/test_nonfinite_failfast.py
@@ -84,10 +84,10 @@ def test_shareable_diagnostic_flags_unsupported_reconstruction(
     assert "RBC" not in output
 
 
-def test_shareable_diagnostic_flags_unsupported_lforbal(
+def test_shareable_diagnostic_supports_lforbal(
     tmp_path: Path, capsys
 ) -> None:
-    """An active non-variational force mode must not be silently ignored."""
+    """The active non-variational force mode reaches the finite force audit."""
     path = tmp_path / "input.private_lforbal"
     path.write_text(
         """&INDATA
@@ -101,9 +101,11 @@ def test_shareable_diagnostic_flags_unsupported_lforbal(
         """
     )
 
-    assert diagnose(path) == 1
+    assert diagnose(path) == 0
     output = capsys.readouterr().out
-    assert "D00D_LFORBAL_MODE_UNSUPPORTED" in output
+    assert "input physics mode supported: PASS" in output
+    assert "assessment: OK_FIRST_FORCE_PASS_FINITE" in output
+    assert "D00D_LFORBAL_MODE_UNSUPPORTED" not in output
     assert "private_lforbal" not in output
     assert "RBC" not in output
 

--- a/tests/test_nonfinite_failfast.py
+++ b/tests/test_nonfinite_failfast.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from vmex.core.errors import VmecNumericalError
@@ -81,6 +82,47 @@ def test_shareable_diagnostic_flags_unsupported_reconstruction(
     assert "D00A_RECONSTRUCTION_MODE_UNSUPPORTED" in output
     assert "private_reconstruction" not in output
     assert "RBC" not in output
+
+
+def test_shareable_diagnostic_flags_unsupported_lforbal(
+    tmp_path: Path, capsys
+) -> None:
+    """An active non-variational force mode must not be silently ignored."""
+    path = tmp_path / "input.private_lforbal"
+    path.write_text(
+        """&INDATA
+        LFORBAL = T
+        MPOL = 3
+        NTOR = 0
+        RBC(0,0) = 1.0
+        RBC(0,1) = 0.1
+        ZBS(0,1) = 0.1
+        /
+        """
+    )
+
+    assert diagnose(path) == 1
+    output = capsys.readouterr().out
+    assert "D00D_LFORBAL_MODE_UNSUPPORTED" in output
+    assert "private_lforbal" not in output
+    assert "RBC" not in output
+
+
+def test_shareable_diagnostic_reports_high_force_axis_recovery(
+    tmp_path: Path, capsys
+) -> None:
+    """A finite irst=4 trigger is reported without printing force values."""
+    inp = VmecInput.from_file(DATA / "input.solovev")
+    path = dataclasses.replace(
+        inp, raxis_c=np.asarray([4.4]), lmove_axis=True,
+    ).to_indata(tmp_path / "input.private_axis_recovery")
+
+    assert diagnose(path) == 0
+    output = capsys.readouterr().out
+    assert "automatic first-pass axis recovery: REQUIRED" in output
+    assert "OK_FIRST_FORCE_PASS_FINITE" in output
+    assert "private_axis_recovery" not in output
+    assert "4.4" not in output
 
 
 def test_shareable_diagnostic_redacts_input_parse_error(

--- a/tests/test_nonfinite_failfast.py
+++ b/tests/test_nonfinite_failfast.py
@@ -159,26 +159,28 @@ def test_shareable_diagnostic_reports_high_force_axis_recovery(
     assert "4.4" not in output
 
 
-def test_shareable_diagnostic_redacts_input_parse_error(
+def test_shareable_diagnostic_accepts_open_boundary_section(
     tmp_path: Path, capsys
 ) -> None:
-    """A parser failure gets a useful code without echoing private syntax."""
-    path = tmp_path / "input.private_parse_error"
+    """Declared Fortran bounds make ``RBC(:,m)`` a legal array section."""
+    path = tmp_path / "input.private_open_section"
     path.write_text(
         """&INDATA
         MPOL = 3
         NTOR = 1
-        RBC(:,0) = 1.0
+        RBC(:,0) = 101*0.0, 1.0
+        RBC(0,1) = 0.1
+        ZBS(0,1) = 0.1
         /
         """
     )
 
-    assert diagnose(path) == 1
+    assert diagnose(path) == 0
     output = capsys.readouterr().out
-    assert "D00C_INPUT_PARSE_ERROR" in output
-    assert "private_parse_error" not in output
+    assert "input parsing: PASS" in output
+    assert "OK_FIRST_FORCE_PASS_FINITE" in output
+    assert "private_open_section" not in output
     assert "RBC" not in output
-    assert "ValueError" not in output
 
 
 def test_inert_reconstruction_flag_matches_vmec2000_disable(

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -242,6 +242,12 @@ def test_l_grad_b(solovev_eq):
     np.testing.assert_allclose(fine, val, rtol=5e-2)
 
 
+def test_l_grad_b_rejects_asymmetric_wout() -> None:
+    """The symmetric diagnostic must not silently omit LASYM partners."""
+    with pytest.raises(NotImplementedError, match="lasym = False"):
+        opt.l_grad_b(SimpleNamespace(lasym=True))
+
+
 # ---------------------------------------------------------------------------
 # QI residual
 # ---------------------------------------------------------------------------
@@ -384,8 +390,8 @@ def test_least_squares_implicit_jac_chunking(solovev_eq):
     """The R17.1 chunked implicit Jacobian matches the unchunked one.
 
     ``jac_chunk_size`` only changes how the per-dof Jacobian columns are
-    batched (:func:`solvax.chunk_map`: one wide ``vmap`` when ``None`` vs
-    ``jax.lax.map`` in fixed-size chunks otherwise), so the Jacobian scipy
+    batched (:func:`solvax.chunk_map`: one full-width ``lax.map`` batch when
+    ``None`` vs smaller fixed-size batches otherwise), so the Jacobian scipy
     evaluates at the initial boundary must be identical.  Compared at a single
     evaluation (``max_nfev=1``, same default x0) to keep the test cheap; the
     solovev deck has 2 boundary dofs so ``jac_chunk_size=1`` is a real
@@ -394,7 +400,7 @@ def test_least_squares_implicit_jac_chunking(solovev_eq):
     jax.config.update("jax_disable_jit", False)
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
     obj = [(opt.aspect_ratio, 4.0, 1.0)]
-    # Pin the reference to the unchunked (one wide vmap) path explicitly — the
+    # Pin the reference to the unchunked (one full-width batch) path explicitly — the
     # default is now jac_chunk_size="auto" (R17.1 memory-bounded default), so
     # None is what makes this an unchunked-vs-chunked comparison.
     ref = opt.least_squares(obj, inp, max_mode=1, jac="implicit",

--- a/tests/test_preconditioner.py
+++ b/tests/test_preconditioner.py
@@ -243,6 +243,57 @@ def test_tridiagonal_solve_broadcast_rank():
         )
 
 
+def test_scalfor_checked_solve_reports_well_conditioned_system() -> None:
+    """The production solve accepts a stable radial system without fallback."""
+    ns, mpol, nrange = 6, 2, 3
+    matrices = newp.TridiagonalMatrices(
+        ax=jnp.full((ns, mpol, nrange), -0.25),
+        bx=jnp.full((ns, mpol, nrange), -0.25),
+        dx=jnp.full((ns, mpol, nrange), 2.0),
+    )
+    force = jnp.arange(ns * mpol * nrange, dtype=float).reshape(
+        ns, mpol, nrange
+    )
+    solved, safe = newp.scalfor(force, matrices, jmax=ns, return_safe=True)
+    reference = np.asarray(force).copy()
+    reference[:, 0] = np.asarray(newp.tridiagonal_solve(
+        matrices.ax[:, 0],
+        matrices.dx[:, 0],
+        matrices.bx[:, 0],
+        force[:, 0],
+    ))
+    reference[1:, 1] = np.asarray(newp.tridiagonal_solve(
+        matrices.ax[1:, 1],
+        matrices.dx[1:, 1],
+        matrices.bx[1:, 1],
+        force[1:, 1],
+    ))
+    reference[0, 1] = 0.0
+    assert bool(safe)
+    np.testing.assert_allclose(np.asarray(solved), reference)
+
+
+def test_scalfor_checked_solve_falls_back_without_nonfinite_update() -> None:
+    """A singular radial block returns its RHS and a typed unsafe status."""
+    ns, mpol, nrange = 5, 2, 2
+    matrices = newp.TridiagonalMatrices(
+        ax=jnp.zeros((ns, mpol, nrange)),
+        bx=jnp.zeros((ns, mpol, nrange)),
+        dx=jnp.zeros((ns, mpol, nrange)),
+    )
+    force = jnp.arange(ns * mpol * nrange, dtype=float).reshape(
+        ns, mpol, nrange
+    )
+    solved, safe = newp.scalfor(force, matrices, jmax=ns, return_safe=True)
+    assert not bool(safe)
+    assert np.all(np.isfinite(np.asarray(solved)))
+    # SOLVAX's identity fallback leaves each rejected RHS column unchanged;
+    # scalfor still enforces VMEC's m>0 axis constraint.
+    np.testing.assert_array_equal(np.asarray(solved[:, 0]), np.asarray(force[:, 0]))
+    np.testing.assert_array_equal(np.asarray(solved[1:, 1]), np.asarray(force[1:, 1]))
+    np.testing.assert_array_equal(np.asarray(solved[0, 1]), 0.0)
+
+
 # ---------------------------------------------------------------------------
 # jit compatibility
 # ---------------------------------------------------------------------------

--- a/tests/test_preconditioner_2d.py
+++ b/tests/test_preconditioner_2d.py
@@ -35,7 +35,7 @@ from vmex.core.preconditioner_2d import (
     Prec2DConfig, flat_operator, newton_direction,
 )
 from vmex.core.solver import (
-    SpectralState, _initial_state, _preconditioned_force_signed,
+    SpectralState, _initial_state, _preconditioned_force_signed, _resolve_prec2d,
     evaluate_forces, prepare_runtime, resolution_from_input, solve,
 )
 
@@ -132,6 +132,19 @@ def test_prec2d_config_is_hashable():
     cfg = Prec2DConfig(threshold=1e-6)
     assert hash(cfg) == hash(Prec2DConfig(threshold=1e-6))
     assert hash(cfg) != hash(Prec2DConfig(threshold=1e-7))
+
+
+def test_precon_type_has_explicit_non_aliasing_semantics() -> None:
+    """DEFAULT is 1-D; VMEC2000's other Krylov names are not GMRES aliases."""
+    assert _resolve_prec2d(
+        VmecInput(precon_type="DEFAULT"), None, None, None
+    ) is None
+    assert isinstance(
+        _resolve_prec2d(VmecInput(precon_type="GMRES"), None, None, None),
+        Prec2DConfig,
+    )
+    with pytest.raises(NotImplementedError, match="CG, GMRESR, and TFQMR"):
+        _resolve_prec2d(VmecInput(precon_type="TFQMR"), None, None, None)
 
 
 @pytest.mark.full

--- a/tests/test_preconditioner_2d.py
+++ b/tests/test_preconditioner_2d.py
@@ -17,6 +17,7 @@ reaches the *same* equilibrium in *fewer* iterations (the R20 showcase claim).
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 import numpy as np
@@ -31,6 +32,7 @@ from jax.flatten_util import ravel_pytree
 
 from vmex.core.fourier import Resolution
 from vmex.core.input import VmecInput
+from vmex.core import solver as solver_module
 from vmex.core.preconditioner_2d import (
     Prec2DConfig, flat_operator, newton_direction,
 )
@@ -135,7 +137,10 @@ def test_prec2d_config_is_hashable():
 
 
 def test_precon_type_has_explicit_non_aliasing_semantics() -> None:
-    """DEFAULT is 1-D; VMEC2000's other Krylov names are not GMRES aliases."""
+    """NONE/DEFAULT are 1-D; other VMEC Krylov names are not GMRES aliases."""
+    assert _resolve_prec2d(
+        VmecInput(precon_type="NONE"), None, None, None
+    ) is None
     assert _resolve_prec2d(
         VmecInput(precon_type="DEFAULT"), None, None, None
     ) is None
@@ -145,6 +150,31 @@ def test_precon_type_has_explicit_non_aliasing_semantics() -> None:
     )
     with pytest.raises(NotImplementedError, match="CG, GMRESR, and TFQMR"):
         _resolve_prec2d(VmecInput(precon_type="TFQMR"), None, None, None)
+
+
+def test_precon_none_keeps_vmec2000_radial_preconditioner(monkeypatch) -> None:
+    """PRECON_TYPE=NONE disables 2-D blocks, never scalfor/faclam."""
+    inp = replace(
+        VmecInput.from_file(str(DATA_DIR / "input.circular_tokamak")),
+        precon_type="NONE",
+        raxis_c=np.asarray([6.0]),
+    )
+    resolution = resolution_from_input(inp, ns=7)
+    runtime = prepare_runtime(inp, resolution)
+    state = _initial_state(runtime.setup)
+    original = solver_module.apply_radial_preconditioner
+    calls = 0
+
+    def tracked(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(solver_module, "apply_radial_preconditioner", tracked)
+    _gc, _residuals, diagnostics = evaluate_forces(state, runtime)
+    assert calls == 1
+    assert bool(diagnostics.health.pipeline.radial_preconditioner_safe)
+    assert runtime.prec2d is None
 
 
 @pytest.mark.full

--- a/tests/test_solver_axis_initialization.py
+++ b/tests/test_solver_axis_initialization.py
@@ -38,3 +38,10 @@ def test_production_runtime_does_not_preinfer_missing_axis() -> None:
         inp, resolution, infer_axis_if_missing=True,
     )
     assert np.any(np.asarray(inferred.raxis_c) != 0.0)
+
+    # Geometry/force-kernel callers can opt into the setup convenience
+    # explicitly without changing the production default.
+    inferred_runtime = prepare_runtime(inp, resolution, setup=inferred)
+    np.testing.assert_array_equal(
+        inferred_runtime.setup.raxis_c, inferred.raxis_c,
+    )

--- a/tests/test_solver_axis_initialization.py
+++ b/tests/test_solver_axis_initialization.py
@@ -1,0 +1,40 @@
+"""Production-axis initialization parity with VMEC2000."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import numpy as np
+
+from vmex.core.input import VmecInput
+from vmex.core.setup import run_setup
+from vmex.core.solver import prepare_runtime, resolution_from_input
+
+
+DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
+
+
+def test_production_runtime_does_not_preinfer_missing_axis() -> None:
+    """eqsolve, not setup, owns VMEC2000's one allowed guess_axis transfer."""
+    inp = VmecInput.from_file(DATA / "input.LandremanPaul2021_QA_lowres")
+    zeros = np.zeros(inp.ntor + 1)
+    inp = dataclasses.replace(
+        inp,
+        raxis_c=zeros,
+        raxis_s=zeros,
+        zaxis_c=zeros,
+        zaxis_s=zeros,
+    )
+    resolution = resolution_from_input(inp)
+
+    runtime = prepare_runtime(inp, resolution)
+    np.testing.assert_array_equal(runtime.setup.raxis_c, zeros)
+    np.testing.assert_array_equal(runtime.setup.raxis_s, zeros)
+    np.testing.assert_array_equal(runtime.setup.zaxis_c, zeros)
+    np.testing.assert_array_equal(runtime.setup.zaxis_s, zeros)
+
+    inferred = run_setup(
+        inp, resolution, infer_axis_if_missing=True,
+    )
+    assert np.any(np.asarray(inferred.raxis_c) != 0.0)

--- a/tests/test_vmec2000_feature_stress.py
+++ b/tests/test_vmec2000_feature_stress.py
@@ -1,0 +1,195 @@
+"""Public integration stress cases for VMEC2000 compatibility controls.
+
+The high-mode case is constructed only from
+``examples/data/input.serial2500170_surface_points_mpol12_ntor12``.  Its
+boundary is already public and tracked in this repository.  The transformed
+header deliberately combines the compatibility seams that are easy to miss
+when tested separately: Fortran ordered overlays and array sections, a
+four-stage radial ladder, APHI starting-element assignment, no supplied axis,
+``LFORBAL=T``, and ``PRECON_TYPE='NONE'`` (VMEC's ordinary 1-D path).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tools.diagnose_input import diagnose
+from vmex.core.errors import MORE_ITER_FLAG
+from vmex.core.fourier import mode_table
+from vmex.core.input import VmecInput
+from vmex.core.multigrid import solve_multigrid
+
+
+REPO = Path(__file__).resolve().parents[1]
+PUBLIC_BOUNDARY = (
+    REPO / "examples" / "data"
+    / "input.serial2500170_surface_points_mpol12_ntor12"
+)
+
+
+def _replace_assignment(text: str, name: str, replacement: str) -> str:
+    result, count = re.subn(
+        rf"(?im)^\s*{re.escape(name)}\s*=.*$",
+        replacement,
+        text,
+        count=1,
+    )
+    assert count == 1, name
+    return result
+
+
+def public_feature_stress_text() -> str:
+    """Return the reproducible 238-mode public VMEC2000 stress deck."""
+    text = PUBLIC_BOUNDARY.read_text()
+    text = _replace_assignment(text, "MPOL", "  MPOL = 13")
+    text = _replace_assignment(text, "NTOR", "  NTOR = 9")
+    text = _replace_assignment(
+        text,
+        "ns_array",
+        "  NS_ARRAY = 21, 34, 55, 89\n"
+        "  NS_ARRAY(1) = 21, 34",
+    )
+    text = _replace_assignment(
+        text,
+        "niter_array",
+        "  NITER_ARRAY = 1000, 1000, 4000, 10000",
+    )
+    text = _replace_assignment(
+        text,
+        "ftol_array",
+        "  FTOL_ARRAY = 1e-6, 1e-11, 1.5e-9, 5e-14\n"
+        "  FTOL_ARRAY = 1e-7, 1e-7",
+    )
+    text = _replace_assignment(text, "DELT", "  DELT = 0.5")
+    text = text.replace(
+        "  NCURR   = 1",
+        "  APHI(1) = 1.0, 0.0\n"
+        "  PRECON_TYPE = 'NONE'\n"
+        "  LFORBAL = T\n"
+        "  NCURR   = 1",
+        1,
+    )
+    # Exercise a compact multidimensional section and later scalar overlays
+    # without changing the public boundary: the existing RBC(n,0) statements
+    # below overwrite the relevant values in normal Fortran source order.
+    text = text.replace(
+        "  ! VMEC coefficient order is (n,m): RBC(n,m), ZBS(n,m).",
+        "  ! VMEC coefficient order is (n,m): RBC(n,m), ZBS(n,m).\n"
+        "  RBC(-6:6,0) = 13*0.0\n"
+        "  ZBS(-6:6,0) = 13*0.0",
+        1,
+    )
+    return text
+
+
+def test_public_stress_parser_and_first_force_diagnostic(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Every combined compatibility seam reaches a finite first force."""
+    text = public_feature_stress_text()
+    inp = VmecInput.from_indata_text(text)
+
+    assert mode_table(inp.mpol, inp.ntor).mnmax == 238
+    np.testing.assert_array_equal(inp.ns_array, [21, 34, 55, 89])
+    np.testing.assert_array_equal(
+        inp.niter_array, [1000, 1000, 4000, 10000]
+    )
+    np.testing.assert_array_equal(
+        inp.ftol_array, [1e-7, 1e-7, 1.5e-9, 5e-14]
+    )
+    np.testing.assert_array_equal(inp.aphi[:2], [1.0, 0.0])
+    assert inp.lforbal
+    assert inp.precon_type.upper() == "NONE"
+    assert not np.any(inp.raxis_c)
+    assert not np.any(inp.zaxis_s)
+
+    path = tmp_path / "input.public_feature_stress"
+    path.write_text(text)
+    assert diagnose(path) == 0
+    output = capsys.readouterr().out
+    assert "input parsing: PASS" in output
+    assert "input physics mode supported: PASS" in output
+    assert "automatic first-pass axis recovery: REQUIRED" in output
+    assert "radial=PASS" in output
+    assert "assessment: OK_FIRST_FORCE_PASS_FINITE" in output
+
+
+@pytest.mark.full
+@pytest.mark.usefixtures("_module_jit_enabled")
+def test_public_238_mode_lforbal_solve_matches_vmec2000() -> None:
+    """The difficult fixed-boundary proxy converges to the VMEC2000 result."""
+    inp = VmecInput.from_indata_text(public_feature_stress_text())
+    lines: list[str] = []
+    result = solve_multigrid(
+        inp,
+        ns_array=[21],
+        ftol_array=[1e-7],
+        niter_array=[1000],
+        verbose=True,
+        emit=lambda value="", end="\n": lines.append(str(value) + end),
+        device="cpu",
+    )
+    output = "".join(lines)
+
+    assert result.converged
+    assert result.iterations == 462
+    assert result.jacobian_resets == 7
+    assert output.count("TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS") == 1
+    np.testing.assert_allclose(
+        [result.fsqr, result.fsqz, result.fsql],
+        [9.78117163e-8, 3.13954504e-8, 7.69528620e-9],
+        rtol=2e-8,
+    )
+    np.testing.assert_allclose(
+        [result.wb, result.r00, result.wmhd],
+        [0.033530284026509774, 1.235051198548, 1.323722555191],
+        rtol=2e-11,
+        atol=2e-13,
+    )
+
+
+@pytest.mark.full
+@pytest.mark.usefixtures("_module_jit_enabled")
+def test_public_238_mode_full_ladder_matches_vmec2000_trajectory() -> None:
+    """All four radial stages reproduce the public VMEC2000 trajectory."""
+    inp = VmecInput.from_indata_text(public_feature_stress_text())
+    lines: list[str] = []
+    result = solve_multigrid(
+        inp,
+        verbose=True,
+        emit=lambda value="", end="\n": lines.append(str(value) + end),
+        device="cpu",
+        raise_on_max_iterations=False,
+    )
+    output = "".join(lines)
+
+    assert not result.converged
+    assert result.ier_flag == MORE_ITER_FLAG
+    assert result.iterations == 10000
+    assert result.jacobian_resets == 2
+    for stage in (
+        "NS =   21 NO. FOURIER MODES =  238 FTOLV =  1.000E-07 NITER =   1000",
+        "NS =   34 NO. FOURIER MODES =  238 FTOLV =  1.000E-07 NITER =   1000",
+        "NS =   55 NO. FOURIER MODES =  238 FTOLV =  1.500E-09 NITER =   4000",
+        "NS =   89 NO. FOURIER MODES =  238 FTOLV =  5.000E-14 NITER =  10000",
+    ):
+        assert stage in output
+
+    # These are the first/final screen rows produced by the same public deck
+    # with the local VMEC2000 Release executable.  In particular, the first
+    # fine-grid rows pin initialize_radial.f's residual-state continuation.
+    for row in (
+        "  462  9.78E-08  3.14E-08  7.70E-09",
+        "    1  2.70E-03  1.31E-03  7.93E-06",
+        "  139  9.84E-08  9.84E-08  6.19E-09",
+        "    1  2.41E-03  1.12E-03  2.24E-06",
+        "  543  1.14E-09  1.48E-09  1.48E-10",
+        "    1  1.51E-03  8.12E-04  1.10E-06",
+        "10000  3.06E-11  6.00E-11  3.11E-12",
+    ):
+        assert row in output

--- a/tools/diagnose_input.py
+++ b/tools/diagnose_input.py
@@ -24,7 +24,13 @@ import numpy as np
 
 from vmex.core.geometry import half_mesh_jacobian
 from vmex.core.input import UnsupportedInputModeError, VmecInput
-from vmex.core.solver import _geometry, _initial_state, evaluate_forces, prepare_runtime
+from vmex.core.solver import (
+    _geometry,
+    _initial_state,
+    evaluate_forces,
+    prepare_runtime,
+    reguess_initial_axis,
+)
 
 
 def _named_arrays(value: Any, prefix: str = ""):
@@ -93,10 +99,43 @@ def diagnose(path: Path, *, details: bool = False) -> int:
     print("input parsing: PASS")
 
     rt = prepare_runtime(inp)
+    theta_floor = 2 * int(inp.mpol) + 6
+    zeta_floor = 1 if int(inp.ntor) == 0 else 2 * int(inp.ntor) + 4
+    angular_grid_ok = (
+        (int(inp.ntheta) <= 0 or int(inp.ntheta) >= theta_floor)
+        and (int(inp.nzeta) <= 0 or int(inp.nzeta) >= zeta_floor)
+    )
     state = _initial_state(rt.setup)
     _, geometry = _geometry(state, rt)
     jacobian = half_mesh_jacobian(geometry, s=rt.setup.s_full)
     gc, residuals, diagnostics = evaluate_forces(state, rt)
+    initial_sqrt_g = np.asarray(jacobian.sqrt_g)[1:]
+    initial_jacobian_good = (
+        np.isfinite(initial_sqrt_g).all()
+        and np.all(initial_sqrt_g != 0.0)
+        and not bool(jacobian.jacobian_sign_changed)
+    )
+    initial_fsq = np.asarray(
+        [residuals.fsqr, residuals.fsqz, residuals.fsql], dtype=float
+    )
+    high_first_force = (
+        initial_jacobian_good
+        and np.isfinite(initial_fsq).all()
+        and float(np.sum(initial_fsq)) > 1.0e2
+    )
+    recovery_required = (
+        not initial_jacobian_good
+        or (high_first_force and bool(inp.lmove_axis))
+    )
+    if recovery_required and rt.resolution.ns >= 3:
+        # Diagnose the effective first force that VMEC2000/VMEX actually
+        # evolve after eqsolve.f's one allowed guess_axis transfer.  The
+        # discarded zero-axis/high-force pass contains no shareable solver
+        # result and must not hide a later normalization failure.
+        rt, state, _ = reguess_initial_axis(rt, state)
+        _, geometry = _geometry(state, rt)
+        jacobian = half_mesh_jacobian(geometry, s=rt.setup.s_full)
+        gc, residuals, diagnostics = evaluate_forces(state, rt)
 
     axis_supplied = any(
         np.any(np.asarray(value) != 0.0)
@@ -119,6 +158,10 @@ def diagnose(path: Path, *, details: bool = False) -> int:
     health = diagnostics.health
 
     print("input physics mode supported: PASS")
+    print(
+        "angular grid meets VMEC automatic-resolution floor: "
+        f"{'PASS' if angular_grid_ok else 'FAIL'}"
+    )
     sqrt_g = np.asarray(jacobian.sqrt_g)[1:]
     jacobian_finite = np.isfinite(sqrt_g).all()
     jacobian_nonzero = _ok(health.jacobian_nonzero)
@@ -126,12 +169,6 @@ def diagnose(path: Path, *, details: bool = False) -> int:
         jacobian_finite
         and jacobian_nonzero
         and not bool(jacobian.jacobian_sign_changed)
-    )
-    high_first_force = (
-        jacobian_good
-        and not raw_bad
-        and bool(np.isfinite(fsq).all())
-        and sum(fsq) > 1.0e2
     )
     rz_norm_good = (
         _ok(health.volume_valid)
@@ -147,13 +184,21 @@ def diagnose(path: Path, *, details: bool = False) -> int:
         and _ok(health.raw_lambda_sum_finite)
     )
     print(f"setup arrays finite: {'PASS' if not setup_bad else 'FAIL'}")
-    print(f"initial Jacobian valid: {'PASS' if jacobian_good else 'FAIL'}")
+    print(
+        "initial Jacobian valid: "
+        f"{'PASS' if initial_jacobian_good else 'FAIL'}"
+    )
     axis_recovery = (
-        "REQUIRED" if high_first_force and inp.lmove_axis
-        else "DISABLED" if high_first_force
+        "REQUIRED" if recovery_required
+        else "DISABLED" if high_first_force and not inp.lmove_axis
         else "NOT_REQUIRED"
     )
     print(f"automatic first-pass axis recovery: {axis_recovery}")
+    if recovery_required:
+        print(
+            "post-recovery Jacobian valid: "
+            f"{'PASS' if jacobian_good else 'FAIL'}"
+        )
     print(f"magnetic field assembly finite: {'PASS' if _ok(health.fields_finite) else 'FAIL'}")
     print(f"R/Z force normalization valid: {'PASS' if rz_norm_good else 'FAIL'}")
     print(f"lambda force normalization valid: {'PASS' if lambda_norm_good else 'FAIL'}")
@@ -207,7 +252,7 @@ def diagnose(path: Path, *, details: bool = False) -> int:
         )
         print(
             "axis: "
-            f"input={'supplied' if axis_supplied else 'missing -> inferred'} "
+            f"input={'supplied' if axis_supplied else 'missing -> VMEC first-pass recovery'} "
             f"R(0)={float(np.sum(np.asarray(rt.setup.raxis_c))):.6e} "
             f"Z-coeff-max={float(np.max(np.abs(np.asarray(rt.setup.zaxis_s)))):.6e}"
         )
@@ -304,6 +349,8 @@ def diagnose(path: Path, *, details: bool = False) -> int:
         assessment = "D04_PRECONDITIONED_UPDATE_NONFINITE"
     elif diagnostic_bad:
         assessment = "D05_FORCE_DIAGNOSTIC_NONFINITE"
+    elif not angular_grid_ok:
+        assessment = "W01_ANGULAR_GRID_BELOW_VMEC_DEFAULT"
     else:
         assessment = "OK_FIRST_FORCE_PASS_FINITE"
     print(f"assessment: {assessment}")

--- a/tools/diagnose_input.py
+++ b/tools/diagnose_input.py
@@ -100,14 +100,23 @@ def _print_header() -> None:
 
 def diagnose(path: Path, *, details: bool = False) -> int:
     text = path.read_text()
-    unsupported = _unsupported_mode_code(text)
     _print_header()
+    try:
+        unsupported = _unsupported_mode_code(text)
+        inp = VmecInput.from_file(path)
+    except ValueError:
+        # Keep the default diagnostic shareable: parsing exceptions can quote
+        # filenames, namelist designators, and input-derived values.
+        print("input parsing: FAIL")
+        print("assessment: D00C_INPUT_PARSE_ERROR")
+        return 1
+
+    print("input parsing: PASS")
     if unsupported is not None:
         print("input physics mode supported: FAIL")
         print(f"assessment: {unsupported}")
         return 1
 
-    inp = VmecInput.from_file(path)
     rt = prepare_runtime(inp)
     state = _initial_state(rt.setup)
     _, geometry = _geometry(state, rt)

--- a/tools/diagnose_input.py
+++ b/tools/diagnose_input.py
@@ -23,7 +23,7 @@ import jax
 import numpy as np
 
 from vmex.core.geometry import half_mesh_jacobian
-from vmex.core.input import VmecInput, _read_indata_text
+from vmex.core.input import UnsupportedInputModeError, VmecInput
 from vmex.core.solver import _geometry, _initial_state, evaluate_forces, prepare_runtime
 
 
@@ -64,30 +64,6 @@ def _ok(value: Any) -> bool:
     return bool(np.asarray(value))
 
 
-def _unsupported_mode_code(text: str) -> str | None:
-    """Return a value-free code for active VMEC modes VMEX does not solve."""
-    if text.lstrip()[:1] == "{":
-        return None
-    scalars, _indexed = _read_indata_text(text)
-
-    def first(name: str, default: Any = None) -> Any:
-        values = scalars.get(name)
-        return values[0] if values else default
-
-    # vsetup.f starts with LRECON=T, while read_indata.f disables it when
-    # neither diagnostic profile is active.  Reproduce that effective-mode
-    # decision so an inert explicit LRECON=T is not a false positive.
-    reconstruction_requested = bool(first("LRECON", True))
-    reconstruction_active = reconstruction_requested and (
-        int(first("ITSE", 0)) > 0 or int(first("IMSE", -1)) > 0
-    )
-    if reconstruction_active:
-        return "D00A_RECONSTRUCTION_MODE_UNSUPPORTED"
-    if bool(first("LRFP", False)):
-        return "D00B_RFP_MODE_UNSUPPORTED"
-    return None
-
-
 def _print_header() -> None:
     print("VMEX first-iteration diagnostic (shareable, input details redacted)")
     print(
@@ -99,11 +75,14 @@ def _print_header() -> None:
 
 
 def diagnose(path: Path, *, details: bool = False) -> int:
-    text = path.read_text()
     _print_header()
     try:
-        unsupported = _unsupported_mode_code(text)
         inp = VmecInput.from_file(path)
+    except UnsupportedInputModeError as exc:
+        print("input parsing: PASS")
+        print("input physics mode supported: FAIL")
+        print(f"assessment: {exc.code}")
+        return 1
     except ValueError:
         # Keep the default diagnostic shareable: parsing exceptions can quote
         # filenames, namelist designators, and input-derived values.
@@ -112,10 +91,6 @@ def diagnose(path: Path, *, details: bool = False) -> int:
         return 1
 
     print("input parsing: PASS")
-    if unsupported is not None:
-        print("input physics mode supported: FAIL")
-        print(f"assessment: {unsupported}")
-        return 1
 
     rt = prepare_runtime(inp)
     state = _initial_state(rt.setup)

--- a/tools/diagnose_input.py
+++ b/tools/diagnose_input.py
@@ -85,6 +85,12 @@ def _unsupported_mode_code(text: str) -> str | None:
         return "D00A_RECONSTRUCTION_MODE_UNSUPPORTED"
     if bool(first("LRFP", False)):
         return "D00B_RFP_MODE_UNSUPPORTED"
+    # tomnsp_mod.f's non-variational m=1 force-balance replacement is not yet
+    # implemented in VMEX.  The VMEC2000 default is false, so only an active
+    # explicit request is rejected; silently treating it as false can change
+    # difficult-case convergence while still producing finite diagnostics.
+    if bool(first("LFORBAL", False)):
+        return "D00D_LFORBAL_MODE_UNSUPPORTED"
     return None
 
 
@@ -152,6 +158,12 @@ def diagnose(path: Path, *, details: bool = False) -> int:
         and jacobian_nonzero
         and not bool(jacobian.jacobian_sign_changed)
     )
+    high_first_force = (
+        jacobian_good
+        and not raw_bad
+        and bool(np.isfinite(fsq).all())
+        and sum(fsq) > 1.0e2
+    )
     rz_norm_good = (
         _ok(health.volume_valid)
         and _ok(health.energy_scale_valid)
@@ -167,6 +179,12 @@ def diagnose(path: Path, *, details: bool = False) -> int:
     )
     print(f"setup arrays finite: {'PASS' if not setup_bad else 'FAIL'}")
     print(f"initial Jacobian valid: {'PASS' if jacobian_good else 'FAIL'}")
+    axis_recovery = (
+        "REQUIRED" if high_first_force and inp.lmove_axis
+        else "DISABLED" if high_first_force
+        else "NOT_REQUIRED"
+    )
+    print(f"automatic first-pass axis recovery: {axis_recovery}")
     print(f"magnetic field assembly finite: {'PASS' if _ok(health.fields_finite) else 'FAIL'}")
     print(f"R/Z force normalization valid: {'PASS' if rz_norm_good else 'FAIL'}")
     print(f"lambda force normalization valid: {'PASS' if lambda_norm_good else 'FAIL'}")

--- a/tools/diagnose_input.py
+++ b/tools/diagnose_input.py
@@ -217,11 +217,18 @@ def diagnose(path: Path, *, details: bool = False) -> int:
         f"Z={'PASS' if _ok(health.raw_z_residual_finite) else 'FAIL'} "
         f"L={'PASS' if _ok(health.raw_lambda_residual_finite) else 'FAIL'}"
     )
+    if (
+        _ok(health.pipeline.radial_solve_finite)
+        and _ok(health.pipeline.radial_preconditioner_safe)
+    ):
+        radial_status = "PASS"
+    else:
+        radial_status = "FAIL"
     print(
         "preconditioner stages finite: "
         f"cache={'PASS' if _ok(health.cache_finite) else 'FAIL'} "
         f"rhs={'PASS' if _ok(health.pipeline.rhs_finite) else 'FAIL'} "
-        f"radial={'PASS' if _ok(health.pipeline.radial_solve_finite) else 'FAIL'} "
+        f"radial={radial_status} "
         f"lambda={'PASS' if _ok(health.pipeline.preconditioned_finite) else 'FAIL'}"
     )
     print(f"raw force residuals finite: {'PASS' if not raw_bad else 'FAIL'}")
@@ -341,6 +348,10 @@ def diagnose(path: Path, *, details: bool = False) -> int:
         assessment = "D04A_PRECONDITIONER_CACHE_NONFINITE"
     elif not _ok(health.pipeline.rhs_finite):
         assessment = "D04B_PRECONDITIONER_RHS_NONFINITE"
+    elif (
+        not _ok(health.pipeline.radial_preconditioner_safe)
+    ):
+        assessment = "D04E_RADIAL_PRECONDITIONER_REJECTED"
     elif not _ok(health.pipeline.radial_solve_finite):
         assessment = "D04C_RADIAL_PRECONDITIONER_NONFINITE"
     elif not _ok(health.pipeline.preconditioned_finite):

--- a/tools/diagnose_input.py
+++ b/tools/diagnose_input.py
@@ -85,12 +85,6 @@ def _unsupported_mode_code(text: str) -> str | None:
         return "D00A_RECONSTRUCTION_MODE_UNSUPPORTED"
     if bool(first("LRFP", False)):
         return "D00B_RFP_MODE_UNSUPPORTED"
-    # tomnsp_mod.f's non-variational m=1 force-balance replacement is not yet
-    # implemented in VMEX.  The VMEC2000 default is false, so only an active
-    # explicit request is rejected; silently treating it as false can change
-    # difficult-case convergence while still producing finite diagnostics.
-    if bool(first("LFORBAL", False)):
-        return "D00D_LFORBAL_MODE_UNSUPPORTED"
     return None
 
 

--- a/vmex/__init__.py
+++ b/vmex/__init__.py
@@ -5,14 +5,15 @@ Public API (lazily imported; ``import vmex as vj``):
 - :class:`~vmex.core.input.VmecInput` — INDATA / VMEC++-JSON input pytree
 - :func:`~vmex.core.solver.solve` — single-grid fixed-boundary solve
 - :func:`~vmex.core.multigrid.solve_multigrid` — NS_ARRAY ladder (runvmec.f)
+- :func:`~vmex.core.multigrid.solve_free_boundary_multigrid` — free-boundary ladder
 - :func:`~vmex.core.freeboundary.solve_free_boundary` — NESTOR free boundary
 - :func:`~vmex.core.wout.read_wout` / :func:`~vmex.core.wout.write_wout`
   / :func:`~vmex.core.wout.wout_from_state` / :class:`~vmex.core.wout.WoutData`
 - :func:`~vmex.core.plotting.plot_wout` / :func:`~vmex.core.plotting.plot_boozmn`
 - :func:`~vmex.core.boozer.run_booz_xform` — Boozer transform (booz_xform_jax)
 - :func:`~vmex.core.mgrid.read_mgrid` / :func:`~vmex.core.mgrid.write_mgrid`
-  / :class:`~vmex.core.mgrid.MgridField` (external field is an mgrid or any
-  ``xyz->B`` callable; coils live in ESSOS, ``essos.coils.Coils``)
+  / :func:`~vmex.core.mgrid.tabulate_cartesian_field`
+  / :class:`~vmex.core.mgrid.MgridField` (mgrid or tabulated direct field)
 - ``vmex.optimize`` — objectives + least-squares driver (module)
 - ``vmex.implicit`` — implicit differentiation of the equilibrium (module)
 - ``vmex.parallel`` — concurrent ensembles of independent solves (module)
@@ -83,6 +84,8 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
     # solvers
     "solve": (".core.solver", "solve"),
     "solve_multigrid": (".core.multigrid", "solve_multigrid"),
+    "solve_free_boundary_multigrid": (
+        ".core.multigrid", "solve_free_boundary_multigrid"),
     "solve_free_boundary": (".core.freeboundary", "solve_free_boundary"),
     # wout IO
     "WoutData": (".core.wout", "WoutData"),
@@ -97,6 +100,7 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
     "MgridData": (".core.mgrid", "MgridData"),
     "MgridField": (".core.mgrid", "MgridField"),
     "read_mgrid": (".core.mgrid", "read_mgrid"),
+    "tabulate_cartesian_field": (".core.mgrid", "tabulate_cartesian_field"),
     "write_mgrid": (".core.mgrid", "write_mgrid"),
     # errors
     "VmecError": (".core.errors", "VmecError"),

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -7,7 +7,8 @@ VMEC2000 counterpart: the ``xvmec2000`` executable driver
 
 The solve path is the clean-room core end to end:
 :class:`vmex.core.input.VmecInput` (INDATA or VMEC++-style JSON) ->
-:func:`vmex.core.multigrid.solve_multigrid` ->
+:func:`vmex.core.multigrid.solve_multigrid` (fixed boundary) or
+:func:`vmex.core.multigrid.solve_free_boundary_multigrid` (free boundary) ->
 :func:`vmex.core.wout.wout_from_state` -> :func:`vmex.core.wout.write_wout`,
 plus the core plotting (``--plot``) and Boozer (``--booz``) drivers.
 
@@ -18,8 +19,8 @@ Zero-crash policy (§2.5): every failure maps to a typed
 
 Free-boundary routing (``LFREEB = T``):
 
-- a readable mgrid file goes to
-  :func:`vmex.core.freeboundary.solve_free_boundary` with the VMEC2000
+- a readable mgrid file goes to the full free-boundary ``NS_ARRAY`` ladder
+  with the VMEC2000
   console output (``In VACUUM`` block, ``VACUUM PRESSURE TURNED ON`` banner)
   and free-boundary wout metadata (``nextcur``/``extcur``/``curlabel``/
   ``mgrid_mode``);
@@ -33,10 +34,6 @@ Free-boundary routing (``LFREEB = T``):
 
 Documented divergences of the free-boundary lane:
 
-- :func:`~vmex.core.freeboundary.solve_free_boundary` is single-grid
-  with no warm-start seam, so only the *final* ``NS_ARRAY`` stage is run
-  (from the standard interior guess); VMEC2000 runs the whole ladder with
-  vacuum re-activating per stage.  Multi-stage decks print a note.
 - The NESTOR vacuum potential is not returned by the solver, so the wout
   ``potsin``/``xmpot``/``xnpot`` and ``*_sur`` variables are written as
   netCDF fill (see :func:`vmex.core.wout.wout_from_state`).
@@ -487,24 +484,6 @@ def _free_boundary_plan(args, inp, input_path: Path, *, emit):
     )
 
 
-def _final_stage_params(inp, args) -> tuple[int, float, int]:
-    """Final ``NS_ARRAY`` stage ``(ns, ftol, niter)`` incl. CLI overrides."""
-    import numpy as np
-
-    ns_arr = np.atleast_1d(np.asarray(inp.ns_array, dtype=np.int64)).ravel()
-    positive = ns_arr[ns_arr > 0]
-    ns = int(positive.max()) if positive.size else int(ns_arr[0])
-    ftol = (
-        float(args.ftol) if args.ftol is not None
-        else float(np.atleast_1d(np.asarray(inp.ftol_array, dtype=float)).ravel()[-1])
-    )
-    niter = (
-        int(args.max_iter) if args.max_iter is not None
-        else int(np.atleast_1d(np.asarray(inp.niter_array)).ravel()[-1])
-    )
-    return ns, ftol, niter
-
-
 def _stage_overrides(inp, *, ftol: float | None, max_iter: int | None):
     """Final-stage ftol/niter overrides for the multigrid ladder."""
     import numpy as np
@@ -561,8 +540,6 @@ def _write_wout_from_result(inp, input_path: Path, result, wout_path: Path,
 
 def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> int:
     """Full solve pipeline for one input deck (fixed- or free-boundary)."""
-    import numpy as np
-
     case = case_from_input(input_path)
     verbose = not bool(args.quiet)
 
@@ -576,26 +553,17 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
 
     t1 = time.perf_counter()
     if freeb_plan is not None:
-        from .freeboundary import solve_free_boundary
-        from .solver import resolution_from_input
+        from .multigrid import solve_free_boundary_multigrid
 
-        ns, ftol, niter = _final_stage_params(inp, args)
-        n_stages = np.atleast_1d(np.asarray(inp.ns_array, dtype=np.int64))
-        if verbose and int(np.count_nonzero(n_stages > 0)) > 1:
-            emit(
-                " NOTE: free-boundary solves are single-grid; running only the "
-                f"final NS_ARRAY stage (NS = {ns})."
-            )
+        ftol_array, niter_array = _stage_overrides(
+            inp, ftol=args.ftol, max_iter=args.max_iter)
         # NITER-exhausted runs return (not raise) so the wout is still
         # written (VMEC2000 behavior); the exit code carries ier_flag = 2.
-        result = solve_free_boundary(
-            inp,
-            resolution=resolution_from_input(inp, ns=ns),
-            ftol=ftol,
-            max_iterations=niter,
+        result = solve_free_boundary_multigrid(
+            inp, ftol_array=ftol_array, niter_array=niter_array,
             verbose=verbose,
             emit=emit,
-            error_on_no_convergence=False,
+            raise_on_max_iterations=False,
             device=None if args.device == "none" else args.device,
             **freeb_plan.solver_kwargs,
         )

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -37,10 +37,10 @@ Documented divergences of the free-boundary lane:
 - The NESTOR vacuum potential is not returned by the solver, so the wout
   ``potsin``/``xmpot``/``xnpot`` and ``*_sur`` variables are written as
   netCDF fill (see :func:`vmex.core.wout.wout_from_state`).
-- An NITER-exhausted free-boundary run still writes the wout (VMEC2000
-  behavior) and exits with ``ier_flag = 2`` (MORE ITERATIONS REQUIRED).
-- For fixed boundary, ``LFULL3D1OUT = T`` requests the same NITER-exhausted
-  WOUT; fatal numerical/Jacobian errors still do not produce one.
+- ``LFULL3D1OUT = T`` requests a WOUT after NITER exhaustion for either
+  boundary mode.  With the default ``F``, VMEC2000 and VMEX return
+  ``ier_flag = 2`` without a WOUT.  Fatal numerical/Jacobian errors never
+  produce one.
 """
 
 from __future__ import annotations
@@ -254,7 +254,7 @@ def _parse_booz_surfaces(text: str | None):
 # ---------------------------------------------------------------------------
 
 
-def _preamble(case: str) -> str:
+def _preamble(case: str, *, time_slice: float = 0.0) -> str:
     """Run header block (vmec.f banner, structural match to xvmec2000)."""
     import platform
 
@@ -263,7 +263,7 @@ def _preamble(case: str) -> str:
     clock = time.strftime("%H:%M:%S", now)
     return (
         " - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -\n"
-        "  SEQ =    1 TIME SLICE  0.0000E+00\n"
+        f"  SEQ =    1 TIME SLICE {float(time_slice):11.4E}\n"
         f"  PROCESSING INPUT.{case}\n"
         f"  THIS IS VMEX, VERSION {_package_version()}\n"
         "  Lambda: Full Radial Mesh. L-Force: hybrid full/half.\n"
@@ -550,8 +550,16 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
     read_s = time.perf_counter() - t0
 
     if verbose:
-        emit(_preamble(case))
+        emit(_preamble(case, time_slice=float(getattr(inp, "time_slice", 0.0))))
     freeb_plan = _free_boundary_plan(args, inp, input_path, emit=emit)
+    # VMEC2000 turns off LFREEB when the requested mgrid cannot be opened.
+    # Use that effective mode in setup and WOUT metadata, not merely in CLI
+    # routing; otherwise a fixed-boundary fallback is mislabeled free-boundary.
+    effective_inp = inp
+    if bool(getattr(inp, "lfreeb", False)) and freeb_plan is None:
+        import dataclasses
+
+        effective_inp = dataclasses.replace(inp, lfreeb=False)
 
     t1 = time.perf_counter()
     if freeb_plan is not None:
@@ -559,13 +567,13 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
 
         ftol_array, niter_array = _stage_overrides(
             inp, ftol=args.ftol, max_iter=args.max_iter)
-        # NITER-exhausted runs return (not raise) so the wout is still
-        # written (VMEC2000 behavior); the exit code carries ier_flag = 2.
         result = solve_free_boundary_multigrid(
             inp, ftol_array=ftol_array, niter_array=niter_array,
             verbose=verbose,
             emit=emit,
-            raise_on_max_iterations=False,
+            raise_on_max_iterations=not bool(
+                getattr(inp, "lfull3d1out", False)
+            ),
             device=None if args.device == "none" else args.device,
             **freeb_plan.solver_kwargs,
         )
@@ -574,7 +582,7 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
 
         ftol_array, niter_array = _stage_overrides(inp, ftol=args.ftol, max_iter=args.max_iter)
         result = solve_multigrid(
-            inp,
+            effective_inp,
             ftol_array=ftol_array,
             niter_array=niter_array,
             mode=str(args.mode),
@@ -590,7 +598,7 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
     wout_path = resolve_wout_path(input_path=input_path, outdir=outdir)
     wout_path.parent.mkdir(parents=True, exist_ok=True)
     t2 = time.perf_counter()
-    wout = _write_wout_from_result(inp, input_path, result, wout_path,
+    wout = _write_wout_from_result(effective_inp, input_path, result, wout_path,
                                    freeb_plan=freeb_plan)
     wout_s = time.perf_counter() - t2
 

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -203,6 +203,15 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--ftol", type=float, default=None, help="Override the final-stage FTOL_ARRAY tolerance.")
     p.add_argument("--max-iter", type=int, default=None, help="Override the final-stage NITER_ARRAY iteration cap.")
     p.add_argument(
+        "--jacobian-retries",
+        type=int,
+        default=2,
+        help=(
+            "Best-checkpoint retries after 75 Jacobian resets (default: 2; "
+            "0 preserves the VMEC2000 fatal-stop policy)."
+        ),
+    )
+    p.add_argument(
         "--coils",
         metavar="PATH",
         type=str,
@@ -575,6 +584,7 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
                 getattr(inp, "lfull3d1out", False)
             ),
             device=None if args.device == "none" else args.device,
+            jacobian_retries=int(args.jacobian_retries),
             **freeb_plan.solver_kwargs,
         )
     else:
@@ -592,6 +602,7 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
                 getattr(inp, "lfull3d1out", False)
             ),
             device=None if args.device == "none" else args.device,
+            jacobian_retries=int(args.jacobian_retries),
         )
     solve_s = time.perf_counter() - t1
 

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -39,6 +39,8 @@ Documented divergences of the free-boundary lane:
   netCDF fill (see :func:`vmex.core.wout.wout_from_state`).
 - An NITER-exhausted free-boundary run still writes the wout (VMEC2000
   behavior) and exits with ``ier_flag = 2`` (MORE ITERATIONS REQUIRED).
+- For fixed boundary, ``LFULL3D1OUT = T`` requests the same NITER-exhausted
+  WOUT; fatal numerical/Jacobian errors still do not produce one.
 """
 
 from __future__ import annotations
@@ -578,6 +580,9 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
             mode=str(args.mode),
             verbose=verbose,
             emit=emit,
+            raise_on_max_iterations=not bool(
+                getattr(inp, "lfull3d1out", False)
+            ),
             device=None if args.device == "none" else args.device,
         )
     solve_s = time.perf_counter() - t1

--- a/vmex/core/device.py
+++ b/vmex/core/device.py
@@ -44,6 +44,7 @@ import contextlib
 from typing import Any
 
 import jax
+import numpy as np
 
 __all__ = [
     "AUTO",
@@ -180,3 +181,23 @@ def device_context(device: Any = AUTO, resolution: Any = None):
     if dev is None:
         return contextlib.nullcontext()
     return jax.default_device(dev)
+
+
+def _placement_device(device: Any = AUTO, resolution: Any = None):
+    """Concrete target for already-committed input arrays, or ``None``."""
+    dev = resolve_device(device, resolution)
+    if dev is not None or device is None:
+        return dev
+    configured = jax.config.jax_default_device
+    return configured if configured is not None else jax.devices()[0]
+
+
+def _put_numeric_leaves(value: Any, device: Any):
+    """Move registered-pytree array leaves while preserving metadata/objects."""
+    if value is None or device is None:
+        return value
+    return jax.tree.map(
+        lambda leaf: jax.device_put(leaf, device)
+        if isinstance(leaf, (jax.Array, np.ndarray)) else leaf,
+        value,
+    )

--- a/vmex/core/errors.py
+++ b/vmex/core/errors.py
@@ -33,6 +33,13 @@ SUCCESSFUL_TERM_FLAG = 11
 # ``solver._finalize`` distinguish NaN/Inf from a Jacobian-retry failure.
 NONFINITE_FLAG = 90
 
+# Internal-only eqsolve control transfer.  VMEC2000 communicates this as
+# ``irst = 4`` (not an ier_flag): with ``LMOVE_AXIS=T``, a finite first force
+# sum above 1e2 returns to eqsolve so ``guess_axis`` can rebuild the initial
+# profiles before any momentum step is taken.  A distinct carry status lets
+# the jitted VMEX loop make the same host-side control transfer.
+AXIS_REGUESS_FLAG = 91
+
 #: VMEC2000 termination messages, keyed by ier_flag
 #: (Sources/Input_Output/fileout.f, ``werror`` table).
 WERROR_MESSAGES: dict[int, str] = {

--- a/vmex/core/fields.py
+++ b/vmex/core/fields.py
@@ -53,6 +53,8 @@ __all__ = [
     "energies_and_force_norms",
     "preconditioned_force_norm",
     "surface_currents",
+    "radial_force_balance_error",
+    "force_balance_preconditioner_factor",
     "constraint_scaling",
 ]
 
@@ -610,6 +612,130 @@ def surface_currents(
     rbtor = 1.5 * bvco[-1] - 0.5 * bvco[-2]
     rbtor0 = 1.5 * bvco[1] - 0.5 * bvco[2] if ns >= 3 else bvco[-1]
     return CurrentDiagnostics(buco=buco, bvco=bvco, ctor=ctor, rbtor=rbtor, rbtor0=rbtor0)
+
+
+# ---------------------------------------------------------------------------
+# Non-variational m=1 force-balance replacement (fbal.f / precondn.f)
+# ---------------------------------------------------------------------------
+
+
+def radial_force_balance_error(
+    *,
+    fields: MagneticFields,
+    phipf: Array,
+    trig: TrigTables,
+    s: Array,
+    signgs: int,
+) -> Array:
+    """Flux-surface-averaged radial force error ``equif`` (VMEC ``fbal.f``).
+
+    This is the non-normalized quantity consumed by ``tomnsp_mod.f`` when
+    ``LFORBAL = T``.  On the interior full mesh,
+
+    ``equif = (-phipf*jcuru + chipf*jcurv)/vpphi + dp/ds``,
+
+    where the contravariant current averages follow from radial differences
+    of ``<B_u>`` and ``<B_v>``.  The axis and edge rows are zero, exactly as
+    in ``calc_fbal``.  ``fields.chips`` is the effective ``chipf`` after the
+    ``NCURR=1`` current constraint, when active.
+    """
+    s = jnp.asarray(s)
+    ns = int(s.shape[0])
+    dtype = fields.bsubu.dtype
+    if ns < 3:
+        return jnp.zeros((ns,), dtype=dtype)
+
+    currents = surface_currents(
+        bsubu=fields.bsubu,
+        bsubv=fields.bsubv,
+        trig=trig,
+        s=s,
+        signgs=signgs,
+    )
+    hs = jnp.asarray(s[1] - s[0], dtype=dtype)
+    ohs = 1.0 / hs
+    signgs_f = jnp.asarray(float(int(signgs)), dtype=dtype)
+
+    jcurv = signgs_f * ohs * (currents.buco[2:] - currents.buco[1:-1])
+    jcuru = -signgs_f * ohs * (currents.bvco[2:] - currents.bvco[1:-1])
+    vpphi = 0.5 * (fields.vp[2:] + fields.vp[1:-1])
+    presgrad = ohs * (fields.pressure[2:] - fields.pressure[1:-1])
+    core = (
+        -jnp.asarray(phipf, dtype=dtype)[1:-1] * jcuru
+        + fields.chips[1:-1] * jcurv
+    ) / vpphi + presgrad
+    return jnp.concatenate(
+        [jnp.zeros((1,), dtype=dtype), core, jnp.zeros((1,), dtype=dtype)]
+    )
+
+
+def force_balance_preconditioner_factor(
+    *,
+    axd_odd: Array,
+    dxdu_half: Array,
+    trig_multiplier: Array,
+    jacobian: HalfMeshJacobian,
+    fields: MagneticFields,
+    trig: TrigTables,
+    s: Array,
+    signgs: int,
+) -> Array:
+    """Return the pre-halving ``rzu_fac``/``rru_fac`` of VMEC ``bcovar.f``.
+
+    ``precondn.f`` returns
+
+    ``eqfactor = axd(m-odd)*hs**2 / [signgs*(temp(js)+temp(js+1))]``
+
+    with ``temp = <(-4*r0scale**2)*R*bsq*trigmult*X_u*wint>/vp``.
+    ``bcovar.f`` multiplies this by ``sqrt(s)`` before constructing the
+    reciprocal ``frcc_fac``/``fzsc_fac`` and then halves it for the final
+    ``tomnsp_mod.f`` replacement.  This function deliberately returns the
+    value *before* that final division by two.
+
+    For the R-force factor, pass ``X_u=Z_u`` and ``trigmult=cos(theta)``;
+    for the Z-force factor, pass ``X_u=R_u`` and
+    ``trigmult=-sin(theta)``.
+    """
+    s = jnp.asarray(s)
+    ns = int(s.shape[0])
+    dtype = fields.total_pressure.dtype
+    if ns < 3:
+        return jnp.zeros((ns,), dtype=dtype)
+
+    hs = jnp.asarray(s[1] - s[0], dtype=dtype)
+    r0scale = jnp.asarray(_r0scale(trig), dtype=dtype)
+    pfactor = -4.0 * r0scale * r0scale
+    wint = _angle_weights(trig, dtype)[None, :, :]
+    multiplier = jnp.asarray(trig_multiplier, dtype=dtype)[None, :, None]
+    temp_half = jnp.sum(
+        pfactor
+        * jacobian.r12
+        * fields.total_pressure
+        * wint
+        * multiplier
+        * jnp.asarray(dxdu_half, dtype=dtype),
+        axis=(1, 2),
+    )
+    vp_safe = jnp.where(fields.vp != 0.0, fields.vp, jnp.ones_like(fields.vp))
+    temp_half = jnp.where(fields.vp != 0.0, temp_half / vp_safe, 0.0)
+    temp_full = jnp.asarray(float(int(signgs)), dtype=dtype) * (
+        temp_half
+        + jnp.concatenate([temp_half[1:], jnp.zeros((1,), dtype=dtype)])
+    )
+    eqfactor_core = (
+        jnp.asarray(axd_odd, dtype=dtype)[1:-1]
+        * hs
+        * hs
+        / temp_full[1:-1]
+    )
+    factor_core = jnp.sqrt(jnp.maximum(s[1:-1], 0.0)) * eqfactor_core
+    return jnp.concatenate(
+        [
+            jnp.zeros((1,), dtype=dtype),
+            factor_core,
+            jnp.zeros((1,), dtype=dtype),
+        ]
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/vmex/core/fields.py
+++ b/vmex/core/fields.py
@@ -636,8 +636,9 @@ def radial_force_balance_error(
 
     where the contravariant current averages follow from radial differences
     of ``<B_u>`` and ``<B_v>``.  The axis and edge rows are zero, exactly as
-    in ``calc_fbal``.  ``fields.chips`` is the effective ``chipf`` after the
-    ``NCURR=1`` current constraint, when active.
+    in ``calc_fbal``.  ``fields.chips`` is the effective half-mesh profile
+    after the ``NCURR=1`` current constraint, when active.  ``add_fluxes.f90``
+    reconstructs the full-mesh ``chipf`` used here for both current modes.
     """
     s = jnp.asarray(s)
     ns = int(s.shape[0])
@@ -660,9 +661,17 @@ def radial_force_balance_error(
     jcuru = -signgs_f * ohs * (currents.bvco[2:] - currents.bvco[1:-1])
     vpphi = 0.5 * (fields.vp[2:] + fields.vp[1:-1])
     presgrad = ohs * (fields.pressure[2:] - fields.pressure[1:-1])
+    chips = jnp.asarray(fields.chips, dtype=dtype)
+    chipf = jnp.concatenate(
+        (
+            (1.5 * chips[1] - 0.5 * chips[2])[None],
+            0.5 * (chips[1:-1] + chips[2:]),
+            (1.5 * chips[-1] - 0.5 * chips[-2])[None],
+        )
+    )
     core = (
         -jnp.asarray(phipf, dtype=dtype)[1:-1] * jcuru
-        + fields.chips[1:-1] * jcurv
+        + chipf[1:-1] * jcurv
     ) / vpphi + presgrad
     return jnp.concatenate(
         [jnp.zeros((1,), dtype=dtype), core, jnp.zeros((1,), dtype=dtype)]

--- a/vmex/core/forces.py
+++ b/vmex/core/forces.py
@@ -76,6 +76,7 @@ __all__ = [
     "mhd_forces",
     "symmetrize_forces",
     "spectral_mhd_forces",
+    "apply_m1_force_balance",
 ]
 
 Array = Any
@@ -911,3 +912,49 @@ def spectral_mhd_forces(
         force_lambda_cc=out_asym.force_lambda_cc,
         force_lambda_ss=out_asym.force_lambda_ss,
     )
+
+
+def apply_m1_force_balance(
+    force: SpectralForce,
+    *,
+    equif: Array,
+    factor_R: Array,
+    factor_Z: Array,
+) -> SpectralForce:
+    """Apply VMEC2000's ``LFORBAL`` ``(m=1,n=0)`` force replacement.
+
+    ``tomnsp_mod.f`` replaces only the stellarator-symmetric ``frcc`` and
+    ``fzsc`` blocks, including in ``LASYM`` runs.  With ``factor_R/Z`` equal
+    to the pre-halving ``rzu_fac/rru_fac`` values from ``bcovar.f``, the
+    interior full-mesh rows are
+
+    ``work = frcc/factor_R - fzsc/factor_Z``
+
+    ``frcc = (factor_R/2)*(equif + work)``
+
+    ``fzsc = (factor_Z/2)*(equif - work)``.
+
+    Axis and edge rows, all other modes, and all asymmetric blocks are
+    unchanged.
+    """
+    frcc = force.force_R_cc
+    fzsc = force.force_Z_sc
+    if frcc is None or fzsc is None:
+        return force
+    frcc = jnp.asarray(frcc)
+    fzsc = jnp.asarray(fzsc)
+    ns, mpol, _ = frcc.shape
+    if int(ns) < 3 or int(mpol) < 2:
+        return force
+
+    factor_R = jnp.asarray(factor_R, dtype=frcc.dtype)
+    factor_Z = jnp.asarray(factor_Z, dtype=fzsc.dtype)
+    equif = jnp.asarray(equif, dtype=frcc.dtype)
+    old_R = frcc[1:-1, 1, 0]
+    old_Z = fzsc[1:-1, 1, 0]
+    work = old_R / factor_R[1:-1] - old_Z / factor_Z[1:-1]
+    new_R = 0.5 * factor_R[1:-1] * (equif[1:-1] + work)
+    new_Z = 0.5 * factor_Z[1:-1] * (equif[1:-1] - work)
+    frcc = frcc.at[1:-1, 1, 0].set(new_R)
+    fzsc = fzsc.at[1:-1, 1, 0].set(new_Z)
+    return replace(force, force_R_cc=frcc, force_Z_sc=fzsc)

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -30,12 +30,10 @@ and the whole post-turn-on steady state — vacuum cadence, constraint damping,
 because it applies the one-time soft restart and prints the banners.  The
 per-iteration numerics are identical to the per-pass host driver.
 
-Known divergence from VMEC2000 (documented): at turn-on VMEC computes the
-turn-on iteration's forces from the pre-restart geometry while evolving the
-restored state; here the restart is applied *before* the turn-on iteration,
-so that iteration's forces come from the restored state.  The golden
-free-boundary fixture is chaotic/unconverged past turn-on, so trajectories
-are compared structurally, not pointwise.
+The one unusual turn-on pass preserves VMEC2000's ordering: its forces use
+the geometry computed before the soft restart while the momentum update
+evolves the restored best state.  Subsequent passes use the ordinary shared
+iteration body.
 """
 
 from __future__ import annotations
@@ -58,6 +56,7 @@ from .fourier import ModeTable
 from .geometry import half_mesh_jacobian
 from .input import VmecInput
 from .mgrid import MgridField
+from .preconditioner_2d import Prec2DConfig
 from .printing import (
     FORCE_ITERATIONS_BANNER, screen_header, screen_line, stage_banner,
     vacuum_banner,
@@ -66,7 +65,7 @@ from .solver import (
     SolveResult, SolverRuntime, SpectralState,
     _finalize, _geometry, _initial_carry, _initial_state, _make_body,
     _result_from_carry, _zero_cache, prepare_runtime, resolution_from_input,
-    reguess_initial_axis,
+    reguess_initial_axis, runtime_with_baselines,
 )
 from .transforms import register_pytree_dataclass as _register
 from .vacuum import (
@@ -363,6 +362,12 @@ def _iter_lane(carry, rt: SolverRuntime):
     return _make_body(rt)(carry)
 
 
+@jax.jit
+def _turnon_iter_lane(carry, rt: SolverRuntime, evaluation_state: SpectralState):
+    """VMEC2000 turn-on pass: old-geometry forces evolve restored ``xc``."""
+    return _make_body(rt, evaluation_state=evaluation_state)(carry)
+
+
 # ---------------------------------------------------------------------------
 # Free-boundary driver state
 # ---------------------------------------------------------------------------
@@ -379,6 +384,7 @@ class FreeBoundaryState:
     banner_pending: bool = False
     delbsq: float = 1.0
     bsqvac: np.ndarray | None = None
+    rbsq: np.ndarray | None = None
     # NESTOR cache (amatsav / bvecsav of scalpot.f):
     mode_matrix: Any = None
     bvec_nonsing: Any = None
@@ -389,9 +395,39 @@ class FreeBoundaryState:
     full_updates: int = 0
 
 
+@dataclass(frozen=True)
+class _FreeBoundaryStageResult:
+    """One radial stage plus the vacuum continuation state for the next grid."""
+
+    result: SolveResult
+    vacuum: FreeBoundaryState
+    continuation_state: SpectralState
+    rcon0: Array
+    zcon0: Array
+
+
 def _resolve_mgrid(inp: VmecInput, mgrid_path: str | Path | None) -> Path:
     p = Path(str(mgrid_path if mgrid_path is not None else inp.mgrid_file)).expanduser()
     return p
+
+
+def _external_field_from_input(
+    inp: VmecInput, mgrid_path: str | Path | None = None,
+) -> MgridField:
+    """Load and scale the deck's external field once for one solve/ladder."""
+    path = _resolve_mgrid(inp, mgrid_path)
+    data_extcur = np.atleast_1d(np.asarray(
+        inp.extcur if inp.extcur is not None else [], dtype=float))
+    from .mgrid import read_mgrid
+
+    data = read_mgrid(path)  # raises MgridNotFoundError when missing
+    extcur = np.zeros((data.nextcur,), dtype=float)
+    n_copy = min(data_extcur.size, data.nextcur)
+    extcur[:n_copy] = data_extcur[:n_copy]
+    if str(data.mgrid_mode).upper().startswith(("R", "N")):
+        raw = np.asarray(data.raw_coil_cur, dtype=float)
+        extcur = np.divide(extcur, raw, out=extcur, where=raw != 0.0)
+    return MgridField.from_mgrid_data(data, extcur=extcur)
 
 
 # ---------------------------------------------------------------------------
@@ -640,6 +676,8 @@ def _make_fused_vacuum(basis: VacuumBasis, *, modes: ModeTable, signgs: int,
         )
         return {
             "bsqvac": bsqvac, "ctor": ctor, "rbtor": rbtor, "potvac": potvac,
+            "rbsq": (bsqvac + pres_ns * jnp.asarray(rt.presf_ns_scale))
+                    * boundary.R / jnp.asarray(rt.setup.hs),
             "mode_matrix": mode_matrix, "bvec_nonsing": bvec_nonsing,
             "delbsq_num": delbsq_num, "delbsq_den": delbsq_den,
             "bsubuvac": bsubuvac, "bsubvvac": bsubvvac,
@@ -665,6 +703,8 @@ def _make_fused_vacuum(basis: VacuumBasis, *, modes: ModeTable, signgs: int,
         )
         return {
             "bsqvac": bsqvac, "ctor": ctor, "rbtor": rbtor, "potvac": potvac,
+            "rbsq": (bsqvac + pres_ns * jnp.asarray(rt.presf_ns_scale))
+                    * boundary.R / jnp.asarray(rt.setup.hs),
             "delbsq_num": delbsq_num, "delbsq_den": delbsq_den,
             "bsubuvac": bsubuvac, "bsubvvac": bsubvvac,
         }
@@ -780,6 +820,7 @@ def _vacuum_step(
     else:
         out = fused_vac.skip(carry.state, rt, field, fb.bvec_nonsing, fb.mode_matrix)
     bsqvac = out["bsqvac"]
+    fb.rbsq = out["rbsq"]
     fb.potvac = out["potvac"]
     fb.ctor = float(out["ctor"])
     fb.rbtor = float(out["rbtor"])
@@ -884,6 +925,7 @@ class _VacuumLoopCarry:
     carry: Any                  # solver._LoopCarry
     rcon0: Array; zcon0: Array
     bsqvac: Array               # NESTOR 0.5*|B|^2 on the boundary grid
+    rbsq: Array                 # carried forces.f edge-pressure product
     mode_matrix: Array          # amatsav (scalpot.f)
     bvec_nonsing: Array         # bvecsav (scalpot.f)
     potvac: Array
@@ -932,18 +974,18 @@ def _make_vacuum_lane(fused: FusedVacuum):
 
         def _full(_):
             out = fused.full(c.state, rt_vac, field)
-            return (out["bsqvac"], out["ctor"], out["rbtor"], out["potvac"],
+            return (out["bsqvac"], out["rbsq"], out["ctor"], out["rbtor"], out["potvac"],
                     out["delbsq_num"], out["delbsq_den"],
                     out["mode_matrix"], out["bvec_nonsing"])
 
         def _skip(_):
             out = fused.skip(c.state, rt_vac, field, vc.bvec_nonsing,
                              vc.mode_matrix)
-            return (out["bsqvac"], out["ctor"], out["rbtor"], out["potvac"],
+            return (out["bsqvac"], out["rbsq"], out["ctor"], out["rbtor"], out["potvac"],
                     out["delbsq_num"], out["delbsq_den"],
                     vc.mode_matrix, vc.bvec_nonsing)
 
-        (bsqvac, ctor, rbtor, potvac, num, den, mode_matrix,
+        (bsqvac, rbsq, ctor, rbtor, potvac, num, den, mode_matrix,
          bvec_nonsing) = lax.cond(full, _full, _skip, None)
 
         delbsq = jnp.where(den != 0.0, num / den, vc.delbsq)
@@ -956,6 +998,7 @@ def _make_vacuum_lane(fused: FusedVacuum):
 
         return _VacuumLoopCarry(
             carry=new_carry, rcon0=rcon0, zcon0=zcon0, bsqvac=bsqvac,
+            rbsq=rbsq,
             mode_matrix=mode_matrix, bvec_nonsing=bvec_nonsing, potvac=potvac,
             ivac=ivac, nvacskip=nvacskip, nvskip0=vc.nvskip0,
             delbsq=delbsq, delbsq_traj=delbsq_traj, ctor=ctor, rbtor=rbtor,
@@ -976,7 +1019,7 @@ def _make_vacuum_lane(fused: FusedVacuum):
 # ---------------------------------------------------------------------------
 
 
-def _solve_free_boundary_impl(
+def _solve_free_boundary_stage(
     inp: VmecInput,
     *,
     mgrid_path: str | Path | None = None,
@@ -987,8 +1030,20 @@ def _solve_free_boundary_impl(
     verbose: bool = False,
     emit=print,
     error_on_no_convergence: bool = True,
-) -> SolveResult:
-    """Single-grid free-boundary solve (``eqsolve.f`` + ``funct3d.f`` IVAC0).
+    initial_state: SpectralState | None = None,
+    vacuum_continuation: FreeBoundaryState | None = None,
+    time_step: float | None = None,
+    tcon0: float | None = None,
+    gamma: float | None = None,
+    nstep: int | None = None,
+    lconm1: bool = True,
+    precon_type: str | None = None,
+    prec2d_threshold: float | None = None,
+    prec2d: Prec2DConfig | None = None,
+    constraint_continuation: tuple[Array, Array] | None = None,
+    reuse_vacuum_cache: bool = False,
+) -> _FreeBoundaryStageResult:
+    """Internal single-grid free-boundary stage with multigrid continuation.
 
     ``external_field`` overrides the mgrid file (any
     :class:`~vmex.core.mgrid.MgridField`-compatible object with a
@@ -1003,26 +1058,47 @@ def _solve_free_boundary_impl(
     if not bool(inp.lfreeb):
         raise ValueError("solve_free_boundary requires an LFREEB=T input")
     if external_field is None:
-        path = _resolve_mgrid(inp, mgrid_path)
-        data_extcur = np.atleast_1d(np.asarray(inp.extcur if inp.extcur is not None else [], dtype=float))
-        from .mgrid import read_mgrid
-
-        data = read_mgrid(path)  # raises MgridNotFoundError when missing
-        extcur = np.zeros((data.nextcur,), dtype=float)
-        n_copy = min(data_extcur.size, data.nextcur)
-        extcur[:n_copy] = data_extcur[:n_copy]
-        if str(data.mgrid_mode).upper().startswith("R") or str(data.mgrid_mode).upper().startswith("N"):
-            raw = np.asarray(data.raw_coil_cur, dtype=float)
-            extcur = np.divide(extcur, raw, out=extcur, where=raw != 0.0)
-        external_field = MgridField.from_mgrid_data(data, extcur=extcur)
+        external_field = _external_field_from_input(inp, mgrid_path)
 
     if resolution is None:
         resolution = resolution_from_input(inp)
-    rt = prepare_runtime(inp, resolution, ftol=ftol, max_iterations=max_iterations)
+    rt = prepare_runtime(
+        inp, resolution, ftol=ftol, max_iterations=max_iterations,
+        time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
+        lconm1=lconm1, precon_type=precon_type,
+        prec2d_threshold=prec2d_threshold, prec2d=prec2d,
+    )
     ns = int(resolution.ns)
     dtype = rt.setup.s_full.dtype
 
-    _init_state = _initial_state(rt.setup)
+    if initial_state is None:
+        _init_state = _initial_state(rt.setup)
+    else:
+        expected = (ns, rt.modes.mnmax)
+        if tuple(initial_state.R_cos.shape) != expected:
+            raise ValueError(
+                f"initial_state has shape {tuple(initial_state.R_cos.shape)}, "
+                f"expected {expected}; interpolate with "
+                "vmex.core.multigrid.interpolate_state first"
+            )
+        _init_state = initial_state
+        # Unlike fixed boundary, do not replace the edge row: it is an evolved
+        # unknown.  On a reset-style start (IVAC=-1), funct3d.f seeds the
+        # constraint baseline from this state at iter2==iter1.  Across an
+        # already-active radial transition, allocate_ns creates new zeroed
+        # rcon0/zcon0 arrays and funct3d deliberately does not reseed them
+        # (the seeding predicate requires IVAC<=0).
+        if constraint_continuation is not None:
+            rt = replace(
+                rt, rcon0=jnp.asarray(constraint_continuation[0]),
+                zcon0=jnp.asarray(constraint_continuation[1]))
+        elif (vacuum_continuation is not None
+              and vacuum_continuation.turned_on):
+            rt = replace(
+                rt, rcon0=jnp.zeros_like(rt.rcon0),
+                zcon0=jnp.zeros_like(rt.zcon0))
+        else:
+            rt = runtime_with_baselines(rt, _init_state)
     _initial_ijacob = 0
     # ``eqsolve.f`` retries a supplied axis when the first Jacobian changes
     # sign.  The fixed-boundary driver already did this in ``_solve_stage``;
@@ -1057,25 +1133,76 @@ def _solve_free_boundary_impl(
     )
 
     zeros_edge = jnp.zeros((basis.ntheta3, basis.nzeta), dtype=dtype)
+    carried_edge = zeros_edge
+    if (vacuum_continuation is not None
+            and vacuum_continuation.turned_on):
+        if vacuum_continuation.rbsq is not None:
+            # rbsq is a persistent angular array in VMEC2000.  At iter2=1
+            # funct3d skips IVAC0, so forces.f consumes the coarse-stage rbsq
+            # verbatim.  Express that product as an equivalent bsqvac on the
+            # new geometry for the shared force seam.
+            _, carried_geometry = _geometry(_init_state, rt)
+            r_edge = carried_geometry.R_even[-1] + carried_geometry.R_odd[-1]
+            pres_ns = _vacuum_scalars(_init_state, rt)[5]
+            rbsq = jnp.asarray(vacuum_continuation.rbsq, dtype=dtype)
+            carried_edge = jnp.where(
+                r_edge != 0.0, rbsq * jnp.asarray(rt.setup.hs) / r_edge,
+                jnp.zeros_like(r_edge),
+            ) - pres_ns * jnp.asarray(_presf_ns_scale(inp, ns), dtype=dtype)
+        elif vacuum_continuation.bsqvac is not None:
+            carried_edge = jnp.asarray(vacuum_continuation.bsqvac, dtype=dtype)
+        if tuple(carried_edge.shape) != tuple(zeros_edge.shape):
+            raise ValueError(
+                "carried vacuum-pressure grid has shape "
+                f"{tuple(carried_edge.shape)}, expected {tuple(zeros_edge.shape)}"
+            )
     rt_fixed = replace(rt, lfreeb=False, bsqvac_edge=zeros_edge,
                        presf_ns_scale=jnp.asarray(0.0, dtype=dtype))
     rt_freeb = replace(
-        rt, lfreeb=True, jmax=ns, bsqvac_edge=zeros_edge,
+        rt, lfreeb=True, jmax=ns, bsqvac_edge=carried_edge,
         presf_ns_scale=jnp.asarray(_presf_ns_scale(inp, ns), dtype=dtype),
     )
 
-    fb = FreeBoundaryState(
-        ivac=-1,
-        nvacskip=max(1, int(inp.nvacskip)),
-        nvskip0=max(1, int(inp.nvacskip)),
-    )
+    if vacuum_continuation is None:
+        fb = FreeBoundaryState(
+            ivac=-1,
+            nvacskip=max(1, int(inp.nvacskip)),
+            nvskip0=max(1, int(inp.nvacskip)),
+        )
+    else:
+        # runvmec.f does not reset IVAC or the adaptive NVACSKIP at an
+        # initialize_radial.f transition.  Carry those scalar controls (and
+        # DEL-BSQ for screen parity).  A changed radial grid discards the
+        # dynamic NESTOR matrix/vector; an equal-grid rerun preserves them,
+        # matching initialize_radial.f's early return.
+        fb = FreeBoundaryState(
+            ivac=int(vacuum_continuation.ivac),
+            nvacskip=max(1, int(vacuum_continuation.nvacskip)),
+            nvskip0=max(1, int(vacuum_continuation.nvskip0)),
+            turned_on=bool(vacuum_continuation.turned_on),
+            delbsq=float(vacuum_continuation.delbsq),
+            bsqvac=vacuum_continuation.bsqvac,
+            rbsq=vacuum_continuation.rbsq,
+            ctor=float(vacuum_continuation.ctor),
+            rbtor=float(vacuum_continuation.rbtor),
+            mode_matrix=(vacuum_continuation.mode_matrix
+                         if reuse_vacuum_cache else None),
+            bvec_nonsing=(vacuum_continuation.bvec_nonsing
+                          if reuse_vacuum_cache else None),
+            potvac=(vacuum_continuation.potvac
+                    if reuse_vacuum_cache else None),
+        )
+    vacuum_active = fb.turned_on
 
     if verbose:
         emit(stage_banner(ns, resolution.mnmax, rt.ftol, rt.max_iterations), end="")
         emit(FORCE_ITERATIONS_BANNER, end="")
         emit(screen_header(lasym=resolution.lasym, lfreeb=True), end="")
 
-    carry = _initial_carry(_init_state, rt_fixed, ijacob=_initial_ijacob)
+    # An already-active multigrid stage evaluates with the free-boundary edge
+    # row on its first pass, so its zero cache must have jmax=ns (not ns-1).
+    rt_initial = rt_freeb if vacuum_active else rt_fixed
+    carry = _initial_carry(_init_state, rt_initial, ijacob=_initial_ijacob)
     printed: set[int] = set()
     #: per-iteration DEL-BSQ recorded by the batched steady-state lane; rows
     #: not covered (pre-activation, turn-on pass) fall back to ``fb.delbsq``
@@ -1117,13 +1244,23 @@ def _solve_free_boundary_impl(
                 break
             # Activation is now due: fall through to the host-stepped
             # turn-on pass (first vacuum call, soft restart, banners).
-        elif fb.turned_on and not fb.banner_pending:
+        elif fb.turned_on and int(carry.iteration) == 1:
+            # funct3d.f wraps the entire IVAC0 block in ``iter2 > 1``.  At a
+            # new radial grid, iteration 1 therefore uses the coarse stage's
+            # carried bsqvac once; iteration 2 performs the first full update
+            # against freshly selected resolution-specific NESTOR programs.
+            carry = _iter_lane(carry, rt_freeb)
+            _emit_due(final=False)
+            continue
+        elif (fb.turned_on and not fb.banner_pending
+              and fb.mode_matrix is not None):
             # F.2: the whole post-turn-on steady state runs as ONE jitted
             # while_loop (vacuum cadence + damping + iteration, traced).
             vc = _VacuumLoopCarry(
                 carry=carry,
                 rcon0=rt_freeb.rcon0, zcon0=rt_freeb.zcon0,
                 bsqvac=rt_freeb.bsqvac_edge,
+                rbsq=jnp.asarray(fb.rbsq, dtype=dtype),
                 mode_matrix=fb.mode_matrix, bvec_nonsing=fb.bvec_nonsing,
                 potvac=fb.potvac,
                 ivac=jnp.asarray(fb.ivac, dtype=int_dtype),
@@ -1144,6 +1281,7 @@ def _solve_free_boundary_impl(
             fb.nvacskip = int(vc.nvacskip)
             fb.delbsq = float(vc.delbsq)
             fb.bsqvac = vc.bsqvac
+            fb.rbsq = vc.rbsq
             fb.mode_matrix = vc.mode_matrix
             fb.bvec_nonsing = vc.bvec_nonsing
             fb.potvac = vc.potvac
@@ -1165,6 +1303,7 @@ def _solve_free_boundary_impl(
         if it > 1 and fsq_rz <= ACTIVATION_FSQ:
             fb.ivac += 1
         rt_use = rt_fixed
+        turnon_evaluation_state = None
         if fb.ivac >= 0:
             # Damp the constraint baselines (funct3d: 0.9 per iteration).
             rt_fixed = replace(rt_fixed, rcon0=0.9 * rt_fixed.rcon0, zcon0=0.9 * rt_fixed.zcon0)
@@ -1182,11 +1321,12 @@ def _solve_free_boundary_impl(
             if fb.ivac >= 1 and not fb.turned_on:
                 # funct3d.f soft start (restart_iter, irst = 2) applied on
                 # the host: best state restored, velocity zeroed, delt*0.9,
-                # iter1 = iter2, ijacob += 1.  Divergence from VMEC noted in
-                # the module docstring (restart applied before this
-                # iteration's force evaluation).
+                # iter1 = iter2, ijacob += 1.  funct3d.f has already computed
+                # geometry at the pre-restart state, so preserve it for this
+                # pass's force evaluation (the momentum base remains xstore).
                 fb.turned_on = True
                 fb.banner_pending = True
+                turnon_evaluation_state = carry.state
                 carry = replace(
                     carry,
                     state=carry.xstore,
@@ -1203,7 +1343,10 @@ def _solve_free_boundary_impl(
                 rt_freeb = replace(rt_freeb, bsqvac_edge=jnp.asarray(bsqvac, dtype=dtype))
                 rt_use = rt_freeb
 
-        carry = _iter_lane(carry, rt_use)
+        if turnon_evaluation_state is None:
+            carry = _iter_lane(carry, rt_use)
+        else:
+            carry = _turnon_iter_lane(carry, rt_use, turnon_evaluation_state)
 
         if fb.banner_pending:
             if verbose:
@@ -1216,10 +1359,19 @@ def _solve_free_boundary_impl(
     ier = int(carry.ier)
     if ier == MORE_ITER_FLAG and not error_on_no_convergence:
         result = _result_from_carry(carry, rt_freeb if fb.turned_on else rt_fixed)
-        return replace(result, converged=False, ier_flag=MORE_ITER_FLAG)
+        return _FreeBoundaryStageResult(
+            replace(result, converged=False, ier_flag=MORE_ITER_FLAG), fb,
+            carry.xstore, rt_freeb.rcon0 if fb.turned_on else rt_fixed.rcon0,
+            rt_freeb.zcon0 if fb.turned_on else rt_fixed.zcon0)
     if ier == SUCCESSFUL_TERM_FLAG:
-        return _result_from_carry(carry, rt_freeb if fb.turned_on else rt_fixed)
-    return _finalize(carry, rt_freeb if fb.turned_on else rt_fixed)
+        return _FreeBoundaryStageResult(
+            _result_from_carry(carry, rt_freeb if fb.turned_on else rt_fixed), fb,
+            carry.xstore, rt_freeb.rcon0 if fb.turned_on else rt_fixed.rcon0,
+            rt_freeb.zcon0 if fb.turned_on else rt_fixed.zcon0)
+    return _FreeBoundaryStageResult(
+        _finalize(carry, rt_freeb if fb.turned_on else rt_fixed), fb,
+        carry.xstore, rt_freeb.rcon0 if fb.turned_on else rt_fixed.rcon0,
+        rt_freeb.zcon0 if fb.turned_on else rt_fixed.zcon0)
 
 
 def solve_free_boundary(
@@ -1233,24 +1385,44 @@ def solve_free_boundary(
     verbose: bool = False,
     emit=print,
     error_on_no_convergence: bool = True,
+    initial_state: SpectralState | None = None,
     device: Any = AUTO,
+    time_step: float | None = None,
+    tcon0: float | None = None,
+    gamma: float | None = None,
+    nstep: int | None = None,
+    lconm1: bool = True,
+    precon_type: str | None = None,
+    prec2d_threshold: float | None = None,
+    prec2d: Prec2DConfig | None = None,
 ) -> SolveResult:
-    """Run a single-grid free-boundary solve on the selected JAX device.
+    """Single-grid free-boundary solve (``eqsolve.f`` + ``funct3d.f`` IVAC0).
 
-    ``device`` has the same semantics as :func:`vmex.core.solver.solve`:
-    explicit devices are honored, ``"auto"`` applies VMEX's measured policy,
-    and ``None`` leaves placement to JAX.
+    ``initial_state`` hot-restarts at the same radial resolution.  Its entire
+    plasma state, including the evolved edge, is preserved; use
+    :func:`vmex.core.multigrid.interpolate_state` first when the resolution
+    differs.  As in VMEC2000 reset-file starts, vacuum activation is repeated.
+
+    ``device`` has the same explicit/default placement semantics as
+    :func:`vmex.core.solver.solve`.  Use
+    :func:`vmex.core.multigrid.solve_free_boundary_multigrid` for the complete
+    ``NS_ARRAY`` ladder.  Time-step, constraint, print-cadence, m=1-constraint,
+    and optional 2D-preconditioner overrides mirror
+    :func:`vmex.core.solver.solve`.
     """
-    resolved = resolution if resolution is not None else resolution_from_input(inp)
-    with device_context(device, resolved):
-        return _solve_free_boundary_impl(
-            inp,
-            mgrid_path=mgrid_path,
-            external_field=external_field,
-            resolution=resolved,
-            ftol=ftol,
-            max_iterations=max_iterations,
-            verbose=verbose,
-            emit=emit,
+    if resolution is None:
+        resolution = resolution_from_input(inp)
+    with device_context(device, resolution):
+        stage = _solve_free_boundary_stage(
+            inp, mgrid_path=mgrid_path, external_field=external_field,
+            resolution=resolution, ftol=ftol, max_iterations=max_iterations,
+            verbose=verbose, emit=emit,
             error_on_no_convergence=error_on_no_convergence,
+            initial_state=initial_state, vacuum_continuation=None,
+            time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
+            lconm1=lconm1,
+            precon_type=precon_type, prec2d_threshold=prec2d_threshold,
+            prec2d=prec2d,
+            constraint_continuation=None, reuse_vacuum_cache=False,
         )
+    return stage.result

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -770,12 +770,13 @@ def _vacuum_executables(resolution, *, mf: int, nf: int, signgs: int, wint,
                         modes: ModeTable, axis_r0, axis_z0) -> tuple[VacuumBasis, FusedVacuum, Any]:
     """Return the cached ``(basis, fused vacuum, steady lane)`` for one resolution/signgs.
 
-    ``wint``/``modes``/``axis_r0``/``axis_z0`` are resolution-determined build
-    inputs (not part of the key); they are consumed only on a cache miss.
+    ``wint``/``modes`` are resolution-determined build inputs consumed only on
+    a cache miss.  The dynamic axis is validated on every call.
     """
     key = (resolution, int(signgs), int(mf), int(nf))
     cached = _VACUUM_EXECUTABLE_CACHE.get(key)
     if cached is not None:
+        _assert_static_filament_topology(cached[0], axis_r0, axis_z0)
         return cached
     basis = vacuum_basis(
         mf=int(mf), nf=int(nf), ntheta3=int(resolution.ntheta3),

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -50,7 +50,12 @@ from jax import lax
 
 from . import profiles as _profiles
 from .device import AUTO, _placement_device, _put_numeric_leaves, device_context
-from .errors import AXIS_REGUESS_FLAG, MORE_ITER_FLAG, SUCCESSFUL_TERM_FLAG
+from .errors import (
+    AXIS_REGUESS_FLAG,
+    JAC75_FLAG,
+    MORE_ITER_FLAG,
+    SUCCESSFUL_TERM_FLAG,
+)
 from .fields import magnetic_fields, metric_elements
 from .fourier import ModeTable
 from .geometry import half_mesh_jacobian
@@ -1041,6 +1046,7 @@ def _solve_free_boundary_stage(
     precon_type: str | None = None,
     prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
+    jacobian_retries: int = 2,
     constraint_continuation: tuple[Array, Array] | None = None,
     reuse_vacuum_cache: bool = False,
 ) -> _FreeBoundaryStageResult:
@@ -1055,7 +1061,13 @@ def _solve_free_boundary_stage(
 
     ``error_on_no_convergence=False`` returns the final state instead of
     raising when NITER is exhausted (useful against unconverged goldens).
+    After VMEC2000's fatal 75-Jacobian-reset condition,
+    ``jacobian_retries`` restarts the best finite plasma checkpoint with
+    zero velocity and a halved/capped ``DELT``.  Vacuum/NESTOR structures are
+    rebuilt for that checkpoint.  Set zero for the exact VMEC2000 stop.
     """
+    if int(jacobian_retries) < 0:
+        raise ValueError("jacobian_retries must be non-negative")
     if not bool(inp.lfreeb):
         raise ValueError("solve_free_boundary requires an LFREEB=T input")
     if external_field is None:
@@ -1421,6 +1433,43 @@ def _solve_free_boundary_stage(
 
     _emit_due(final=True)
     ier = int(carry.ier)
+    if ier == JAC75_FLAG and int(jacobian_retries) > 0:
+        retry_step = min(0.5, 0.5 * float(rt.time_step0))
+        if verbose:
+            emit(
+                " JACOBIAN RECOVERY RETRY: RESTARTING BEST FINITE "
+                f"STATE WITH DELT = {retry_step:.6g}"
+            )
+        current_rt = rt_freeb if fb.turned_on else rt_fixed
+        return _solve_free_boundary_stage(
+            inp,
+            mgrid_path=mgrid_path,
+            external_field=external_field,
+            resolution=resolution,
+            ftol=ftol,
+            max_iterations=max_iterations,
+            verbose=verbose,
+            emit=emit,
+            error_on_no_convergence=error_on_no_convergence,
+            initial_state=carry.xstore,
+            vacuum_continuation=fb,
+            time_step=retry_step,
+            tcon0=tcon0,
+            gamma=gamma,
+            nstep=nstep,
+            lconm1=lconm1,
+            precon_type=precon_type,
+            prec2d_threshold=prec2d_threshold,
+            prec2d=prec2d,
+            jacobian_retries=int(jacobian_retries) - 1,
+            constraint_continuation=(
+                current_rt.rcon0, current_rt.zcon0
+            ) if fb.turned_on else None,
+            # NESTOR's matrix and axis-current filament depend on the
+            # checkpoint geometry; never reuse the failed attempt's compiled
+            # dynamic cache even at an equal radial resolution.
+            reuse_vacuum_cache=False,
+        )
     if ier == MORE_ITER_FLAG and not error_on_no_convergence:
         result = _result_from_carry(carry, rt_freeb if fb.turned_on else rt_fixed)
         return _FreeBoundaryStageResult(
@@ -1459,6 +1508,7 @@ def solve_free_boundary(
     precon_type: str | None = None,
     prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
+    jacobian_retries: int = 2,
 ) -> SolveResult:
     """Single-grid free-boundary solve (``eqsolve.f`` + ``funct3d.f`` IVAC0).
 
@@ -1471,8 +1521,8 @@ def solve_free_boundary(
     :func:`vmex.core.solver.solve`.  Use
     :func:`vmex.core.multigrid.solve_free_boundary_multigrid` for the complete
     ``NS_ARRAY`` ladder.  Time-step, constraint, print-cadence, m=1-constraint,
-    and optional 2D-preconditioner overrides mirror
-    :func:`vmex.core.solver.solve`.
+    optional 2D-preconditioner overrides and bounded ``jacobian_retries``
+    recovery mirror :func:`vmex.core.solver.solve`.
     """
     if resolution is None:
         resolution = resolution_from_input(inp)
@@ -1490,6 +1540,7 @@ def solve_free_boundary(
             lconm1=lconm1,
             precon_type=precon_type, prec2d_threshold=prec2d_threshold,
             prec2d=prec2d,
+            jacobian_retries=jacobian_retries,
             constraint_continuation=None, reuse_vacuum_cache=False,
         )
     return stage.result

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -50,7 +50,7 @@ from jax import lax
 
 from . import profiles as _profiles
 from .device import AUTO, _placement_device, _put_numeric_leaves, device_context
-from .errors import MORE_ITER_FLAG, SUCCESSFUL_TERM_FLAG
+from .errors import AXIS_REGUESS_FLAG, MORE_ITER_FLAG, SUCCESSFUL_TERM_FLAG
 from .fields import magnetic_fields, metric_elements
 from .fourier import ModeTable
 from .geometry import half_mesh_jacobian
@@ -1229,6 +1229,69 @@ def _solve_free_boundary_stage(
                 del_bsq=delbsq_rows.get(it_p, float(fb.delbsq)),
             ), end="")
             printed.add(it_p)
+
+    # VMEC2000's LMOVE_AXIS path is triggered by the *first force pass*, not
+    # only by a bad Jacobian.  Run that pass explicitly before entering the
+    # batched pre-/post-vacuum lanes.  If the shared solver body returns the
+    # internal irst=4 transfer, rebuild both the plasma profiles and the
+    # axis-dependent NESTOR filament/executables, then repeat iteration 1
+    # once with ijacob=1.  The discarded triggering pass is not printed.
+    carry = _iter_lane(carry, rt_initial)
+    if (int(carry.ier) == AXIS_REGUESS_FLAG
+            and int(carry.ijacob) == 0 and ns >= 3):
+        if verbose:
+            emit(" TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS")
+        rt, _init_state, _axis = reguess_initial_axis(rt, _init_state)
+        _initial_ijacob = 1
+
+        _axis_r0, _axis_z0 = _vacuum_scalars(_init_state, rt)[2:4]
+        basis, fused_vac, vacuum_lane = _vacuum_executables(
+            resolution, mf=int(inp.mpol) + 1, nf=int(inp.ntor),
+            signgs=int(rt.setup.signgs),
+            wint=np.asarray(rt.trig.wint, dtype=float),
+            modes=rt.modes, axis_r0=_axis_r0, axis_z0=_axis_z0,
+        )
+        zeros_edge = jnp.zeros(
+            (basis.ntheta3, basis.nzeta), dtype=dtype)
+        carried_edge = zeros_edge
+        if (vacuum_continuation is not None
+                and vacuum_continuation.turned_on):
+            if vacuum_continuation.rbsq is not None:
+                _, carried_geometry = _geometry(_init_state, rt)
+                r_edge = (
+                    carried_geometry.R_even[-1] + carried_geometry.R_odd[-1]
+                )
+                pres_ns = _vacuum_scalars(_init_state, rt)[5]
+                rbsq = jnp.asarray(vacuum_continuation.rbsq, dtype=dtype)
+                carried_edge = jnp.where(
+                    r_edge != 0.0,
+                    rbsq * jnp.asarray(rt.setup.hs) / r_edge,
+                    jnp.zeros_like(r_edge),
+                ) - pres_ns * jnp.asarray(
+                    _presf_ns_scale(inp, ns), dtype=dtype)
+            elif vacuum_continuation.bsqvac is not None:
+                carried_edge = jnp.asarray(
+                    vacuum_continuation.bsqvac, dtype=dtype)
+        rt_fixed = replace(
+            rt, lfreeb=False, bsqvac_edge=zeros_edge,
+            presf_ns_scale=jnp.asarray(0.0, dtype=dtype),
+        )
+        rt_freeb = replace(
+            rt, lfreeb=True, jmax=ns, bsqvac_edge=carried_edge,
+            presf_ns_scale=jnp.asarray(
+                _presf_ns_scale(inp, ns), dtype=dtype),
+        )
+        # The NESTOR matrix/vector were built for the discarded axis.
+        fb.mode_matrix = None
+        fb.bvec_nonsing = None
+        fb.potvac = None
+        rt_initial = rt_freeb if vacuum_active else rt_fixed
+        retry_xcdot = carry.xcdot
+        carry = _initial_carry(
+            _init_state, rt_initial, ijacob=_initial_ijacob,
+            xcdot=retry_xcdot)
+        carry = _iter_lane(carry, rt_initial)
+    _emit_due(final=False)
 
     int_dtype = carry.iteration.dtype
     max_passes = rt.max_iterations + 400

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -49,7 +49,7 @@ import jax.numpy as jnp
 from jax import lax
 
 from . import profiles as _profiles
-from .device import AUTO, device_context
+from .device import AUTO, _placement_device, _put_numeric_leaves, device_context
 from .errors import MORE_ITER_FLAG, SUCCESSFUL_TERM_FLAG
 from .fields import magnetic_fields, metric_elements
 from .fourier import ModeTable
@@ -1413,6 +1413,9 @@ def solve_free_boundary(
     """
     if resolution is None:
         resolution = resolution_from_input(inp)
+    target = _placement_device(device, resolution)
+    external_field = _put_numeric_leaves(external_field, target)
+    initial_state = _put_numeric_leaves(initial_state, target)
     with device_context(device, resolution):
         stage = _solve_free_boundary_stage(
             inp, mgrid_path=mgrid_path, external_field=external_field,

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -1049,6 +1049,10 @@ def _solve_free_boundary_stage(
     jacobian_retries: int = 2,
     constraint_continuation: tuple[Array, Array] | None = None,
     reuse_vacuum_cache: bool = False,
+    allow_initial_axis_reguess: bool = True,
+    residual_continuation: (
+        tuple[float | Array, float | Array, float | Array] | None
+    ) = None,
 ) -> _FreeBoundaryStageResult:
     """Internal single-grid free-boundary stage with multigrid continuation.
 
@@ -1081,6 +1085,8 @@ def _solve_free_boundary_stage(
         lconm1=lconm1, precon_type=precon_type,
         prec2d_threshold=prec2d_threshold, prec2d=prec2d,
     )
+    if not allow_initial_axis_reguess:
+        rt = replace(rt, lmove_axis=False)
     ns = int(resolution.ns)
     dtype = rt.setup.s_full.dtype
 
@@ -1120,7 +1126,11 @@ def _solve_free_boundary_stage(
     # guard before iteration 1.
     _, _initial_geometry = _geometry(_init_state, rt)
     _initial_jacobian = half_mesh_jacobian(_initial_geometry, s=rt.setup.s_full)
-    if bool(_initial_jacobian.jacobian_sign_changed) and ns >= 3:
+    if (
+        allow_initial_axis_reguess
+        and bool(_initial_jacobian.jacobian_sign_changed)
+        and ns >= 3
+    ):
         if verbose:
             emit(" INITIAL JACOBIAN CHANGED SIGN!")
             emit(" TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS")
@@ -1215,7 +1225,12 @@ def _solve_free_boundary_stage(
     # An already-active multigrid stage evaluates with the free-boundary edge
     # row on its first pass, so its zero cache must have jmax=ns (not ns-1).
     rt_initial = rt_freeb if vacuum_active else rt_fixed
-    carry = _initial_carry(_init_state, rt_initial, ijacob=_initial_ijacob)
+    carry = _initial_carry(
+        _init_state,
+        rt_initial,
+        ijacob=_initial_ijacob,
+        residuals=residual_continuation,
+    )
     printed: set[int] = set()
     #: per-iteration DEL-BSQ recorded by the batched steady-state lane; rows
     #: not covered (pre-activation, turn-on pass) fall back to ``fb.delbsq``
@@ -1249,7 +1264,8 @@ def _solve_free_boundary_stage(
     # axis-dependent NESTOR filament/executables, then repeat iteration 1
     # once with ijacob=1.  The discarded triggering pass is not printed.
     carry = _iter_lane(carry, rt_initial)
-    if (int(carry.ier) == AXIS_REGUESS_FLAG
+    if (allow_initial_axis_reguess
+            and int(carry.ier) == AXIS_REGUESS_FLAG
             and int(carry.ijacob) == 0 and ns >= 3):
         if verbose:
             emit(" TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS")
@@ -1301,7 +1317,9 @@ def _solve_free_boundary_stage(
         retry_xcdot = carry.xcdot
         carry = _initial_carry(
             _init_state, rt_initial, ijacob=_initial_ijacob,
-            xcdot=retry_xcdot)
+            xcdot=retry_xcdot,
+            residuals=(carry.fsqr, carry.fsqz, carry.fsql),
+        )
         carry = _iter_lane(carry, rt_initial)
     _emit_due(final=False)
 
@@ -1469,6 +1487,8 @@ def _solve_free_boundary_stage(
             # checkpoint geometry; never reuse the failed attempt's compiled
             # dynamic cache even at an equal radial resolution.
             reuse_vacuum_cache=False,
+            allow_initial_axis_reguess=False,
+            residual_continuation=(carry.fsqr, carry.fsqz, carry.fsql),
         )
     if ier == MORE_ITER_FLAG and not error_on_no_convergence:
         result = _result_from_carry(carry, rt_freeb if fb.turned_on else rt_fixed)

--- a/vmex/core/freeboundary_diff.py
+++ b/vmex/core/freeboundary_diff.py
@@ -337,10 +337,15 @@ def surface_field_data_from_state(
     ``jax.grad`` threads through both this surface field and the coil field.
 
     ``inp`` supplies the static resolution / profile metadata; ``state`` the
-    (possibly traced) spectral geometry.  Stellarator-symmetric only for now
-    (``lasym`` uses the same path but is untested here).
+    (possibly traced) spectral geometry.  Stellarator-symmetric only for now;
+    ``lasym=True`` is rejected because this path has not been validated with
+    the asymmetric surface-field channels.
     """
     _require_vcj()
+    if bool(inp.lasym):
+        raise NotImplementedError(
+            "surface_field_data_from_state supports lasym = False only"
+        )
     from .fields import magnetic_fields, metric_elements
     from .fourier import Resolution, mode_table, trig_tables
     from .geometry import (

--- a/vmex/core/input.py
+++ b/vmex/core/input.py
@@ -7,17 +7,21 @@ VMEC2000 counterparts: ``LIBSTELL/Sources/Modules/vmec_input.f``
 ``{"m": int, "n": int, "value": float}`` lists, dense axis arrays, and
 ``adiabatic_index`` accepted as an alias for ``gamma``.
 
-:class:`VmecInput` is a frozen dataclass holding the full INDATA content this
-code base consumes, with VMEC2000 defaults.  Parsing is host-side NumPy code
-(nothing here needs JAX).
+:class:`VmecInput` is a frozen dataclass holding the INDATA content this code
+base actually consumes, with VMEC2000 defaults.  Parsing is host-side NumPy
+code (nothing here needs JAX).  Controls which would change the mathematical
+problem or iteration contract but are not implemented are rejected by
+:class:`UnsupportedInputModeError`; they are never silently converted into an
+ordinary fixed-/free-boundary solve.
 
 Normalizations applied on construction (all from VMEC2000):
 
 * ``read_indata_namelist``: ``raxis_s[0] = 0`` and ``zaxis_s[0] = 0``; the
   obsolete ``RAXIS``/``ZAXIS`` arrays override ``RAXIS_CC``/``ZAXIS_CS`` where
   nonzero; ``niter_array`` falls back to ``NITER`` when absent.
-* ``readin.f``: ``lfreeb`` is forced ``False`` when ``mgrid_file == 'NONE'``;
-  ``nvacskip <= 0`` falls back to ``nfp``.
+* ``readin.f``: the explicit legacy ``NS_ARRAY(1)=0`` form expands to
+  ``[max(3, NSIN), 31]``; ``lfreeb`` is forced ``False`` when
+  ``mgrid_file == 'NONE'``; ``nvacskip <= 0`` falls back to ``nfp``.
 * Boundary coefficients outside ``|n| <= ntor``, ``0 <= m < mpol`` are
   dropped (VMEC2000 reads them into oversized arrays but never uses them).
 
@@ -30,6 +34,7 @@ from __future__ import annotations
 
 import json
 import re
+import warnings
 from dataclasses import dataclass, fields
 from itertools import product
 from pathlib import Path
@@ -37,10 +42,25 @@ from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 
-__all__ = ["VmecInput"]
+__all__ = ["UnsupportedInputModeError", "VmecInput"]
 
 Scalar = Union[str, bool, int, float]
 IndexComponent = Union[int, slice]
+
+
+class UnsupportedInputModeError(ValueError):
+    """An input requests semantics which VMEX does not implement.
+
+    ``code`` is a stable, value-free diagnostic code suitable for the
+    privacy-preserving input checker.  ``control`` names the INDATA/JSON
+    control without echoing its value or any equilibrium data.
+    """
+
+    def __init__(self, code: str, control: str, reason: str):
+        self.code = str(code)
+        self.control = str(control)
+        self.reason = str(reason)
+        super().__init__(f"{self.control}: {self.reason}")
 
 # ---------------------------------------------------------------------------
 # Tolerant Fortran-namelist tokenizer (targeted at VMEC &INDATA files)
@@ -50,6 +70,39 @@ _ASSIGN_RE = re.compile(r"(?P<key>[A-Za-z_]\w*(?:\([^\)]*\))?)\s*=", re.MULTILIN
 _REPEAT_RE = re.compile(r"^(?P<count>\d+)\*(?P<value>.+)$")
 _BOOL_TRUE = {"T", ".T.", ".TRUE.", "TRUE"}
 _BOOL_FALSE = {"F", ".F.", ".FALSE.", "FALSE"}
+
+# Complete &INDATA name inventory from
+# STELLOPT/LIBSTELL/Sources/Modules/vmec_input.f, plus the documented VMEX
+# Boozer post-processing extension.  Values may be supported, explicitly
+# rejected when active, or accepted as output-only compatibility controls;
+# an unclassified spelling is always an input error.
+_KNOWN_INDATA_NAMES = {
+    "MGRID_FILE", "TIME_SLICE", "NFP", "NCURR", "NSIN", "NITER", "NSTEP",
+    "NVACSKIP", "DELT", "FTOL", "GAMMA", "BLOAT", "AM", "AI", "AC", "APHI",
+    "PCURR_TYPE", "PMASS_TYPE", "PIOTA_TYPE",
+    "AM_AUX_S", "AM_AUX_F", "AI_AUX_S", "AI_AUX_F", "AC_AUX_S", "AC_AUX_F",
+    "AH", "AT", "BCRIT", "PH_TYPE", "AH_AUX_S", "AH_AUX_F",
+    "PT_TYPE", "AT_AUX_S", "AT_AUX_F",
+    "RBC", "ZBS", "RBS", "ZBC", "SPRES_PED", "PRES_SCALE",
+    "RAXIS_CC", "ZAXIS_CS", "RAXIS_CS", "ZAXIS_CC", "RAXIS", "ZAXIS",
+    "MPOL", "NTOR", "NTHETA", "NZETA", "MFILTER_FBDY", "NFILTER_FBDY",
+    "NITER_ARRAY", "PRE_NITER", "NS_ARRAY", "FTOL_ARRAY", "TCON0",
+    "PRECON_TYPE", "PREC2D_THRESHOLD", "CURTOR", "SIGMA_CURRENT", "EXTCUR",
+    "OMP_NUM_THREADS", "PHIEDGE",
+    "PSA", "PFA", "ISA", "IFA", "IMATCH_PHIEDGE", "IOPT_RAXIS",
+    "TENSI", "TENSP", "MSEANGLE_OFFSET", "MSEANGLE_OFFSETM", "IMSE",
+    "ISNODES", "RSTARK", "DATASTARK", "SIGMA_STARK", "ITSE", "IPNODES",
+    "PRESFAC", "PRES_OFFSET", "RTHOM", "DATATHOM", "SIGMA_THOM", "PHIDIAM",
+    "SIGMA_DELPHID", "TENSI2", "FPOLYI", "NFLXS", "INDXFLX", "DSIOBT",
+    "SIGMA_FLUX", "NBFLD", "INDXBFLD", "BBC", "SIGMA_B", "LPOFR",
+    "LFORBAL", "LFREEB", "LMOVE_AXIS", "LRECON", "LMAC", "LMOVIE",
+    "LASYM", "LEDGE_DUMP", "LSPECTRUM_DUMP", "LOPTIM", "LRFP",
+    "LOLDOUT", "LWOUTTXT", "LDIAGNO", "LFULL3D1OUT",
+    "MAX_MAIN_ITERATIONS", "LGIVEUP", "FGIVEUP", "LBSUBS", "TRIP3D_FILE",
+    "LNYQUIST", "TVOLUME", "LVOLUME_RFIX",
+    # VMEX post-processing spellings found in the repository's input decks.
+    "LBOOZ", "MBOOZ", "NBOOZ", "BOOZ_SURFACES",
+}
 
 
 def _strip_fortran_comments(line: str) -> str:
@@ -283,6 +336,162 @@ def _trim_aux(aux_s, aux_f) -> tuple[np.ndarray, np.ndarray]:
     return s[:n_valid].copy(), f[:n_valid].copy()
 
 
+def _indata_values(
+    name: str,
+    scalars: Dict[str, List[Scalar]],
+    indexed: Dict[str, Dict[Tuple[int, ...], Scalar]],
+) -> list[Scalar]:
+    """All explicitly assigned values for one INDATA variable."""
+    return list(scalars.get(name, ())) + list(indexed.get(name, {}).values())
+
+
+def _validate_indata_modes(
+    scalars: Dict[str, List[Scalar]],
+    indexed: Dict[str, Dict[Tuple[int, ...], Scalar]],
+) -> None:
+    """Reject active VMEC2000 modes that VMEX cannot faithfully execute.
+
+    This check deliberately runs before :class:`VmecInput` construction:
+    parsing a switch is not evidence that the production force/iteration path
+    honors it.  Neutral legacy spellings remain accepted so standard VMEC2000
+    decks need not be edited merely to remove default-valued controls.
+    """
+
+    unknown = sorted((set(scalars) | set(indexed)) - _KNOWN_INDATA_NAMES)
+    if unknown:
+        raise ValueError("unknown INDATA variable(s): " + ", ".join(unknown))
+
+    def first(name: str, default: Scalar) -> Scalar:
+        values = scalars.get(name)
+        return values[0] if values else default
+
+    reconstruction_active = bool(first("LRECON", True)) and (
+        int(first("ITSE", 0)) > 0 or int(first("IMSE", -1)) > 0
+    )
+    if reconstruction_active:
+        raise UnsupportedInputModeError(
+            "D00A_RECONSTRUCTION_MODE_UNSUPPORTED",
+            "LRECON/ITSE/IMSE",
+            "equilibrium reconstruction is not implemented",
+        )
+    if bool(first("LRFP", False)):
+        raise UnsupportedInputModeError(
+            "D00B_RFP_MODE_UNSUPPORTED",
+            "LRFP",
+            "reversed-field-pinch profile and vacuum semantics are not implemented",
+        )
+
+    trip3d_file = str(first("TRIP3D_FILE", "NONE")).strip().strip("'\"")
+    if trip3d_file.upper() not in {"", "NONE"}:
+        raise UnsupportedInputModeError(
+            "D00E_TRIP3D_MODE_UNSUPPORTED",
+            "TRIP3D_FILE",
+            "TRIP3D external-field coupling is not implemented",
+        )
+
+    ah_active = any(float(value) != 0.0 for value in _indata_values("AH", scalars, indexed))
+    at_active = False
+    dense_at = scalars.get("AT", ())
+    if dense_at:
+        at_active = float(dense_at[0]) != 1.0 or any(
+            float(value) != 0.0 for value in dense_at[1:]
+        )
+    for position, value in indexed.get("AT", {}).items():
+        if len(position) == 1:
+            expected = 1.0 if position[0] == 0 else 0.0
+            at_active = at_active or float(value) != expected
+    if ah_active or at_active:
+        raise UnsupportedInputModeError(
+            "D00F_ANIMEC_MODE_UNSUPPORTED",
+            "AH/AT",
+            "anisotropic-pressure/flow (ANIMEC) physics is not implemented",
+        )
+
+    if float(first("TVOLUME", -1.0)) > 0.0:
+        raise UnsupportedInputModeError(
+            "D00G_VOLUME_RESCALE_UNSUPPORTED",
+            "TVOLUME/LVOLUME_RFIX",
+            "VMEC2000 boundary-volume rescaling is not implemented",
+        )
+
+    precon_type = str(first("PRECON_TYPE", "NONE")).strip().upper()
+    if precon_type not in {"", "NONE", "DEFAULT", "GMRES"}:
+        raise UnsupportedInputModeError(
+            "D00H_PRECONDITIONER_MODE_UNSUPPORTED",
+            "PRECON_TYPE",
+            "only NONE/DEFAULT (1-D) and VMEX matrix-free GMRES are implemented",
+        )
+    if precon_type == "GMRES" and int(first("PRE_NITER", -1)) != -1:
+        raise UnsupportedInputModeError(
+            "D00I_ITERATION_CONTROL_UNSUPPORTED",
+            "PRE_NITER",
+            "the VMEC2000 post-activation iteration-budget override is not implemented",
+        )
+    if int(first("MAX_MAIN_ITERATIONS", 1)) > 1:
+        raise UnsupportedInputModeError(
+            "D00I_ITERATION_CONTROL_UNSUPPORTED",
+            "MAX_MAIN_ITERATIONS",
+            "automatic continuation by additional NITER blocks is not implemented",
+        )
+    if bool(first("LGIVEUP", False)):
+        raise UnsupportedInputModeError(
+            "D00I_ITERATION_CONTROL_UNSUPPORTED",
+            "LGIVEUP/FGIVEUP",
+            "VMEC2000 early termination between multigrid stages is not implemented",
+        )
+
+    if bool(first("LBSUBS", False)):
+        raise UnsupportedInputModeError(
+            "D00J_OUTPUT_MODE_UNSUPPORTED",
+            "LBSUBS",
+            "the alternative VMEC2000 B_s WOUT diagnostic is not implemented",
+        )
+    if not bool(first("LNYQUIST", True)):
+        raise UnsupportedInputModeError(
+            "D00J_OUTPUT_MODE_UNSUPPORTED",
+            "LNYQUIST",
+            "suppressing Nyquist WOUT tables is not implemented",
+        )
+    if bool(first("LBOOZ", False)):
+        raise UnsupportedInputModeError(
+            "D00J_OUTPUT_MODE_UNSUPPORTED",
+            "LBOOZ",
+            "INDATA-driven Boozer output is not implemented; use the --booz CLI option",
+        )
+    requested_legacy_artifacts = [
+        name
+        for name in ("LMAC", "LEDGE_DUMP", "LOLDOUT", "LWOUTTXT", "LDIAGNO")
+        if bool(first(name, False))
+    ]
+    if requested_legacy_artifacts:
+        controls = "/".join(requested_legacy_artifacts)
+        warnings.warn(
+            f"{controls}: requested VMEC2000 auxiliary output artifact is not "
+            "implemented; the equilibrium solve will continue",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+
+
+def _validate_json_modes(data: Dict[str, Any]) -> None:
+    """Apply the same no-silent-fallback policy to VMEC++ JSON controls."""
+    method = str(data.get("free_boundary_method", "nestor")).strip().lower()
+    if method != "nestor":
+        raise UnsupportedInputModeError(
+            "D00K_FREE_BOUNDARY_METHOD_UNSUPPORTED",
+            "free_boundary_method",
+            "VMEX JSON solves support NESTOR; only_coils/biest are different models",
+        )
+
+    field_names = {field.name for field in fields(VmecInput)}
+    known = field_names | {"adiabatic_index", "free_boundary_method"}
+    unknown = sorted(set(data) - known)
+    if unknown:
+        raise ValueError(
+            "unknown VMEC++ JSON input key(s): " + ", ".join(unknown)
+        )
+
+
 @dataclass(frozen=True, eq=False)
 class VmecInput:
     """Full ``&INDATA`` content with VMEC2000 semantics and defaults.
@@ -313,6 +522,7 @@ class VmecInput:
     aphi: Any = None             #: radial-flux remap polynomial (default [1,0,...], len 20)
     phiedge: float = 1.0         #: total enclosed toroidal flux [Wb]
     nstep: int = 10              #: iterations between progress prints
+    time_slice: float = 0.0      #: informational value in the VMEC run header
 
     # -- pressure profile (pmass; Pa before mu0 conversion) --
     pmass_type: str = "power_series"
@@ -369,8 +579,9 @@ class VmecInput:
         for name in ("nfp", "mpol", "ntor", "ntheta", "nzeta", "ncurr", "nstep",
                      "nvacskip", "mfilter_fbdy", "nfilter_fbdy"):
             set_(self, name, int(getattr(self, name)))
-        for name in ("delt", "tcon0", "phiedge", "pres_scale", "gamma", "spres_ped",
-                     "curtor", "bloat", "prec2d_threshold"):
+        for name in ("delt", "tcon0", "phiedge", "time_slice", "pres_scale",
+                     "gamma", "spres_ped", "curtor", "bloat",
+                     "prec2d_threshold"):
             set_(self, name, float(getattr(self, name)))
         for name in ("pmass_type", "pcurr_type", "piota_type"):
             set_(self, name, str(getattr(self, name)).strip().lower())
@@ -467,6 +678,7 @@ class VmecInput:
     def from_indata_text(cls, text: str) -> "VmecInput":
         """Build from ``&INDATA`` namelist text (VMEC2000 read_indata_namelist)."""
         scalars, indexed = _read_indata_text(text)
+        _validate_indata_modes(scalars, indexed)
 
         def get(name: str, default=None):
             values = scalars.get(name)
@@ -520,9 +732,11 @@ class VmecInput:
         mpol = int(get("MPOL", 6))
         ntor = int(get("NTOR", 0))
 
-        # ns_array: NS_ARRAY, or legacy NS, or the VMEC default 31.
-        ns_default = [int(get("NS", 31))]
-        ns_array = vector("NS_ARRAY", lower=1, default=ns_default)
+        # vmec_input.f initializes NS_ARRAY(1)=31.  readin.f's explicitly
+        # requested old-style sentinel NS_ARRAY(1)=0 expands to NSIN then 31.
+        ns_array = vector("NS_ARRAY", lower=1, default=[31])
+        if ns_array.size and int(ns_array[0]) == 0:
+            ns_array = np.asarray([max(3, int(get("NSIN", 31))), 31], dtype=np.int64)
         ns_positive = np.asarray(ns_array, dtype=np.int64) > 0
         n_stages = (
             int(np.argmax(~ns_positive)) if np.any(~ns_positive) else len(ns_array)
@@ -591,6 +805,7 @@ class VmecInput:
             aphi=vector("APHI", lower=1, default=aphi_default, size=20),
             phiedge=float(get("PHIEDGE", 1.0)),
             nstep=int(get("NSTEP", 10)),
+            time_slice=float(get("TIME_SLICE", 0.0)),
             pmass_type=str(get("PMASS_TYPE", "power_series")),
             am=vector("AM", lower=0, default=np.zeros((21,)), size=21),
             am_aux_s=vector("AM_AUX_S", lower=1),
@@ -633,10 +848,13 @@ class VmecInput:
 
         Same key names as the dataclass fields; ``adiabatic_index`` is
         accepted as an alias for ``gamma``; ``rbc/zbs/rbs/zbc`` are sparse
-        ``{"m", "n", "value"}`` lists; axis arrays are dense.  Unknown keys
-        (e.g. VMEC++ ``free_boundary_method``) are ignored.
+        ``{"m", "n", "value"}`` lists; axis arrays are dense.  The VMEC++
+        ``free_boundary_method="nestor"`` spelling is accepted.  Other
+        free-boundary methods and unknown keys fail explicitly instead of
+        being silently ignored.
         """
         data = json.loads(text)
+        _validate_json_modes(data)
         if "adiabatic_index" in data and "gamma" not in data:
             data["gamma"] = data["adiabatic_index"]
 
@@ -740,6 +958,7 @@ class VmecInput:
         put("APHI", self.aphi)
         put("PHIEDGE", self.phiedge)
         put("NSTEP", self.nstep)
+        put("TIME_SLICE", self.time_slice)
         put("GAMMA", self.gamma)
         put("SPRES_PED", self.spres_ped)
         put("PRES_SCALE", self.pres_scale)

--- a/vmex/core/input.py
+++ b/vmex/core/input.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, fields
+from itertools import product
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 
@@ -170,35 +171,65 @@ def _read_indata_text(text: str) -> tuple[Dict[str, List[Scalar]], Dict[str, Dic
             continue
         if idx is None:
             scalars[name] = values
+        elif any(isinstance(component, slice) for component in idx):
+            # Fortran fills an array section in column-major order: the first
+            # subscript varies fastest.  This matters for compact VMEC boundary
+            # assignments such as ``RBC(-6:6,0) = ...`` and for sections that
+            # span both Fourier indices.
+            axes: list[list[int]] = []
+            n_slices = sum(isinstance(component, slice) for component in idx)
+            for component in idx:
+                if not isinstance(component, slice):
+                    axes.append([component])
+                    continue
+                step = 1 if component.step is None else component.step
+                if component.start is None:
+                    # The declared bounds of VMEC arrays are not available to
+                    # the generic tokenizer.  ``KEY(:)`` is handled as a dense
+                    # assignment above; mixed sections must state their bound.
+                    raise ValueError(f"array section needs a lower bound: {m.group('key')}")
+                if component.stop is None:
+                    # An open upper bound is unambiguous only when every other
+                    # subscript is scalar, in which case supplied values set
+                    # the section length.
+                    if n_slices != 1:
+                        raise ValueError(
+                            f"ambiguous open multidimensional array section: {m.group('key')}"
+                        )
+                    positions = [
+                        component.start + step * j for j in range(len(values))
+                    ]
+                else:
+                    end = component.stop + (1 if step > 0 else -1)
+                    positions = list(range(component.start, end, step))
+                axes.append(positions)
+
+            # itertools.product varies its last input fastest, so reverse both
+            # the axes and each result to obtain Fortran array-element order.
+            positions_nd = [
+                tuple(reversed(position))
+                for position in product(*reversed(axes))
+            ]
+            if len(values) > len(positions_nd):
+                raise ValueError(
+                    f"too many values for namelist array section: {m.group('key')}"
+                )
+            entries = indexed.setdefault(name, {})
+            for position, value in zip(positions_nd, values):
+                entries[position] = value
         elif len(idx) == 1:
             # A one-dimensional namelist designator identifies the first
             # destination element, not a scalar-only assignment.  Thus
             # ``APHI(1)=0,1`` initializes APHI(1:2), exactly like VMEC2000.
-            # Array sections use inclusive Fortran bounds; an omitted upper
-            # bound consumes as many destinations as values supplied.
-            component = idx[0]
-            if isinstance(component, slice):
-                step = 1 if component.step is None else component.step
-                if component.start is None:
-                    # The only lower-bound-free form accepted here is a whole
-                    # vector, already handled as a dense assignment above.
-                    raise ValueError(f"array section needs a lower bound: {m.group('key')}")
-                if component.stop is None:
-                    positions = [component.start + step * j for j in range(len(values))]
-                else:
-                    end = component.stop + (1 if step > 0 else -1)
-                    positions = list(range(component.start, end, step))
-                if len(values) > len(positions):
-                    raise ValueError(f"too many values for namelist array section: {m.group('key')}")
-            else:
-                positions = [component + j for j in range(len(values))]
+            component = int(idx[0])
+            positions = [component + j for j in range(len(values))]
             entries = indexed.setdefault(name, {})
             for position, value in zip(positions, values):
                 entries[(position,)] = value
         else:
-            if any(isinstance(component, slice) for component in idx):
-                raise ValueError(f"multidimensional array sections are unsupported: {m.group('key')}")
-            indexed.setdefault(name, {})[tuple(int(component) for component in idx)] = values[0]
+            indexed.setdefault(name, {})[
+                tuple(int(component) for component in idx)
+            ] = values[0]
     return scalars, indexed
 
 

--- a/vmex/core/input.py
+++ b/vmex/core/input.py
@@ -307,6 +307,7 @@ class VmecInput:
     niter_array: Any = None      #: iteration cap per stage (default [100] = NITER)
     delt: float = 1.0            #: initial time step
     tcon0: float = 1.0           #: constraint-force multiplier (bcovar.f)
+    lmove_axis: bool = True      #: improve the axis when the first force sum is > 1e2
     aphi: Any = None             #: radial-flux remap polynomial (default [1,0,...], len 20)
     phiedge: float = 1.0         #: total enclosed toroidal flux [Wb]
     nstep: int = 10              #: iterations between progress prints
@@ -360,6 +361,7 @@ class VmecInput:
     def __post_init__(self) -> None:
         set_ = object.__setattr__
         set_(self, "lasym", bool(self.lasym))
+        set_(self, "lmove_axis", bool(self.lmove_axis))
         for name in ("nfp", "mpol", "ntor", "ntheta", "nzeta", "ncurr", "nstep",
                      "nvacskip", "mfilter_fbdy", "nfilter_fbdy"):
             set_(self, name, int(getattr(self, name)))
@@ -579,6 +581,7 @@ class VmecInput:
             niter_array=niter_array,
             delt=float(get("DELT", 1.0)),
             tcon0=float(get("TCON0", 1.0)),
+            lmove_axis=bool(get("LMOVE_AXIS", True)),
             aphi=vector("APHI", lower=1, default=aphi_default, size=20),
             phiedge=float(get("PHIEDGE", 1.0)),
             nstep=int(get("NSTEP", 10)),
@@ -725,6 +728,7 @@ class VmecInput:
         put("NITER_ARRAY", self.niter_array)
         put("DELT", self.delt)
         put("TCON0", self.tcon0)
+        put("LMOVE_AXIS", self.lmove_axis)
         put("APHI", self.aphi)
         put("PHIEDGE", self.phiedge)
         put("NSTEP", self.nstep)

--- a/vmex/core/input.py
+++ b/vmex/core/input.py
@@ -47,6 +47,40 @@ __all__ = ["UnsupportedInputModeError", "VmecInput"]
 Scalar = Union[str, bool, int, float]
 IndexComponent = Union[int, slice]
 
+# Declared VMEC2000 namelist bounds for arrays consumed by VMEX or inspected
+# by the active-mode classifier.  Bounds are inclusive and ordered exactly as
+# in Fortran; the first subscript therefore varies fastest during namelist
+# sequence association.  vmec_input.f uses ntord=101, mpol1d=100,
+# ndatafmax=101, and nigroup=300.
+_INDATA_ARRAY_BOUNDS: dict[str, tuple[tuple[int, int], ...]] = {
+    "NS_ARRAY": ((1, 100),),
+    "NITER_ARRAY": ((1, 100),),
+    "FTOL_ARRAY": ((1, 100),),
+    "APHI": ((1, 20),),
+    **{name: ((0, 20),) for name in ("AM", "AI", "AC", "AH", "AT")},
+    **{
+        name: ((1, 101),)
+        for name in (
+            "AM_AUX_S", "AM_AUX_F", "AI_AUX_S", "AI_AUX_F",
+            "AC_AUX_S", "AC_AUX_F", "AH_AUX_S", "AH_AUX_F",
+            "AT_AUX_S", "AT_AUX_F", "PSA", "PFA", "ISA", "IFA",
+        )
+    },
+    **{
+        name: ((0, 101),)
+        for name in (
+            "RAXIS", "ZAXIS", "RAXIS_CC", "RAXIS_CS",
+            "ZAXIS_CC", "ZAXIS_CS",
+        )
+    },
+    **{
+        name: ((-101, 101), (0, 100))
+        for name in ("RBC", "ZBS", "RBS", "ZBC")
+    },
+    "EXTCUR": ((1, 300),),
+    "BOOZ_SURFACES": ((1, 10001),),
+}
+
 
 class UnsupportedInputModeError(ValueError):
     """An input requests semantics which VMEX does not implement.
@@ -168,17 +202,15 @@ def _parse_scalar(tok: str) -> Scalar:
 def _parse_key(key: str) -> Tuple[str, Tuple[IndexComponent, ...] | None]:
     """Split a namelist key into its name and scalar/section designator.
 
-    A bare key and the whole-vector ``KEY(:)`` form return ``None``.  Fortran
-    triplets retain their inclusive upper bound in a :class:`slice`; they are
-    expanded after the assignment values have been tokenized.
+    A bare key returns ``None``.  Fortran triplets, including ``KEY(:)``,
+    retain their inclusive upper bound in a :class:`slice`; they are expanded
+    against the declared VMEC2000 bounds after tokenization.
     """
     key = key.strip()
     if "(" not in key:
         return key.upper(), None
     base, rest = key.split("(", 1)
     rest = rest.rstrip(")")
-    if rest.strip() == ":":
-        return base.upper(), None
     components: list[IndexComponent] = []
     for component in rest.split(","):
         component = component.strip()
@@ -197,11 +229,95 @@ def _parse_key(key: str) -> Tuple[str, Tuple[IndexComponent, ...] | None]:
     return base.upper(), tuple(components)
 
 
+def _fortran_positions(
+    name: str,
+    designator: Tuple[IndexComponent, ...] | None,
+    value_count: int,
+) -> list[tuple[int, ...]]:
+    """Expand one array assignment in Fortran namelist element order."""
+    bounds = _INDATA_ARRAY_BOUNDS.get(name)
+    if bounds is None:
+        if designator is None:
+            raise ValueError(f"array bounds unavailable for INDATA variable {name}")
+        if any(isinstance(component, slice) for component in designator):
+            raise ValueError(f"array bounds unavailable for INDATA section {name}")
+        # Explicit scalar subscripts remain usable for compatibility-only
+        # arrays whose compile-time extents do not affect the VMEX solve.
+        if value_count != 1:
+            raise ValueError(
+                f"multivalue starting-element assignment needs declared bounds: {name}"
+            )
+        return [tuple(int(component) for component in designator)]
+
+    rank = len(bounds)
+    if designator is None:
+        designator = tuple(slice(None, None, 1) for _ in bounds)
+    if len(designator) != rank:
+        raise ValueError(
+            f"wrong number of subscripts for {name}: expected {rank}, "
+            f"got {len(designator)}"
+        )
+
+    if all(not isinstance(component, slice) for component in designator):
+        start = tuple(int(component) for component in designator)
+        sizes = [upper - lower + 1 for lower, upper in bounds]
+        offset = 0
+        stride = 1
+        for component, (lower, upper), size in zip(
+            start, bounds, sizes, strict=True
+        ):
+            if not lower <= component <= upper:
+                raise ValueError(f"array subscript outside declared bounds: {name}")
+            offset += (component - lower) * stride
+            stride *= size
+        if offset + value_count > stride:
+            raise ValueError(f"too many values for namelist array assignment: {name}")
+        positions: list[tuple[int, ...]] = []
+        for linear in range(offset, offset + value_count):
+            remainder = linear
+            position: list[int] = []
+            for (lower, _upper), size in zip(bounds, sizes, strict=True):
+                position.append(lower + remainder % size)
+                remainder //= size
+            positions.append(tuple(position))
+        return positions
+
+    axes: list[list[int]] = []
+    for component, (lower, upper) in zip(designator, bounds, strict=True):
+        if not isinstance(component, slice):
+            value = int(component)
+            if not lower <= value <= upper:
+                raise ValueError(f"array subscript outside declared bounds: {name}")
+            axes.append([value])
+            continue
+        step = 1 if component.step is None else int(component.step)
+        start = (
+            lower if step > 0 else upper
+        ) if component.start is None else int(component.start)
+        stop = (
+            upper if step > 0 else lower
+        ) if component.stop is None else int(component.stop)
+        if not lower <= start <= upper or not lower <= stop <= upper:
+            raise ValueError(f"array section outside declared bounds: {name}")
+        exclusive = stop + (1 if step > 0 else -1)
+        axes.append(list(range(start, exclusive, step)))
+
+    positions = [
+        tuple(reversed(position))
+        for position in product(*reversed(axes))
+    ]
+    if value_count > len(positions):
+        raise ValueError(f"too many values for namelist array section: {name}")
+    return positions[:value_count]
+
+
 def _read_indata_text(text: str) -> tuple[Dict[str, List[Scalar]], Dict[str, Dict[Tuple[int, ...], Scalar]]]:
-    """Parse the ``&INDATA`` block of ``text`` into scalar and indexed maps.
+    """Parse and sequentially replay the ``&INDATA`` block.
 
     Returns ``(scalars, indexed)`` where ``scalars`` maps upper-case names to
-    token lists and ``indexed`` maps names like ``RBC`` to ``{(n, m): value}``.
+    their final scalar token and ``indexed`` contains the final value of every
+    explicitly assigned array element.  Replaying assignments in source order
+    reproduces Fortran overlay semantics for repeated dense/indexed writes.
     """
     m_start = re.search(r"&\s*INDATA", text, flags=re.IGNORECASE)
     if not m_start:
@@ -222,67 +338,16 @@ def _read_indata_text(text: str) -> tuple[Dict[str, List[Scalar]], Dict[str, Dic
         values = [_parse_scalar(t) for t in _tokenize_values(chunk)]
         if not values:
             continue
-        if idx is None:
+        is_array = name in _INDATA_ARRAY_BOUNDS or idx is not None
+        if not is_array:
+            if len(values) != 1:
+                raise ValueError(f"too many values for scalar INDATA variable: {name}")
             scalars[name] = values
-        elif any(isinstance(component, slice) for component in idx):
-            # Fortran fills an array section in column-major order: the first
-            # subscript varies fastest.  This matters for compact VMEC boundary
-            # assignments such as ``RBC(-6:6,0) = ...`` and for sections that
-            # span both Fourier indices.
-            axes: list[list[int]] = []
-            n_slices = sum(isinstance(component, slice) for component in idx)
-            for component in idx:
-                if not isinstance(component, slice):
-                    axes.append([component])
-                    continue
-                step = 1 if component.step is None else component.step
-                if component.start is None:
-                    # The declared bounds of VMEC arrays are not available to
-                    # the generic tokenizer.  ``KEY(:)`` is handled as a dense
-                    # assignment above; mixed sections must state their bound.
-                    raise ValueError(f"array section needs a lower bound: {m.group('key')}")
-                if component.stop is None:
-                    # An open upper bound is unambiguous only when every other
-                    # subscript is scalar, in which case supplied values set
-                    # the section length.
-                    if n_slices != 1:
-                        raise ValueError(
-                            f"ambiguous open multidimensional array section: {m.group('key')}"
-                        )
-                    positions = [
-                        component.start + step * j for j in range(len(values))
-                    ]
-                else:
-                    end = component.stop + (1 if step > 0 else -1)
-                    positions = list(range(component.start, end, step))
-                axes.append(positions)
-
-            # itertools.product varies its last input fastest, so reverse both
-            # the axes and each result to obtain Fortran array-element order.
-            positions_nd = [
-                tuple(reversed(position))
-                for position in product(*reversed(axes))
-            ]
-            if len(values) > len(positions_nd):
-                raise ValueError(
-                    f"too many values for namelist array section: {m.group('key')}"
-                )
-            entries = indexed.setdefault(name, {})
-            for position, value in zip(positions_nd, values):
-                entries[position] = value
-        elif len(idx) == 1:
-            # A one-dimensional namelist designator identifies the first
-            # destination element, not a scalar-only assignment.  Thus
-            # ``APHI(1)=0,1`` initializes APHI(1:2), exactly like VMEC2000.
-            component = int(idx[0])
-            positions = [component + j for j in range(len(values))]
-            entries = indexed.setdefault(name, {})
-            for position, value in zip(positions, values):
-                entries[(position,)] = value
         else:
-            indexed.setdefault(name, {})[
-                tuple(int(component) for component in idx)
-            ] = values[0]
+            entries = indexed.setdefault(name, {})
+            positions = _fortran_positions(name, idx, len(values))
+            for position, value in zip(positions, values, strict=True):
+                entries[position] = value
     return scalars, indexed
 
 
@@ -312,6 +377,19 @@ def _fixed_length(values, n: int, fill: float = 0.0) -> np.ndarray:
     k = min(arr.size, n)
     out[:k] = arr[:k]
     return out
+
+
+def _vmec_ns_prefix(values: Any) -> np.ndarray:
+    """Return the positive nondecreasing prefix selected by ``readin.f``."""
+    ns = np.atleast_1d(np.asarray(values, dtype=np.int64)).ravel()
+    end = 0
+    previous = 1
+    for value in ns:
+        if int(value) <= 0 or int(value) < previous:
+            break
+        previous = max(previous, int(value))
+        end += 1
+    return ns[:end].copy()
 
 
 def _trim_aux(aux_s, aux_f) -> tuple[np.ndarray, np.ndarray]:
@@ -588,14 +666,13 @@ class VmecInput:
         set_(self, "precon_type", str(self.precon_type).strip())
         set_(self, "mgrid_file", str(self.mgrid_file).strip())
 
-        # Multigrid ladder: ns_array trimmed to its positive prefix; ftol and
-        # niter arrays resized to the same number of stages (missing trailing
-        # entries repeat the last given value).
-        ns = np.atleast_1d(np.asarray(
-            [31] if self.ns_array is None else self.ns_array, dtype=np.int64)).ravel()
-        n_stages = int(np.argmax(ns <= 0)) if np.any(ns <= 0) else ns.size
-        n_stages = max(n_stages, 1)
-        set_(self, "ns_array", ns[:n_stages].copy())
+        # readin.f stops at the first nonpositive or decreasing entry; later
+        # values are outside multi_ns_grid and never reach runvmec.f.
+        ns = _vmec_ns_prefix([31] if self.ns_array is None else self.ns_array)
+        if ns.size == 0:
+            ns = np.asarray([31], dtype=np.int64)
+        n_stages = int(ns.size)
+        set_(self, "ns_array", ns)
         ftol = _float_array([1e-10] if self.ftol_array is None else self.ftol_array)
         niter = np.atleast_1d(np.asarray(
             [100] if self.niter_array is None else self.niter_array, dtype=np.int64)).ravel()
@@ -737,11 +814,10 @@ class VmecInput:
         ns_array = vector("NS_ARRAY", lower=1, default=[31])
         if ns_array.size and int(ns_array[0]) == 0:
             ns_array = np.asarray([max(3, int(get("NSIN", 31))), 31], dtype=np.int64)
-        ns_positive = np.asarray(ns_array, dtype=np.int64) > 0
-        n_stages = (
-            int(np.argmax(~ns_positive)) if np.any(~ns_positive) else len(ns_array)
-        )
-        n_stages = max(n_stages, 1)
+        ns_array = _vmec_ns_prefix(ns_array)
+        if ns_array.size == 0:
+            ns_array = np.asarray([31], dtype=np.int64)
+        n_stages = int(ns_array.size)
 
         # ftol_array: FTOL_ARRAY, or scalar FTOL (vmec_input.f: ftol_array(1)=ftol).
         ftol_default = np.zeros((n_stages,))
@@ -749,6 +825,15 @@ class VmecInput:
         ftol_array = vector(
             "FTOL_ARRAY", lower=1, default=ftol_default
         )
+        if ftol_array.size and float(ftol_array[0]) == 0.0:
+            target_ftol = float(get("FTOL", 1e-10))
+            if n_stages == 1:
+                ftol_array[0] = target_ftol
+            else:
+                stage = np.arange(n_stages, dtype=float)
+                ftol_array[:n_stages] = 1.0e-8 * (
+                    1.0e8 * target_ftol
+                ) ** (stage / float(n_stages - 1))
         # vmec_input.f initializes every NITER_ARRAY entry to -1, and replaces
         # the complete array with NITER only when no element was assigned.
         niter_assigned = "NITER_ARRAY" in scalars or "NITER_ARRAY" in indexed

--- a/vmex/core/input.py
+++ b/vmex/core/input.py
@@ -307,7 +307,9 @@ class VmecInput:
     niter_array: Any = None      #: iteration cap per stage (default [100] = NITER)
     delt: float = 1.0            #: initial time step
     tcon0: float = 1.0           #: constraint-force multiplier (bcovar.f)
+    lforbal: bool = False        #: replace m=1,n=0 R/Z forces by average force balance
     lmove_axis: bool = True      #: improve the axis when the first force sum is > 1e2
+    lfull3d1out: bool = False    #: write a WOUT when the iteration limit is reached
     aphi: Any = None             #: radial-flux remap polynomial (default [1,0,...], len 20)
     phiedge: float = 1.0         #: total enclosed toroidal flux [Wb]
     nstep: int = 10              #: iterations between progress prints
@@ -361,7 +363,9 @@ class VmecInput:
     def __post_init__(self) -> None:
         set_ = object.__setattr__
         set_(self, "lasym", bool(self.lasym))
+        set_(self, "lforbal", bool(self.lforbal))
         set_(self, "lmove_axis", bool(self.lmove_axis))
+        set_(self, "lfull3d1out", bool(self.lfull3d1out))
         for name in ("nfp", "mpol", "ntor", "ntheta", "nzeta", "ncurr", "nstep",
                      "nvacskip", "mfilter_fbdy", "nfilter_fbdy"):
             set_(self, name, int(getattr(self, name)))
@@ -581,7 +585,9 @@ class VmecInput:
             niter_array=niter_array,
             delt=float(get("DELT", 1.0)),
             tcon0=float(get("TCON0", 1.0)),
+            lforbal=bool(get("LFORBAL", False)),
             lmove_axis=bool(get("LMOVE_AXIS", True)),
+            lfull3d1out=bool(get("LFULL3D1OUT", False)),
             aphi=vector("APHI", lower=1, default=aphi_default, size=20),
             phiedge=float(get("PHIEDGE", 1.0)),
             nstep=int(get("NSTEP", 10)),
@@ -728,7 +734,9 @@ class VmecInput:
         put("NITER_ARRAY", self.niter_array)
         put("DELT", self.delt)
         put("TCON0", self.tcon0)
+        put("LFORBAL", self.lforbal)
         put("LMOVE_AXIS", self.lmove_axis)
+        put("LFULL3D1OUT", self.lfull3d1out)
         put("APHI", self.aphi)
         put("PHIEDGE", self.phiedge)
         put("NSTEP", self.nstep)

--- a/vmex/core/mgrid.py
+++ b/vmex/core/mgrid.py
@@ -12,6 +12,9 @@ inputs (§8):
 - :class:`MgridField` — a JAX pytree wrapping the field tables plus external
   currents, providing extcur-scaled trilinear interpolation of
   ``B(r, phi, z)`` that is jit- and grad-compatible.
+- :func:`tabulate_cartesian_field` — sample an ESSOS-, SIMSOPT-, or plain
+  callable Cartesian Biot--Savart field into the same one-group mgrid
+  representation used by the fused free-boundary solver.
 
 VMEC2000 counterpart: ``Sources/NESTOR_vacuum/mgrid_mod.f`` (read_mgrid,
 becoil).  The IO layer is ported from the legacy parity-proven
@@ -296,6 +299,93 @@ def write_mgrid(path: str | Path, data: MgridData) -> None:
                 var[:, :, :] = np.asarray(arr[i], dtype=np.float64)
 
 
+def _cartesian_field_values(field: Any, points: np.ndarray) -> np.ndarray:
+    """Evaluate common Cartesian magnetic-field protocols on ``points``.
+
+    Supported inputs are ``callable(points)``, ESSOS-style ``field.B(point)``
+    objects, and SIMSOPT-style mutable ``set_points(points); B()`` objects.
+    ESSOS' ``B`` is normally a single-point JAX function, so a vector call is
+    attempted first and falls back to deterministic pointwise sampling.
+    """
+    pts = np.asarray(points, dtype=np.float64).reshape(-1, 3)
+    if hasattr(field, "set_points") and hasattr(field, "B"):
+        field.set_points(pts)
+        values = field.B()
+    else:
+        evaluate = field if callable(field) else getattr(field, "B", None)
+        if evaluate is None:
+            raise TypeError(
+                "Cartesian field must be callable, expose B(points), or "
+                "expose set_points(points) followed by B()"
+            )
+        try:
+            values = evaluate(pts)
+            if np.shape(values) != pts.shape:
+                raise ValueError("field did not return one vector per point")
+        except (TypeError, ValueError, IndexError):
+            values = np.stack([np.asarray(evaluate(p), dtype=float) for p in pts])
+    out = np.asarray(values, dtype=np.float64)
+    if out.shape != pts.shape:
+        raise ValueError(
+            f"Cartesian field returned shape {out.shape}; expected {pts.shape}"
+        )
+    if not np.all(np.isfinite(out)):
+        raise ValueError("Cartesian field returned non-finite values while tabulating")
+    return out
+
+
+def tabulate_cartesian_field(
+    field: Any,
+    *,
+    rmin: float,
+    rmax: float,
+    zmin: float,
+    zmax: float,
+    ir: int,
+    jz: int,
+    kp: int,
+    nfp: int,
+    label: str = "direct_biot_savart",
+) -> MgridData:
+    """Sample a Cartesian field into a one-group MAKEGRID table.
+
+    Toroidal planes cover ``[0, 2*pi/nfp)`` (endpoint excluded), while R and
+    Z include both endpoints.  ``field`` may be an ESSOS ``BiotSavart``
+    object, a SIMSOPT ``BiotSavart`` object, or a callable returning Cartesian
+    ``(Bx, By, Bz)`` vectors.  The result uses ``mgrid_mode='S'`` and unit raw
+    current; multiply it with :meth:`MgridField.from_mgrid_data`'s ``extcur``
+    when a global scale is wanted.
+
+    Tabulation is intentionally host-side and is performed once before a
+    solve.  The returned :class:`MgridField` is JAX differentiable with
+    respect to its table values and scale, but the sampling operation itself
+    does not retain derivatives with respect to coil geometry.  Use
+    :mod:`vmex.core.freeboundary_diff` with a direct JAX field for coil-shape
+    derivatives of the virtual-casing residual.
+    """
+    ir, jz, kp, nfp = int(ir), int(jz), int(kp), int(nfp)
+    if ir < 2 or jz < 2 or kp < 1 or nfp < 1:
+        raise ValueError("ir and jz must be >=2; kp and nfp must be >=1")
+    if not (float(rmax) > float(rmin) and float(zmax) > float(zmin)):
+        raise ValueError("mgrid bounds require rmax>rmin and zmax>zmin")
+
+    r = np.linspace(float(rmin), float(rmax), ir)
+    z = np.linspace(float(zmin), float(zmax), jz)
+    phi = np.arange(kp, dtype=float) * (2.0 * np.pi / (nfp * kp))
+    pp, zz, rr = np.meshgrid(phi, z, r, indexing="ij")
+    xyz = np.stack((rr * np.cos(pp), rr * np.sin(pp), zz), axis=-1)
+    bxyz = _cartesian_field_values(field, xyz.reshape(-1, 3)).reshape(kp, jz, ir, 3)
+    bx, by, bz = np.moveaxis(bxyz, -1, 0)
+    br = bx * np.cos(pp) + by * np.sin(pp)
+    bp = -bx * np.sin(pp) + by * np.cos(pp)
+    return MgridData(
+        rmin=float(rmin), rmax=float(rmax), zmin=float(zmin), zmax=float(zmax),
+        ir=ir, jz=jz, kp=kp, nfp=nfp, nextcur=1, mgrid_mode="S",
+        coil_groups=(str(label),), raw_coil_cur=(1.0,),
+        br=br[None, ...], bp=bp[None, ...], bz=bz[None, ...],
+    )
+
+
 def _interpolate_bfield(
     br: Any,
     bp: Any,
@@ -422,6 +512,29 @@ class MgridField:
 
         return cls.from_mgrid_data(read_mgrid(path), extcur=extcur)
 
+    @classmethod
+    def from_cartesian_field(
+        cls,
+        field: Any,
+        *,
+        rmin: float,
+        rmax: float,
+        zmin: float,
+        zmax: float,
+        ir: int,
+        jz: int,
+        kp: int,
+        nfp: int,
+        scale: float = 1.0,
+        label: str = "direct_biot_savart",
+    ) -> "MgridField":
+        """Tabulate an ESSOS/SIMSOPT/callable Cartesian field for a solve."""
+        data = tabulate_cartesian_field(
+            field, rmin=rmin, rmax=rmax, zmin=zmin, zmax=zmax,
+            ir=ir, jz=jz, kp=kp, nfp=nfp, label=label,
+        )
+        return cls.from_mgrid_data(data, extcur=jnp.asarray([scale]))
+
     def b_cyl(self, r: Any, phi: Any, z: Any) -> tuple[Any, Any, Any]:
         """Return ``(B_r, B_phi, B_z)`` at cylindrical points (broadcastable)."""
 
@@ -453,4 +566,7 @@ jax.tree_util.register_dataclass(
     meta_fields=["rmin", "rmax", "zmin", "zmax", "nfp"],
 )
 
-__all__ = ["MgridData", "MgridField", "read_mgrid", "write_mgrid"]
+__all__ = [
+    "MgridData", "MgridField", "read_mgrid", "tabulate_cartesian_field",
+    "write_mgrid",
+]

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -192,6 +192,9 @@ def solve_multigrid(
     initial_state: SpectralState | None = None,
     time_step: float | None = None, tcon0: float | None = None,
     gamma: float | None = None, nstep: int | None = None,
+    precon_type: str | None = None,
+    prec2d_threshold: float | None = None,
+    prec2d: Prec2DConfig | None = None,
     device: Any = AUTO,
     raise_on_max_iterations: bool = True,
 ) -> SolveResult:
@@ -212,6 +215,8 @@ def solve_multigrid(
     given they are broadcast to a common stage count (shorter ``ftol/niter``
     arrays repeat their last entry).  ``initial_state`` seeds the *first*
     executed stage (hot restart; must match that stage's ``ns``).
+    ``precon_type``, ``prec2d_threshold``, and ``prec2d`` override the input's
+    optional 2D-preconditioner configuration at every stage.
 
     Intermediate stages are allowed to exhaust their iteration cap
     (``more_iter_flag`` — VMEC2000 proceeds to the next grid); any other
@@ -274,6 +279,8 @@ def solve_multigrid(
             inp, resolution, ftol=float(ftol_arr[igrid]),
             max_iterations=int(niter_arr[igrid]), lconm1=lconm1,
             time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
+            precon_type=precon_type, prec2d_threshold=prec2d_threshold,
+            prec2d=prec2d,
         )
         if state is not None and int(state.R_cos.shape[0]) != nsval:
             state = interpolate_state(state, ns_fine=nsval, modes=rt.modes)

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -230,8 +230,8 @@ def solve_multigrid(
     like :func:`vmex.core.solver.solve`.  With
     ``raise_on_max_iterations=False`` a final stage that merely hits NITER
     returns its last state instead (``converged=False``, ``ier_flag =
-    more_iter_flag``) — VMEC2000's own behavior, which writes the
-    NITER-exhausted state to the wout file.
+    more_iter_flag``).  This exposes the state to callers; the CLI writes it
+    only when ``LFULL3D1OUT=T``, matching the VMEC2000 driver policy.
 
     Executable reuse: stage runtimes are structural pytrees (solver.py,
     Phase 2 item (1)), so one XLA executable is compiled per distinct

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -343,9 +343,10 @@ def solve_free_boundary_multigrid(
     banner or soft restart).  If an intermediate stage reaches ``NITER`` before
     activation, the next stage continues in the pre-activation lane.
 
-    ``initial_state`` hot-starts the first executed stage and must already have
-    that stage's radial shape.  It follows reset-file semantics: the first
-    stage repeats vacuum activation, while subsequent radial stages carry it.
+    ``initial_state`` hot-starts the first executed stage and is interpolated
+    when its radial shape differs from that stage.  It follows reset-file
+    semantics: the first stage repeats vacuum activation, while subsequent
+    radial stages carry it.
     The fixed-boundary ladder's solver controls (``time_step``, ``tcon0``,
     ``gamma``, ``nstep``, ``lconm1``, device placement, and 2D-preconditioner
     configuration) are accepted and forwarded identically.

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -196,6 +196,7 @@ def solve_multigrid(
     precon_type: str | None = None,
     prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
+    jacobian_retries: int = 2,
     device: Any = AUTO,
     raise_on_max_iterations: bool = True,
 ) -> SolveResult:
@@ -222,6 +223,9 @@ def solve_multigrid(
     executed stage (hot restart; must match that stage's ``ns``).
     ``precon_type``, ``prec2d_threshold``, and ``prec2d`` override the input's
     optional 2D-preconditioner configuration at every stage.
+    ``jacobian_retries`` applies the same bounded best-checkpoint/``DELT``
+    recovery as :func:`vmex.core.solver.solve` independently at each stage;
+    zero preserves VMEC2000's immediate fatal stop after 75 resets.
 
     Intermediate stages are allowed to exhaust their iteration cap
     (``more_iter_flag`` — VMEC2000 proceeds to the next grid); any other
@@ -303,6 +307,7 @@ def solve_multigrid(
                 # both bad-Jacobian and LMOVE_AXIS first-force retries remain
                 # available after interpolation and on hot starts.
                 try_axis_reguess=True,
+                jacobian_retries=jacobian_retries,
             )
         first_executed = False
         ier = int(carry.ier)
@@ -341,6 +346,7 @@ def solve_free_boundary_multigrid(
     precon_type: str | None = None,
     prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
+    jacobian_retries: int = 2,
 ) -> SolveResult:
     """Free-boundary solve over the VMEC2000 ``NS_ARRAY`` ladder.
 
@@ -365,7 +371,8 @@ def solve_free_boundary_multigrid(
     radial stages carry it.
     The fixed-boundary ladder's solver controls (``time_step``, ``tcon0``,
     ``gamma``, ``nstep``, ``lconm1``, device placement, and 2D-preconditioner
-    configuration) are accepted and forwarded identically.
+    configuration) are accepted and forwarded identically, including bounded
+    ``jacobian_retries`` recovery (zero restores the VMEC2000 fatal policy).
     ``device="auto"`` (default) applies the measured policy independently at
     each grid and relocates carried plasma/vacuum arrays when the policy changes;
     ``None`` leaves placement to JAX.
@@ -459,6 +466,7 @@ def solve_free_boundary_multigrid(
                 lconm1=lconm1,
                 precon_type=precon_type,
                 prec2d_threshold=prec2d_threshold, prec2d=prec2d,
+                jacobian_retries=jacobian_retries,
                 constraint_continuation=(
                     constraint_continuation if same_grid else None),
                 reuse_vacuum_cache=bool(same_grid),

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -42,8 +42,9 @@ import jax.numpy as jnp
 
 from .device import AUTO, device_context
 from .errors import MORE_ITER_FLAG, SUCCESSFUL_TERM_FLAG
-from .fourier import ModeTable
+from .fourier import ModeTable, mode_table
 from .input import VmecInput
+from .preconditioner_2d import Prec2DConfig
 from .solver import (
     SolveResult, SpectralState, _finalize, _result_from_carry, _solve_stage,
     hot_restart_state, prepare_runtime, resolution_from_input,
@@ -51,7 +52,10 @@ from .solver import (
 )
 from .transforms import odd_m_sqrt_s_scaling
 
-__all__ = ["interpolate_coefficients", "interpolate_state", "solve_multigrid"]
+__all__ = [
+    "interpolate_coefficients", "interpolate_state", "solve_multigrid",
+    "solve_free_boundary_multigrid",
+]
 
 Array = Any
 
@@ -298,3 +302,134 @@ def solve_multigrid(
     if int(carry.ier) == MORE_ITER_FLAG and not raise_on_max_iterations:
         return _result_from_carry(carry, rt)
     return _finalize(carry, rt)
+
+
+def solve_free_boundary_multigrid(
+    inp: VmecInput,
+    ns_array=None,
+    ftol_array=None,
+    niter_array=None,
+    *,
+    mgrid_path=None,
+    external_field: Any = None,
+    verbose: bool = False,
+    emit=print,
+    initial_state: SpectralState | None = None,
+    device: Any = None,
+    raise_on_max_iterations: bool = True,
+    time_step: float | None = None,
+    tcon0: float | None = None,
+    gamma: float | None = None,
+    nstep: int | None = None,
+    lconm1: bool = True,
+    precon_type: str | None = None,
+    prec2d_threshold: float | None = None,
+    prec2d: Prec2DConfig | None = None,
+) -> SolveResult:
+    """Free-boundary solve over the VMEC2000 ``NS_ARRAY`` ladder.
+
+    The plasma continuation follows :func:`solve_multigrid`: each increasing
+    grid starts from ``interp.f`` interpolation of the preceding stage's best
+    stored state, equal grids rerun without interpolation, and decreasing
+    entries are skipped.  The external field is loaded once.  Resolution-
+    specific NESTOR bases, Green-function programs, axis-current filament
+    tables and traced vacuum loops are selected/rebuilt when the radial grid
+    changes; equal-grid reruns reuse their dynamic vacuum cache.
+
+    VMEC2000 carries ``ivac`` between grids.  Consequently, after vacuum has
+    activated on a coarse stage, the next stage begins with vacuum active and
+    uses the carried coarse-grid boundary pressure on iteration 1, then performs
+    a full vacuum update on iteration 2 with new caches (no second turn-on
+    banner or soft restart).  If an intermediate stage reaches ``NITER`` before
+    activation, the next stage continues in the pre-activation lane.
+
+    ``initial_state`` hot-starts the first executed stage and must already have
+    that stage's radial shape.  It follows reset-file semantics: the first
+    stage repeats vacuum activation, while subsequent radial stages carry it.
+    The fixed-boundary ladder's solver controls (``time_step``, ``tcon0``,
+    ``gamma``, ``nstep``, ``lconm1``, device placement, and 2D-preconditioner
+    configuration) are accepted and forwarded identically.
+    """
+    if not bool(inp.lfreeb):
+        raise ValueError("solve_free_boundary_multigrid requires an LFREEB=T input")
+
+    ns_arr = np.atleast_1d(np.asarray(
+        inp.ns_array if ns_array is None else ns_array, dtype=np.int64)).ravel()
+    ns_arr = ns_arr[: int(np.argmax(ns_arr <= 0))] if np.any(ns_arr <= 0) else ns_arr
+    if ns_arr.size == 0:
+        raise ValueError("ns_array has no positive stages")
+    n_stages = int(ns_arr.size)
+
+    def _stage_values(values, default, dtype):
+        arr = np.atleast_1d(np.asarray(
+            default if values is None else values, dtype=dtype)).ravel()
+        if arr.size == 0:
+            raise ValueError("empty ftol/niter stage array")
+        if arr.size < n_stages:
+            arr = np.concatenate([
+                arr, np.full(n_stages - arr.size, arr[-1], dtype=dtype),
+            ])
+        return arr[:n_stages]
+
+    ftol_arr = _stage_values(ftol_array, inp.ftol_array, np.float64)
+    niter_arr = _stage_values(niter_array, inp.niter_array, np.int64)
+
+    # Lazy import avoids a module cycle: freeboundary uses SolverRuntime while
+    # this module owns the shared interp.f transfer.
+    from .freeboundary import (
+        _external_field_from_input, _solve_free_boundary_stage,
+    )
+
+    if external_field is None:
+        external_field = _external_field_from_input(inp, mgrid_path)
+
+    state = initial_state
+    interpolation_source = initial_state
+    previous_ns = int(initial_state.R_cos.shape[0]) if initial_state is not None else None
+    vacuum_continuation = None
+    constraint_continuation = None
+    ns_min = 0
+    stage_result = None
+    modes = mode_table(int(inp.mpol), int(inp.ntor))
+    for igrid in range(n_stages):
+        nsval = int(ns_arr[igrid])
+        if nsval < ns_min:
+            continue
+        ns_min = nsval
+        resolution = resolution_from_input(inp, ns=nsval)
+        same_grid = previous_ns == nsval
+        if state is not None and previous_ns != nsval:
+            # initialize_radial.f interpolates pxstore only when ns increases;
+            # an equal-grid entry returns before allocation/interpolation and
+            # therefore reruns the current xc state unchanged.
+            state = interpolate_state(
+                interpolation_source, ns_fine=nsval, modes=modes)
+
+        last_stage = not np.any(ns_arr[igrid + 1:] >= nsval)
+        with device_context(device, resolution):
+            stage_result = _solve_free_boundary_stage(
+                inp, external_field=external_field, resolution=resolution,
+                ftol=float(ftol_arr[igrid]),
+                max_iterations=int(niter_arr[igrid]), verbose=verbose,
+                emit=emit,
+                error_on_no_convergence=bool(
+                    last_stage and raise_on_max_iterations),
+                initial_state=state,
+                vacuum_continuation=vacuum_continuation,
+                time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
+                lconm1=lconm1,
+                precon_type=precon_type,
+                prec2d_threshold=prec2d_threshold, prec2d=prec2d,
+                constraint_continuation=(
+                    constraint_continuation if same_grid else None),
+                reuse_vacuum_cache=bool(same_grid),
+            )
+        interpolation_source = stage_result.continuation_state
+        state = stage_result.result.state
+        previous_ns = nsval
+        vacuum_continuation = stage_result.vacuum
+        constraint_continuation = (stage_result.rcon0, stage_result.zcon0)
+
+    if stage_result is None:  # defensive; positive ns_arr guarantees a stage
+        raise ValueError("ns_array has no executable stages")
+    return stage_result.result

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -34,13 +34,14 @@ host round-trips of traced values.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import numpy as np
 
 import jax.numpy as jnp
 
-from .device import AUTO, device_context
+from .device import AUTO, _placement_device, _put_numeric_leaves, device_context
 from .errors import MORE_ITER_FLAG, SUCCESSFUL_TERM_FLAG
 from .fourier import ModeTable, mode_table
 from .input import VmecInput
@@ -322,7 +323,7 @@ def solve_free_boundary_multigrid(
     verbose: bool = False,
     emit=print,
     initial_state: SpectralState | None = None,
-    device: Any = None,
+    device: Any = AUTO,
     raise_on_max_iterations: bool = True,
     time_step: float | None = None,
     tcon0: float | None = None,
@@ -357,6 +358,9 @@ def solve_free_boundary_multigrid(
     The fixed-boundary ladder's solver controls (``time_step``, ``tcon0``,
     ``gamma``, ``nstep``, ``lconm1``, device placement, and 2D-preconditioner
     configuration) are accepted and forwarded identically.
+    ``device="auto"`` (default) applies the measured policy independently at
+    each grid and relocates carried plasma/vacuum arrays when the policy changes;
+    ``None`` leaves placement to JAX.
     """
     if not bool(inp.lfreeb):
         raise ValueError("solve_free_boundary_multigrid requires an LFREEB=T input")
@@ -414,6 +418,25 @@ def solve_free_boundary_multigrid(
                 interpolation_source, ns_fine=nsval, modes=modes)
 
         last_stage = not np.any(ns_arr[igrid + 1:] >= nsval)
+        target = _placement_device(device, resolution)
+        external_field = _put_numeric_leaves(external_field, target)
+        state = _put_numeric_leaves(state, target)
+        constraint_continuation = _put_numeric_leaves(
+            constraint_continuation, target)
+        if (vacuum_continuation is not None and target is not None
+                and any(getattr(vacuum_continuation, name) is not None for name in (
+                    "bsqvac", "rbsq", "mode_matrix", "bvec_nonsing", "potvac",
+                ))):
+            vacuum_continuation = replace(
+                vacuum_continuation,
+                bsqvac=_put_numeric_leaves(vacuum_continuation.bsqvac, target),
+                rbsq=_put_numeric_leaves(vacuum_continuation.rbsq, target),
+                mode_matrix=_put_numeric_leaves(
+                    vacuum_continuation.mode_matrix, target),
+                bvec_nonsing=_put_numeric_leaves(
+                    vacuum_continuation.bvec_nonsing, target),
+                potvac=_put_numeric_leaves(vacuum_continuation.potvac, target),
+            )
         with device_context(device, resolution):
             stage_result = _solve_free_boundary_stage(
                 inp, external_field=external_field, resolution=resolution,

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -208,7 +208,11 @@ def solve_multigrid(
     (``IF (nsval < ns_min) CYCLE`` — decreasing entries are ignored, equal
     entries re-run), and each executed stage after the first starts from the
     ``interp.f`` coarse -> fine interpolation (:func:`interpolate_state`) of
-    the previous stage's final state.  The time step resets to the input
+    the previous stage's final state.  Although ``initialize_radial.f`` reads
+    ``xstore``, ``allocate_ns.f`` first overwrites it from the old ``xc``;
+    therefore the effective VMEC2000 continuation source is the final
+    iterate, including when the preceding stage exhausts NITER.  The time
+    step resets to the input
     ``DELT`` at every stage, and each stage prints its own ``NS = ...``
     banner (``verbose=True``, ``mode="cli"``).
 
@@ -295,8 +299,10 @@ def solve_multigrid(
         with device_context(device, resolution):
             carry = _solve_stage(
                 rt, state, mode=mode, verbose=verbose, emit=emit,
-                # the eqsolve.f axis re-guess applies to the fresh interior guess
-                try_axis_reguess=first_executed and state is None,
+                # initialize_radial.f resets ijacob at every NS stage, so
+                # both bad-Jacobian and LMOVE_AXIS first-force retries remain
+                # available after interpolation and on hot starts.
+                try_axis_reguess=True,
             )
         first_executed = False
         ier = int(carry.ier)
@@ -305,6 +311,8 @@ def solve_multigrid(
                 last_stage and ier != SUCCESSFUL_TERM_FLAG
                 and not (ier == MORE_ITER_FLAG and not raise_on_max_iterations)):
             _finalize(carry, rt)  # raises the typed error for this stage
+        # allocate_ns.f saves old xc and copies it into the newly allocated
+        # xstore before initialize_radial.f scales/interpolates that array.
         state = carry.state
 
     if int(carry.ier) == MORE_ITER_FLAG and not raise_on_max_iterations:
@@ -337,8 +345,8 @@ def solve_free_boundary_multigrid(
     """Free-boundary solve over the VMEC2000 ``NS_ARRAY`` ladder.
 
     The plasma continuation follows :func:`solve_multigrid`: each increasing
-    grid starts from ``interp.f`` interpolation of the preceding stage's best
-    stored state, equal grids rerun without interpolation, and decreasing
+    grid starts from ``interp.f`` interpolation of the preceding stage's final
+    state, equal grids rerun without interpolation, and decreasing
     entries are skipped.  The external field is loaded once.  Resolution-
     specific NESTOR bases, Green-function programs, axis-current filament
     tables and traced vacuum loops are selected/rebuilt when the radial grid
@@ -455,7 +463,10 @@ def solve_free_boundary_multigrid(
                     constraint_continuation if same_grid else None),
                 reuse_vacuum_cache=bool(same_grid),
             )
-        interpolation_source = stage_result.continuation_state
+        # allocate_ns.f overwrites xstore from old xc before interp.f, so the
+        # effective VMEC2000 source is the stage's final state, not its
+        # best-residual restart checkpoint.
+        interpolation_source = stage_result.result.state
         state = stage_result.result.state
         previous_ns = nsval
         vacuum_continuation = stage_result.vacuum

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -44,7 +44,7 @@ import jax.numpy as jnp
 from .device import AUTO, _placement_device, _put_numeric_leaves, device_context
 from .errors import MORE_ITER_FLAG, SUCCESSFUL_TERM_FLAG
 from .fourier import ModeTable, mode_table
-from .input import VmecInput
+from .input import VmecInput, _vmec_ns_prefix
 from .preconditioner_2d import Prec2DConfig
 from .solver import (
     SolveResult, SpectralState, _finalize, _result_from_carry, _solve_stage,
@@ -205,9 +205,8 @@ def solve_multigrid(
     VMEC2000 ``Sources/TimeStep/runvmec.f``: for each grid ``igrid`` the
     radial resolution ``nsval = ns_array(igrid)`` is solved with tolerance
     ``ftol_array(igrid)`` and iteration cap ``niter_array(igrid)``; stages
-    with ``nsval`` *below* the best resolution reached so far are skipped
-    (``IF (nsval < ns_min) CYCLE`` — decreasing entries are ignored, equal
-    entries re-run), and each executed stage after the first starts from the
+    stop at the first decreasing entry during ``readin.f`` normalization
+    (equal entries re-run), and each executed stage after the first starts from the
     ``interp.f`` coarse -> fine interpolation (:func:`interpolate_state`) of
     the previous stage's final state.  Although ``initialize_radial.f`` reads
     ``xstore``, ``allocate_ns.f`` first overwrites it from the old ``xc``;
@@ -255,9 +254,7 @@ def solve_multigrid(
 
     Returns the final stage's :class:`~vmex.core.solver.SolveResult`.
     """
-    ns_arr = np.atleast_1d(np.asarray(
-        inp.ns_array if ns_array is None else ns_array, dtype=np.int64)).ravel()
-    ns_arr = ns_arr[: int(np.argmax(ns_arr <= 0))] if np.any(ns_arr <= 0) else ns_arr
+    ns_arr = _vmec_ns_prefix(inp.ns_array if ns_array is None else ns_array)
     if ns_arr.size == 0:
         raise ValueError("ns_array has no positive stages")
     n_stages = int(ns_arr.size)
@@ -276,13 +273,10 @@ def solve_multigrid(
 
     state: SpectralState | None = initial_state
     first_executed = True
-    ns_min = 0
+    residual_continuation = None
     carry = rt = None
     for igrid in range(n_stages):
         nsval = int(ns_arr[igrid])
-        if nsval < ns_min:      # runvmec.f: decreasing ns values are skipped
-            continue
-        ns_min = nsval
         resolution = resolution_from_input(inp, ns=nsval)
         rt = prepare_runtime(
             inp, resolution, ftol=float(ftol_arr[igrid]),
@@ -308,6 +302,7 @@ def solve_multigrid(
                 # available after interpolation and on hot starts.
                 try_axis_reguess=True,
                 jacobian_retries=jacobian_retries,
+                residual_continuation=residual_continuation,
             )
         first_executed = False
         ier = int(carry.ier)
@@ -319,6 +314,10 @@ def solve_multigrid(
         # allocate_ns.f saves old xc and copies it into the newly allocated
         # xstore before initialize_radial.f scales/interpolates that array.
         state = carry.state
+        # initialize_radial.f resets fsq/iter counters but not the three
+        # invariant residual module variables.  The next grid's residue.f90
+        # edge and m=1 startup gates therefore see this stage's final values.
+        residual_continuation = (carry.fsqr, carry.fsqz, carry.fsql)
 
     if int(carry.ier) == MORE_ITER_FLAG and not raise_on_max_iterations:
         return _result_from_carry(carry, rt)
@@ -352,8 +351,8 @@ def solve_free_boundary_multigrid(
 
     The plasma continuation follows :func:`solve_multigrid`: each increasing
     grid starts from ``interp.f`` interpolation of the preceding stage's final
-    state, equal grids rerun without interpolation, and decreasing
-    entries are skipped.  The external field is loaded once.  Resolution-
+    state, equal grids rerun without interpolation, and the ladder stops at
+    the first decreasing entry.  The external field is loaded once.  Resolution-
     specific NESTOR bases, Green-function programs, axis-current filament
     tables and traced vacuum loops are selected/rebuilt when the radial grid
     changes; equal-grid reruns reuse their dynamic vacuum cache.
@@ -362,8 +361,10 @@ def solve_free_boundary_multigrid(
     activated on a coarse stage, the next stage begins with vacuum active and
     uses the carried coarse-grid boundary pressure on iteration 1, then performs
     a full vacuum update on iteration 2 with new caches (no second turn-on
-    banner or soft restart).  If an intermediate stage reaches ``NITER`` before
-    activation, the next stage continues in the pre-activation lane.
+    banner or soft restart).  The prior stage's ``fsqr/fsqz/fsql`` values are
+    retained too, matching ``initialize_radial.f`` and its first-pass
+    ``residue.f90`` edge gate.  If an intermediate stage reaches ``NITER``
+    before activation, the next stage continues in the pre-activation lane.
 
     ``initial_state`` hot-starts the first executed stage and is interpolated
     when its radial shape differs from that stage.  It follows reset-file
@@ -380,9 +381,7 @@ def solve_free_boundary_multigrid(
     if not bool(inp.lfreeb):
         raise ValueError("solve_free_boundary_multigrid requires an LFREEB=T input")
 
-    ns_arr = np.atleast_1d(np.asarray(
-        inp.ns_array if ns_array is None else ns_array, dtype=np.int64)).ravel()
-    ns_arr = ns_arr[: int(np.argmax(ns_arr <= 0))] if np.any(ns_arr <= 0) else ns_arr
+    ns_arr = _vmec_ns_prefix(inp.ns_array if ns_array is None else ns_array)
     if ns_arr.size == 0:
         raise ValueError("ns_array has no positive stages")
     n_stages = int(ns_arr.size)
@@ -415,14 +414,11 @@ def solve_free_boundary_multigrid(
     previous_ns = int(initial_state.R_cos.shape[0]) if initial_state is not None else None
     vacuum_continuation = None
     constraint_continuation = None
-    ns_min = 0
+    residual_continuation = None
     stage_result = None
     modes = mode_table(int(inp.mpol), int(inp.ntor))
     for igrid in range(n_stages):
         nsval = int(ns_arr[igrid])
-        if nsval < ns_min:
-            continue
-        ns_min = nsval
         resolution = resolution_from_input(inp, ns=nsval)
         same_grid = previous_ns == nsval
         if state is not None and previous_ns != nsval:
@@ -470,6 +466,7 @@ def solve_free_boundary_multigrid(
                 constraint_continuation=(
                     constraint_continuation if same_grid else None),
                 reuse_vacuum_cache=bool(same_grid),
+                residual_continuation=residual_continuation,
             )
         # allocate_ns.f overwrites xstore from old xc before interp.f, so the
         # effective VMEC2000 source is the stage's final state, not its
@@ -479,6 +476,11 @@ def solve_free_boundary_multigrid(
         previous_ns = nsval
         vacuum_continuation = stage_result.vacuum
         constraint_continuation = (stage_result.rcon0, stage_result.zcon0)
+        residual_continuation = (
+            stage_result.result.fsqr,
+            stage_result.result.fsqz,
+            stage_result.result.fsql,
+        )
 
     if stage_result is None:  # defensive; positive ns_arr guarantees a stage
         raise ValueError("ns_array has no executable stages")

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -579,12 +579,18 @@ def l_grad_b(eq, *, s_index: int = -1, ntheta: int = 24, nphi: int = 24) -> Arra
     Returns the (hard) minimum over a uniform ``(theta, phi)`` grid on the
     selected surface (``s_index`` indexes the ``ns``-long half-mesh arrays;
     default edge).  Larger is better; a practical least-squares term is
-    ``max(1/L - 1/threshold, 0)``.  Symmetric configurations only (lasym
-    sine partners are ignored).  Accepts an :class:`Equilibrium` or wout-like.
+    ``max(1/L - 1/threshold, 0)``.  Symmetric configurations only; asymmetric
+    inputs raise instead of silently dropping their sine/cosine partners.
+    Accepts an :class:`Equilibrium` or wout-like.
     This lane consumes host-NumPy wout tables (finite-difference-only); use
     :func:`l_grad_b_state` for ``jac="implicit"``.
     """
     wout = eq.wout if isinstance(eq, Equilibrium) else eq
+    if bool(wout.lasym):
+        raise NotImplementedError(
+            "l_grad_b supports stellarator-symmetric equilibria only "
+            "(lasym = False); asymmetric Fourier partners are not ignored"
+        )
     grid = _lgradb_grid(
         xm=jnp.asarray(np.asarray(wout.xm, dtype=float)),
         xn=jnp.asarray(np.asarray(wout.xn, dtype=float)),
@@ -1591,8 +1597,12 @@ def _least_squares_implicit(
         tangent_stack = (jnp.asarray(t_rbc), jnp.asarray(t_zbs),
                          jnp.asarray(t_ac), jnp.asarray(t_curtor))
 
-    # R17.1 memory knob: chunk_size None == one wide vmap (current behavior),
-    # an int / "auto" caps peak Jacobian memory at that many dofs at a time.
+    # R17.1 memory knob: chunk_size None == one full-width batch, while an int
+    # / "auto" caps peak Jacobian memory at that many dofs at a time.  Route
+    # the full-width case through lax.map(batch_size=ndof), not a bare vmap:
+    # JAX 0.6.2 mis-transforms the nested iterative implicit solve under the
+    # latter (a wrong aspect-ratio column), whereas the full-width lax.map
+    # batch agrees with the chunked paths and independent central FD.
     if jac_chunk_size == "auto":
         chunk = int(auto_chunk_size(ndof))
     elif jac_chunk_size is None or isinstance(jac_chunk_size, int):
@@ -1665,7 +1675,10 @@ def _least_squares_implicit(
             dz, _ = imp._adjoint_solve(Fz, rhs_of(tp), cfg)
             return column_of(dz, tp), dz
 
-        cols, dz_cols = chunk_map(column, tangent_stack, chunk_size=chunk)
+        tangent_chunk = ndof if chunk is None else chunk
+        cols, dz_cols = chunk_map(
+            column, tangent_stack, chunk_size=tangent_chunk
+        )
         return jnp.transpose(cols), dz_cols
 
     # R25.2 amortized block-tridiagonal variant.  The *raw* residual
@@ -1698,6 +1711,8 @@ def _least_squares_implicit(
     probe_col = jnp.asarray(np.tile(np.tile(np.arange(mn_state), n_act), 3))
     if jac_chunk_size == "auto":
         probe_chunk = int(auto_chunk_size(3 * m_block))
+    elif jac_chunk_size is None:
+        probe_chunk = 3 * m_block
     else:
         probe_chunk = chunk
 
@@ -1770,7 +1785,8 @@ def _least_squares_implicit(
             b = jax.jvp(lambda prm: F_raw(z_star, prm), (params,), (tp,))[1]
             return _pack(jax.tree.map(jnp.negative, b))
 
-        rhs = chunk_map(raw_rhs, tangent_stack, chunk_size=chunk)
+        tangent_chunk = ndof if chunk is None else chunk
+        rhs = chunk_map(raw_rhs, tangent_stack, chunk_size=tangent_chunk)
         dz0 = block_thomas_solve(factors, jnp.moveaxis(rhs, 0, -1))
 
         def column(args):
@@ -1783,7 +1799,7 @@ def _least_squares_implicit(
 
         cols, dz_cols = chunk_map(
             column, (*tangent_stack, jnp.moveaxis(dz0, -1, 0)),
-            chunk_size=chunk)
+            chunk_size=tangent_chunk)
         return jnp.transpose(cols), dz_cols
 
     # R25.3 recycled variant: all ndof solves share the operator Fz (and Fz

--- a/vmex/core/preconditioner.py
+++ b/vmex/core/preconditioner.py
@@ -90,7 +90,10 @@ import numpy as np
 
 import jax.numpy as jnp
 
-from solvax import tridiagonal_solve as _sx_tridiagonal_solve
+from solvax import (
+    tridiagonal_solve as _sx_tridiagonal_solve,
+    tridiagonal_solve_checked as _sx_tridiagonal_solve_checked,
+)
 
 __all__ = [
     "RadialPreconditionerCoefficients",
@@ -646,7 +649,8 @@ def scalfor(
     *,
     jmax: int,
     tridiagonal_method: str = "auto",
-) -> Array:
+    return_safe: bool = False,
+) -> Array | tuple[Array, Array]:
     """Apply the assembled preconditioner to a spectral force (``scalfor.f``).
 
     Solves the radial tridiagonal systems of ``matrices`` against ``force``
@@ -666,10 +670,16 @@ def scalfor(
     jmax:
         Same ``jmax`` used to assemble ``matrices`` (static).
     tridiagonal_method:
-        Forwarded to :func:`tridiagonal_solve` (``"auto"``/``"thomas"``/
-        ``"lax"``; static).  The default picks per lowering platform: the
-        bit-parity Thomas scan on CPU, the fused cuSPARSE-backed kernel on
-        accelerators.
+        Forwarded to SOLVAX's checked tridiagonal solve
+        (``"auto"``/``"thomas"``/``"lax"``; static).  The default picks per
+        lowering platform: the bit-parity Thomas scan on CPU, the fused
+        backend on accelerators.
+    return_safe:
+        Also return a scalar status.  Production calls use SOLVAX's
+        unregularized pivot and backward-residual checks.  A rejected column
+        receives the identity fallback (its RHS is preserved) and makes this
+        status false, preventing a singular preconditioner from injecting a
+        NaN/Inf update while retaining a diagnosable failure signal.
     """
     ax, bx, dx = matrices
     f = jnp.asarray(force)
@@ -679,19 +689,34 @@ def scalfor(
     jmax = int(jmax)
     mpol = int(f.shape[1])
     out = f
+    safe = jnp.asarray(True)
+
+    def checked_solve(superdiagonal, diagonal, subdiagonal, rhs):
+        result = _sx_tridiagonal_solve_checked(
+            subdiagonal,
+            diagonal,
+            superdiagonal,
+            rhs,
+            method=tridiagonal_method,
+            pivot_rtol=1.0e-8,
+            residual_rtol=1.0e-8,
+            fallback="identity",
+        )
+        return result.solution, jnp.all(~result.diagnostics.fallback_used)
 
     if jmax > 0:
-        solution_m0 = tridiagonal_solve(
+        solution_m0, safe_m0 = checked_solve(
             ax[:jmax, 0, :], dx[:jmax, 0, :], bx[:jmax, 0, :], f[:jmax, 0, :, :],
-            method=tridiagonal_method,
         )
+        safe = safe & safe_m0
         out = out.at[:jmax, 0].set(solution_m0)
         if mpol > 1 and jmax > 1:
-            solution_m = tridiagonal_solve(
+            solution_m, safe_m = checked_solve(
                 ax[1:jmax, 1:, :], dx[1:jmax, 1:, :], bx[1:jmax, 1:, :], f[1:jmax, 1:, :, :],
-                method=tridiagonal_method,
             )
+            safe = safe & safe_m
             out = out.at[1:jmax, 1:].set(solution_m)
             out = out.at[0, 1:].set(0.0)
 
-    return out[..., 0] if not stacked else out
+    result = out[..., 0] if not stacked else out
+    return (result, safe) if return_safe else result

--- a/vmex/core/preconditioner_2d.py
+++ b/vmex/core/preconditioner_2d.py
@@ -42,10 +42,11 @@ could equally drive the block-tridiagonal :func:`solvax.block_thomas_truncated`
 route if the blocks were assembled explicitly (they are not, by design — the
 matrix-free HVP keeps peak memory at one force graph).
 
-Wiring lives in :mod:`vmex.core.solver` (``_make_body``): when
-``precon_type != "NONE"`` the traced iteration replaces the 1D force direction
-by :func:`newton_direction` under a ``lax.cond`` gated on the activation
-predicate, so the default 1D-only path is untouched.
+Wiring lives in :mod:`vmex.core.solver` (``_make_body``): when VMEX's explicit
+``PRECON_TYPE='GMRES'`` mode is selected, the traced iteration replaces the
+1D force direction by :func:`newton_direction` under a ``lax.cond`` gated on
+the activation predicate.  ``NONE`` and ``DEFAULT`` retain VMEC2000's ordinary
+1D radial/lambda preconditioner.
 """
 
 from __future__ import annotations

--- a/vmex/core/residuals.py
+++ b/vmex/core/residuals.py
@@ -42,7 +42,7 @@ modules ``solvers/fixed_boundary/residual/payload_blocks.py`` /
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Any
+from typing import Any, Literal, overload
 
 import numpy as np
 
@@ -525,13 +525,36 @@ def scale_m1_preconditioner_rhs(
     return replace(force, **updates) if updates else force
 
 
+@overload
 def apply_radial_preconditioner(
     force: SpectralForce,
     *,
     matrices_R: TridiagonalMatrices,
     matrices_Z: TridiagonalMatrices,
     jmax: int,
-) -> SpectralForce:
+    return_safe: Literal[False] = False,
+) -> SpectralForce: ...
+
+
+@overload
+def apply_radial_preconditioner(
+    force: SpectralForce,
+    *,
+    matrices_R: TridiagonalMatrices,
+    matrices_Z: TridiagonalMatrices,
+    jmax: int,
+    return_safe: Literal[True],
+) -> tuple[SpectralForce, Array]: ...
+
+
+def apply_radial_preconditioner(
+    force: SpectralForce,
+    *,
+    matrices_R: TridiagonalMatrices,
+    matrices_Z: TridiagonalMatrices,
+    jmax: int,
+    return_safe: bool = False,
+) -> SpectralForce | tuple[SpectralForce, Array]:
     """Solve the R and Z radial tridiagonal systems against all force blocks.
 
     VMEC2000: ``scalfor.f`` applied to ``gcr`` (with the ``arm/ard/brm/brd/
@@ -540,15 +563,20 @@ def apply_radial_preconditioner(
     Lambda blocks pass through (see :func:`apply_lambda_preconditioner`).
     """
     updates: dict[str, Array] = {}
+    safe = jnp.asarray(True)
     for names, matrices in ((_R_BLOCKS, matrices_R), (_Z_BLOCKS, matrices_Z)):
         present = [name for name in names if getattr(force, name) is not None]
         if not present:
             continue
         stacked = jnp.stack([jnp.asarray(getattr(force, name)) for name in present], axis=-1)
-        solved = scalfor(stacked, matrices, jmax=jmax)
+        solved, block_safe = scalfor(
+            stacked, matrices, jmax=jmax, return_safe=True
+        )
+        safe = safe & block_safe
         for idx, name in enumerate(present):
             updates[name] = solved[..., idx]
-    return replace(force, **updates)
+    result = replace(force, **updates)
+    return (result, safe) if return_safe else result
 
 
 def apply_lambda_preconditioner(force: SpectralForce, faclam: Array) -> SpectralForce:

--- a/vmex/core/setup.py
+++ b/vmex/core/setup.py
@@ -934,9 +934,11 @@ def run_setup(
         Apply the m = 1 constraint conversion (VMEC2000 default T).
     infer_axis_if_missing:
         When every input axis coefficient is zero, run :func:`guess_axis` on
-        the zero-axis interior guess and re-blend (the legacy driver default;
-        VMEC2000 itself would start from the zero axis and only call
-        ``guess_axis`` after the first bad-Jacobian restart).
+        the zero-axis interior guess and re-blend.  This is an explicit
+        geometry/setup convenience; production solver construction passes
+        ``False`` because VMEC2000 starts from the supplied zero axis and
+        calls ``guess_axis`` exactly once after its first bad-Jacobian or
+        high-force control transfer.
 
     Returns
     -------

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -585,9 +585,11 @@ def _resolve_prec2d(
     """Resolve the 2D-preconditioner config (``precon2d.f`` / ``evolve.f``).
 
     An explicit ``prec2d`` config wins (used verbatim); otherwise it is built
-    from ``precon_type``/``prec2d_threshold`` (input defaults, overridable) when
-    ``precon_type != "NONE"``.  Returns ``None`` (the default 1D-only path)
-    when the 2D preconditioner is off.
+    from ``precon_type``/``prec2d_threshold`` (input defaults, overridable).
+    ``NONE`` and VMEC2000's ``DEFAULT`` select the parity 1-D path.  ``GMRES``
+    selects VMEX's documented matrix-free JAX/SOLVAX Newton--GMRES path.
+    VMEC2000's distinct ``CG``, ``GMRESR`` and ``TFQMR`` algorithms are
+    rejected rather than silently aliased to GMRES.
     """
     if prec2d is not None:
         return prec2d
@@ -597,8 +599,14 @@ def _resolve_prec2d(
     else:
         pt = "NONE" if precon_type is None else precon_type
         thr = 1e-30 if prec2d_threshold is None else prec2d_threshold
-    if str(pt).strip().upper() == "NONE":
+    pt_normalized = str(pt).strip().upper()
+    if pt_normalized in {"", "NONE", "DEFAULT"}:
         return None
+    if pt_normalized != "GMRES":
+        raise NotImplementedError(
+            "PRECON_TYPE must be NONE/DEFAULT or GMRES; VMEC2000's distinct "
+            "CG, GMRESR, and TFQMR evolution algorithms are not implemented"
+        )
     return Prec2DConfig(threshold=float(thr), finest=bool(finest))
 
 

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -1198,8 +1198,20 @@ def reguess_initial_axis(
 # -- Iteration body (evolve.f + TimeStepControl + the eqsolve.f checks) ----------------------------------------------
 
 
-def _make_body(rt: SolverRuntime) -> Callable[[_LoopCarry], _LoopCarry]:
-    """Build the traced single-iteration body shared by both lanes."""
+def _make_body(
+    rt: SolverRuntime,
+    *,
+    evaluation_state: SpectralState | None = None,
+) -> Callable[[_LoopCarry], _LoopCarry]:
+    """Build the traced single-iteration body shared by both lanes.
+
+    ``evaluation_state`` is the narrowly scoped VMEC2000 free-boundary
+    turn-on seam.  ``funct3d.f`` computes geometry and vacuum pressure, then
+    performs the ``irst=2`` soft restart, and finally evaluates forces using
+    the already-computed geometry.  Supplying the pre-restart state here
+    reproduces that one pass while momentum still evolves ``carry.state``
+    (the restored best state).  Normal iterations leave it as ``None``.
+    """
     ftol = rt.ftol
     max_iter = rt.max_iterations
     gamma = rt.gamma
@@ -1209,7 +1221,8 @@ def _make_body(rt: SolverRuntime) -> Callable[[_LoopCarry], _LoopCarry]:
         running = jnp.logical_not(carry.done)
 
         # ---- funct3d (evolve.f) -------------------------------------------
-        e1 = _evaluate(carry.state, carry.cache, it, carry.iter1, carry.fsqz, rt,
+        state_e1 = carry.state if evaluation_state is None else evaluation_state
+        e1 = _evaluate(state_e1, carry.cache, it, carry.iter1, carry.fsqz, rt,
                        carry.fsqr + carry.fsqz)
         jac1 = e1.jacobian_sign_changed
         nonfinite1 = (~jac1) & (~_evaluation_is_finite(e1))

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -649,7 +649,17 @@ def prepare_runtime(
         if resolution is None:
             resolution = resolution_from_input(inp)
         if setup is None:
-            setup = run_setup(inp, resolution, lconm1=lconm1)
+            # VMEC2000 profil3d.f starts from the axis coefficients exactly as
+            # supplied, including an all-zero/missing axis.  Its eqsolve.f
+            # driver calls guess_axis once only after the first bad-Jacobian
+            # or high-force (irst=4) pass.  The setup helper retains its
+            # explicit legacy inference option for geometry-only callers, but
+            # a production solve must not pre-guess here and then guess a
+            # second time in _solve_stage.
+            setup = run_setup(
+                inp, resolution, lconm1=lconm1,
+                infer_axis_if_missing=False,
+            )
         defaults = dict(ftol=float(inp.ftol_array[0]), niter=int(inp.niter_array[0]),
                         delt=float(inp.delt), tcon0=float(inp.tcon0),
                         gamma=float(inp.gamma), nstep=int(inp.nstep),
@@ -1688,37 +1698,90 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
 
 def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
                  mode: str, verbose: bool, emit,
-                 try_axis_reguess: bool = True) -> _LoopCarry:
+                 try_axis_reguess: bool = True,
+                 jacobian_retries: int = 2) -> _LoopCarry:
     """Run one solve at a fixed runtime, with the eqsolve.f axis-retry.
 
     ``state0=None`` starts from the runtime's ``profil3d.f`` interior guess.
     On a first-iteration Jacobian sign change with ``ijacob == 0``
     (``eqsolve.f``), the axis is re-guessed from the failing geometry and the
-    loop restarted once (``try_axis_reguess``).  Returns the final carry;
-    the caller maps ``carry.ier`` to results/exceptions (:func:`_finalize`).
-    """
-    setup = rt.setup
-    if state0 is None:
-        state0 = _initial_state(setup)
-    carry = _run_loop(state0, rt, mode=mode, ijacob=0, verbose=verbose, emit=emit)
+    loop restarted once (``try_axis_reguess``).
 
-    # eqsolve.f: on a first-iteration Jacobian sign change with ijacob == 0,
-    # re-guess the axis from the current geometry and restart once.
-    retry_reason = int(carry.ier)
-    if try_axis_reguess and retry_reason in (
-            BAD_JACOBIAN_FLAG, AXIS_REGUESS_FLAG) \
-            and int(carry.ijacob) == 0 and rt.resolution.ns >= 3:
+    VMEC2000 stops after 75 Jacobian resets and tells the user to change
+    ``DELT``.  VMEX makes that manual recovery deterministic: up to
+    ``jacobian_retries`` attempts restart the best finite checkpoint with
+    zero velocity and half the preceding initial step, capped at 0.5.  The
+    equilibrium equations and convergence test are unchanged; setting
+    ``jacobian_retries=0`` preserves the exact VMEC2000 fatal-stop policy.
+    Returns the final carry; the caller maps ``carry.ier`` to
+    results/exceptions (:func:`_finalize`).
+    """
+    if int(jacobian_retries) < 0:
+        raise ValueError("jacobian_retries must be non-negative")
+
+    def run_attempt(
+        attempt_rt: SolverRuntime,
+        attempt_state: SpectralState,
+        *,
+        emit_banner: bool,
+    ) -> tuple[_LoopCarry, SolverRuntime]:
+        carry = _run_loop(
+            attempt_state, attempt_rt, mode=mode, ijacob=0,
+            verbose=verbose, emit=emit, emit_banner=emit_banner,
+        )
+
+        # eqsolve.f: on a first-iteration Jacobian sign change with
+        # ijacob == 0, re-guess the axis from the current geometry and restart
+        # once.  A high finite first force uses the same transfer while
+        # preserving the triggering pass's momentum.
+        retry_reason = int(carry.ier)
+        if (
+            try_axis_reguess
+            and retry_reason in (BAD_JACOBIAN_FLAG, AXIS_REGUESS_FLAG)
+            and int(carry.ijacob) == 0
+            and attempt_rt.resolution.ns >= 3
+        ):
+            if verbose:
+                if retry_reason == BAD_JACOBIAN_FLAG:
+                    emit(" INITIAL JACOBIAN CHANGED SIGN!")
+                emit(" TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS")
+            attempt_rt, attempt_state, _axis = reguess_initial_axis(
+                attempt_rt, attempt_state
+            )
+            carry = _run_loop(
+                attempt_state, attempt_rt, mode=mode, ijacob=1,
+                verbose=verbose, emit=emit, emit_banner=False,
+                initial_xcdot=(
+                    carry.xcdot
+                    if retry_reason == AXIS_REGUESS_FLAG else None
+                ),
+            )
+        return carry, attempt_rt
+
+    attempt_state = _initial_state(rt.setup) if state0 is None else state0
+    attempt_rt = rt
+    carry, attempt_rt = run_attempt(
+        attempt_rt, attempt_state, emit_banner=True,
+    )
+    for attempt in range(1, int(jacobian_retries) + 1):
+        if int(carry.ier) != JAC75_FLAG:
+            break
+        retry_step = min(0.5, 0.5 * float(attempt_rt.time_step0))
+        attempt_state = carry.xstore
+        attempt_rt = runtime_with_baselines(
+            replace(attempt_rt, time_step0=retry_step),
+            attempt_state,
+        )
         if verbose:
-            if retry_reason == BAD_JACOBIAN_FLAG:
-                emit(" INITIAL JACOBIAN CHANGED SIGN!")
-            emit(" TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS")
-        rt, state0, _axis = reguess_initial_axis(rt, state0)
-        carry = _run_loop(state0, rt, mode=mode, ijacob=1, verbose=verbose,
-                          emit=emit, emit_banner=False,
-                          initial_xcdot=(
-                              carry.xcdot
-                              if retry_reason == AXIS_REGUESS_FLAG else None
-                          ))
+            emit(
+                " JACOBIAN RECOVERY RETRY "
+                f"{attempt}/{int(jacobian_retries)}: "
+                "RESTARTING BEST FINITE STATE WITH "
+                f"DELT = {retry_step:.6g}"
+            )
+        carry, attempt_rt = run_attempt(
+            attempt_rt, attempt_state, emit_banner=False,
+        )
     return carry
 
 
@@ -1766,6 +1829,7 @@ def solve(
     device: Any = AUTO,
     precon_type: str | None = None, prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
+    jacobian_retries: int = 2,
 ) -> SolveResult:
     """Single-grid fixed-boundary solve (VMEC2000 ``eqsolve.f``).
 
@@ -1780,7 +1844,10 @@ def solve(
     printing (``verbose=True``); ``mode="jit"`` runs one ``lax.while_loop``
     over the same traced body.
 
-    Returns a :class:`SolveResult` on convergence.  Raises
+    Returns a :class:`SolveResult` on convergence.  ``jacobian_retries``
+    (default 2) restarts the best finite checkpoint with a reduced ``DELT``
+    after VMEC2000's 75-reset condition; set it to zero for the exact
+    VMEC2000 fatal-stop policy.  Raises
     :class:`VmecJacobianError` when the initial Jacobian changes sign twice
     (after one ``guess_axis`` retry — the ``eqsolve.f`` ``ijacob == 0`` path)
     or at ``ijacob >= 75`` (``jac75_flag``), and :class:`VmecConvergenceError`
@@ -1829,5 +1896,8 @@ def solve(
         initial_state = hot_restart_state(rt, initial_state)
         rt = runtime_with_baselines(rt, initial_state)  # funct3d.f iter2==iter1
     with device_context(device, rt.resolution):
-        carry = _solve_stage(rt, initial_state, mode=mode, verbose=verbose, emit=emit)
+        carry = _solve_stage(
+            rt, initial_state, mode=mode, verbose=verbose, emit=emit,
+            jacobian_retries=jacobian_retries,
+        )
     return _finalize(carry, rt)

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -133,10 +133,14 @@ from .errors import (
     WERROR_MESSAGES,
 )
 from .fields import (
-    constraint_scaling, energies_and_force_norms, magnetic_fields,
-    metric_elements, preconditioned_force_norm,
+    constraint_scaling, energies_and_force_norms,
+    force_balance_preconditioner_factor, magnetic_fields, metric_elements,
+    preconditioned_force_norm, radial_force_balance_error,
 )
-from .forces import constraint_force, mhd_forces, spectral_mhd_forces
+from .forces import (
+    apply_m1_force_balance, constraint_force, mhd_forces,
+    spectral_mhd_forces,
+)
 from .fourier import ModeTable, Resolution, TrigTables, mode_table, trig_tables
 from .geometry import apply_lambda_axis_closure, half_mesh_jacobian, real_space_geometry
 from .input import VmecInput
@@ -219,7 +223,8 @@ class PreconditionerCache:
 
     ``tcon`` (constraint scaling), the residual norms ``fnorm/fnormL/fnorm1``,
     the :func:`precondn` coefficients and assembled :func:`scalfor_matrices`
-    for the R and Z force families, and the ``lamcal`` diagonal ``faclam``.
+    for the R and Z force families, the ``LFORBAL`` ``rzu_fac/rru_fac``
+    factors, and the ``lamcal`` diagonal ``faclam``.
     """
 
     tcon: Array
@@ -228,6 +233,8 @@ class PreconditionerCache:
     fnorm1: Array
     coefficients_R: RadialPreconditionerCoefficients
     coefficients_Z: RadialPreconditionerCoefficients
+    force_balance_R: Array
+    force_balance_Z: Array
     matrices_R: TridiagonalMatrices
     matrices_Z: TridiagonalMatrices
     faclam: Array
@@ -393,6 +400,7 @@ class SolverRuntime:
     gamma: float; tcon0: float; ftol: float
     max_iterations: int; time_step0: float; nstep: int
     jmax: int                           # evolved radial rows (fixed: ns-1)
+    lforbal: bool = False               # tomnsp_mod.f m=1,n=0 force replacement
     lmove_axis: bool = True             # funct3d.f first-force irst=4 path
 
     # -- free-boundary seam (core/freeboundary.py; funct3d.f/forces.f) ------
@@ -449,7 +457,7 @@ class SolverRuntime:
 
 _register(SolverRuntime, meta=(
     "resolution", "gamma", "tcon0", "ftol", "max_iterations", "time_step0",
-    "nstep", "jmax", "lmove_axis", "lfreeb", "prec2d",
+    "nstep", "jmax", "lforbal", "lmove_axis", "lfreeb", "prec2d",
 ))
 
 
@@ -601,7 +609,8 @@ def prepare_runtime(
     ftol: float | None = None, max_iterations: int | None = None,
     time_step: float | None = None, tcon0: float | None = None,
     gamma: float | None = None, nstep: int | None = None,
-    lconm1: bool = True, setup: RunSetup | None = None,
+    lconm1: bool = True, lforbal: bool | None = None,
+    setup: RunSetup | None = None,
     precon_type: str | None = None, prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
 ) -> SolverRuntime:
@@ -614,7 +623,9 @@ def prepare_runtime(
     spectral row never evolves in fixed-boundary mode, so they are constants
     of the run.
 
-    ``precon_type``/``prec2d_threshold`` (or an explicit ``prec2d``
+    ``lforbal`` overrides the input's non-variational ``(m=1,n=0)`` force
+    replacement when supplied (a prebuilt :class:`RunSetup` defaults it to
+    false).  ``precon_type``/``prec2d_threshold`` (or an explicit ``prec2d``
     :class:`~vmex.core.preconditioner_2d.Prec2DConfig`) switch on the
     optional 2D block preconditioner (``precon2d.f``); ``None``/``"NONE"``
     (the default) leaves the 1D-only path byte-identical.
@@ -624,7 +635,7 @@ def prepare_runtime(
             raise ValueError("prepare_runtime(RunSetup) requires a Resolution")
         setup = source
         defaults = dict(ftol=1e-10, niter=100, delt=1.0, tcon0=1.0, gamma=0.0,
-                        nstep=200, lmove_axis=True)
+                        nstep=200, lforbal=False, lmove_axis=True)
     else:
         inp = source
         if resolution is None:
@@ -634,6 +645,7 @@ def prepare_runtime(
         defaults = dict(ftol=float(inp.ftol_array[0]), niter=int(inp.niter_array[0]),
                         delt=float(inp.delt), tcon0=float(inp.tcon0),
                         gamma=float(inp.gamma), nstep=int(inp.nstep),
+                        lforbal=bool(inp.lforbal),
                         lmove_axis=bool(inp.lmove_axis))
 
     rt = SolverRuntime(
@@ -645,6 +657,7 @@ def prepare_runtime(
         time_step0=float(defaults["delt"] if time_step is None else time_step),
         nstep=int(defaults["nstep"] if nstep is None else nstep),
         jmax=int(resolution.ns) - 1,
+        lforbal=bool(defaults["lforbal"] if lforbal is None else lforbal),
         lmove_axis=bool(defaults["lmove_axis"]),
         rcon0=jnp.zeros(()), zcon0=jnp.zeros(()),  # placeholder, replaced below
         prec2d=_resolve_prec2d(source, prec2d, precon_type, prec2d_threshold),
@@ -735,6 +748,7 @@ def _zero_cache(rt: SolverRuntime) -> PreconditionerCache:
     return PreconditionerCache(
         tcon=z((ns,)), fnorm=z(()), fnormL=z(()), fnorm1=z(()),
         coefficients_R=coeffs, coefficients_Z=coeffs,
+        force_balance_R=z((ns,)), force_balance_Z=z((ns,)),
         matrices_R=mats, matrices_Z=mats, faclam=z((ns, mpol, nr)),
     )
 
@@ -822,6 +836,20 @@ def _force_pipeline(
     spectral = spectral_mhd_forces(
         forces, mpol=res.mpol, ntor=res.ntor, trig=rt.trig, include_edge=bool(rt.lfreeb)
     )
+    if rt.lforbal:
+        equif = radial_force_balance_error(
+            fields=fields,
+            phipf=setup.phipf,
+            trig=rt.trig,
+            s=s,
+            signgs=setup.signgs,
+        )
+        spectral = apply_m1_force_balance(
+            spectral,
+            equif=equif,
+            factor_R=cache.force_balance_R,
+            factor_Z=cache.force_balance_Z,
+        )
 
     # -- residue.f90 chain ---------------------------------------------------
     rotated = m1_residue_rotation(spectral, lconm1=setup.lconm1)
@@ -1007,6 +1035,30 @@ def _evaluate(
         dxdu_even_full=geometry.dR_dtheta_even, dxdu_odd_full=geometry.dR_dtheta_odd,
         x_odd_full=geometry.R_odd, **common,
     )
+    if rt.lforbal and res.mpol >= 2:
+        force_balance_R = force_balance_preconditioner_factor(
+            axd_odd=coefficients_R.axd[:, 1],
+            dxdu_half=jacobian.zu12,
+            trig_multiplier=np.asarray(rt.trig.cosmu)[:, 1],
+            jacobian=jacobian,
+            fields=fields,
+            trig=rt.trig,
+            s=s,
+            signgs=setup.signgs,
+        )
+        force_balance_Z = force_balance_preconditioner_factor(
+            axd_odd=coefficients_Z.axd[:, 1],
+            dxdu_half=jacobian.ru12,
+            trig_multiplier=-np.asarray(rt.trig.sinmu)[:, 1],
+            jacobian=jacobian,
+            fields=fields,
+            trig=rt.trig,
+            s=s,
+            signgs=setup.signgs,
+        )
+    else:
+        force_balance_R = jnp.zeros((ns,), dtype=s.dtype)
+        force_balance_Z = jnp.zeros((ns,), dtype=s.dtype)
     # jmax follows scalfor.f: ns-1 fixed boundary (rt.jmax default), ns once
     # the vacuum field is on (free-boundary lane) — activates the
     # EDGE_PEDESTAL / ZC(0,0) edge stiffening inside scalfor_matrices.
@@ -1028,7 +1080,9 @@ def _evaluate(
     fresh = PreconditionerCache(
         tcon=tcon_new, fnorm=energies.fnorm, fnormL=energies.fnormL,
         fnorm1=fnorm1_new, coefficients_R=coefficients_R,
-        coefficients_Z=coefficients_Z, matrices_R=matrices_R,
+        coefficients_Z=coefficients_Z,
+        force_balance_R=force_balance_R,
+        force_balance_Z=force_balance_Z, matrices_R=matrices_R,
         matrices_Z=matrices_Z, faclam=faclam_new,
     )
     refresh = (((iteration - iter_last_reset) % NS4) == 0) & (~jac_changed)

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -127,7 +127,7 @@ from jax import lax
 
 from .device import AUTO, device_context
 from .errors import (
-    BAD_JACOBIAN_FLAG, JAC75_FLAG, MISC_ERROR_FLAG, MORE_ITER_FLAG,
+    AXIS_REGUESS_FLAG, BAD_JACOBIAN_FLAG, JAC75_FLAG, MISC_ERROR_FLAG, MORE_ITER_FLAG,
     NONFINITE_FLAG, NORM_TERM_FLAG, SUCCESSFUL_TERM_FLAG,
     VmecConvergenceError, VmecJacobianError, VmecNumericalError,
     WERROR_MESSAGES,
@@ -393,6 +393,7 @@ class SolverRuntime:
     gamma: float; tcon0: float; ftol: float
     max_iterations: int; time_step0: float; nstep: int
     jmax: int                           # evolved radial rows (fixed: ns-1)
+    lmove_axis: bool = True             # funct3d.f first-force irst=4 path
 
     # -- free-boundary seam (core/freeboundary.py; funct3d.f/forces.f) ------
     # lfreeb=True selects the vacuum-coupled lane: the edge row is evolved
@@ -448,7 +449,7 @@ class SolverRuntime:
 
 _register(SolverRuntime, meta=(
     "resolution", "gamma", "tcon0", "ftol", "max_iterations", "time_step0",
-    "nstep", "jmax", "lfreeb", "prec2d",
+    "nstep", "jmax", "lmove_axis", "lfreeb", "prec2d",
 ))
 
 
@@ -623,7 +624,7 @@ def prepare_runtime(
             raise ValueError("prepare_runtime(RunSetup) requires a Resolution")
         setup = source
         defaults = dict(ftol=1e-10, niter=100, delt=1.0, tcon0=1.0, gamma=0.0,
-                        nstep=200)
+                        nstep=200, lmove_axis=True)
     else:
         inp = source
         if resolution is None:
@@ -632,7 +633,8 @@ def prepare_runtime(
             setup = run_setup(inp, resolution, lconm1=lconm1)
         defaults = dict(ftol=float(inp.ftol_array[0]), niter=int(inp.niter_array[0]),
                         delt=float(inp.delt), tcon0=float(inp.tcon0),
-                        gamma=float(inp.gamma), nstep=int(inp.nstep))
+                        gamma=float(inp.gamma), nstep=int(inp.nstep),
+                        lmove_axis=bool(inp.lmove_axis))
 
     rt = SolverRuntime(
         resolution=resolution, setup=setup,
@@ -643,6 +645,7 @@ def prepare_runtime(
         time_step0=float(defaults["delt"] if time_step is None else time_step),
         nstep=int(defaults["nstep"] if nstep is None else nstep),
         jmax=int(resolution.ns) - 1,
+        lmove_axis=bool(defaults["lmove_axis"]),
         rcon0=jnp.zeros(()), zcon0=jnp.zeros(()),  # placeholder, replaced below
         prec2d=_resolve_prec2d(source, prec2d, precon_type, prec2d_threshold),
     )
@@ -1162,11 +1165,13 @@ def _evaluation_is_finite(result: _EvalResult) -> Array:
 def reguess_initial_axis(
     rt: SolverRuntime, state: SpectralState
 ) -> tuple[SolverRuntime, SpectralState, tuple[Array, Array, Array, Array]]:
-    """Apply the VMEC2000 first-bad-Jacobian magnetic-axis retry.
+    """Apply VMEC2000's first-pass magnetic-axis retry.
 
-    Shared by fixed- and free-boundary drivers.  Besides rebuilding the
-    ``profil3d`` state, this updates the setup's axis arrays and rebinds the
-    constraint baselines to that state (``funct3d.f: iter2 == iter1``).
+    Shared by fixed- and free-boundary drivers for a first bad Jacobian and
+    for ``LMOVE_AXIS=T`` with a first raw-force sum above ``1e2``.  Besides
+    rebuilding the ``profil3d`` state, this updates the setup's axis arrays
+    and rebinds the constraint baselines to that state
+    (``funct3d.f: iter2 == iter1``).
     """
     setup = rt.setup
     _, geometry = _geometry(state, rt)
@@ -1234,6 +1239,22 @@ def _make_body(
 
         converged = (~jac1) & (fsqr_c <= ftol) & (fsqz_c <= ftol) & (fsql_c <= ftol)
         bad_init = jac1 & (it == 1)
+        # funct3d.f/eqsolve.f: LMOVE_AXIS=T and a finite first raw-force sum
+        # above 1e2 set irst=4 and return to guess_axis before evolving xc.
+        # ijacob=0 makes this a single retry, exactly like the Fortran guard.
+        axis_reguess = (
+            bool(rt.lmove_axis)
+            & (~jac1)
+            & (~nonfinite1)
+            & (it == 1)
+            & (carry.ijacob == 0)
+            & (rt.resolution.ns >= 3)
+            & (fsq0 > 1.0e2)
+        )
+        # Unlike a bad Jacobian, irst=4 does not return from evolve.f: the
+        # triggering pass still performs its damping/momentum update, and
+        # eqsolve carries that xcdot into the rebuilt-axis retry.  ``done``
+        # below transfers control after that update; only its xc is discarded.
         stepping = running & (~converged) & (~bad_init) & (~nonfinite1)
 
         # ---- TimeStepControl (evolve.f) ------------------------------------
@@ -1333,19 +1354,26 @@ def _make_body(
         jac75 = stepping & (ijacob_n >= 75)
         maxed = stepping & (~eq_reset) & (~jac75) & (it >= max_iter)
 
-        stop_now = running & (converged | bad_init | numerical_bad) | jac75 | maxed | reeval_bad
+        stop_now = (
+            running & (converged | bad_init | axis_reguess | numerical_bad)
+            | jac75 | maxed | reeval_bad
+        )
         done_n = carry.done | stop_now
         ier_n = jnp.where(
             carry.done, carry.ier,
             jnp.where(running & converged, SUCCESSFUL_TERM_FLAG,
             jnp.where(running & bad_init, BAD_JACOBIAN_FLAG,
+            jnp.where(running & axis_reguess, AXIS_REGUESS_FLAG,
             jnp.where(running & numerical_bad, NONFINITE_FLAG,
             jnp.where(jac75, JAC75_FLAG,
             jnp.where(reeval_bad, MISC_ERROR_FLAG,
-            jnp.where(maxed, MORE_ITER_FLAG, carry.ier)))))),
+            jnp.where(maxed, MORE_ITER_FLAG, carry.ier))))))),
         ).astype(carry.ier.dtype)
 
-        advance = stepping & (~eq_reset) & (~jac75) & (~maxed) & (~reeval_bad) & (~numerical_bad)
+        advance = (
+            stepping & (~axis_reguess) & (~eq_reset) & (~jac75) & (~maxed)
+            & (~reeval_bad) & (~numerical_bad)
+        )
         iteration_n = jnp.where(advance, it + 1, it)
 
         # ---- trajectory row (printout.f values) ----------------------------
@@ -1385,11 +1413,20 @@ def _make_body(
     return body
 
 
-def _initial_carry(state: SpectralState, rt: SolverRuntime, *, ijacob: int) -> _LoopCarry:
+def _initial_carry(
+    state: SpectralState,
+    rt: SolverRuntime,
+    *,
+    ijacob: int,
+    xcdot: SpectralState | None = None,
+) -> _LoopCarry:
     """Initial loop carry (reset_params.f / initialize_radial.f values)."""
     dtype = rt.setup.s_full.dtype
     one = jnp.asarray(1.0, dtype=dtype)
-    zeros = jax.tree.map(jnp.zeros_like, state)
+    zeros = (
+        jax.tree.map(jnp.zeros_like, state)
+        if xcdot is None else xcdot
+    )
     delt0 = jnp.asarray(rt.time_step0, dtype=dtype)
     zero, inf = jnp.zeros((), dtype=dtype), jnp.asarray(jnp.inf, dtype=dtype)
     # NOTE: scalar counters/flags carry explicit (non-weak) dtypes so that the
@@ -1544,9 +1581,12 @@ def _block_lane(carry: _LoopCarry, rt: SolverRuntime) -> _LoopCarry:
 
 
 def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
-              ijacob: int, verbose: bool, emit) -> _LoopCarry:
+              ijacob: int, verbose: bool, emit,
+              emit_banner: bool = True,
+              initial_xcdot: SpectralState | None = None) -> _LoopCarry:
     """Run the iteration loop in the requested lane; return the final carry."""
-    carry = _initial_carry(state0, rt, ijacob=ijacob)
+    carry = _initial_carry(
+        state0, rt, ijacob=ijacob, xcdot=initial_xcdot)
 
     if mode == "jit":
         return _while_lane(carry, rt)
@@ -1559,7 +1599,7 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
     # (values bit-for-bit unchanged) makes the per-block donation valid and is
     # amortized over the whole solve.
     carry = jax.tree.map(jnp.array, carry)
-    if verbose:
+    if verbose and emit_banner:
         # initialize_radial.f prints the total Fourier mode count (mnmax), not mpol.
         emit(stage_banner(rt.resolution.ns, rt.resolution.mnmax, rt.ftol, rt.max_iterations), end="")
         emit(FORCE_ITERATIONS_BANNER, end="")
@@ -1571,7 +1611,12 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
         carry = _block_lane(carry, rt)
         done = bool(carry.done)
         upto = int(carry.iteration) if done else int(carry.iteration) - 1
-        if verbose:
+        # VMEC2000's irst=4 and first-bad-Jacobian transfers return to
+        # eqsolve before printout.f, so the discarded first pass has no row.
+        retry_transfer = done and int(carry.ier) in (
+            AXIS_REGUESS_FLAG, BAD_JACOBIAN_FLAG,
+        )
+        if verbose and not retry_transfer:
             trajectory = np.asarray(carry.trajectory[:max(upto, 0)])
             _emit_lines(rt, trajectory, upto, printed, done, emit)
         if done:
@@ -1597,14 +1642,21 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
 
     # eqsolve.f: on a first-iteration Jacobian sign change with ijacob == 0,
     # re-guess the axis from the current geometry and restart once.
-    if try_axis_reguess and int(carry.ier) == BAD_JACOBIAN_FLAG \
+    retry_reason = int(carry.ier)
+    if try_axis_reguess and retry_reason in (
+            BAD_JACOBIAN_FLAG, AXIS_REGUESS_FLAG) \
             and int(carry.ijacob) == 0 and rt.resolution.ns >= 3:
         if verbose:
-            emit(" INITIAL JACOBIAN CHANGED SIGN!")
+            if retry_reason == BAD_JACOBIAN_FLAG:
+                emit(" INITIAL JACOBIAN CHANGED SIGN!")
             emit(" TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS")
         rt, state0, _axis = reguess_initial_axis(rt, state0)
         carry = _run_loop(state0, rt, mode=mode, ijacob=1, verbose=verbose,
-                          emit=emit)
+                          emit=emit, emit_banner=False,
+                          initial_xcdot=(
+                              carry.xcdot
+                              if retry_reason == AXIS_REGUESS_FLAG else None
+                          ))
     return carry
 
 

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -253,6 +253,7 @@ class ForcePipelineHealth:
     spectral_finite: Array
     scaled_finite: Array
     rhs_finite: Array
+    radial_preconditioner_safe: Array
     radial_solve_finite: Array
     preconditioned_finite: Array
 
@@ -600,7 +601,7 @@ def _resolve_prec2d(
         pt = "NONE" if precon_type is None else precon_type
         thr = 1e-30 if prec2d_threshold is None else prec2d_threshold
     pt_normalized = str(pt).strip().upper()
-    if pt_normalized in {"", "NONE", "DEFAULT"}:
+    if pt_normalized in {"NONE", "DEFAULT"}:
         return None
     if pt_normalized != "GMRES":
         raise NotImplementedError(
@@ -636,7 +637,7 @@ def prepare_runtime(
     false).  ``precon_type``/``prec2d_threshold`` (or an explicit ``prec2d``
     :class:`~vmex.core.preconditioner_2d.Prec2DConfig`) switch on the
     optional 2D block preconditioner (``precon2d.f``); ``None``/``"NONE"``
-    (the default) leaves the 1D-only path byte-identical.
+    (the default) leaves the VMEC2000 1-D radial/lambda path unchanged.
     """
     if isinstance(source, RunSetup):
         if resolution is None:
@@ -666,12 +667,19 @@ def prepare_runtime(
                         lforbal=bool(inp.lforbal),
                         lmove_axis=bool(inp.lmove_axis))
 
+    requested_iterations = int(
+        defaults["niter"] if max_iterations is None else max_iterations
+    )
+    # readin.f can leave -1 in a partially assigned NITER_ARRAY.  eqsolve.f
+    # still performs its first evolve/funct3d pass before ``iter2 >= niter``
+    # terminates the stage, so the effective trajectory capacity is one.
+    effective_iterations = max(1, requested_iterations)
     rt = SolverRuntime(
         resolution=resolution, setup=setup,
         gamma=float(defaults["gamma"] if gamma is None else gamma),
         tcon0=float(defaults["tcon0"] if tcon0 is None else tcon0),
         ftol=float(defaults["ftol"] if ftol is None else ftol),
-        max_iterations=int(defaults["niter"] if max_iterations is None else max_iterations),
+        max_iterations=effective_iterations,
         time_step0=float(defaults["delt"] if time_step is None else time_step),
         nstep=int(defaults["nstep"] if nstep is None else nstep),
         jmax=int(resolution.ns) - 1,
@@ -886,7 +894,13 @@ def _force_pipeline(
     else:
         rhs = scaled
     rhs_finite = _all_finite(rhs) if collect_health else passing
-    solved = apply_radial_preconditioner(rhs, matrices_R=cache.matrices_R, matrices_Z=cache.matrices_Z, jmax=rt.jmax)
+    solved, radial_safe = apply_radial_preconditioner(
+        rhs,
+        matrices_R=cache.matrices_R,
+        matrices_Z=cache.matrices_Z,
+        jmax=rt.jmax,
+        return_safe=True,
+    )
     radial_solve_finite = _all_finite(solved) if collect_health else passing
     preconditioned = apply_lambda_preconditioner(solved, cache.faclam)
     health = ForcePipelineHealth(
@@ -894,6 +908,7 @@ def _force_pipeline(
         spectral_finite=spectral_finite,
         scaled_finite=scaled_finite,
         rhs_finite=rhs_finite,
+        radial_preconditioner_safe=radial_safe,
         radial_solve_finite=radial_solve_finite,
         preconditioned_finite=(
             _all_finite(preconditioned) if collect_health else passing
@@ -1491,8 +1506,16 @@ def _initial_carry(
     *,
     ijacob: int,
     xcdot: SpectralState | None = None,
+    residuals: tuple[float | Array, float | Array, float | Array] | None = None,
 ) -> _LoopCarry:
-    """Initial loop carry (reset_params.f / initialize_radial.f values)."""
+    """Initial loop carry (``reset_params.f`` / ``initialize_radial.f``).
+
+    ``initialize_radial.f`` resets ``fsq`` to one but intentionally leaves
+    the module variables ``fsqr/fsqz/fsql`` unchanged across radial grids.
+    Those retained values control the first-pass free-boundary edge gate in
+    ``residue.f90``.  ``residuals=None`` is the cold-start
+    ``reset_params.f`` value ``(1, 1, 1)``.
+    """
     dtype = rt.setup.s_full.dtype
     one = jnp.asarray(1.0, dtype=dtype)
     zeros = (
@@ -1506,12 +1529,19 @@ def _initial_carry(
     # return; weak-typed Python scalars here would force a second lane
     # compilation on the first block round-trip.
     int_ = lambda v: jnp.asarray(v, dtype=jnp.int64)  # noqa: E731
+    if residuals is None:
+        fsqr0 = fsqz0 = fsql0 = one
+    else:
+        fsqr0, fsqz0, fsql0 = (
+            jnp.asarray(value, dtype=dtype) for value in residuals
+        )
     return _LoopCarry(
         state=state, xcdot=zeros, xstore=state, cache=_zero_cache(rt),
         time_step=delt0,
         inv_tau=jnp.full((NDAMP,), DAMPING_CAP, dtype=dtype) / delt0,
         fsq=one, res0=inf, res1=inf,
-        fsqr=one, fsqz=one, fsql=one, fsqr1=one, fsqz1=one, fsql1=one,
+        fsqr=fsqr0, fsqz=fsqz0, fsql=fsql0,
+        fsqr1=one, fsqz1=one, fsql1=one,
         wb=zero, wp=zero, r00=zero,
         iteration=int_(1), iter1=int_(1),
         ijacob=int_(int(ijacob)),
@@ -1655,10 +1685,15 @@ def _block_lane(carry: _LoopCarry, rt: SolverRuntime) -> _LoopCarry:
 def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
               ijacob: int, verbose: bool, emit,
               emit_banner: bool = True,
-              initial_xcdot: SpectralState | None = None) -> _LoopCarry:
+              initial_xcdot: SpectralState | None = None,
+              initial_residuals: (
+                  tuple[float | Array, float | Array, float | Array] | None
+              ) = None) -> _LoopCarry:
     """Run the iteration loop in the requested lane; return the final carry."""
     carry = _initial_carry(
-        state0, rt, ijacob=ijacob, xcdot=initial_xcdot)
+        state0, rt, ijacob=ijacob, xcdot=initial_xcdot,
+        residuals=initial_residuals,
+    )
 
     if mode == "jit":
         return _while_lane(carry, rt)
@@ -1699,7 +1734,10 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
 def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
                  mode: str, verbose: bool, emit,
                  try_axis_reguess: bool = True,
-                 jacobian_retries: int = 2) -> _LoopCarry:
+                 jacobian_retries: int = 2,
+                 residual_continuation: (
+                     tuple[float | Array, float | Array, float | Array] | None
+                 ) = None) -> _LoopCarry:
     """Run one solve at a fixed runtime, with the eqsolve.f axis-retry.
 
     ``state0=None`` starts from the runtime's ``profil3d.f`` interior guess.
@@ -1724,10 +1762,24 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
         attempt_state: SpectralState,
         *,
         emit_banner: bool,
+        allow_axis_reguess: bool,
+        attempt_residuals: (
+            tuple[float | Array, float | Array, float | Array] | None
+        ),
     ) -> tuple[_LoopCarry, SolverRuntime]:
+        # A JAC75 recovery is a continuation from xstore, not a new
+        # profil3d.f initialization.  Disable the iteration-1 LMOVE_AXIS
+        # transfer for that attempt so the checkpoint cannot be replaced by a
+        # reconstructed cold state merely because its force is still large.
+        loop_rt = (
+            attempt_rt
+            if allow_axis_reguess
+            else replace(attempt_rt, lmove_axis=False)
+        )
         carry = _run_loop(
-            attempt_state, attempt_rt, mode=mode, ijacob=0,
+            attempt_state, loop_rt, mode=mode, ijacob=0,
             verbose=verbose, emit=emit, emit_banner=emit_banner,
+            initial_residuals=attempt_residuals,
         )
 
         # eqsolve.f: on a first-iteration Jacobian sign change with
@@ -1736,7 +1788,8 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
         # preserving the triggering pass's momentum.
         retry_reason = int(carry.ier)
         if (
-            try_axis_reguess
+            allow_axis_reguess
+            and try_axis_reguess
             and retry_reason in (BAD_JACOBIAN_FLAG, AXIS_REGUESS_FLAG)
             and int(carry.ijacob) == 0
             and attempt_rt.resolution.ns >= 3
@@ -1755,13 +1808,17 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
                     carry.xcdot
                     if retry_reason == AXIS_REGUESS_FLAG else None
                 ),
+                initial_residuals=(
+                    carry.fsqr, carry.fsqz, carry.fsql
+                ),
             )
         return carry, attempt_rt
 
     attempt_state = _initial_state(rt.setup) if state0 is None else state0
     attempt_rt = rt
     carry, attempt_rt = run_attempt(
-        attempt_rt, attempt_state, emit_banner=True,
+        attempt_rt, attempt_state, emit_banner=True, allow_axis_reguess=True,
+        attempt_residuals=residual_continuation,
     )
     for attempt in range(1, int(jacobian_retries) + 1):
         if int(carry.ier) != JAC75_FLAG:
@@ -1781,6 +1838,8 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
             )
         carry, attempt_rt = run_attempt(
             attempt_rt, attempt_state, emit_banner=False,
+            allow_axis_reguess=False,
+            attempt_residuals=(carry.fsqr, carry.fsqz, carry.fsql),
         )
     return carry
 

--- a/vmex/core/statephysics.py
+++ b/vmex/core/statephysics.py
@@ -272,7 +272,8 @@ def _lgradb_grid(
     wout-lane :func:`vmex.core.optimize.l_grad_b` and the traceable
     :func:`vmex.core.optimize.l_grad_b_state` (via
     :func:`_lgradb_state_tables`), which therefore agree to float round-off.
-    Symmetric configurations only (lasym sine partners are ignored).
+    Symmetric configurations only.  Public callers must reject ``lasym=True``
+    rather than silently omitting the asymmetric Fourier partners.
     """
     ns = int(ns)
     j = max(1, min(int(s_index) % ns, ns - 1))
@@ -426,8 +427,7 @@ def _lgradb_state_tables(state: SpectralState, rt: SolverRuntime) -> dict:
     setup = rt.setup
     if bool(setup.lasym):
         raise NotImplementedError(
-            "l_grad_b_state supports lasym = False only (the wout-lane "
-            "l_grad_b ignores the lasym sine partners too)")
+            "l_grad_b_state supports lasym = False only")
     res = rt.resolution
     nfp = int(res.nfp)
     ns = int(np.shape(state.R_cos)[0])

--- a/vmex/core/transforms.py
+++ b/vmex/core/transforms.py
@@ -76,9 +76,26 @@ def register_pytree_dataclass(cls, *, meta: tuple[str, ...] = (),
     """
     names = [f.name for f in dataclass_fields(cls)
              if f.name not in meta and f.name not in drop]
-    return jax.tree_util.register_dataclass(
-        cls, data_fields=names, meta_fields=list(meta), drop_fields=list(drop)
-    )
+    try:
+        return jax.tree_util.register_dataclass(
+            cls, data_fields=names, meta_fields=list(meta), drop_fields=list(drop)
+        )
+    except ValueError as exc:
+        # JAX 0.6.2 validates ``drop_fields`` with
+        # ``init_fields.difference_update(*drop_fields)``.  A normal
+        # ``["runtime"]`` is consequently expanded into characters and the
+        # field is reported missing.  Newer JAX releases accept the public
+        # sequence-of-names contract above.  Retry only that diagnosed old-JAX
+        # failure with singleton iterables, which gives 0.6.2 the intended set
+        # subtraction without changing flatten/unflatten semantics.
+        if not drop or "Missing fields" not in str(exc):
+            raise
+        return jax.tree_util.register_dataclass(
+            cls,
+            data_fields=names,
+            meta_fields=list(meta),
+            drop_fields=tuple((name,) for name in drop),
+        )
 
 
 def _einsum(expr: str, *operands: Array) -> Array:

--- a/vmex/core/transforms.py
+++ b/vmex/core/transforms.py
@@ -90,11 +90,12 @@ def register_pytree_dataclass(cls, *, meta: tuple[str, ...] = (),
         # subtraction without changing flatten/unflatten semantics.
         if not drop or "Missing fields" not in str(exc):
             raise
+        legacy_drop_fields: Any = tuple((name,) for name in drop)
         return jax.tree_util.register_dataclass(
             cls,
             data_fields=names,
             meta_fields=list(meta),
-            drop_fields=tuple((name,) for name in drop),
+            drop_fields=legacy_drop_fields,
         )
 
 

--- a/vmex/core/wout.py
+++ b/vmex/core/wout.py
@@ -799,7 +799,7 @@ def wout_from_state(
         niter=int(niter), itfsq=int(itfsq),
         lasym=lasym, lrecon=False,
         lfreeb=bool(inp.lfreeb),
-        lmove_axis=True,
+        lmove_axis=bool(inp.lmove_axis),
         lrfp=False,
         ier_flag=0 if bool(converged) else 2,
         aspect=aspect, betatotal=betatotal,

--- a/vmex/core/wout.py
+++ b/vmex/core/wout.py
@@ -648,14 +648,13 @@ def wout_from_state(
     phips = np.asarray(prof["phips"], dtype=float).copy()
     phips[0] = 0.0
     phipf_int = np.asarray(prof["phipf"], dtype=float)
+    chips = np.asarray(fields.chips, dtype=float)
+    chipf_int = _pp.chipf_from_chips(chips)
     if ncurr == 1:
         # add_fluxes.f90: the current-constrained chips defines iota/chipf.
-        chips = np.asarray(fields.chips, dtype=float)
         iotas = np.divide(chips, phips, out=np.zeros_like(chips), where=phips != 0.0)
-        chipf_int = _pp.chipf_from_chips(chips)
     else:
         iotas = np.asarray(prof["iotas"], dtype=float).copy()
-        chipf_int = np.asarray(prof["chipf"], dtype=float)
     iotas[0] = 0.0
     iotaf = _pp.iotaf_from_iotas(iotas)
     two_pi_sg = 2.0 * np.pi * float(signgs)


### PR DESCRIPTION
## Summary

Bring VMEX fixed- and free-boundary execution into explicit, tested parity with
the VMEC2000 driver and namelist semantics, while retaining VMEX extensions for
JAX execution, automatic differentiation, external-field adapters, and bounded
recovery.

This PR now includes:

- free-boundary radial multigrid with hot restarts and resolution-aware
  NESTOR/vacuum continuation;
- Fortran-compatible `&INDATA` array assignment replay;
- the VMEC2000 `LFORBAL=T` formulation on the correct radial meshes;
- VMEC2000-compatible `NS_ARRAY`, `FTOL_ARRAY`, `NITER_ARRAY`, axis-recovery,
  and residual-state transitions;
- robust but non-regularizing radial tridiagonal diagnostics through
  SOLVAX 0.8.8;
- best-finite-state JAC75 recovery for both fixed and free boundary;
- privacy-safe, stage-local numerical diagnostics;
- public stress tests and direct VMEC2000 trajectory/WOUT comparisons.

The branch contains no private input, input-derived value, filename, path,
solver log, coil/mgrid data, or WOUT. All committed validation cases use public
repository fixtures or generated data.

## Why this belongs in one PR

The affected behaviors meet at the first coarse solve and at every radial-grid
transition. Testing them independently can hide errors that only appear when a
Fortran namelist overlay, `LFORBAL`, axis recovery, a nonconverged coarse stage,
the ordinary radial preconditioner, and free-boundary vacuum state are combined.
The public 238-mode stress test deliberately exercises those seams together.

This is stacked on #69. Downstream PRs #71-#74 were created before some of the
follow-up corrections in this branch. Merge/retarget in stack order and refresh
each child from the updated parent. Conflict resolution must retain the
behaviors and tests listed below rather than taking an older downstream parser,
solver, CLI, free-boundary, or documentation file wholesale.

## VMEC2000 source contracts audited

The implementation was checked directly against the local VMEC2000/STELLOPT
sources, including:

- `readin.f`, `vmec_input.f`, and `runvmec.f`;
- `allocate_ns.f`, `initialize_radial.f`, and `interp.f`;
- `eqsolve.f`, `evolve.f`, `restart.f`, `funct3d.f`, and `residue.f90`;
- `fbal.f`, `add_fluxes.f90`, `precondn.f`, `scalfor.f`, and
  `tomnsp_mod.f`;
- the NESTOR/vacuum allocation, matrix, potential, and cadence paths.

The resulting contracts are documented in
`docs/input_reference.rst`, `docs/algorithms.rst`, and
`docs/vmec2000_compatibility.rst`.

## Corrections

### 1. Fortran namelist equivalence

`&INDATA` assignments are now replayed sequentially, using the declared
VMEC2000 bounds and Fortran element order (first subscript varies fastest).
This supports:

- dense writes followed by indexed/section overlays, and the reverse;
- whole and open sections, inclusive bounds, and positive/negative strides;
- starting-element sequence association such as `APHI(1)=...`;
- multidimensional starting-element writes;
- compact boundary sections such as `RBC(-6:6,0)=...`;
- repeated `NS_ARRAY`, `FTOL_ARRAY`, and profile assignments with source-order
  semantics.

Malformed or unsupported input still fails before the solve with a redacted
diagnostic classification.

### 2. Radial ladder parity

- `readin.f`'s positive nondecreasing `NS_ARRAY` prefix is used; the first
  decreasing or nonpositive entry terminates the ladder, while equal entries
  rerun.
- An all-zero `FTOL_ARRAY` is expanded with VMEC2000's logarithmic ladder.
- Partially assigned `NITER_ARRAY` entries retain `-1`; the solver performs the
  one first pass that `eqsolve.f` performs before the iteration-cap check.
- Increasing grids interpolate the preceding final `xc`, matching the
  `allocate_ns.f`/`initialize_radial.f` ordering.
- `fsqr/fsqz/fsql` continue across grids even though iteration counters reset.
  This is required for `residue.f90`'s first-fine-grid edge gate and was the
  remaining source of a large transition mismatch.

The same rules are used by fixed- and free-boundary multigrid.

### 3. Free-boundary multigrid and hot restart

- The external field is loaded/tabulated once per ladder.
- Increasing radial resolution rebuilds resolution-dependent NESTOR surface,
  Green-function, matrix/vector, potential, axis-current filament, and traced
  loop structures.
- Equal-grid stages may reuse valid dynamic caches.
- Vacuum activation occurs once; `ivac`, adaptive cadence, `delbsq`, evolved
  edge state, and constraint baselines continue across stages.
- An already-active fine stage starts from the carried edge state and performs
  its first new full vacuum update at the VMEC2000 cadence.
- User and internal hot restarts preserve the full plasma state and apply the
  documented reset/continuation semantics.
- Mgrid input and host-side ESSOS/SIMSOPT Biot-Savart protocols remain
  supported; the sampled field is represented by the common JAX mgrid path.

### 4. `LFORBAL` radial meshes

`LFORBAL=T` now uses the VMEC2000 averaged radial force-balance formulation in
the production force map, cache refresh, 2-D preconditioner map, diagnostics,
and WOUT processing. In particular, the effective half-mesh `chips` profile is
converted to the full-mesh `chipf` used by `calc_fbal`/`add_fluxes.f90`; using
half-mesh values directly produced a systematic physics and energy mismatch.

### 5. `PRECON_TYPE='NONE'`

VMEC2000's `NONE` disables the optional 2-D Newton/Krylov preconditioner. It
does **not** disable the ordinary 1-D radial and lambda preconditioners. VMEX
now preserves that distinction consistently in fixed boundary, free boundary,
multigrid, diagnostics, and documentation.

The radial solve remains unregularized. SOLVAX 0.8.8 adds per-column pivot and
backward-residual checks plus a deterministic identity fallback for a rejected
preconditioner column. VMEX reports
`D04E_RADIAL_PRECONDITIONER_REJECTED` instead of allowing a singular
preconditioner to inject NaN/Inf into an otherwise finite force evaluation.
SOLVAX PR
[uwplasma/SOLVAX#40](https://github.com/uwplasma/SOLVAX/pull/40) is merged and
the 0.8.8 release is published; VMEX now requires `solvax>=0.8.8`.

### 6. Axis and JAC75 recovery

- Production preserves a missing/all-zero supplied axis until VMEC2000's one
  `eqsolve.f` first-force recovery transfer; geometry-only test utilities may
  explicitly request pre-inference.
- The first bad-Jacobian/high-force recovery keeps the VMEC2000 momentum
  transfer and is available on every radial stage.
- When the original attempt reaches JAC75, bounded VMEX recovery restarts the
  best finite `xstore`, zeros momentum, reduces the initial `DELT`, retains the
  residual continuation, and does not replace the checkpoint with another
  `LMOVE_AXIS` cold reconstruction.
- Free-boundary JAC75 recovery rebuilds all geometry-dependent NESTOR/vacuum
  structures rather than reusing failed-attempt caches.
- `jacobian_retries=0` retains the exact immediate VMEC2000 fatal-stop policy.

`LFULL3D1OUT=T` continues to permit WOUT output after ordinary `NITER`
exhaustion, but not after a fatal numerical/Jacobian abort.

## Public stress and parity validation

### Combined 238-mode fixed-boundary stress

`tests/test_vmec2000_feature_stress.py` constructs a public 238-mode deck from
a tracked boundary and combines:

- no supplied axis;
- `LFORBAL=T`;
- `PRECON_TYPE='NONE'`;
- APHI starting-element sequence association;
- repeated dense/indexed `NS_ARRAY` and `FTOL_ARRAY` writes;
- compact multidimensional RBC/ZBS sections;
- the complete `21 -> 34 -> 55 -> 89` radial ladder.

Against the local VMEC2000 Release executable, VMEX reproduces the displayed
trajectory exactly:

- stage exits at iterations 462, 139, and 543;
- identical first rows after each interpolation;
- two Jacobian resets on the finest stage;
- identical residual screen row at iteration 10,000, where the intentionally
  extreme final tolerance is not reached by either code.

The quick test pins the converged first stage; a full/nightly test pins all four
stages and the ordinary final iteration-limit state.

### Public converged free-boundary benchmark

The tracked CTH-like `7 -> 15` mgrid benchmark now has the same one vacuum
activation and the same first fine-grid residual row as VMEC2000. Both codes
converge the fine stage at iteration 340. Final normalized WOUT differences are:

- `rmnc`: `6.08e-5`;
- `zmns`: `3.59e-4`;
- `iotaf`: `1.99e-6`;
- magnetic energy: `6.07e-8` relative.

The benchmark report embeds only aggregate timings/residuals and normalized
errors, never input or field data.

### Current local gates

- ordinary suite: **757 passed, 34 skipped, 2 expected xfails**;
- combined 238-mode public stress: **3 passed**, including the exact full
  four-stage trajectory;
- full free-boundary physics selection: **3 passed**, covering active 2-D
  preconditioning, `LFORBAL` across vacuum activation, and converged WOUT
  parity;
- Ruff: clean;
- mypy: clean across 53 source files;
- Sphinx documentation with warnings as errors: passed;
- wheel and source distribution builds: passed;
- `git diff --check`: clean.

### Final hosted validation

The original catch-all parity-C worker was externally shut down twice above
84% with no failed assertion or traceback. Its 41-file ownership set is now
partitioned explicitly into disjoint C1/C2 shards; a mechanical ownership
check proves that all 53 ordinary core test files remain assigned exactly once,
and the coverage gate combines both new artifacts.

[CI run 30111998499](https://github.com/uwplasma/vmex/actions/runs/30111998499)
passed all **18** ordinary checks, including C1 (16m06s), C2 (6m19s), all
three implicit-gradient shards, and the combined **>=95%** coverage gate. The
only skipped job is the workflow's expected nightly/manual full-physics matrix.

## Merge-preservation checklist

The final merged stack must retain:

- sequential Fortran namelist replay and compact multidimensional boundary
  sections;
- privacy-safe first-force and radial-preconditioner diagnostics;
- fixed/free complete ladder and residual-state continuation;
- final-`xc` interpolation and equal/decreasing stage semantics;
- correct full-mesh `LFORBAL` data flow;
- `PRECON_TYPE='NONE'` as ordinary 1-D preconditioning, not no
  preconditioning;
- one-transfer axis recovery and best-state JAC75 recovery;
- WOUT-on-ordinary-limit behavior under `LFULL3D1OUT`;
- free-boundary hot restart, one-time vacuum activation, cadence/edge/constraint
  continuation, and resolution-aware NESTOR rebuilds;
- mgrid and ESSOS/SIMSOPT external-field adapters;
- free-boundary AD-versus-FD coverage;
- the public combined stress case and VMEC2000 benchmark;
- the compatibility/design documentation added here.

Post-merge validation should run the parser/diagnostic suite, fixed/free
multigrid tests, the mandatory public stress diagnostic, and the converged
public free-boundary benchmark. The full four-stage stress trajectory belongs
in nightly/manual full-physics CI.
