### PR TITLE
Support differentiable LASYM parallel current safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,6 @@ jobs:
                    tests/test_freeboundary_multigrid.py \
                    tests/test_freeboundary_diff.py \
                    tests/test_cli_freeboundary.py \
-                   tests/test_stability.py \
                    tests/test_solver_end_to_end.py"
           B_FILES="tests/test_golden_digests.py \
                    tests/test_bootstrap.py \
@@ -233,6 +232,7 @@ jobs:
                    tests/test_optimize_penalty.py \
                    tests/test_lgradb.py \
                    tests/test_package_api.py \
+                   tests/test_stability.py \
                    tests/test_multigrid_interp.py"
           D_FILES="tests/test_optimize.py"
           if [ "${{ matrix.shard }}" = "a" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
       #   a = heaviest solver-golden modules, including all free-boundary
       #       modules so their JAX caches leave with this bounded shard instead
       #       of accumulating in the catch-all worker processes;
-      #   c = everything else, incl. omnigenity/turbulence/bootstrap/stability.
+      #   c = everything else, incl. omnigenity/turbulence/bootstrap.
       # Together they cover the whole non-gradient, non-example core suite once;
       # the separate mirror matrix owns tests/mirror. Therefore
       # every test file appears in exactly one shard (coverage gate combines
@@ -217,6 +217,7 @@ jobs:
                    tests/test_freeboundary_multigrid.py \
                    tests/test_freeboundary_diff.py \
                    tests/test_cli_freeboundary.py \
+                   tests/test_stability.py \
                    tests/test_solver_end_to_end.py"
           B_FILES="tests/test_golden_digests.py \
                    tests/test_bootstrap.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
   `glasser_stability_residual` expose the published Glasser--Greene--Johnson
   `D_R <= 0` condition to JIT, AD and optimization, with the documented
   `DMerc > 0` and nonzero-shear prerequisites.
+- **Differentiable LASYM parallel current.** `jdotb_state` and its implicit
+  least-squares Jacobian now support non-stellarator-symmetric equilibria.
+  LASYM `DMerc` and `D_R` remain guarded after independent DCON validation
+  exposed unresolved sensitivity near marginal stability.
 - **LASYM NESTOR WOUT fields.** Free-boundary asymmetric runs now write
   `potcos` and all cosine/sine surface-field tables instead of netCDF fill.
 - **Live VMEC2000 integration gate.** `pytest --run-vmec2000` runs both public

--- a/README.md
+++ b/README.md
@@ -331,7 +331,9 @@ Optimization building blocks live in `vmex.core.optimize`
 magnetic well, `DMerc`, Glasser `D_R`, `<J·B>`, and ballooning-stability
 targets; a least-squares driver over boundary Fourier coefficients) with
 implicit-differentiation gradients from
-`vmex.core.implicit` (`jac="implicit"`). The recommended pattern is **one
+`vmex.core.implicit` (`jac="implicit"`). `<J·B>` also supports `LASYM = T`;
+`DMerc` and `D_R` remain symmetry-gated pending independent DCON/JMC parity.
+The recommended pattern is **one
 `least_squares` call** — no `max_mode` continuation loop — with **Exponential
 Spectral Scaling** ordering the harmonics through the trust region:
 

--- a/docs/confinement.rst
+++ b/docs/confinement.rst
@@ -310,8 +310,8 @@ and the edge and returns
 penalizes unstable (negative) ``DMerc`` with a smooth gradient.  At finite
 ``smoothing`` the residual is positive, rather than exactly zero, on stable
 surfaces but decays exponentially with the stability margin.  Both profile
-lanes retain VMEC's near-axis and edge limitations; the traceable lane does
-not yet support ``lasym = True``.
+lanes retain VMEC's near-axis and edge limitations; the traceable Mercier
+lane does not yet support ``lasym = True``.
 
 Parallel current and resistive interchange
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -325,10 +325,9 @@ an implicit-differentiation current objective. This is a direct port of the
 ``bootstrap.vmec_j_dot_B`` force-balance identity used by the Redl mismatch.
 For optimization, :func:`~vmex.core.stability.jdotb_residual` selects
 ``jdotb[2:-1]`` to exclude the usual axis/edge entries.
