### PR TITLE
Stabilize bounded full-physics nightly validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,14 +142,14 @@ jobs:
   parity:
     name: Parity suite ${{ matrix.shard }} (goldens, coverage)
     runs-on: ubuntu-latest
-    # Headroom for slow shared runners: the golden solves run ~15-20 min on a
-    # healthy runner but tip over a tighter limit on a slow one (the suite
-    # content is unchanged). 35 absorbs that variance without masking a hang.
+    # The former 431-test catch-all passed in 15-20 min on healthy runners but
+    # repeatedly lost slow shared runners. Shards c/e preserve its exact test
+    # set with enough headroom to distinguish runner variance from a hang.
     timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
-        shard: [a, b, c, d]
+        shard: [a, b, c, d, e]
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -182,8 +182,8 @@ jobs:
           print("golden dir:", mod.resolve_golden_dir())
           EOF
 
-      # Four bounded shards.  The xdist dist MODE is chosen PER SHARD by
-      # whether its modules share an expensive fixture:
+      # Five bounded shards.  The xdist dist MODE is
+      # chosen PER SHARD by whether its modules share an expensive fixture:
       #   * loadscope groups a whole module onto ONE worker, so module-scoped
       #     equilibrium fixtures (omnigenity qi_eq/tok_eq, bootstrap eq,
       #     stability vacuum/highbeta/shaped) are solved ONCE, not once-per-
@@ -202,11 +202,12 @@ jobs:
       #   a = heaviest solver-golden modules, including all free-boundary
       #       modules so their JAX caches leave with this bounded shard instead
       #       of accumulating in the catch-all worker processes;
-      #   c = everything else, incl. omnigenity/turbulence/bootstrap/stability.
+      #   c = the slow fixture-sharing modules from the former catch-all;
+      #   e = the remaining catch-all modules.
       # Together they cover the whole non-gradient, non-example core suite once;
       # the separate mirror matrix owns tests/mirror. Therefore
       # every test file appears in exactly one shard (coverage gate combines
-      # a+b+c+d), so coverage is invariant under this reshuffle.
+      # a+b+c+d+e), so coverage is invariant under this reshuffle.
       - name: Run parity shard ${{ matrix.shard }} with coverage
         env:
           JAX_ENABLE_X64: "1"
@@ -222,6 +223,17 @@ jobs:
           B_FILES="tests/test_golden_digests.py \
                    tests/test_bootstrap.py \
                    tests/test_wout_golden.py"
+          C_FILES="tests/test_input_profiles.py \
+                   tests/test_setup.py \
+                   tests/test_profiles.py \
+                   tests/test_omnigenity.py \
+                   tests/test_implicit_multi_rhs.py \
+                   tests/test_parallel.py \
+                   tests/test_optimize_penalty.py \
+                   tests/test_lgradb.py \
+                   tests/test_package_api.py \
+                   tests/test_stability.py \
+                   tests/test_multigrid_interp.py"
           D_FILES="tests/test_optimize.py"
           if [ "${{ matrix.shard }}" = "a" ]; then
             pytest -q -n 4 --dist loadscope $A_FILES --durations=15 --cov=vmex --cov-report=term
@@ -229,8 +241,10 @@ jobs:
             pytest -q -n 4 --dist load $B_FILES --durations=15 --cov=vmex --cov-report=term
           elif [ "${{ matrix.shard }}" = "d" ]; then
             pytest -q -n 4 --dist load $D_FILES --durations=15 --cov=vmex --cov-report=term
+          elif [ "${{ matrix.shard }}" = "c" ]; then
+            pytest -q -n 4 --dist loadscope $C_FILES --durations=15 --cov=vmex --cov-report=term
           else
-            IGNORES=$(for f in $A_FILES $B_FILES $D_FILES; do echo "--ignore=$f"; done)
+            IGNORES=$(for f in $A_FILES $B_FILES $C_FILES $D_FILES; do echo "--ignore=$f"; done)
             pytest -q -n 4 --dist loadscope tests \
               --ignore=tests/mirror \
               --ignore=tests/test_implicit_grad.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ env:
 permissions:
   contents: read
 
