### PR TITLE
Match VMEC2000 curlabel WOUT schema

### DIFF
--- a/docs/wout_reference.rst
+++ b/docs/wout_reference.rst
@@ -69,7 +69,8 @@ Free-boundary extras
 --------------------
 
 When ``lfreeb = T``: ``nextcur``, ``extcur``, ``curlabel``, ``mgrid_mode``
-carry the coil-group metadata from the mgrid file. The NESTOR vacuum
+carry the coil-group metadata from the mgrid file. ``curlabel`` uses
+VMEC2000's 30-character label dimension. The NESTOR vacuum
 potential (``potsin``/``xmpot``/``xnpot``) and the ``*_sur`` surface arrays
 are declared for schema compatibility but currently written as netCDF fill —
 the free-boundary solver does not yet return the vacuum potential (see

--- a/tests/test_cli_freeboundary.py
+++ b/tests/test_cli_freeboundary.py
@@ -119,6 +119,9 @@ def test_wout_written_with_free_boundary_fields(freeb_cli):
         assert int(ds["lfreeb__logical__"][()]) == 1
         assert int(ds["nextcur"][()]) == nextcur
         np.testing.assert_allclose(np.asarray(ds["extcur"][:]), extcur_expected)
+        label_count_dim = f"dim_{nextcur:05d}"
+        assert ds["curlabel"].dimensions == (label_count_dim, "current_label")
+        assert ds["curlabel"].shape == (nextcur, 30)
         # potvac is a documented gap: variables exist (netCDF fill) since
         # solve_free_boundary does not return the NESTOR potential yet.
         assert "potsin" in ds.variables

--- a/vmex/core/wout.py
+++ b/vmex/core/wout.py
@@ -353,7 +353,11 @@ def write_wout(path: str | Path, data: WoutData, *, overwrite: bool = True) -> P
         if lfreeb:
             mnpot = int(np.asarray(d.xmpot).size) if d.xmpot is not None else max(int(d.mnmaxpot or 1), 1)
             ds.createDimension("mn_mode_pot", max(mnpot, 1))
-            ds.createDimension("current_label", max(int(d.nextcur), 1))
+            if int(d.nextcur) > 0:
+                label_count_dim = f"dim_{int(d.nextcur):05d}"
+                if label_count_dim not in ds.dimensions:
+                    ds.createDimension(label_count_dim, int(d.nextcur))
+                ds.createDimension("current_label", 30)
 
         _put(ds, "version_", (), float(d.version_))
         for name, dim, width in _STRINGS:
@@ -411,10 +415,11 @@ def write_wout(path: str | Path, data: WoutData, *, overwrite: bool = True) -> P
             if lasym:
                 _put(ds, "potcos", ("mn_mode_pot",), d.potcos)
             if d.curlabel is not None and int(d.nextcur) > 0:
-                var = ds.createVariable("curlabel", "S1", ("current_label", "dim_00020"))
-                arr = np.full((len(d.curlabel), 20), b" ", dtype="S1")
-                for i, lbl in enumerate(d.curlabel):
-                    for j, ch in enumerate(str(lbl)[:20].ljust(20)):
+                label_count_dim = f"dim_{int(d.nextcur):05d}"
+                var = ds.createVariable("curlabel", "S1", (label_count_dim, "current_label"))
+                arr = np.full((int(d.nextcur), 30), b" ", dtype="S1")
+                for i, lbl in enumerate(d.curlabel[: int(d.nextcur)]):
+                    for j, ch in enumerate(str(lbl)[:30].ljust(30)):
                         arr[i, j] = ch.encode("ascii", "replace")
                 var[:] = arr
         for name in _MN2D_SYM:


### PR DESCRIPTION
## Summary

Make free-boundary `curlabel` serialization match VMEC2000/LIBSTELL exactly.

VMEC2000 defines each coil-group label as `CHARACTER(LEN=30)` and writes the netCDF variable with dimensions `(dim_<nextcur>, current_label)`. VMEX previously wrote 20 characters with `current_label` incorrectly sized as `nextcur`.

This PR:

- writes `(nextcur, 30)` character data;
- uses the same VMEC2000 dimension names and ordering;
- preserves labels up to the reference 30-character width;
- adds exact dimension/shape assertions to the real free-boundary CLI regression;
- documents the reference layout.

VMEX's reader already tolerates both layouts, so routine VMEX users are unaffected; generated WOUT files become more compatible with LIBSTELL and other strict readers.

## Validation

- `pytest -q tests/test_cli_freeboundary.py -ra`: **6 passed**
- focused real WOUT regression: **1 passed**
- `ruff check vmex tests examples benchmarks tools`: passed
- `mypy vmex`: passed (53 source files)
- strict Sphinx (`-W -j auto`): passed
- `git diff --check`: passed

This PR is stacked on the hot-restart/documentation follow-up and should merge after it.