-The live low-resolution current-driven VMEC2000 case measured a maximum
-``4.72e-4`` difference; its regression gate is ``1e-3``.  The remaining
-sensitivity is from the radial derivative of VMEC's filtered ``bsubv``
-coefficients.
+This lane supports ``lasym = True``.  A converged finite-pressure,
+up-down-asymmetric tokamak agrees with live VMEC2000 to ``1.52e-3`` relative
+over ``[2:-1]``; its regression gate is ``2e-3``.
 
 Assuming the ideal prerequisite :math:`D_{\rm Merc}>0`, the
 Glasser--Greene--Johnson necessary condition for local resistive interchange
@@ -356,10 +355,20 @@ ideal-Mercier-unstable surface is never accepted based on :math:`D_R` alone.
 After optimization, use ``mercier_shear_state`` to verify
 ``abs(S) >> shear_epsilon`` on every target surface; regularization makes the
 numerics finite but cannot establish GGJ stability at zero shear.
-VMEC2000 does not write ``D_R`` itself, so validation is by the published
-identity and live VMEC2000 parity of the traceable ``DMerc``, ``jdotb`` and
-``bdotb`` constituents. Independent evaluation of :math:`H` and
-:math:`D_R` with JMC/DCON remains a separate external validation gate.
+VMEC2000 does not write ``D_R`` itself.  A live `DCON/GPEC
+<https://github.com/PrincetonUniversity/GPEC>`_ evaluation independently
+reproduces the symmetric VMEC normalization at ``ns=51`` (``D_I`` maximum
+absolute difference ``9.10e-4`` and ``D_R`` ``8.63e-5`` over normalized
+poloidal flux ``[0.1, 1)``).  The same test on an
+up-down-asymmetric tokamak exposed unresolved sensitivity in :math:`H`:
+at ``ns=201`` the candidate reconstruction's normalized ``D_I`` differs by
+at most ``1.85e-2`` over normalized poloidal flux ``[0.2, 0.9]``, but
+``D_R`` differs by ``1.49e-2`` and can change sign near marginality.
+Consequently :func:`~vmex.core.stability.d_merc_state` and
+:func:`~vmex.core.stability.glasser_d_r_state` still reject ``lasym = True``;
+the independently validated ``jdotb`` lane is available.  A 3-D LASYM
+extension additionally requires JMC or an equivalent nonaxisymmetric
+reference.
 
 Magnetic well
 ~~~~~~~~~~~~~~

--- a/docs/confinement.rst
+++ b/docs/confinement.rst
@@ -364,6 +364,10 @@ up-down-asymmetric tokamak exposed unresolved sensitivity in :math:`H`:
 at ``ns=201`` the candidate reconstruction's normalized ``D_I`` differs by
 at most ``1.85e-2`` over normalized poloidal flux ``[0.2, 0.9]``, but
 ``D_R`` differs by ``1.49e-2`` and can change sign near marginality.
+On that same input, all four geometry families agree with VMEC2000 to
+``2.49e-10`` relative or better, while the interior VMEX/VMEC2000 ``DMerc``
+relative difference is ``18.6`` with sign disagreements.  This isolates the
+problem to the LASYM Mercier reconstruction rather than the equilibrium.
 Consequently :func:`~vmex.core.stability.d_merc_state` and
 :func:`~vmex.core.stability.glasser_d_r_state` still reject ``lasym = True``;
 the independently validated ``jdotb`` lane is available.  A 3-D LASYM

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -60,10 +60,11 @@ must not define ``JAX_PLATFORMS`` or ``JAX_PLATFORM_NAME``.  The workflow
 installs the official ``jax[cuda13]`` distribution, verifies that JAX selects
 the GPU by ordinary hardware discovery, then runs focused placement checks and
 the quick nonzero-shear CPU/GPU parity audit for MHD energy, magnetic well,