-# Sharded CI (plan.md Phase-2 review item 1): five parallel test jobs, each
-# well under the 10-minute wall-time budget, plus a fast lint gate (ruff +
-# mypy) and a coverage gate that combines the parity + gradient shards and
-# enforces >= 95% on vmex.
+# Sharded CI (plan.md Phase-2 review item 1): bounded parallel test jobs, plus
+# a fast lint gate (ruff + mypy) and a coverage gate that combines the parity
+# and gradient shards and enforces >= 95% on vmex. Manual/nightly runs add the
+# full-physics tests below.
 jobs:
   lint:
     # Fast fail-first gate (plan Item I.3): ruff + mypy over the whole tree,
@@ -446,15 +446,19 @@ jobs:
     runs-on: ubuntu-latest
     # A sequential whole-suite job reached only 39% before the previous
     # 150-minute limit, and the core job later lost hosted runners three times
-    # after 37/79/81 minutes. Keep exact RUN_FULL coverage, split core
-    # alphabetically, isolate each stateful optimization campaign, and isolate
-    # examples/mirror so every shard stays bounded on a fresh worker.
+    # after 37/79/81 minutes. Keep exact aggregate RUN_FULL coverage, split
+    # core alphabetically, isolate each stateful optimization campaign, and
+    # isolate examples/mirror so every shard stays bounded on a fresh worker.
+    # The ordinary gradient jobs own non-full implicit tests; the dedicated
+    # shard below adds its full-marked case without rerunning that large JAX
+    # suite in one process.
     timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
-        shard: [core-a-f, core-g-h, core-i-m, core-n-s, core-t-z, opt-qa, opt-qh,
-                opt-qp, examples, mirror-field, mirror-equilibrium, mirror-spline]
+        shard: [core-a-f, core-g-h, core-i-m, implicit-dmerc, core-n-s,
+                core-t-z, opt-qa, opt-qh, opt-qp, examples, mirror-field,
+                mirror-equilibrium, mirror-spline]
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -500,8 +504,14 @@ jobs:
               ;;
             core-i-m)
               FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \
+                     --ignore=tests/test_implicit_grad.py \
                      --ignore-glob=tests/test_[a-h]*.py \
                      --ignore-glob=tests/test_[n-z]*.py"
+              ;;
+            implicit-dmerc)
+              # Ordinary gradient a/b/c already own every non-full test in
+              # this module; this is its single nightly-only DMerc AD case.
+              FILES="tests/test_implicit_grad.py -m full"
               ;;
             core-n-s)
               FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,6 +545,7 @@ jobs:
             sleep 60
             if kill -0 "$pytest_pid" 2>/dev/null; then
               echo "pytest shard ${{ matrix.shard }} still running (${SECONDS}s)"
+              awk '/VmRSS|VmHWM/ {print "  " $0}' "/proc/$pytest_pid/status" 2>/dev/null || true
             fi
           done
           wait "$pytest_pid"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,7 +453,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [core-a-f, core-g-m, core-n-s, core-t-z, opt-qa, opt-qh,
+        shard: [core-a-f, core-g-h, core-i-m, core-n-s, core-t-z, opt-qa, opt-qh,
                 opt-qp, examples, mirror-field, mirror-equilibrium, mirror-spline]
     steps:
       - uses: actions/checkout@v6.0.2
@@ -493,9 +493,14 @@ jobs:
               FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \
                      --ignore-glob=tests/test_[g-z]*.py"
               ;;
-            core-g-m)
+            core-g-h)
               FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \
                      --ignore-glob=tests/test_[a-f]*.py \
+                     --ignore-glob=tests/test_[i-z]*.py"
+              ;;
+            core-i-m)
+              FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \
+                     --ignore-glob=tests/test_[a-h]*.py \
                      --ignore-glob=tests/test_[n-z]*.py"
               ;;
             core-n-s)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,7 +538,7 @@ jobs:
               ;;
           esac
           # Some optimization tests are silent for more than 15 minutes.
-          # Keep the hosted runner live without changing pytest semantics.
+          # Keep long shards observable without changing pytest semantics.
           pytest -q $FILES --durations=25 &
           pytest_pid=$!
           while kill -0 "$pytest_pid" 2>/dev/null; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
 
       - name: Combine shards and enforce the gate
         run: |
