### PR TITLE
Export symmetric NESTOR vacuum fields to WOUT

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -99,9 +99,9 @@ the stored best plasma state, carries VMEC2000's active-vacuum and adaptive
 each new grid.  A user-provided ``initial_state`` is also supported by the
 Python API for hot restarts.
 
-The remaining known divergence is that the NESTOR potential is not yet
-exported to the wout ``potsin``/``xmpot``/
-``xnpot``/``*_sur`` variables (written as netCDF fill). An NITER-exhausted
+For stellarator-symmetric runs the CLI exports the final NESTOR potential
+and surface fields to the wout ``potsin``/``xmpot``/``xnpot``/``*_sur``
+variables. LASYM vacuum tables remain netCDF fill. An NITER-exhausted
 free-boundary run still writes the wout (VMEC2000 behavior) and exits with
 ``ier_flag = 2``.
 

--- a/docs/wout_reference.rst
+++ b/docs/wout_reference.rst
@@ -70,11 +70,12 @@ Free-boundary extras
 
 When ``lfreeb = T``: ``nextcur``, ``extcur``, ``curlabel``, ``mgrid_mode``
 carry the coil-group metadata from the mgrid file. ``curlabel`` uses
-VMEC2000's 30-character label dimension. The NESTOR vacuum
-potential (``potsin``/``xmpot``/``xnpot``) and the ``*_sur`` surface arrays
-are declared for schema compatibility but currently written as netCDF fill —
-the free-boundary solver does not yet return the vacuum potential (see
-:doc:`cli`).
+VMEC2000's 30-character label dimension. For stellarator-symmetric runs,
+passing ``result.vacuum`` to
+:func:`~vmex.core.wout.wout_from_state` as ``vacuum_output`` writes the
+NESTOR potential modes (``potsin``/``xmpot``/``xnpot``) and the four
+``*_sur`` surface-field tables with VMEC2000's Nyquist normalization. The
+CLI does this automatically. LASYM vacuum tables remain netCDF fill.
 
 Parity with VMEC2000
 --------------------

--- a/examples/free_boundary_beta_scan.py
+++ b/examples/free_boundary_beta_scan.py
@@ -53,7 +53,7 @@ for ps in PRES_SCALES:
     wout = vj.wout_from_state(
         inp=inp, state=res.state, fsqr=float(res.fsqr), fsqz=float(res.fsqz),
         fsql=float(res.fsql), niter=int(res.iterations),
-        converged=bool(res.converged))
+        converged=bool(res.converged), vacuum_output=res.vacuum)
     beta = float(wout.betatotal)
     betas.append(beta)
     print(f"{ps:11.1f} {beta:10.3e} {float(wout.volume_p):12.4f} {int(res.iterations):6d}")

--- a/examples/free_boundary_essos_coils.py
+++ b/examples/free_boundary_essos_coils.py
@@ -119,7 +119,7 @@ for target in TARGET_BETAS:
         wout = vj.wout_from_state(
             inp=inp_i, state=res.state, fsqr=float(res.fsqr), fsqz=float(res.fsqz),
             fsql=float(res.fsql), niter=int(res.iterations),
-            converged=bool(res.converged))
+            converged=bool(res.converged), vacuum_output=res.vacuum)
         beta = 100.0 * float(wout.betatotal)
         if target == 0.0 or abs(beta - target) <= BETA_TOL:
             break