-DMerc, ``jdotb``, Glasser ``D_R``, quasisymmetry, and quasi-isodynamic gradients. Timing is
-recorded in the uploaded ``device-parity`` artifact but is not a pass/fail
-gate. A missing or misconfigured accelerator is a failure, not a skipped
-green GPU job.
+DMerc, ``jdotb``, Glasser ``D_R``, quasisymmetry, and quasi-isodynamic
+gradients. Timing is recorded in the uploaded ``device-parity`` artifact but
+is not a pass/fail gate. The focused suite also compares the LASYM ``jdotb``
+implicit Jacobian on CPU and GPU. A missing or misconfigured accelerator is
+a failure, not a skipped green GPU job.
 
 Releasing
 ---------

--- a/docs/objectives.rst
+++ b/docs/objectives.rst
@@ -391,7 +391,8 @@ Which objectives differentiate how
 ``jac="implicit"`` requires a fixed-boundary problem. Its boundary parameter
 map supports both symmetric and ``LASYM = T`` equilibria, but individual
 objectives can be symmetry-limited; in particular the traceable Mercier and
-quasisymmetry objectives currently require ``LASYM = F``. See
+Glasser objectives and quasisymmetry currently require ``LASYM = F``.
+The traceable ``jdotb`` objective supports both symmetry modes. See
 :doc:`optimization` for the gradient machinery and measured cost of each
 piece.
 

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -12,7 +12,7 @@ import pytest
 
 from vmex.core import device as device_policy
 from vmex.core import implicit as im
-from vmex.core import freeboundary, multigrid, solver
+from vmex.core import freeboundary, multigrid, optimize, solver
 from vmex.core.input import VmecInput
 from vmex.core.mgrid import MgridField
 from vmex.core.wout import wout_from_state
@@ -83,6 +83,35 @@ def test_implicit_auto_prefers_cpu_but_none_follows_jax_gpu():
 
     assert {_platform(x) for x in jax.tree.leaves(automatic)} == {"cpu"}
     assert {_platform(x) for x in jax.tree.leaves(following_jax)} == {"gpu"}
+
+
+def test_lasym_jdotb_implicit_cpu_gpu_parity():
+    inp = VmecInput.from_file(DATA_DIR / "input.up_down_asymmetric_tokamak")
+    inp = dataclasses.replace(
+        inp,
+        ns_array=np.array([13]),
+        ftol_array=np.array([1e-10]),
+        niter_array=np.array([5000]),
+        am=np.array([1.0, -1.0]),
+        pres_scale=5000.0,
+    )
+    results = {
+        platform: optimize.least_squares(
+            [(optimize.jdotb_residual, 0.0, 1e-6)],
+            inp,
+            max_mode=1,
+            jac="implicit",
+            max_nfev=1,
+            device=platform,
+        )
+        for platform in ("cpu", "gpu")
+    }
+    cpu, gpu = results["cpu"], results["gpu"]
+    assert np.all(np.isfinite(cpu.jac)) and np.all(np.isfinite(gpu.jac))
+    relative = np.linalg.norm(cpu.jac - gpu.jac) / max(
+        np.linalg.norm(cpu.jac), np.linalg.norm(gpu.jac)
+    )
+    assert relative < 1e-9
 
 
 def test_explicit_gpu_mirror_fixed_boundary():

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -75,6 +75,26 @@ def finite_beta_3d_eq():
     return eq
 
 
+def _lasym_finite_beta_input():
+    inp = VmecInput.from_file(DATA_DIR / "input.up_down_asymmetric_tokamak")
+    return dataclasses.replace(
+        inp,
+        ns_array=np.array([13]),
+        ftol_array=np.array([1e-10]),
+        niter_array=np.array([5000]),
+        am=np.array([1.0, -1.0]),
+        pres_scale=5000.0,
+    )
+
+
+@pytest.fixture(scope="module")
+def lasym_finite_beta_eq():
+    """Converged finite-pressure up-down-asymmetric tokamak."""
+    eq = opt.solve_equilibrium(_lasym_finite_beta_input())
+    assert eq.result.converged
+    return eq
+
+
 def test_zero_pressure_case_is_ballooning_stable(vacuum_eq):
     lam = np.asarray(stab.ballooning_lambda(vacuum_eq.state, vacuum_eq.runtime, **FAST))
     assert lam.shape == (3, 4, 1)  # default surfaces x alphas x zeta0s