-          coverage combine coverage.parity-a coverage.parity-b coverage.parity-c coverage.parity-d coverage.gradient-a coverage.gradient-b coverage.gradient-c coverage.examples
+          coverage combine coverage.parity-a coverage.parity-b coverage.parity-c coverage.parity-d coverage.parity-e coverage.gradient-a coverage.gradient-b coverage.gradient-c coverage.examples
           # The mirror release audit reaches 95% only after appending nightly
           # fixed/free adjoint tests. The fast core artifacts intentionally
           # exclude those tests, so do not mix a partial mirror number into

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,7 @@ jobs:
     # 150-minute limit, and the core job later lost hosted runners three times
     # after 37/79/81 minutes. Keep exact aggregate RUN_FULL coverage, split
     # core alphabetically, isolate each stateful optimization campaign, and
-    # isolate examples/mirror so every shard stays bounded on a fresh worker.
+    # isolate free-boundary, examples, and mirror campaigns on fresh workers.
     # The ordinary gradient jobs own non-full implicit tests; the dedicated
     # shard below adds its full-marked case without rerunning that large JAX
     # suite in one process.
@@ -473,7 +473,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [core-a-f, core-g-h, core-i-m, implicit-dmerc, core-n-s,
+        shard: [core-a-f, core-freeboundary, core-g-h, core-i-m, implicit-dmerc, core-n-s,
                 core-t-z, opt-qa, opt-qh, opt-qp, examples, mirror-field,
                 mirror-equilibrium, mirror-spline]
     steps:
@@ -512,7 +512,17 @@ jobs:
           case "${{ matrix.shard }}" in
             core-a-f)
               FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \
+                     --ignore=tests/test_cli_freeboundary.py \
+                     --ignore=tests/test_freeboundary.py \
+                     --ignore=tests/test_freeboundary_diff.py \
+                     --ignore=tests/test_freeboundary_multigrid.py \
                      --ignore-glob=tests/test_[g-z]*.py"
+              ;;
+            core-freeboundary)
+              FILES="tests/test_cli_freeboundary.py \
+                     tests/test_freeboundary.py \
+                     tests/test_freeboundary_diff.py \
+                     tests/test_freeboundary_multigrid.py"
               ;;
             core-g-h)
               FILES="tests --ignore=tests/mirror --ignore=tests/test_examples.py \

--- a/tests/test_golden_digests.py
+++ b/tests/test_golden_digests.py
@@ -21,6 +21,8 @@ pytest.importorskip("netCDF4")
 
 import vmex as vj  # noqa: E402
 
+pytestmark = pytest.mark.usefixtures("_module_jit_enabled")
+
 REPO = Path(__file__).resolve().parents[1]
 DATA = REPO / "examples" / "data"
 DIGESTS = json.loads((REPO / "tests" / "golden_digests.json").read_text())

--- a/tests/test_optimization_convergence.py
+++ b/tests/test_optimization_convergence.py
@@ -7,13 +7,12 @@ implicit-gradient continuation (``jac="implicit"`` + ESS, the exact path the
 ``examples/optimization`` scripts use) and asserts the achieved
 ``QuasisymmetryRatioResidual.total`` bound.  QA runs two continuation stages
 to its precise bound (< 1e-3); QH and QP run a single stage.  QP uses a
-bounded ten-evaluation smoke: longer campaigns are basin-sensitive and retain
-too much compilation state for a shared CI worker.  The deep
-implicit Jacobian is launch-bound (one preconditioned GMRES per boundary dof,
-~101 s/eval at max_mode 2), so the *full* precise campaigns -- QA 1.70e-04
-(max_mode 2) and QH 5.83e-05 (max_mode 5, ~100 min just for the max_mode-2
-stage) -- are recorded/guarded in the example scripts + README, and the
-nightly guards bounded campaigns that fit reliably on hosted workers.
+bounded ten-evaluation smoke: longer campaigns are basin-sensitive.  The
+module explicitly enables JIT, matching the example scripts instead of the
+suite-wide interpreted unit-test default.  The *full* precise campaigns -- QA
+1.70e-04 (max_mode 2) and QH 5.83e-05 (max_mode 5, ~100 min just for the
+max_mode-2 stage) -- are recorded/guarded in the example scripts + README, and
+the nightly guards bounded campaigns that fit reliably on hosted workers.
 
 Measured on the office 36-core CPU (2026-07-11, implicit Jacobian CPU-pinned):
 QA 2.043e-01 -> 9.82e-03 (max_mode 1) -> 1.70e-04 (2, precise); QH 6.908e-01