--- a/examples/free_boundary_mgrid.py
+++ b/examples/free_boundary_mgrid.py
@@ -44,7 +44,7 @@ print(f"\nconverged = {result.converged} after {int(result.iterations)} "
 wout = vj.wout_from_state(
     inp=inp, state=result.state, fsqr=float(result.fsqr), fsqz=float(result.fsqz),
     fsql=float(result.fsql), niter=int(result.iterations),
-    converged=bool(result.converged))
+    converged=bool(result.converged), vacuum_output=result.vacuum)
 OUT_DIR.mkdir(parents=True, exist_ok=True)
 wout_path = vj.write_wout(OUT_DIR / "wout_cth_like_free_bdy.nc", wout)
 print(f"aspect = {float(wout.aspect):.4f}, volume = {float(wout.volume_p):.4f} m^3 "

--- a/tests/test_cli_freeboundary.py
+++ b/tests/test_cli_freeboundary.py
@@ -122,9 +122,10 @@ def test_wout_written_with_free_boundary_fields(freeb_cli):
         label_count_dim = f"dim_{nextcur:05d}"
         assert ds["curlabel"].dimensions == (label_count_dim, "current_label")
         assert ds["curlabel"].shape == (nextcur, 30)
-        # potvac is a documented gap: variables exist (netCDF fill) since
-        # solve_free_boundary does not return the NESTOR potential yet.
+        # LASYM vacuum WOUT export remains explicitly unsupported: schema
+        # variables exist but stay at netCDF fill.
         assert "potsin" in ds.variables
+        assert np.ma.getmaskarray(ds["potsin"][:]).all()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_freeboundary_multigrid.py
+++ b/tests/test_freeboundary_multigrid.py
@@ -220,3 +220,60 @@ def test_converged_multigrid_final_state_matches_vmec2000_wout() -> None:
     assert rerr < 1e-2
     assert zerr < 1e-2
     assert ierr < 1.5e-2
+
+
+@pytest.mark.full
+def test_symmetric_multigrid_exports_final_nestor_wout(tmp_path) -> None:
+    """The final ladder stage publishes VMEC-compatible vacuum tables."""
+    if not CONV_MGRID.exists():
+        pytest.skip("converged CTH mgrid asset unavailable")
+    netCDF4 = pytest.importorskip("netCDF4")
+    from vmex.core.wout import wout_from_state, write_wout
+
+    inp = VmecInput.from_file(CONV_DECK)
+    result = solve_free_boundary_multigrid(
+        inp, ns_array=[7, 15], ftol_array=[1e-10, 1e-10],
+        niter_array=[60, 5], mgrid_path=CONV_MGRID,
+        raise_on_max_iterations=False,
+    )
+    vacuum = result.vacuum
+    assert vacuum is not None
+    assert vacuum.bsubu.shape == (
+        resolution_from_input(inp, ns=15).ntheta3, int(inp.nzeta))
+    assert vacuum.potsin.shape == vacuum.xmpot.shape == vacuum.xnpot.shape
+    assert vacuum.potsin.size == (int(inp.mpol) + 2) * (2 * int(inp.ntor) + 1)
+
+    wout = wout_from_state(
+        inp=inp, state=result.state,
+        fsqr=result.fsqr, fsqz=result.fsqz, fsql=result.fsql,
+        niter=result.iterations, converged=result.converged,
+        vacuum_output=vacuum,
+    )
+    np.testing.assert_array_equal(wout.xmpot, vacuum.xmpot)
+    np.testing.assert_array_equal(wout.xnpot, vacuum.xnpot)
+    for name in (
+        "potsin", "bsubumnc_sur", "bsubvmnc_sur",
+        "bsupumnc_sur", "bsupvmnc_sur",
+    ):
+        values = np.asarray(getattr(wout, name), dtype=float)
+        assert values.size > 0 and np.isfinite(values).all()
+        assert np.max(np.abs(values)) > 0.0
+
+    path = write_wout(tmp_path / "wout_cth.nc", wout)
+    with netCDF4.Dataset(path) as ds:
+        for name in (
+            "potsin", "xmpot", "xnpot", "bsubumnc_sur",
+            "bsubvmnc_sur", "bsupumnc_sur", "bsupvmnc_sur",
+        ):
+            assert not np.ma.getmaskarray(ds[name][:]).any(), name
+
+    fixed = wout_from_state(
+        inp=replace(inp, lfreeb=False), state=result.state,
+        fsqr=result.fsqr, fsqz=result.fsqz, fsql=result.fsql,
+        niter=result.iterations, converged=result.converged,
+    )
+    assert fixed.potsin is fixed.bsubumnc_sur is None
+    fixed_path = write_wout(tmp_path / "wout_fixed.nc", fixed)
+    with netCDF4.Dataset(fixed_path) as ds:
+        assert "potsin" not in ds.variables
+        assert "bsubumnc_sur" not in ds.variables

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -141,8 +141,12 @@ def test_explicit_free_boundary_multigrid_cpu_gpu_parity(monkeypatch):
         value = vacuum_step(*args, **kwargs)
         fb = kwargs["fb"]
         vacuum_devices[active_platform[0]] = {
-            _platform(getattr(fb, name))
-            for name in ("potvac", "mode_matrix", "bvec_nonsing", "bsqvac")
+            _platform(x)
+            for name in (
+                "potvac", "mode_matrix", "bvec_nonsing", "bsqvac",
+                "surface_fields",
+            )
+            for x in jax.tree.leaves(getattr(fb, name))
         }
         return value
 
@@ -159,8 +163,12 @@ def test_explicit_free_boundary_multigrid_cpu_gpu_parity(monkeypatch):
         vacuum = kwargs["vacuum_continuation"]
         if vacuum is not None:
             record["vacuum"] = {
-                _platform(getattr(vacuum, name))
-                for name in ("bsqvac", "rbsq", "mode_matrix", "bvec_nonsing", "potvac")
+                _platform(x)
+                for name in (
+                    "bsqvac", "rbsq", "mode_matrix", "bvec_nonsing",
+                    "potvac", "surface_fields",
+                )
+                for x in jax.tree.leaves(getattr(vacuum, name))
             }
         stage_devices[active_platform[0]].append(record)
         return solve_stage(*args, **kwargs)
@@ -210,6 +218,25 @@ def test_explicit_free_boundary_multigrid_cpu_gpu_parity(monkeypatch):
     delta = gpu_state - cpu_state
     assert np.linalg.norm(delta) / np.linalg.norm(cpu_state) < 5e-6
     assert np.max(np.abs(delta)) < 1e-6
+    assert results["cpu"].vacuum is not None
+    assert results["gpu"].vacuum is not None
+    for name in ("xmpot", "xnpot"):
+        np.testing.assert_array_equal(
+            getattr(results["gpu"].vacuum, name),
+            getattr(results["cpu"].vacuum, name),
+        )
+    relative_errors = {}
+    for name in ("potsin", "potcos", "bsubu", "bsubv", "bsupu", "bsupv"):
+        gpu_values = np.asarray(getattr(results["gpu"].vacuum, name))
+        cpu_values = np.asarray(getattr(results["cpu"].vacuum, name))
+        scale = max(float(np.max(np.abs(cpu_values))), np.finfo(float).tiny)
+        relative_errors[name] = (
+            float(np.max(np.abs(gpu_values - cpu_values))) / scale)
+    assert max(relative_errors[name] for name in (
+        "potsin", "potcos", "bsubu", "bsubv",
+    )) < 1e-4, relative_errors
+    assert max(relative_errors[name] for name in ("bsupu", "bsupv")) < 5e-4, (
+        relative_errors)
 
     resolution = solver.resolution_from_input(inp, ns=15)
     restart_inputs = []
@@ -265,6 +292,7 @@ def test_free_boundary_multigrid_auto_relocates_every_carry(monkeypatch):
         vacuum = freeboundary.FreeBoundaryState(
             turned_on=True, bsqvac=cache, rbsq=cache, mode_matrix=cache,
             bvec_nonsing=cache, potvac=cache,
+            surface_fields=(cache, cache, cache, cache),
         )
         result = type("Result", (), {"state": state})()
         return freeboundary._FreeBoundaryStageResult(

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -32,11 +32,10 @@ Free-boundary routing (``LFREEB = T``):
   :class:`vmex.core.mgrid.MgridField`
   (``solve_free_boundary(inp, external_field=mgrid_field)``); requires ESSOS.
 
-Documented divergences of the free-boundary lane:
+Documented divergence of the free-boundary lane:
 
-- The NESTOR vacuum potential is not returned by the solver, so the wout
-  ``potsin``/``xmpot``/``xnpot`` and ``*_sur`` variables are written as
-  netCDF fill (see :func:`vmex.core.wout.wout_from_state`).
+- Symmetric NESTOR potential and surface-field arrays are exported to wout;
+  LASYM vacuum arrays remain netCDF fill.
 - An NITER-exhausted free-boundary run still writes the wout (VMEC2000
   behavior) and exits with ``ier_flag = 2`` (MORE ITERATIONS REQUIRED).
 """
@@ -532,6 +531,7 @@ def _write_wout_from_result(inp, input_path: Path, result, wout_path: Path,
         niter=int(result.iterations),
         converged=bool(result.converged),
         input_extension=case_from_input(input_path),
+        vacuum_output=result.vacuum,
         **freeb_kwargs,
     )
     write_wout(wout_path, wout)

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -62,7 +62,7 @@ from .printing import (
     vacuum_banner,
 )
 from .solver import (
-    SolveResult, SolverRuntime, SpectralState,
+    SolveResult, SolverRuntime, SpectralState, VacuumOutput,
     _finalize, _geometry, _initial_carry, _initial_state, _make_body,
     _result_from_carry, _zero_cache, prepare_runtime, resolution_from_input,
     reguess_initial_axis, runtime_with_baselines,
@@ -75,6 +75,7 @@ from .vacuum import (
 
 __all__ = [
     "FreeBoundaryState",
+    "VacuumOutput",
     "boundary_from_coefficients",
     "solve_free_boundary",
 ]
@@ -389,6 +390,7 @@ class FreeBoundaryState:
     mode_matrix: Any = None
     bvec_nonsing: Any = None
     potvac: np.ndarray | None = None
+    surface_fields: Any = None
     ctor: float = 0.0
     rbtor: float = 0.0
     vacuum_calls: int = 0
@@ -404,6 +406,26 @@ class _FreeBoundaryStageResult:
     continuation_state: SpectralState
     rcon0: Array
     zcon0: Array
+
+
+def _vacuum_output(fb: FreeBoundaryState, basis: VacuumBasis) -> VacuumOutput | None:
+    """Strip private NESTOR caches from the final public result."""
+    if fb.potvac is None or fb.surface_fields is None:
+        return None
+    bsubu, bsubv, bsupu, bsupv = fb.surface_fields
+    pot = np.asarray(fb.potvac, dtype=float).reshape(-1)
+    mnpd = int(basis.mnpd)
+    shape = (int(basis.ntheta3), int(basis.nzeta))
+    return VacuumOutput(
+        potsin=pot[:mnpd].copy(),
+        potcos=(pot[mnpd:2 * mnpd].copy() if basis.lasym else None),
+        xmpot=np.asarray(basis.xmpot, dtype=float).copy(),
+        xnpot=(np.asarray(basis.n_raw, dtype=float) * float(basis.nfp)),
+        bsubu=np.asarray(bsubu, dtype=float).reshape(shape).copy(),
+        bsubv=np.asarray(bsubv, dtype=float).reshape(shape).copy(),
+        bsupu=np.asarray(bsupu, dtype=float).reshape(shape).copy(),
+        bsupv=np.asarray(bsupv, dtype=float).reshape(shape).copy(),
+    )
 
 
 def _resolve_mgrid(inp: VmecInput, mgrid_path: str | Path | None) -> Path:
@@ -667,7 +689,7 @@ def _make_fused_vacuum(basis: VacuumBasis, *, modes: ModeTable, signgs: int,
         potvac, mode_matrix, bvec_nonsing, _rhs, _gsrc, _grp = solver_vac.full(
             boundary, ext["bexni"]
         )
-        bsqvac, bsubu_s, bsubv_s, _bu, _bv = vacuum_channels(
+        bsqvac, bsubu_s, bsubv_s, bsupu_s, bsupv_s = vacuum_channels(
             basis=basis, potvac=potvac, bexu=ext["bexu"], bexv=ext["bexv"],
             guu=ext["guu"], guv=ext["guv"], gvv=ext["gvv"],
         )
@@ -679,6 +701,7 @@ def _make_fused_vacuum(basis: VacuumBasis, *, modes: ModeTable, signgs: int,
             "rbsq": (bsqvac + pres_ns * jnp.asarray(rt.presf_ns_scale))
                     * boundary.R / jnp.asarray(rt.setup.hs),
             "mode_matrix": mode_matrix, "bvec_nonsing": bvec_nonsing,
+            "surface_fields": (bsubu_s, bsubv_s, bsupu_s, bsupv_s),
             "delbsq_num": delbsq_num, "delbsq_den": delbsq_den,
             "bsubuvac": bsubuvac, "bsubvvac": bsubvvac,
         }
@@ -694,7 +717,7 @@ def _make_fused_vacuum(basis: VacuumBasis, *, modes: ModeTable, signgs: int,
         potvac, _rhs = solver_vac.skip(
             boundary, ext["bexni"], bvec_nonsing, mode_matrix
         )
-        bsqvac, bsubu_s, bsubv_s, _bu, _bv = vacuum_channels(
+        bsqvac, bsubu_s, bsubv_s, bsupu_s, bsupv_s = vacuum_channels(
             basis=basis, potvac=potvac, bexu=ext["bexu"], bexv=ext["bexv"],
             guu=ext["guu"], guv=ext["guv"], gvv=ext["gvv"],
         )
@@ -705,6 +728,7 @@ def _make_fused_vacuum(basis: VacuumBasis, *, modes: ModeTable, signgs: int,
             "bsqvac": bsqvac, "ctor": ctor, "rbtor": rbtor, "potvac": potvac,
             "rbsq": (bsqvac + pres_ns * jnp.asarray(rt.presf_ns_scale))
                     * boundary.R / jnp.asarray(rt.setup.hs),
+            "surface_fields": (bsubu_s, bsubv_s, bsupu_s, bsupv_s),
             "delbsq_num": delbsq_num, "delbsq_den": delbsq_den,
             "bsubuvac": bsubuvac, "bsubvvac": bsubvvac,
         }
@@ -823,6 +847,7 @@ def _vacuum_step(
     bsqvac = out["bsqvac"]
     fb.rbsq = out["rbsq"]
     fb.potvac = out["potvac"]
+    fb.surface_fields = out["surface_fields"]
     fb.ctor = float(out["ctor"])
     fb.rbtor = float(out["rbtor"])
     fb.vacuum_calls += 1
@@ -930,6 +955,7 @@ class _VacuumLoopCarry:
     mode_matrix: Array          # amatsav (scalpot.f)
     bvec_nonsing: Array         # bvecsav (scalpot.f)
     potvac: Array
+    surface_fields: tuple[Array, Array, Array, Array]
     ivac: Array; nvacskip: Array; nvskip0: Array
     delbsq: Array; delbsq_traj: Array
     ctor: Array; rbtor: Array
@@ -976,6 +1002,7 @@ def _make_vacuum_lane(fused: FusedVacuum):
         def _full(_):
             out = fused.full(c.state, rt_vac, field)
             return (out["bsqvac"], out["rbsq"], out["ctor"], out["rbtor"], out["potvac"],
+                    out["surface_fields"],
                     out["delbsq_num"], out["delbsq_den"],
                     out["mode_matrix"], out["bvec_nonsing"])
 
@@ -983,11 +1010,13 @@ def _make_vacuum_lane(fused: FusedVacuum):
             out = fused.skip(c.state, rt_vac, field, vc.bvec_nonsing,
                              vc.mode_matrix)
             return (out["bsqvac"], out["rbsq"], out["ctor"], out["rbtor"], out["potvac"],
+                    out["surface_fields"],
                     out["delbsq_num"], out["delbsq_den"],
                     vc.mode_matrix, vc.bvec_nonsing)
 
-        (bsqvac, rbsq, ctor, rbtor, potvac, num, den, mode_matrix,
-         bvec_nonsing) = lax.cond(full, _full, _skip, None)
+        (bsqvac, rbsq, ctor, rbtor, potvac, surface_fields,
+         num, den, mode_matrix, bvec_nonsing) = lax.cond(
+             full, _full, _skip, None)
 
         delbsq = jnp.where(den != 0.0, num / den, vc.delbsq)
         idx = jnp.clip(it - 1, 0, rt.max_iterations - 1)
@@ -1001,6 +1030,7 @@ def _make_vacuum_lane(fused: FusedVacuum):
             carry=new_carry, rcon0=rcon0, zcon0=zcon0, bsqvac=bsqvac,
             rbsq=rbsq,
             mode_matrix=mode_matrix, bvec_nonsing=bvec_nonsing, potvac=potvac,
+            surface_fields=surface_fields,
             ivac=ivac, nvacskip=nvacskip, nvskip0=vc.nvskip0,
             delbsq=delbsq, delbsq_traj=delbsq_traj, ctor=ctor, rbtor=rbtor,
             vacuum_calls=vc.vacuum_calls + 1,
@@ -1192,6 +1222,8 @@ def _solve_free_boundary_stage(
                           if reuse_vacuum_cache else None),
             potvac=(vacuum_continuation.potvac
                     if reuse_vacuum_cache else None),
+            surface_fields=(vacuum_continuation.surface_fields
+                            if reuse_vacuum_cache else None),
         )
     vacuum_active = fb.turned_on
 
@@ -1257,6 +1289,7 @@ def _solve_free_boundary_stage(
               and fb.mode_matrix is not None):
             # F.2: the whole post-turn-on steady state runs as ONE jitted
             # while_loop (vacuum cadence + damping + iteration, traced).
+            zeros_sur = jnp.zeros_like(rt_freeb.bsqvac_edge)
             vc = _VacuumLoopCarry(
                 carry=carry,
                 rcon0=rt_freeb.rcon0, zcon0=rt_freeb.zcon0,
@@ -1264,6 +1297,8 @@ def _solve_free_boundary_stage(
                 rbsq=jnp.asarray(fb.rbsq, dtype=dtype),
                 mode_matrix=fb.mode_matrix, bvec_nonsing=fb.bvec_nonsing,
                 potvac=fb.potvac,
+                surface_fields=((zeros_sur,) * 4 if fb.surface_fields is None
+                                else fb.surface_fields),
                 ivac=jnp.asarray(fb.ivac, dtype=int_dtype),
                 nvacskip=jnp.asarray(fb.nvacskip, dtype=int_dtype),
                 nvskip0=jnp.asarray(fb.nvskip0, dtype=int_dtype),
@@ -1286,6 +1321,7 @@ def _solve_free_boundary_stage(
             fb.mode_matrix = vc.mode_matrix
             fb.bvec_nonsing = vc.bvec_nonsing
             fb.potvac = vc.potvac
+            fb.surface_fields = vc.surface_fields
             fb.ctor = float(vc.ctor)
             fb.rbtor = float(vc.rbtor)
             fb.vacuum_calls = int(vc.vacuum_calls)
@@ -1361,16 +1397,24 @@ def _solve_free_boundary_stage(
     if ier == MORE_ITER_FLAG and not error_on_no_convergence:
         result = _result_from_carry(carry, rt_freeb if fb.turned_on else rt_fixed)
         return _FreeBoundaryStageResult(
-            replace(result, converged=False, ier_flag=MORE_ITER_FLAG), fb,
+            replace(result, converged=False, ier_flag=MORE_ITER_FLAG,
+                    vacuum=_vacuum_output(fb, basis)), fb,
             carry.xstore, rt_freeb.rcon0 if fb.turned_on else rt_fixed.rcon0,
             rt_freeb.zcon0 if fb.turned_on else rt_fixed.zcon0)
     if ier == SUCCESSFUL_TERM_FLAG:
         return _FreeBoundaryStageResult(
-            _result_from_carry(carry, rt_freeb if fb.turned_on else rt_fixed), fb,
+            replace(
+                _result_from_carry(
+                    carry, rt_freeb if fb.turned_on else rt_fixed),
+                vacuum=_vacuum_output(fb, basis),
+            ), fb,
             carry.xstore, rt_freeb.rcon0 if fb.turned_on else rt_fixed.rcon0,
             rt_freeb.zcon0 if fb.turned_on else rt_fixed.zcon0)
     return _FreeBoundaryStageResult(
-        _finalize(carry, rt_freeb if fb.turned_on else rt_fixed), fb,
+        replace(
+            _finalize(carry, rt_freeb if fb.turned_on else rt_fixed),
+            vacuum=_vacuum_output(fb, basis),
+        ), fb,
         carry.xstore, rt_freeb.rcon0 if fb.turned_on else rt_fixed.rcon0,
         rt_freeb.zcon0 if fb.turned_on else rt_fixed.zcon0)
 
@@ -1409,7 +1453,9 @@ def solve_free_boundary(
     :func:`vmex.core.multigrid.solve_free_boundary_multigrid` for the complete
     ``NS_ARRAY`` ladder.  Time-step, constraint, print-cadence, m=1-constraint,
     and optional 2D-preconditioner overrides mirror
-    :func:`vmex.core.solver.solve`.
+    :func:`vmex.core.solver.solve`.  The returned ``result.vacuum`` contains
+    the final NESTOR potential modes and surface fields, without internal
+    matrix caches.
     """
     if resolution is None:
         resolution = resolution_from_input(inp)

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -361,6 +361,8 @@ def solve_free_boundary_multigrid(
     ``device="auto"`` (default) applies the measured policy independently at
     each grid and relocates carried plasma/vacuum arrays when the policy changes;
     ``None`` leaves placement to JAX.
+    The final stage's publishable potential and surface fields are retained in
+    ``result.vacuum``; internal NESTOR matrix caches are not exposed.
     """
     if not bool(inp.lfreeb):
         raise ValueError("solve_free_boundary_multigrid requires an LFREEB=T input")
@@ -426,6 +428,7 @@ def solve_free_boundary_multigrid(
         if (vacuum_continuation is not None and target is not None
                 and any(getattr(vacuum_continuation, name) is not None for name in (
                     "bsqvac", "rbsq", "mode_matrix", "bvec_nonsing", "potvac",
+                    "surface_fields",
                 ))):
             vacuum_continuation = replace(
                 vacuum_continuation,
@@ -436,6 +439,8 @@ def solve_free_boundary_multigrid(
                 bvec_nonsing=_put_numeric_leaves(
                     vacuum_continuation.bvec_nonsing, target),
                 potvac=_put_numeric_leaves(vacuum_continuation.potvac, target),
+                surface_fields=_put_numeric_leaves(
+                    vacuum_continuation.surface_fields, target),
             )
         with device_context(device, resolution):
             stage_result = _solve_free_boundary_stage(

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -1415,6 +1415,24 @@ def _initial_carry(state: SpectralState, rt: SolverRuntime, *, ijacob: int) -> _
 
 
 @dataclass(frozen=True)
+class VacuumOutput:
+    """Publishable final NESTOR state (potential modes + surface fields).
+
+    Arrays use NESTOR's reduced boundary grid.  Internal Green-function
+    matrices and cached right-hand sides deliberately remain private.
+    """
+
+    potsin: np.ndarray
+    potcos: np.ndarray | None
+    xmpot: np.ndarray
+    xnpot: np.ndarray
+    bsubu: np.ndarray
+    bsubv: np.ndarray
+    bsupu: np.ndarray
+    bsupv: np.ndarray
+
+
+@dataclass(frozen=True)
 class SolveResult:
     """Converged fixed-boundary solve output.
 
@@ -1423,7 +1441,8 @@ class SolveResult:
     wout ``xm/xn`` arrays; ``iotaf`` follows ``add_fluxes.f90`` for
     ``ncurr = 1``.  ``fsq_history`` has one row per iteration:
     ``(fsqr, fsqz, fsql, fsqr1, fsqz1, fsql1)``.  ``wmhd`` is the printed
-    ``WMHD = (wb + wp/(gamma-1)) * (2 pi)^2``.
+    ``WMHD = (wb + wp/(gamma-1)) * (2 pi)^2``.  ``vacuum`` is ``None`` for
+    fixed-boundary solves.
     """
 
     converged: bool; iterations: int; ier_flag: int
@@ -1435,6 +1454,7 @@ class SolveResult:
     rmnc: np.ndarray; zmns: np.ndarray
     rmns: np.ndarray | None; zmnc: np.ndarray | None
     iotaf: np.ndarray; fsq_history: np.ndarray
+    vacuum: VacuumOutput | None = None
 
 
 def _result_from_carry(carry: _LoopCarry, rt: SolverRuntime) -> SolveResult:

--- a/vmex/core/wout.py
+++ b/vmex/core/wout.py
@@ -2,9 +2,9 @@
 
 This module implements the full variable set written by VMEC2000's
 ``wrout.f`` (Appendix A).  Core fixed-boundary fields use the reference
-netCDF names, dimensions, dtypes and unit conventions; NESTOR potential and
-surface fields are currently declared but written as fill values (see the
-free-boundary section of ``docs/wout_reference.rst``):
+netCDF names, dimensions, dtypes and unit conventions.  Symmetric
+free-boundary results also populate the NESTOR potential and surface fields
+when their public ``VacuumOutput`` is supplied:
 
 - ``presf``/``pres``/``mass`` are stored in Pa (``wrout.f`` divides the
   internal ``mu0*Pa`` values by ``mu0`` on write);
@@ -35,10 +35,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass, fields as _dc_fields
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from . import postprocess as _pp
+
+if TYPE_CHECKING:
+    from .solver import VacuumOutput
 
 MU0 = _pp.MU0
 
@@ -550,8 +554,9 @@ def wout_from_state(
     extcur=None,
     mgrid_mode: str = "",
     curlabel=None,
+    vacuum_output: VacuumOutput | None = None,
 ) -> WoutData:
-    """Build a complete :class:`WoutData` from a solved fixed-boundary state.
+    """Build a complete :class:`WoutData` from a solved equilibrium state.
 
     ``inp`` is the parsed :class:`vmex.core.input.VmecInput` deck and
     ``state`` the converged :class:`vmex.core.solver.SpectralState`
@@ -572,12 +577,10 @@ def wout_from_state(
     Free-boundary metadata: ``nextcur``/``extcur``/``mgrid_mode``/
     ``curlabel`` are caller-supplied (the CLI reads them from the mgrid file;
     ``extcur`` is the input EXTCUR array in Amperes, as ``wrout.f`` writes
-    it).  The NESTOR vacuum potential is NOT populated: ``potsin``/
-    ``potcos``/``xmpot``/``xnpot`` and the ``*_sur`` surface-field tables
-    stay ``None`` (netCDF fill) because
-    :func:`vmex.core.freeboundary.solve_free_boundary` does not return
-    its :class:`~vmex.core.freeboundary.FreeBoundaryState` (which holds
-    ``potvac``) — a documented gap until the solver exposes it.
+    it).  Pass the public ``result.vacuum`` as ``vacuum_output`` to populate
+    symmetric NESTOR ``potsin``/``xmpot``/``xnpot`` and ``*_sur`` tables.
+    LASYM vacuum export remains unsupported and those variables stay
+    ``None`` (netCDF fill).
     """
     import jax
 
@@ -726,6 +729,29 @@ def wout_from_state(
     nyq_a = {name: (np.asarray(getattr(tabs, name), dtype=float) if lasym else None)
              for name in ("gmns", "bmns", "bsubumns", "bsubvmns",
                           "bsubsmnc", "bsupumns", "bsupvmns")}
+    vacuum_sur: dict[str, np.ndarray] = {}
+    export_vacuum = (
+        vacuum_output is not None and bool(inp.lfreeb) and not lasym)
+    if export_vacuum:
+        expected = (int(trig.ntheta3), int(res.nzeta))
+        nyq_modes = mode_table(
+            int(np.max(xm_nyq)) + 1,
+            int(np.max(np.abs(xn_nyq))) // nfp if xn_nyq.size else 0,
+        )
+        for output_name, source_name in (
+            ("bsubumnc_sur", "bsubu"),
+            ("bsubvmnc_sur", "bsubv"),
+            ("bsupumnc_sur", "bsupu"),
+            ("bsupvmnc_sur", "bsupv"),
+        ):
+            surface = np.asarray(getattr(vacuum_output, source_name), dtype=float)
+            if surface.shape != expected:
+                raise ValueError(
+                    f"vacuum_output.{source_name} has shape {surface.shape}, "
+                    f"expected {expected}"
+                )
+            vacuum_sur[output_name] = _nyq.wrout_cos_coeffs(
+                f=surface[None, ...], modes=nyq_modes, trig=trig)[0]
     nzeta_vmec = int(inp.nzeta) or (1 if ntor == 0 else nzeta)
     nnyq_target = int(nzeta_vmec) // 2
     nnyq_have = int(np.max(xn_nyq)) // nfp if xn_nyq.size else 0
@@ -737,6 +763,9 @@ def wout_from_state(
         if lasym:
             for name, tab in nyq_a.items():
                 nyq_a[name] = _pp.expand_mode_columns(tab, xm_nyq, xn_nyq, xm_new, xn_new)
+        for name, tab in vacuum_sur.items():
+            vacuum_sur[name] = _pp.expand_mode_columns(
+                tab[None, :], xm_nyq, xn_nyq, xm_new, xn_new)[0]
         xm_nyq, xn_nyq = xm_new, xn_new
 
     # -- fbal.f/bcovar.f: current averages from the bsub[uv]mnc tables ------
@@ -864,6 +893,18 @@ def wout_from_state(
         bsubsmnc=nyq_a["bsubsmnc"],
         currumns=currumns, currvmns=currvmns,
         bsupumns=nyq_a["bsupumns"], bsupvmns=nyq_a["bsupvmns"],
+        mnmaxpot=(int(np.asarray(vacuum_output.xmpot).size)
+                  if export_vacuum else None),
+        potsin=(np.asarray(vacuum_output.potsin, dtype=float)
+                if export_vacuum else None),
+        xmpot=(np.asarray(vacuum_output.xmpot, dtype=float)
+               if export_vacuum else None),
+        xnpot=(np.asarray(vacuum_output.xnpot, dtype=float)
+               if export_vacuum else None),
+        bsubumnc_sur=vacuum_sur.get("bsubumnc_sur"),
+        bsubvmnc_sur=vacuum_sur.get("bsubvmnc_sur"),
+        bsupumnc_sur=vacuum_sur.get("bsupumnc_sur"),
+        bsupvmnc_sur=vacuum_sur.get("bsupvmnc_sur"),
     )
 
 


### PR DESCRIPTION
## Summary

Export the final publishable NESTOR state into symmetric free-boundary WOUT files.

The solver already computed and retained the vacuum potential internally, but the public result discarded it and the four surface-field channels before WOUT assembly. This PR adds a small, backwards-compatible `SolveResult.vacuum` payload containing only:

- `potsin` / `potcos` and their mode arrays;
- final `bsubu`, `bsubv`, `bsupu`, and `bsupv` surface grids.

Private NESTOR matrices, right-hand sides, and cache state remain private. Fixed-boundary results continue to have `vacuum=None`.

Single-grid, multigrid, hot continuation, and device relocation now preserve this publishable payload. `wout_from_state(..., vacuum_output=result.vacuum)` projects the symmetric surface grids with the existing VMEC `wrout` Nyquist normalization, and the CLI passes the payload automatically. LASYM vacuum WOUT export remains explicitly unsupported and continues to use netCDF fill values.

## VMEC2000 comparison

Fresh symmetric CTH runs with local `xvmec2000` produced exact WOUT dimensions, `mnmaxpot=63`, and bit-exact `xmpot`/`xnpot`. Scale-relative differences were:

| Quantity | Relative difference |
|---|---:|
| `potsin` | `4.023e-4` |
| `bsubumnc_sur` | `2.120e-4` |
| `bsubvmnc_sur` | `5.218e-5` |
| `bsupumnc_sur` | `1.692e-3` |
| `bsupvmnc_sur` | `5.775e-5` |

All exported symmetric vacuum variables are finite, nonzero, unmasked, and dimensionally identical to VMEC2000.

The full public DIII-D free-boundary ladder (`NS_ARRAY=16,32,64,128`) also
converged in both solvers. NESTOR mode arrays matched exactly; scale-relative
surface-field differences ranged from `7.38e-9` to `1.08e-5`. Final equilibrium
differences were `1.64e-6` (`rmnc`), `3.78e-6` (`zmns`), `7.51e-6` (`iotaf`),
and `1.20e-7` (`wb`). VMEX and VMEC2000 took 1,207 and 1,157 final-stage
iterations, respectively.

## Validation

- Existing focused free-boundary/multigrid/CLI/WOUT suite: **30 passed, 5 expected full skips**
- Existing LASYM CLI/multigrid integration: **2 passed**; LASYM `potsin` remains fully masked as documented
- Final rebased symmetric NESTOR export + CLI regression: **7 passed**
- Office CPU/GPU NESTOR payload/placement regression: **1 passed in 86.97 s**
  with no platform-selection environment variables; mode arrays are exact,
  potential/covariant fields pass a `1e-4` scale-relative gate, and the more
  sensitive contravariant fields pass `5e-4`
- Ruff over code, tests, examples, benchmarks, and tools: passed
- mypy over `vmex`: passed (53 source files)
- strict Sphinx (`-E -W --keep-going`): passed
- compileall and `git diff --check`: passed

This PR is stacked on #72 and should merge after it.