@@ -178,6 +198,28 @@ def test_traceable_jdotb_and_glasser_profiles(shaped_eq):
         interior = np.asarray(profile)[2:-1]
         assert np.all(np.isfinite(interior))
         assert np.any(interior != 0.0)
+
+
+def test_glasser_profiles_match_independent_dcon_reference():
+    """Normalized D_I and D_R retain the independent DCON comparison."""
+    eq = opt.solve_equilibrium(
+        VmecInput.from_file(DATA_DIR / "input.shaped_tokamak_pressure")
+    )
+    shear = np.asarray(stab.mercier_shear_state(eq.state, eq.runtime))
+    shear2 = np.where(shear != 0.0, shear**2, 1.0)
+    d_i = -np.asarray(stab.d_merc_state(eq.state, eq.runtime)) / shear2
+    d_r = np.asarray(stab.glasser_d_r_state(eq.state, eq.runtime)) / shear2
+    use = (np.asarray(eq.wout.chi) / eq.wout.chi[-1] >= 0.1) & (shear != 0.0)
+    sample = np.flatnonzero(use)[[0, 11, 22, 33, 44]]
+    np.testing.assert_allclose(
+        d_i[sample], [-0.2512125, -0.2520461, -0.2521, -0.2521, -0.252],
+        atol=1e-3,
+    )
+    np.testing.assert_allclose(
+        d_r[sample], [-0.00246688, -0.00337077, -0.00351137,
+                      -0.00358343, -0.003687],
+        atol=1e-4,
+    )
 
 
 def test_mercier_stability_residual_is_smooth_interior_hinge(shaped_eq):
@@ -333,6 +375,59 @@ def test_traceable_dmerc_matches_wout_in_3d(finite_beta_3d_eq):
         rtol=1e-10,
         atol=1e-12,
     )
+
+
+def test_lasym_jdotb_profile_and_derivative(lasym_finite_beta_eq):
+    """The LASYM current profile retains WOUT parity and a finite JVP."""
+    eq = lasym_finite_beta_eq
+    _, jdotb, bdotb, _, _ = jax.jit(
+        stab._mercier_profiles_state
+    )(eq.state, eq.runtime)
+    np.testing.assert_allclose(jdotb, eq.wout.jdotb, rtol=1e-10, atol=1e-6)
+    np.testing.assert_allclose(bdotb, eq.wout.bdotb, rtol=1e-10, atol=1e-12)
+    vmec2000 = np.array([
+        -6616939.15535494, -5857538.49901135, -5122081.61798096,
+        -4407383.21220917, -3718146.82840926, -3061781.04575250,
+        -2445074.81564557, -1869459.08846507, -1317836.93988867,
+        -658744.51123515,
+    ])
+    np.testing.assert_allclose(
+        np.asarray(jdotb)[2:-1], vmec2000, rtol=2e-3
+    )
+
+    tangent = jax.tree.map(jnp.zeros_like, eq.state)
+    tangent = dataclasses.replace(
+        tangent,
+        R_sin=jnp.ones_like(eq.state.R_sin),
+        Z_cos=jnp.ones_like(eq.state.Z_cos),
+    )
+    _, profile = jax.jvp(
+        lambda state: stab.jdotb_state(state, eq.runtime),
+        (eq.state,),
+        (tangent,),
+    )
+    interior = np.asarray(profile)[2:-1]
+    assert np.all(np.isfinite(interior))
+    assert np.any(interior != 0.0)
+    with pytest.raises(NotImplementedError, match="independently validated"):
+        stab.d_merc_state(eq.state, eq.runtime)
+    with pytest.raises(NotImplementedError, match="independently validated"):
+        stab.glasser_d_r_state(eq.state, eq.runtime)
+    with pytest.raises(NotImplementedError, match="independently validated"):
+        opt.d_merc(eq)
+
+
+@pytest.mark.full
+def test_lasym_jdotb_has_implicit_jacobian():
+    result = opt.least_squares(
+        [(opt.jdotb_residual, 0.0, 1e-6)],
+        _lasym_finite_beta_input(),
+        max_mode=1,
+        jac="implicit",
+        max_nfev=1,
+    )
+    assert result.nfev == 1
+    assert np.all(np.isfinite(result.jac))
 
 
 def test_reductions_hard_and_smooth_max(highbeta_eq):

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -567,9 +567,14 @@ def d_merc(eq) -> jnp.ndarray:
     two surfaces and the edge carry the usual near-axis noise, so practical
     targets should penalize e.g. ``min(DMerc[2:-1], 0)``).  Accepts an
     :class:`Equilibrium` or any wout-like object.  Use traceable