@@ -30,6 +29,8 @@ import numpy as np
 import pytest
 
 pytest.importorskip("jax")
+
+pytestmark = pytest.mark.usefixtures("_module_jit_enabled")
 
 from vmex.core.input import VmecInput
 from vmex.core import optimize as opt
@@ -116,9 +117,9 @@ def test_qp_implicit_descends():
 
     Basin-limited (not precise): a bounded ten-evaluation max-mode-1 smoke at
     ns=25 reaches QS 4.461e-01 -> 1.402e-01 (CPU replay, 2026-07-22). Near-axis
-    theory forbids exact QP, and longer campaigns are rounding-sensitive while
-    retaining tens of GiB of compilation state on CI workers. This test guards
-    substantial descent without turning a physics smoke into a resource test.
+    theory forbids exact QP, and longer campaigns are rounding-sensitive. This
+    test guards substantial descent without turning a physics smoke into a
+    resource test.
     """
     inp = dataclasses.replace(_nfp2_seed(), ns_array=[25])
     qs = opt.QuasisymmetryRatioResidual(np.linspace(0.1, 1.0, 10), 0, 1)

--- a/tests/test_optimization_convergence.py
+++ b/tests/test_optimization_convergence.py
@@ -13,8 +13,7 @@ implicit Jacobian is launch-bound (one preconditioned GMRES per boundary dof,
 ~101 s/eval at max_mode 2), so the *full* precise campaigns -- QA 1.70e-04
 (max_mode 2) and QH 5.83e-05 (max_mode 5, ~100 min just for the max_mode-2
 stage) -- are recorded/guarded in the example scripts + README, and the
-nightly guards the single-stage bounds that fit the ``full`` job's shared
-150-min budget.
+nightly guards bounded campaigns that fit reliably on hosted workers.
 
 Measured on the office 36-core CPU (2026-07-11, implicit Jacobian CPU-pinned):
 QA 2.043e-01 -> 9.82e-03 (max_mode 1) -> 1.70e-04 (2, precise); QH 6.908e-01
@@ -67,15 +66,16 @@ def test_qa_reaches_precise():
     """QA (nfp2, helicity (1,0)) reaches *precise* QS via implicit continuation.
 
     Measured (office A4000): 2.043e-01 -> 9.82e-03 (max_mode=1) -> 1.70e-04
-    (max_mode=2).  This two-stage nightly run protects the headline precise-QA
-    claim; the bound (< 1e-3) carries margin over the measured 1.7e-4.
+    (max_mode=2).  A bounded 30-evaluation replay reaches 2.62e-04 with aspect
+    6.00008. This two-stage nightly run protects the headline precise-QA claim;
+    the bound (< 1e-3) carries margin over both measurements.
     """
     inp = _nfp2_seed(kick=0.01)  # helical kick breaks the axisymmetric saddle
     qs = opt.QuasisymmetryRatioResidual(np.linspace(0.1, 1.0, 10), 1, 0)
     seed = float(qs.total(opt.solve_equilibrium(inp)))
     terms = [(qs, 0.0, 1.0), (opt.aspect_ratio, 6.0, 1.0), (opt.mean_iota, 0.42, 10.0)]
     r = opt.least_squares(terms, inp, max_mode=(1, 2), jac="implicit", use_ess=True,
-                          max_nfev=80, ftol=1e-9, xtol=1e-10)
+                          max_nfev=30, ftol=1e-9, xtol=1e-10)
     final = float(qs.total(r.equilibrium))
     assert final < 1e-3, f"QA QS {seed:.3e} -> {final:.3e} (expected precise < 1e-3)"
     assert abs(float(opt.aspect_ratio(r.equilibrium.state, r.equilibrium.runtime)) - 6.0) < 0.05
@@ -96,15 +96,16 @@ def test_qh_implicit_converges():
     This nightly test asserts only the single-stage bound: the deep implicit
     Jacobian is launch-bound (~101 s/eval at max_mode 2, and QH needs ~60 evals
     there — ~100 min), so a multi-stage precise assertion would exceed the
-    ``full`` job's shared 150-min budget.  The bound below (< 0.16) tightens the
-    prior < 0.30 over the measured 0.140.
+    reliable hosted-worker budget.  The bound below (< 0.16) tightens the
+    prior < 0.30 over the measured 0.140. A bounded 40-evaluation replay
+    reached 2.12e-03, so the shorter hosted campaign retains ample margin.
     """
     inp = _qh_seed()
     qs = opt.QuasisymmetryRatioResidual(np.linspace(0.1, 1.0, 10), 1, -1)
     seed = float(qs.total(opt.solve_equilibrium(inp)))
     terms = [(qs, 0.0, 1.0), (opt.aspect_ratio, 8.0, 1.0)]
     r = opt.least_squares(terms, inp, max_mode=1, jac="implicit", use_ess=True,
-                          max_nfev=60, ftol=1e-9, xtol=1e-10)
+                          max_nfev=40, ftol=1e-9, xtol=1e-10)
     final = float(qs.total(r.equilibrium))
     assert final < 0.16, f"QH QS {seed:.3e} -> {final:.3e} (measured 0.140; bound < 0.16)"
 