-    :func:`mercier_stability_residual` with ``jac="implicit"``.
+    :func:`mercier_stability_residual` with ``jac="implicit"``.  ``lasym``
+    equilibria are rejected pending independent DCON/JMC validation.
     """
     wout = eq.wout if isinstance(eq, Equilibrium) else eq
+    if bool(getattr(wout, "lasym", False)):
+        raise NotImplementedError(
+            "DMerc is not independently validated for lasym equilibria"
+        )
     return jnp.asarray(np.asarray(wout.DMerc, dtype=float))
 
 

--- a/vmex/core/stability.py
+++ b/vmex/core/stability.py
@@ -40,8 +40,8 @@ all requested (surface, α, ζ0) field lines.
 
 Scope notes
 -----------
-- Stellarator-symmetric states only (``lasym = False``), matching the other
-  traceable objectives in :mod:`vmex.core.optimize`.
+- The current profile supports symmetric and ``lasym`` states. Mercier,
+  Glasser and ballooning stability remain stellarator-symmetric.
 - Surfaces need ``ι ≠ 0`` (the field-line parameterization divides by ι).
 - :func:`d_merc_state` is the traceable counterpart of the parity-proven
   wout calculation.  As in VMEC2000, its first two surfaces and edge are not
@@ -117,8 +117,103 @@ def _mercier_bsubs(geometry, jacobian, fields, s: Array) -> Array:
 
 
 def _mercier_current_tables(bsubu: Array, bsubv: Array, bsubs: Array, rt: SolverRuntime) -> tuple[Array, Array, Array]:
-    """Traceable symmetric jxbforce filter and ``B_s`` derivatives."""
+    """Traceable jxbforce filter and ``B_s`` derivatives."""
     trig = rt.trig
+    if bool(rt.setup.lasym):
+        mmax, nmax = int(rt.resolution.mpol) - 1, int(rt.resolution.ntor)
+        nt1, nt2, nt3 = int(trig.ntheta1), int(trig.ntheta2), int(trig.ntheta3)
+        nzeta = int(np.asarray(trig.cosnv).shape[0])
+        cosmu = jnp.asarray(trig.cosmu[:nt2, : mmax + 1])
+        sinmu = jnp.asarray(trig.sinmu[:nt2, : mmax + 1])
+        cosnv = jnp.asarray(trig.cosnv[:, : nmax + 1])
+        sinnv = jnp.asarray(trig.sinnv[:, : nmax + 1])
+        dnorm = 1.0 / (nzeta * nt3)
+        cosmui = (dnorm * cosmu).at[0].multiply(0.5).at[-1].multiply(0.5)
+        sinmui = dnorm * sinmu
+        dmult = jnp.ones(
+            (mmax + 1, nmax + 1), dtype=jnp.asarray(bsubu).dtype)
+        mnyq, nnyq = nt2 - 1, nzeta // 2
+        if 0 < mnyq <= mmax:
+            dmult = dmult.at[mnyq].multiply(0.5)
+        if 0 < nnyq <= nmax:
+            dmult = dmult.at[:, nnyq].multiply(0.5)
+        reflected_theta = np.where(
+            np.arange(nt2) == 0, 0, nt1 - np.arange(nt2))
+        reflected_zeta = (-np.arange(nzeta)) % nzeta
+        extension_theta = nt1 - np.arange(nt2, nt3)
+
+        def split(field, *, reversed_sym=False):
+            half = field[:, :nt2]
+            reflected = field[:, reflected_theta][:, :, reflected_zeta]
+            sign = -1.0 if reversed_sym else 1.0
+            return (
+                0.5 * (half + sign * reflected),
+                0.5 * (half - sign * reflected),
+            )
+
+        def analyze_lasym(field, theta, zeta):
+            return jnp.einsum(
+                "smk,kn->smn",
+                jnp.einsum("sik,im->smk", field, theta),
+                zeta,
+            ) * dmult
+
+        def synth(first, theta1, zeta1, second, theta2, zeta2):
+            return (
+                jnp.einsum("smn,im,kn->sik", first, theta1, zeta1)
+                + jnp.einsum("smn,im,kn->sik", second, theta2, zeta2)
+            )
+
+        def extend(symmetric, asymmetric):
+            full = jnp.zeros(
+                (symmetric.shape[0], nt3, nzeta), dtype=symmetric.dtype)
+            full = full.at[:, :nt2].set(symmetric + asymmetric)
+            return full.at[:, nt2:].set(
+                symmetric[:, extension_theta][:, :, reflected_zeta]
+                - asymmetric[:, extension_theta][:, :, reflected_zeta]
+            )
+
+        def filter_lasym(field):
+            symmetric, asymmetric = split(field)
+            symmetric = synth(
+                analyze_lasym(symmetric, cosmui, cosnv), cosmu, cosnv,
+                analyze_lasym(symmetric, sinmui, sinnv), sinmu, sinnv)
+            asymmetric = synth(
+                analyze_lasym(asymmetric, sinmui, cosnv), sinmu, cosnv,
+                analyze_lasym(asymmetric, cosmui, sinnv), cosmu, sinnv)
+            return extend(symmetric, asymmetric)
+
+        bsubu, bsubv = filter_lasym(bsubu), filter_lasym(bsubv)
+        bsubu, bsubv = filter_lasym(bsubu), filter_lasym(bsubv)
+        bsubs_full = bsubs.at[1:-1].set(
+            0.5 * (bsubs[1:-1] + bsubs[2:])).at[0].set(0.0)
+        symmetric, asymmetric = split(bsubs_full, reversed_sym=True)
+        symmetric_sin = (
+            analyze_lasym(symmetric, sinmui, cosnv),
+            analyze_lasym(symmetric, cosmui, sinnv),
+        )
+        asymmetric_cos = (
+            analyze_lasym(asymmetric, cosmui, cosnv),
+            analyze_lasym(asymmetric, sinmui, sinnv),
+        )
+        bsubsu = extend(
+            synth(
+                symmetric_sin[0], jnp.asarray(trig.cosmum[:nt2, :mmax + 1]), cosnv,
+                symmetric_sin[1], jnp.asarray(trig.sinmum[:nt2, :mmax + 1]), sinnv),
+            synth(
+                asymmetric_cos[0], jnp.asarray(trig.sinmum[:nt2, :mmax + 1]), cosnv,
+                asymmetric_cos[1], jnp.asarray(trig.cosmum[:nt2, :mmax + 1]), sinnv),
+        )
+        bsubsv = extend(
+            synth(
+                symmetric_sin[0], sinmu, jnp.asarray(trig.sinnvn[:, :nmax + 1]),
+                symmetric_sin[1], cosmu, jnp.asarray(trig.cosnvn[:, :nmax + 1])),
+            synth(
+                asymmetric_cos[0], cosmu, jnp.asarray(trig.sinnvn[:, :nmax + 1]),
+                asymmetric_cos[1], sinmu, jnp.asarray(trig.cosnvn[:, :nmax + 1])),
+        )
+        return bsubu, bsubv, (bsubsu, bsubsv)
+
     mmax, nmax = int(rt.resolution.mpol) - 1, int(rt.resolution.ntor)
     nt2 = int(trig.ntheta2)
     cosmu = jnp.asarray(trig.cosmu[:nt2, : mmax + 1])
@@ -167,10 +262,6 @@ def _mercier_profiles_state(
     Landreman & Jorge (2020), Eqs. (51) and (53).
     """
     setup = rt.setup
-    if bool(setup.lasym):
-        raise NotImplementedError(
-            "traceable Mercier/Glasser profiles support lasym = False only"
-        )
     s = jnp.asarray(setup.s_full)
     ns = int(s.shape[0])
     if ns < 3:
@@ -244,6 +335,8 @@ def _mercier_profiles_state(
     )
     bdotb = average_norm * jnp.einsum("sij,ij->s", sqgb2, wint)
     jdotb_full = jnp.zeros_like(s).at[1:-1].set(jdotb_mu0 / _MU0)
+    if bool(setup.lasym):
+        jdotb_full = 16.0 * jdotb_full
     jdotb_full = jdotb_full.at[0].set(2.0 * jdotb_full[1] - jdotb_full[2])
     jdotb_full = jdotb_full.at[-1].set(
         2.0 * jdotb_full[-2] - jdotb_full[-3]
@@ -276,6 +369,11 @@ def d_merc_state(state: SpectralState, rt: SolverRuntime) -> Array:
     The axis, first near-axis surface and edge retain VMEC's zero/noisy output
     convention and should be excluded from objectives (normally ``[2:-1]``).
     """
+    if bool(rt.setup.lasym):
+        raise NotImplementedError(
+            "traceable Mercier profiles are not independently validated "
+            "for lasym equilibria"
+        )
     return _mercier_profiles_state(state, rt)[0]
 
 
@@ -313,6 +411,11 @@ def glasser_d_r_state(
     As for ``DMerc``, use only validated interior surfaces (normally
     ``[2:-1]``) as optimization targets.
     """
+    if bool(rt.setup.lasym):
+        raise NotImplementedError(
+            "traceable Glasser profiles are not independently validated "
+            "for lasym equilibria"
+        )
     if shear_epsilon < 0.0:
         raise ValueError(
             f"shear_epsilon must be non-negative, got {shear_epsilon}"

--- a/vmex/core/stability.py
+++ b/vmex/core/stability.py
@@ -336,6 +336,8 @@ def _mercier_profiles_state(
     bdotb = average_norm * jnp.einsum("sij,ij->s", sqgb2, wint)
     jdotb_full = jnp.zeros_like(s).at[1:-1].set(jdotb_mu0 / _MU0)
     if bool(setup.lasym):
+        # Match WOUT's four factor-two LASYM output normalizations; see
+        # vmex.core.wout for the VMEC2000 convention and golden comparison.
         jdotb_full = 16.0 * jdotb_full
     jdotb_full = jdotb_full.at[0].set(2.0 * jdotb_full[1] - jdotb_full[2])
     jdotb_full = jdotb_full.at[-1].set(


### PR DESCRIPTION
## Summary

Extends the differentiable parallel-current objective to `LASYM = T` while
preserving a strict scientific boundary around Mercier and Glasser diagnostics
that did not pass independent validation.

## Goals

- extend differentiable stability and parallel-current objectives beyond
  stellarator symmetry only where independent references establish accuracy
- validate `D_R`/Mercier values and implicit derivatives against DCON, JMC, or
  an equivalent independent implementation
- provide CPU/GPU parity for every newly supported objective without platform
  environment routing
- fail explicitly for unvalidated physics instead of exposing plausible but
  incorrect LASYM diagnostics to optimization users

## Achieved so far

- port the LASYM `jxbforce` parity split, low-pass reconstruction, and `B_s`
  angular derivatives to pure `jax.numpy`
- enable `jdotb_state` and `jdotb_residual` for
  non-stellarator-symmetric equilibria
- retain explicit `NotImplementedError` guards for LASYM `DMerc` and `D_R`,
  including the host reporting helper
- add an ordinary five-surface symmetric DCON regression and manual CPU/GPU
  implicit-Jacobian coverage
- keep the stability module in the bounded fixture-sharing parity shard C;
  the five shards are pairwise disjoint and cover all 674 intended node IDs
  exactly once, without removing or weakening any test
- document the validated scope, limitations, DCON results, and optimizer
  behavior in the README and physics/objective/contributor docs

## Independent validation

Princeton GPEC/DCON was built from source and run on VMEC2000 `write_dcon`
output.

- symmetric shaped tokamak, `ns=51`, normalized poloidal flux `[0.1, 1)`:
  - normalized `D_I=-DMerc/S²`: maximum absolute difference `9.10e-4`
  - normalized `D_R`: maximum absolute difference `8.63e-5`
- converged up/down-asymmetric tokamak:
  - LASYM `<J.B>` agrees with live VMEC2000 within `1.52e-3` relative
  - the candidate LASYM Mercier reconstruction still differs from DCON by up
    to `1.85e-2` in normalized `D_I`
  - normalized `D_R` differs by up to `1.49e-2` and can change sign near
    marginality
  - geometry and iota agree with VMEC2000 to `2.49e-10` relative or better,
    while interior `DMerc` differs by `18.6` relative with sign disagreements

The latter result is why this PR enables only the independently validated
current objective. The geometry comparison isolates the problem to the
Mercier reconstruction rather than the equilibrium. It does not expose LASYM
`DMerc` or `D_R` as research-grade results.

## AD and device results

- full LASYM `jdotb` implicit Jacobians on explicit CPU and GPU are finite
- CPU/GPU relative Jacobian difference: `6.76e-12`
- exact manual GPU-CI test: `1 passed` in 70.64s, 4.13 GiB peak RSS
- no `JAX_PLATFORMS` or `JAX_PLATFORM_NAME` routing was used

## Validation

- `RUN_FULL=1 pytest -q tests/test_stability.py`: 17 passed
- selected optimization/implicit suite: 9 passed, 1 skipped
- rebalanced parity shard A with coverage: 94 passed, 18 skipped, 2 expected
  failures in 49.40 s
- reduced parity shard C with coverage: 415 passed, 41 skipped in 178.02 s
- `vmex/core/stability.py`: 97% covered in shard A
- `ruff check vmex tests examples benchmarks tools`: passed
- `mypy vmex`: passed (53 source files)
- strict Sphinx build: passed
- `git diff --check`: passed
- [final required CI and coverage](https://github.com/uwplasma/vmex/actions/runs/30055808081):
  passed on `5c8c11df`

Full commands, DCON mappings, rejected hypotheses, and component audits are
recorded in
[`vmex-plans@cee7b5c`](https://github.com/rogeriojorge/vmex-plans/commit/cee7b5c3148cd7360d7cb7f0dbb98ecb139c1d44).

## Remaining work to achieve the goals

- resolve the LASYM local-current (`DCurr`/`DGeod`) or `H`-normalization
  discrepancy isolated by the VMEC2000/DCON comparison
- compare the intermediate current and `jxbout` fields, then validate a
  corrected reconstruction against three-dimensional JMC or an equivalent
  independent nonaxisymmetric reference
- retain the LASYM `DMerc` and `D_R` guards until values, signs near
  marginality, and implicit gradients all pass those independent references
- only then expose LASYM `DMerc`/`D_R` optimization objectives and add their
  CPU/GPU AD-parity gates; the existing WOUT fields remain readable for file
  compatibility but are not presented as validated helper results

## Final required CI (2026-07-24)

Exact head `96a354e3` passed all **18 required jobs**, including the bounded stability shard and the ≥95% aggregate coverage gate ([run 30101419311](https://github.com/uwplasma/vmex/actions/runs/30101419311)). The five parity shards are pairwise disjoint and cover all **674** intended node IDs exactly once. There is no remaining implementation or validation work in this PR; LASYM DMerc and `D_R` remain deliberately guarded pending independent 3-D validation.

Final exact-head manual matrix passed all **34 jobs** ([run 30101437203](https://github.com/rogeriojorge/vmec_jax/actions/runs/30101437203)), including the bounded core/free-boundary split and the 89-minute mirror-beta observables shard.