@@ -113,13 +114,13 @@ def test_qh_implicit_converges():
 def test_qp_implicit_descends():
     """QP (nfp2, helicity (0,1)) descends via implicit to its documented basin.
 
-    Basin-limited (not precise): a bounded ten-evaluation max-mode-1 smoke
-    reaches QS 4.458e-01 -> 1.393e-01 (office CPU, 2026-07-21). Near-axis
+    Basin-limited (not precise): a bounded ten-evaluation max-mode-1 smoke at
+    ns=25 reaches QS 4.461e-01 -> 1.402e-01 (CPU replay, 2026-07-22). Near-axis
     theory forbids exact QP, and longer campaigns are rounding-sensitive while
     retaining tens of GiB of compilation state on CI workers. This test guards
     substantial descent without turning a physics smoke into a resource test.
     """
-    inp = _nfp2_seed()
+    inp = dataclasses.replace(_nfp2_seed(), ns_array=[25])
     qs = opt.QuasisymmetryRatioResidual(np.linspace(0.1, 1.0, 10), 0, 1)
     seed = float(qs.total(opt.solve_equilibrium(inp)))
 


### PR DESCRIPTION
## Summary

Bound the three expensive full/nightly quasisymmetry optimization guards to
measured campaigns that retain the same physics assertions but fit more
reliably on hosted workers.

- QA keeps its two-stage implicit/ESS continuation and `< 1e-3` precise bound,
  while reducing `max_nfev` from 80 to 30.
- QH keeps its implicit/ESS continuation and `< 0.16` bound, while reducing
  `max_nfev` from 60 to 40.
- QP keeps ten evaluations, ten radial objective samples, and the 15% descent
  assertion; only its nightly equilibrium grid changes from `ns=35` to
  `ns=25`.
- Run the solver-heavy optimization and VMEC2000 golden modules with JIT,
  matching the example/production path instead of pytest's interpreted
  unit-test default. The block implicit Jacobian remains the tested and public
  default; no alternate solver is selected in these guards.
- Clarify that the one-minute heartbeat makes long shards observable. It does
  not guarantee that a hosted runner will not be reclaimed, and report Linux
  `VmRSS`/`VmHWM` so a future shutdown distinguishes memory pressure from a
  numerical failure.
- Split the oversized `core-g-m` full shard into disjoint `g-h` and `i-m`
  shards. The ordinary gradient jobs retain ownership of the non-full implicit
  tests; an isolated nightly shard runs the full 3-D DMerc AD/FD comparison so
  compiled test state cannot accumulate across the whole implicit module.

Objectives, implicit differentiation, ESS, solver defaults, public APIs, and
all scientific assertions are unchanged.

## Evidence

Manual runs 29975294716 and 29981301289 emitted regular heartbeats and then
lost the optimization campaigns to external runner shutdown (`SIGTERM`, exit
143), without a pytest assertion or traceback. The second run's telemetry
identified the cause: QA, QH, and QP each reached about 15.3 GiB RSS, and the
combined `i-m` shard reached 15.17 GiB.

| Campaign | Old configuration | Runtime before shutdown |
|---|---:|---:|
| QH | `max_nfev=60` | 14m28s |
| QA | `max_nfev=80` | 17m59s |
| QP | `ns=35`, `max_nfev=10` | 21m39s |

Measured bounded replays preserve substantial margin:

- QA: final QS `2.620389e-4`, aspect `6.00007564`;
- QH: final QS `2.1221584e-3`;
- QP: QS `0.446089 -> 0.140203` (68.6% reduction).

The memory discrepancy reproduced locally: the exact pytest path inherited
`jax_disable_jit=True`, while the example scripts and prior calibrations used
JIT. Opting these solver-heavy modules into the existing
`_module_jit_enabled` fixture retained the stronger block-Jacobian results and
made the exact pytest nodes both fast and bounded:

| Campaign | Exact pytest wall | Maximum RSS |
|---|---:|---:|
| QA | 65.0 s | 4.24 GiB |
| QH | 89.5 s | 3.92 GiB |
| QP | 33.0 s | 3.76 GiB |

The new nightly ownership was also replayed locally: `core-g-h` passed 27
tests with 7 expected GPU skips in 18.6 s; `core-i-m` passed 126 with 4 skips
and 2 expected xfails in 106.1 s; and the isolated 3-D DMerc implicit AD versus
frozen-path FD test passed in 37.4 s.

Exact-head hosted nightly run 29984290253 confirms the fix: QA, QH, and QP all
pass with sampled `VmHWM` of 3.93, 3.93, and 3.89 GiB, respectively. The
isolated 3-D DMerc AD test passes at 4.76 GiB and `core-g-h` passes at 3.89 GiB,
all far below the prior 15.2--15.3 GiB shutdown point.

The run completed successfully on exact SHA `923e0c46`: all 30 jobs passed,
including coverage >=95%, 19 full examples, and the unchanged 28-test
mirror-field convergence shard (81m32s test wall, 9.11 GiB peak RSS).

On exact head `923e0c46`, the office GPU/device suite passed **35 tests in
130.44 s** (including all 7 dedicated GPU tests) with both RTX A4000s
discovered and no platform-selection environment variables. A fresh
five-metric CPU/GPU audit also passed at `1e-7`; relative
gradient differences were `5.68e-16` (MHD energy), `1.21e-10` (magnetic well),
`1.56e-12` (DMerc), `1.94e-15` (quasisymmetry), and `5.75e-14`
(quasi-isodynamicity), with zero forward-state difference.

With the fetched reference assets on the same unpinned GPU installation, the
converged free-boundary/VMEC2000 comparison and NESTOR WOUT structure export
both passed (137.47 s), as did vacuum carry transfer, two-stage free-boundary
rebuild, and single-grid hot restart (3 tests in 51.33 s).

This PR is stacked on #73 and should merge after it.

## Final parity-shard follow-up (2026-07-24)

**Goal:** eliminate the repeatedly reclaimed parity catch-all without removing a test, weakening an assertion, lowering coverage, or changing VMEX source.

**Achieved:** split the old catch-all into bounded C/E jobs and include both coverage artifacts. Independent collection checks prove that C∪E equals the old set exactly (**490 node IDs**). The workflow parses cleanly, every selected file exists, and the same split is already green on the tree-identical downstream integration head.

**Remaining:** no implementation or validation work. Exact-head required CI passed all **18 jobs**, including the ≥95% coverage gate ([run 30097632321](https://github.com/uwplasma/vmex/actions/runs/30097632321)). This PR is ready for review after #73.

## Final full/nightly process split (2026-07-24)

**Goal:** prevent the integrated `core-a-f` process from accumulating JAX executables until a hosted runner is reclaimed, while preserving every RUN_FULL test.

**Achieved:** isolate the four free-boundary modules on a fresh worker. On integrated head `697d3e33`, collection equality is exact (**157 = 128 + 29 unique node IDs**, no overlap). Fresh local processes passed **128 tests in 38.99s / 5.03 GiB** and **25 passed, 5 skipped in 81.62s / 6.10 GiB**, versus the former combined hosted process reaching 15.37 GiB before SIGTERM. No source, assertion, or coverage threshold changed.

**Remaining:** no implementation or required-CI work. Exact head `28da9808` passed all **18 required jobs**, including ≥95% coverage ([run 30101354470](https://github.com/uwplasma/vmex/actions/runs/30101354470)). The final exact-head manual matrix passed all **34 jobs** ([run 30101437203](https://github.com/rogeriojorge/vmec_jax/actions/runs/30101437203)); hosted `core-a-f` completed in 5m36s and `core-freeboundary` in 32m50s.