### PR TITLE
Add bounded-storage profile optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,14 +141,14 @@ jobs:
   parity:
     name: Parity suite ${{ matrix.shard }} (goldens, coverage)
     runs-on: ubuntu-latest
-    # Headroom for slow shared runners: the golden solves run ~15-20 min on a
-    # healthy runner but tip over a tighter limit on a slow one (the suite
-    # content is unchanged). 35 absorbs that variance without masking a hang.
+    # The former 431-test catch-all passed in 15-20 min on healthy runners but
+    # repeatedly lost slow shared runners. Shards c/e preserve its exact test
+    # set with enough headroom to distinguish runner variance from a hang.
     timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
-        shard: [a, b, c, d]
+        shard: [a, b, c, d, e]
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -181,7 +181,7 @@ jobs:
           print("golden dir:", mod.resolve_golden_dir())
           EOF
 
-      # Four shards, each well under the 10-min budget.  The xdist dist MODE is
+      # Five bounded shards.  The xdist dist MODE is
       # chosen PER SHARD by whether its modules share an expensive fixture:
       #   * loadscope groups a whole module onto ONE worker, so module-scoped
       #     equilibrium fixtures (omnigenity qi_eq/tok_eq, bootstrap eq,
@@ -201,11 +201,12 @@ jobs:
       #   a = heaviest solver-golden modules, including all free-boundary
       #       modules so their JAX caches leave with this bounded shard instead
       #       of accumulating in the catch-all worker processes;
-      #   c = everything else, incl. omnigenity/turbulence/bootstrap/stability.
+      #   c = the slow fixture-sharing modules from the former catch-all;
+      #   e = the remaining catch-all modules.
       # Together they cover the whole non-gradient, non-example core suite once;
       # the separate mirror matrix owns tests/mirror. Therefore
       # every test file appears in exactly one shard (coverage gate combines
-      # a+b+c+d), so coverage is invariant under this reshuffle.
+      # a+b+c+d+e), so coverage is invariant under this reshuffle.
       - name: Run parity shard ${{ matrix.shard }} with coverage
         env:
           JAX_ENABLE_X64: "1"
@@ -221,6 +222,17 @@ jobs:
           B_FILES="tests/test_golden_digests.py \
                    tests/test_bootstrap.py \
                    tests/test_wout_golden.py"
+          C_FILES="tests/test_input_profiles.py \
+                   tests/test_setup.py \
+                   tests/test_profiles.py \
+                   tests/test_omnigenity.py \
+                   tests/test_implicit_multi_rhs.py \
+                   tests/test_parallel.py \
+                   tests/test_optimize_penalty.py \
+                   tests/test_lgradb.py \
+                   tests/test_package_api.py \
+                   tests/test_stability.py \
+                   tests/test_multigrid_interp.py"
           D_FILES="tests/test_optimize.py"
           if [ "${{ matrix.shard }}" = "a" ]; then
             pytest -q -n 4 --dist loadscope $A_FILES --durations=15 --cov=vmex --cov-report=term
@@ -228,8 +240,10 @@ jobs:
             pytest -q -n 4 --dist load $B_FILES --durations=15 --cov=vmex --cov-report=term
           elif [ "${{ matrix.shard }}" = "d" ]; then
             pytest -q -n 4 --dist load $D_FILES --durations=15 --cov=vmex --cov-report=term
+          elif [ "${{ matrix.shard }}" = "c" ]; then
+            pytest -q -n 4 --dist loadscope $C_FILES --durations=15 --cov=vmex --cov-report=term
           else
-            IGNORES=$(for f in $A_FILES $B_FILES $D_FILES; do echo "--ignore=$f"; done)
+            IGNORES=$(for f in $A_FILES $B_FILES $C_FILES $D_FILES; do echo "--ignore=$f"; done)
             pytest -q -n 4 --dist loadscope tests \
               --ignore=tests/mirror \
               --ignore=tests/test_implicit_grad.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
 
       - name: Combine shards and enforce the gate
         run: |
-          coverage combine coverage.parity-a coverage.parity-b coverage.parity-c coverage.parity-d coverage.gradient-a coverage.gradient-b coverage.gradient-c coverage.examples
+          coverage combine coverage.parity-a coverage.parity-b coverage.parity-c coverage.parity-d coverage.parity-e coverage.gradient-a coverage.gradient-b coverage.gradient-c coverage.examples
           # The mirror release audit reaches 95% only after appending nightly
           # fixed/free adjoint tests. The fast core artifacts intentionally
           # exclude those tests, so do not mix a partial mirror number into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
 ## [Unreleased]
 
 ### Added
+- **Bounded-storage profile optimization.** `optimize.minimize` scalarizes the
+  existing least-squares rows and uses L-BFGS-B with one matrix-free reverse
+  adjoint per gradient, avoiding dense residual Jacobians for high-resolution
+  `DMerc`, `jdotb`, and Glasser `D_R` campaigns without changing defaults.
 - **High-resolution resource profiler.**
   `benchmarks/profile_high_resolution.py` records fresh-process implicit
   Jacobian checksums and per-resolution mirror wall/RSS scaling without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
   implicit-gradient parity without JAX platform environment variables.
 
 ### Changed
+- **Measured high-mode synthesis.** Above 512 modes on accelerators and ARM
+  CPUs, equilibrium solves now repack signed helical modes into toroidal FFTs
+  plus a short poloidal contraction; smaller decks retain the dense lane
+  after routine M4 timing. The exact supplied HSX run on an Apple M4 falls
+  from
+  676.46 s / 3.896 GiB to
+  206.56 s / 1.634 GiB without changing convergence or WOUT parity. The
+  dense real contraction remains the x86 CPU default after it beat the FFT
+  path 413.24 s to 570.47 s on the office Xeon; explicit `use_fft` wins.
+  The one-shot CLI releases completed radial-stage executables; library
+  calls retain them by default. Implicit AD keeps the established real
+  contraction to avoid complex batched tangent storage.
+- **Direction-adaptive implicit Jacobians.** Scalar least-squares residuals
+  now use one matrix-free reverse adjoint by default, avoiding the dense
+  high-mode block assembly; vector residuals retain the exact block path.
+  Automatic probe chunks are capped by the conservative square-root width.
 - **Mirror-specific device policy.** Fixed/free-boundary mirror solves and
   beta scans now accept the common `device=` contract and default to CPU for
   their measured host-SciPy/JAX callback workload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
 ## [Unreleased]
 
 ### Added
+- **High-resolution resource profiler.**
+  `benchmarks/profile_high_resolution.py` records fresh-process implicit
+  Jacobian checksums and per-resolution mirror wall/RSS scaling without
+  hardware-selection environment variables.
 - **Explicit device selection.** Forward, free-boundary, implicit, and CLI
   solve paths accept public CPU/GPU/JAX placement controls: omitted or
   `"auto"` retains VMEX's measured policy, `None` follows JAX, and explicit

--- a/README.md
+++ b/README.md
@@ -433,6 +433,23 @@ objective at a stiff weight:
 - lower the aspect ratio to 4.8 at fixed iota;
 - push the Mercier criterion `DMerc` toward stability at ⟨β⟩ ≈ 1.25%.
 
+High-resolution vector profiles can use `opt.minimize(...)` with the same
+`(objective, target, weight)` terms. It minimizes the identical squared
+residual cost with L-BFGS-B and one matrix-free reverse adjoint per gradient,
+avoiding the dense residual Jacobian used by Gauss–Newton:
+
+```python
+result = opt.minimize(
+    [(opt.mercier_stability_residual, 0.0, 1.0),
+     (opt.glasser_stability_residual, 0.0, 1.0),
+     (opt.jdotb_residual, 0.0, 1e-6)],
+    inp, max_mode=5, bounds=bounds, options={"maxiter": 100},
+)
+```
+
+This bounded-storage optimizer is opt-in because its quasi-Newton steps differ
+from `least_squares`; existing defaults and objective minima are unchanged.
+
 The first four use the implicit adjoint (`jac="implicit"`). The published
 `DMerc` showcase deliberately preserves its legacy host-side reporting lane
 and finite-difference baseline at `max_mode` 2. New campaigns can instead use

--- a/README.md
+++ b/README.md
@@ -164,15 +164,33 @@ CPU, single thread; `benchmarks/baseline.json`; reproduce with
   858-mode HSX case was instead 3.44× slower than CPU. The measured device
   policy therefore keeps both small-work and very-high-mode stages on CPU,
   while explicit placement always wins.
-- **Memory** — the bundled warm cases peak at 0.6–3.3 GB, but that is not a
-  high-resolution upper bound. The supplied `ns=101`, `mpol=18`, `ntor=24`
-  HSX deck used 3.90 GiB in a fresh CPU VMEX process versus 380 MiB in VMEC++
-  and 265 MiB in one-radial-process VMEC2000.
+- **High resolution** — on Apple Silicon, separable toroidal FFT synthesis
+  cuts the supplied
+  `ns=101`, `mpol=18`, `ntor=24` HSX deck from 676.46 s / 3.90 GiB to
+  206.56 s / 1.63 GiB in a fresh CPU VMEX CLI process; the CLI releases
+  completed radial-stage executables while the reusable library API retains
+  them by default. Convergence and VMEC2000 parity are unchanged. That is
+  faster than the measured
+  one-thread VMEC++ control (449.79 s), though ten-thread VMEC++ remains
+  faster and smaller (92.03 s / 380 MiB); one-radial-process VMEC2000
+  took 1154.82 s / 265 MiB.
+  The measured default selects this kernel only above 512 modes on ARM CPUs
+  and accelerators. Smaller problems retain the established dense lane (FFT
+  was slower on three routine M4 decks and only marginally faster warm at
+  128 modes); x86 CPUs also remain dense because FFT was slower.
+  Dense synthesis with CLI stage-cache release took 413.24 s /
+  4.04 GiB on the office Xeon, versus 570.47 s for FFT and the previous
+  cache-retaining dense baseline of 426.94 s / 6.52 GiB (3.2% faster and
+  38.0% lower peak RSS). `use_fft=True` or `False` remains an explicit
+  library override.
   Column chunking bounds simultaneous design probes, while the implicit
   block factors still scale as `O(ns * m_block²)`; an `ns=201` one-Jacobian
-  measurement used 4.11 GiB. A candidate chunk schedule that raised RSS by
-  36.7% was rejected, and the lower-memory GMRES path was over 5× slower
-  without finishing. Reducing the block-factor storage remains open work.
+  measurement used 4.11 GiB. The implicit callback deliberately retains the
+  real dense transform: complex FFT tangents exceeded 10 GiB. A candidate
+  chunk schedule that raised RSS by 36.7% was rejected, and the lower-memory
+  GMRES path was over 5× slower without finishing. Scalar objectives now
+  default to one matrix-free reverse adjoint and avoid that block assembly;
+  reducing block storage for high-mode vector objectives remains open work.
 
 ## Features
 
@@ -388,8 +406,8 @@ These campaigns need implicit gradients. Finite differences stall at the
 axisymmetric seed of the QH target (a saddle point) and land in a worse basin
 for QP. Three measured optimizations keep each campaign in the minutes range:
 
-- the residual Jacobian uses a block-tridiagonal factorization of the force
-  linearization (33× faster than per-dof GMRES);
+- scalar residuals use one reverse adjoint; vector residual Jacobians use a
+  block-tridiagonal factorization (33× faster than per-dof GMRES);
 - each trial equilibrium starts from a first-order perturbation prediction
   (3.7× fewer solver iterations);
 - a converged-state memo avoids re-solving the point the residual just

--- a/benchmarks/profile_high_resolution.py
+++ b/benchmarks/profile_high_resolution.py
@@ -33,20 +33,25 @@ def _implicit(args) -> dict:
     if args.input is None:
         raise ValueError("--input is required for the implicit case")
     inp = VmecInput.from_file(args.input)
-    result = opt.least_squares(
-        [(opt.aspect_ratio, args.aspect_target, 1.0)],
-        inp,
-        max_mode=args.max_mode,
-        jac="implicit",
-        jac_solver=args.jac_solver,
-        jac_chunk_size=args.jac_chunk,
-        max_nfev=1,
-        ftol=1e-9,
-        xtol=1e-10,
-        device=args.device,
-    )
+    terms = ([(opt.aspect_ratio, args.aspect_target, 1.0)]
+             if args.implicit_objective == "aspect" else
+             [(opt.mercier_stability_residual, 0.0, 1.0),
+              (opt.glasser_stability_residual, 0.0, 1.0),
+              (opt.jdotb_residual, 0.0, 1.0e-6)])
+    if args.optimizer == "minimize":
+        x0 = opt.pack_boundary(inp, args.max_mode)
+        result = opt.minimize(
+            terms, inp, max_mode=args.max_mode, device=args.device,
+            bounds=list(zip(x0, x0)))
+    else:
+        result = opt.least_squares(
+            terms, inp, max_mode=args.max_mode, jac="implicit",
+            jac_solver=args.jac_solver, jac_chunk_size=args.jac_chunk,
+            max_nfev=1, ftol=1e-9, xtol=1e-10, device=args.device)
     jac = np.asarray(result.jac, dtype=np.float64)
     return {
+        "optimizer": args.optimizer,
+        "objective": args.implicit_objective,
         "jac_solver": args.jac_solver,
         "ns_array": np.asarray(inp.ns_array).tolist(),
         "mpol": int(inp.mpol),
@@ -132,6 +137,14 @@ def main() -> None:
     parser.add_argument("--input")
     parser.add_argument("--max-mode", type=int, default=5)
     parser.add_argument("--aspect-target", type=float, default=8.0)
+    parser.add_argument(
+        "--implicit-objective", choices=("aspect", "stability"),
+        default="aspect",
+    )
+    parser.add_argument(
+        "--optimizer", choices=("least-squares", "minimize"),
+        default="least-squares",
+    )
     parser.add_argument(
         "--jac-solver", choices=("auto", "block", "gmres", "reverse"),
         default="auto",

--- a/benchmarks/profile_high_resolution.py
+++ b/benchmarks/profile_high_resolution.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+"""Fresh-process resource profiles for implicit AD and mirror scaling."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import resource
+import sys
+import time
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+
+def _peak_rss_gib() -> float:
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    peak_bytes = peak if platform.system() == "Darwin" else peak * 1024
+    return peak_bytes / 2**30
+
+
+def _implicit(args) -> dict:
+    from vmex.core import optimize as opt
+    from vmex.core.input import VmecInput
+
+    if args.input is None:
+        raise ValueError("--input is required for the implicit case")
+    inp = VmecInput.from_file(args.input)
+    result = opt.least_squares(
+        [(opt.aspect_ratio, args.aspect_target, 1.0)],
+        inp,
+        max_mode=args.max_mode,
+        jac="implicit",
+        jac_solver=args.jac_solver,
+        jac_chunk_size=args.jac_chunk,
+        max_nfev=1,
+        ftol=1e-9,
+        xtol=1e-10,
+        device=args.device,
+    )
+    jac = np.asarray(result.jac, dtype=np.float64)
+    return {
+        "ns_array": np.asarray(inp.ns_array).tolist(),
+        "mpol": int(inp.mpol),
+        "ntor": int(inp.ntor),
+        "jac_shape": list(jac.shape),
+        "jac_finite": bool(np.all(np.isfinite(jac))),
+        "jac_norm": float(np.linalg.norm(jac)),
+        "jac_sha256": hashlib.sha256(jac.tobytes()).hexdigest(),
+        "solve_stats": result.solve_stats,
+    }
+
+
+def _external_mirror_field(points):
+    points = jnp.asarray(points)
+    x, y, z = jnp.moveaxis(points, -1, 0)
+    curvature = 0.02
+    return jnp.stack(
+        (-curvature * x * z,
+         -curvature * y * z,
+         0.08 + curvature * (z**2 - 0.5 * (x**2 + y**2))),
+        axis=-1,
+    )
+
+
+def _mirror(args) -> dict:
+    from vmex.mirror import (
+        MirrorBoundary,
+        MirrorConfig,
+        MirrorResolution,
+        SplineMirrorDiscretization,
+        solve_beta_scan,
+    )
+
+    config = MirrorConfig(
+        resolution=MirrorResolution(ns=args.ns, mpol=0, nxi=args.nxi),
+        z_min=-0.8,
+        z_max=0.8,
+        ftol=1e-12,
+        max_iterations=args.max_iterations,
+    )
+    source_grid = config.build_grid()
+    discretization = SplineMirrorDiscretization.build_cgl(
+        config, elements=args.elements)
+    grid = discretization.grid
+    on_axis = 0.08 + 0.02 * jnp.asarray(grid.z) ** 2
+    center = grid.nxi // 2
+    flux = 0.5 * on_axis[center] * 0.25**2
+    boundary = discretization.fit_boundary(
+        MirrorBoundary.from_axis_field(flux, on_axis, grid), source_grid)
+    betas = jnp.asarray([float(value) for value in args.betas.split(",")])
+    results = solve_beta_scan(
+        boundary,
+        discretization,
+        config,
+        _external_mirror_field,
+        betas,
+        axial_flux_derivative=flux,
+        reference_field=float(on_axis[center]),
+        exterior_ntheta=args.exterior_ntheta,
+        exterior_order=8,
+        device=args.device,
+    )
+    return {
+        "resolution": {
+            "ns": args.ns,
+            "nxi": args.nxi,
+            "elements": args.elements,
+            "exterior_ntheta": args.exterior_ntheta,
+        },
+        "betas": np.asarray(betas).tolist(),
+        "converged": [bool(result.converged) for result in results],
+        "iterations": [int(result.iterations) for result in results],
+        "variational_max": [
+            float(result.variational_max) for result in results],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("case", choices=("implicit", "mirror"))
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--out")
+    parser.add_argument("--input")
+    parser.add_argument("--max-mode", type=int, default=5)
+    parser.add_argument("--aspect-target", type=float, default=8.0)
+    parser.add_argument("--jac-solver", choices=("block", "gmres"),
+                        default="block")
+    parser.add_argument("--jac-chunk", default="auto")
+    parser.add_argument("--ns", type=int, default=5)
+    parser.add_argument("--nxi", type=int, default=7)
+    parser.add_argument("--elements", type=int, default=4)
+    parser.add_argument("--exterior-ntheta", type=int, default=8)
+    parser.add_argument("--betas", default="0,0.1")
+    parser.add_argument("--max-iterations", type=int, default=500)
+    args = parser.parse_args()
+    if args.device == "none":
+        args.device = None
+    if args.jac_chunk != "auto":
+        args.jac_chunk = int(args.jac_chunk)
+
+    started = time.perf_counter()
+    payload = (_implicit(args) if args.case == "implicit" else _mirror(args))
+    record = {
+        "case": args.case,
+        "device": None if args.device is None else str(args.device),
+        "jax": jax.__version__,
+        "devices": [str(device) for device in jax.devices()],
+        "wall_s": time.perf_counter() - started,
+        "peak_rss_gib": _peak_rss_gib(),
+        **payload,
+    }
+    text = json.dumps(record, indent=2, sort_keys=True)
+    print(text, flush=True)
+    if args.out:
+        Path(args.out).write_text(text + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/profile_high_resolution.py
+++ b/benchmarks/profile_high_resolution.py
@@ -47,6 +47,7 @@ def _implicit(args) -> dict:
     )
     jac = np.asarray(result.jac, dtype=np.float64)
     return {
+        "jac_solver": args.jac_solver,
         "ns_array": np.asarray(inp.ns_array).tolist(),
         "mpol": int(inp.mpol),
         "ntor": int(inp.ntor),
@@ -131,8 +132,10 @@ def main() -> None:
     parser.add_argument("--input")
     parser.add_argument("--max-mode", type=int, default=5)
     parser.add_argument("--aspect-target", type=float, default=8.0)
-    parser.add_argument("--jac-solver", choices=("block", "gmres"),
-                        default="block")
+    parser.add_argument(
+        "--jac-solver", choices=("auto", "block", "gmres", "reverse"),
+        default="auto",
+    )
     parser.add_argument("--jac-chunk", default="auto")
     parser.add_argument("--ns", type=int, default=5)
     parser.add_argument("--nxi", type=int, default=7)

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -493,9 +493,11 @@ Forward-mode Jacobians for least squares (block-tridiagonal)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The adjoint above is the right tool for *one* scalar objective and many
-parameters. A least-squares optimizer needs the opposite object — the full
-residual Jacobian over all boundary dofs — which is computed in **forward**
-mode: per dof tangent :math:`t_j`, the state response is
+parameters. ``jac_solver="auto"`` therefore uses that reverse path for a
+scalar least-squares residual: one matrix-free solve, with no dense angular
+block assembly. Vector residuals need the full Jacobian over all boundary
+dofs, which the automatic policy computes in **forward** mode. Per dof
+tangent :math:`t_j`, the state response is
 
 .. math::
 
@@ -503,7 +505,7 @@ mode: per dof tangent :math:`t_j`, the state response is
           \frac{\partial F}{\partial p}\, t_j ,
 
 one linear solve per dof. Rather than running an independent GMRES per
-column, the default path (``jac_solver="block"``) exploits a structural
+column, the vector-residual path (``jac_solver="block"``) exploits a structural
 fact: in the **raw** force formulation the radial coupling of
 :math:`\partial F/\partial z` is exactly nearest-neighbor (the
 finite-difference stencil in :math:`s`), so the operator is *exactly*

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -52,11 +52,44 @@ Two gradient modes share the same term list.  ``jac=None`` uses scipy
 freedom per Jacobian, works with *every* objective.  ``jac="implicit"``
 computes the exact residual Jacobian by implicit differentiation (one
 amortized linear-algebra pass instead of ~2N solves) and requires traceable
-terms and a stellarator-symmetric fixed-boundary problem — the
+terms and a fixed-boundary problem — the
 compatibility table is in :doc:`objectives`.  ``current_dofs=k``
 additionally frees the first ``k`` current-profile (``AC``) coefficients
 plus ``CURTOR`` in either mode — the dof set of the self-consistent
 bootstrap objective.
+
+Bounded-storage profile optimization
+------------------------------------
+
+Vector profile objectives normally require their complete residual Jacobian
+for a Gauss--Newton step.  At high Fourier resolution those radial
+block-tridiagonal factors can dominate memory.  :func:`~vmex.core.optimize.minimize`
+instead minimizes the identical scalar cost
+
+.. math::
+
+   \Phi(p) = \frac{1}{2}\sum_i r_i(p)^2
+
+with scipy L-BFGS-B.  Reverse implicit differentiation evaluates
+``grad(Phi)`` with one matrix-free adjoint, independent of the number of
+profile samples, and does not form the dense residual Jacobian:
+
+.. code-block:: python
+
+   result = opt.minimize(
+       [(opt.mercier_stability_residual, 0.0, 1.0),
+        (opt.glasser_stability_residual, 0.0, 1.0),
+        (opt.jdotb_residual, 0.0, 1e-6)],
+       inp, max_mode=5,
+       bounds=bounds,
+       options={"maxiter": 100})
+
+This is opt-in because it changes the step model from Gauss--Newton
+trust-region to limited-memory quasi-Newton, although the objective and its
+unconstrained minimizers are unchanged.  Existing
+:func:`~vmex.core.optimize.least_squares` behavior is unaffected.  Plain
+state hot restarts remain enabled; the perturbation warm start is unavailable
+because it would require the forward state-response columns this path avoids.
 
 Single-call ESS optimization (the recommended pattern)
 ------------------------------------------------------

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -206,8 +206,12 @@ default:
    Reproduce the campaign numbers with the two
    ``examples/optimization/QA_optimization*.py`` scripts.
 
-- **Block-tridiagonal Jacobian factorization** (``jac_solver="block"``,
-  default).  The raw force Jacobian ``dF/dz`` is *exactly*
+- **Direction-adaptive Jacobians** (``jac_solver="auto"``, default). A scalar
+  residual uses one matrix-free reverse adjoint and never assembles dense
+  angular blocks. Vector residuals use the block path below; ``"reverse"``
+  and ``"block"`` remain explicit controls.
+- **Block-tridiagonal Jacobian factorization** (``jac_solver="block"``).
+  The raw force Jacobian ``dF/dz`` is *exactly*
   block-tridiagonal in radius (nearest-neighbor coupling; verified to
   1e-14), so ``ns`` dense ``(3mn, 3mn)`` blocks are assembled with
   3-colored ``jax.jvp`` probes — a cost independent of the dof count —
@@ -231,10 +235,10 @@ default:
   hot restart hit a Jacobian-sign failure.  ``"state"`` (plain hot restart)
   and ``None`` are the fallbacks; all three converge to identical fixed
   points.
-- **Memory** stays bounded by column chunking
-  (``jac_chunk_size="auto"``, the same knob DESC exposes): peak Jacobian
-  memory is ``m0 + m1*chunk`` instead of scaling with the dof count, and
-  the chunked columns are identical to float64 round-off.
+- **Memory** stays bounded by column chunking. ``jac_chunk_size="auto"`` caps
+  SOLVAX's device-aware choice by the square-root width, so accelerator
+  capacity cannot accidentally request one full probe ``vmap``. Chunked
+  columns are identical to float64 round-off.
 - **Krylov recycling** (``recycle=True``) carries a GCROT deflation space
   across the per-dof solves.  It is **off by default for a measured
   reason**: solvax v0.1's FIFO recycle space *slows* warm-started columns

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -362,6 +362,41 @@ the baseline) but did not finish one Jacobian in 30m08s, over five times the
 block wall. A lower-storage factorization or a measured resolution-aware
 solver policy is still needed.
 
+``benchmarks/profile_high_resolution.py`` makes that gate reusable on any
+input without hardware-selection environment variables:
+
+.. code-block:: bash
+
+   python benchmarks/profile_high_resolution.py implicit \
+       --input /path/to/input.HSX_QHS_vacuum_ns201 \
+       --max-mode 5 --device cpu --out implicit.json
+
+It records the input resolution, devices, wall time, peak RSS, solve count,
+and the complete Jacobian's finiteness, norm, and SHA-256.  On the case above,
+the unmodified float64 path repeated in 355.25 s with the established
+``74.70287727265259`` norm and checksum.  Three dtype-only lower-storage
+factorizations were rejected: demanding HSX Jacobians became non-finite, or a
+regularized approximate factor took over twice the baseline wall time.
+Low precision is therefore not a safe drop-in replacement; future work must
+change the representation or measured solver policy while preserving this
+gate.
+
+The same profiler isolates one free-boundary mirror resolution per process:
+
+.. code-block:: bash
+
+   python benchmarks/profile_high_resolution.py mirror \
+       --ns 5 --nxi 7 --elements 4 --exterior-ntheta 8 \
+       --betas 0,0.1,0.5 --device cpu --out mirror-coarse.json
+   python benchmarks/profile_high_resolution.py mirror \
+       --ns 9 --nxi 17 --elements 9 --exterior-ntheta 16 \
+       --betas 0,0.1,0.5 --device cpu --out mirror-fine.json
+
+This separates intrinsic fine-grid storage from cross-resolution process
+history.  The combined three-resolution nightly node passes, but takes about
+85 minutes and peaked at 11.04 GiB on the office host; it remains
+manual/nightly coverage rather than a required PR check.
+
 The existing optimization controls remain useful within that limitation:
 
 - The optimization Jacobian is column-chunked (``jac_chunk_size="auto"``, the

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -374,12 +374,19 @@ input without hardware-selection environment variables:
 It records the input resolution, devices, wall time, peak RSS, solve count,
 and the complete Jacobian's finiteness, norm, and SHA-256.  On the case above,
 the unmodified float64 path repeated in 355.25 s with the established
-``74.70287727265259`` norm and checksum.  Three dtype-only lower-storage
-factorizations were rejected: demanding HSX Jacobians became non-finite, or a
-regularized approximate factor took over twice the baseline wall time.
+``74.70287727265259`` norm and checksum.  Four small lower-storage candidates
+were rejected: float32 bands/factors and row scaling made this demanding HSX
+Jacobian non-finite, while a regularized scaled factor took over twice the
+baseline wall time.
 Low precision is therefore not a safe drop-in replacement; future work must
 change the representation or measured solver policy while preserving this
 gate.
+
+A fifth experiment streamed the three radial probe colors instead of retaining
+their complete response tensor.  It preserved the norm and checksum and reduced
+wall time to 284.69 s, but increased peak RSS by 8.6 % to 4.833 GiB as the
+allocator retained loop intermediates into factorization.  It was also rejected:
+lower storage must be demonstrated end to end, not inferred from one live array.
 
 The same profiler isolates one free-boundary mirror resolution per process:
 
@@ -392,10 +399,33 @@ The same profiler isolates one free-boundary mirror resolution per process:
        --ns 9 --nxi 17 --elements 9 --exterior-ntheta 16 \
        --betas 0,0.1,0.5 --device cpu --out mirror-fine.json
 
-This separates intrinsic fine-grid storage from cross-resolution process
-history.  The combined three-resolution nightly node passes, but takes about
-85 minutes and peaked at 11.04 GiB on the office host; it remains
-manual/nightly coverage rather than a required PR check.
+Fresh office CPU processes gave:
+
+.. list-table::
+   :header-rows: 1
+
+   * - ``(ns, nxi, elements, ntheta)``
+     - iterations by beta
+     - wall (s)
+     - peak RSS (GiB)
+   * - ``(5, 7, 4, 8)``
+     - 5 / 8 / 10
+     - 16.67
+     - 2.359
+   * - ``(7, 13, 7, 12)``
+     - 42 / 43 / 44
+     - 1457.30
+     - 4.506
+   * - ``(9, 17, 9, 16)``
+     - 42 / 44 / 45
+     - 3351.74
+     - 8.085
+
+All beta points converged with variational maxima below ``2e-13``.  Isolating
+the fine process lowers the previous combined 11.04 GiB peak by 26.8 %, but
+its 8.085 GiB peak is still 3.43 times the coarse result.  Allocator history
+therefore explains part, not all, of the scaling gap.  This 56-minute fine
+case remains manual/nightly coverage rather than a required PR check.
 
 The existing optimization controls remain useful within that limitation:
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -327,17 +327,21 @@ Peak resident memory is 0.6–1.5 GB on most bundled rows and about 3.3 GB on
 the largest bundled multigrid deck, but those figures are not a
 high-resolution upper bound. The spectral state is small; compiled transform
 graphs and implicit block factors are not. On the supplied HSX
-``ns=101, mpol=18, ntor=24`` deck, a fresh Apple-M4 CPU VMEX process took
-676.46 s and 3.896 GiB maximum RSS. VMEC++ with ten threads took 92.03 s and
-380.0 MiB on the same host; one-radial-process VMEC2000 took 1154.82 s and
-265.0 MiB. A one-thread VMEC++ control took 449.79 s and 445.1 MiB, so its
-advantage is not only thread parallelism: it remained 1.50x faster than VMEX
-and used 8.96x less RSS. VMEX was 1.71x faster than this VMEC2000 run but used
-15.05x its RSS. The VMEX state nevertheless matches VMEC2000 to near
-floating-point accuracy, so this is a performance/storage gap rather than a
-convergence or equilibrium-accuracy failure.
+``ns=101, mpol=18, ntor=24`` deck, replacing the full mode-stacked synthesis
+with a separable toroidal FFT reduced a fresh Apple-M4 CPU VMEX run from
+676.46 s / 3.896 GiB to 206.56 s / 1.634 GiB. The final 2737-iteration path,
+residuals, and energy are unchanged.
 
-Explicit CPU and GPU runs of the same deck on the office host converged in
+VMEC++ with ten threads took 92.03 s and 380.0 MiB on the same host;
+one-radial-process VMEC2000 took 1154.82 s and 265.0 MiB. A one-thread
+VMEC++ control took 449.79 s and 445.1 MiB. VMEX is therefore now 2.18x
+faster than one-thread VMEC++ and 5.61x faster than VMEC2000 on this deck,
+while ten-thread VMEC++ remains 2.24x faster and uses about one quarter the
+RSS. The remaining storage gap is substantive even though the VMEX state
+matches VMEC2000 to near floating-point accuracy.
+
+Before the separable-transform change, explicit CPU and GPU runs of the same
+deck on the office host converged in
 the same 2737 final-stage iterations.  With the GPU persistent cache already
 populated, CPU took 426.94 s and 6.52 GiB host RSS; the RTX A4000 took
 1468.07 s and 5.40 GiB.  CPU was therefore 3.44x faster, while cached GPU
@@ -346,7 +350,41 @@ were ``5.20e-11`` for ``rmnc``, ``3.27e-10`` for ``zmns``, ``9.76e-11`` for
 ``bmnc``, and ``6.54e-11`` for core iota.  An empty-cache GPU process took
 1596.01 s and 6.98 GiB.  These measurements show both that explicit GPU
 placement is correct and that it is not automatically faster for a
-high-mode CLI run.
+high-mode CLI run. This is a pre-change baseline; the updated CPU/GPU result
+must be recorded before changing the measured automatic device cutoff.
+
+The new synthesis repacks the signed helical coefficients into separable
+theta/zeta blocks, evaluates zeta with ``jax.numpy.fft.irfft``, and
+performs a short real poloidal contraction. Undersampled toroidal grids fall
+back to the established dense DFT. The implicit callback also retains the
+dense-real path: a direct FFT tangent expanded complex Jacobian probe batches
+past 10 GiB RSS, and compiling fast primal plus dense tangent representations
+in one process exceeded 7 GiB. Fixed-boundary
+:func:`~vmex.core.solver.solve` and
+:func:`~vmex.core.multigrid.solve_multigrid` select separate FFT lanes only
+above 512 modes on accelerators and ARM CPUs. Smaller problems retain the
+dense-real lane: on the M4, FFT was 38--88% slower warm on three 5--8-mode
+routine decks and its 8% warm win at 128 modes came with a 13% first-solve
+loss. At 162 modes, both lanes reached the supplied 10,000-iteration cap with
+near-zero residuals, but dense was 4.3% faster (279.55 s versus 291.69 s).
+x86 CPUs also remain dense. This is a measured default: on the office Xeon
+the exact FFT run took 570.47 s,
+while dense synthesis with stage-cache release took 413.24 s / 4.04 GiB
+(3.2% faster and 38.0% lower peak RSS than the prior cache-retaining dense
+baseline of 426.94 s / 6.52 GiB).
+Explicit ``use_fft=True`` or ``use_fft=False`` always wins. Implicit AD
+retains the dense lanes and their existing checksum/storage gate. The shared
+runtime pytree is unchanged.
+
+The one-shot fixed-boundary CLI additionally calls JAX's public
+``clear_caches`` between distinct radial grids. This clears in-memory
+compilation/staging entries while VMEX's persistent on-disk compilation cache
+remains available. On the exact deck it changed 205.97 s / 2.970 GiB to
+206.56 s / 1.634 GiB (0.3% wall-time cost, 45.0% lower peak RSS) with
+identical geometry, iteration count, residuals, and energy. Library
+:func:`~vmex.core.multigrid.solve_multigrid` retains warm stage executables by
+default for scans and repeated solves; ``release_stage_cache=True`` opts into
+the one-shot policy.
 
 Column chunking bounds simultaneous design-variable probes, not the dominant
 dense ``O(ns * m_block**2)`` block bands and factors. On an exact
@@ -429,8 +467,11 @@ case remains manual/nightly coverage rather than a required PR check.
 
 The existing optimization controls remain useful within that limitation:
 
+- Scalar objectives default to one matrix-free reverse adjoint
+  (``jac_solver="auto"``), avoiding dense block assembly entirely.
 - The optimization Jacobian is column-chunked (``jac_chunk_size="auto"``, the
-  same knob DESC exposes), limiting the simultaneous probe batch.
+  device-aware choice conservatively capped at a square-root width), limiting
+  the simultaneous probe batch for vector objectives.
 - Factoring the residual and field pipelines into reusable compiled
   sub-computations cut the implicit-gradient compile ~20% in memory and ~21% in
   wall time, bit-identically (R16).

--- a/tests/test_cli_device.py
+++ b/tests/test_cli_device.py
@@ -36,6 +36,7 @@ def test_fixed_boundary_cli_forwards_device(monkeypatch, tmp_path, choice, expec
     monkeypatch.setattr(multigrid, "solve_multigrid", fake_solve)
     assert cli._solve_input_file(args, tmp_path / "input.case", tmp_path, emit=print) == 0
     assert seen["device"] == expected
+    assert seen["release_stage_cache"] is True
 
 
 def test_free_boundary_cli_forwards_device(monkeypatch, tmp_path):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -15,7 +15,7 @@ import numpy as np
 import pytest
 
 from vmex.core import device as dev
-from vmex.core import freeboundary, multigrid
+from vmex.core import freeboundary, multigrid, solver
 from vmex.core.fourier import Resolution
 
 
@@ -89,6 +89,30 @@ def test_auto_cpu_recommendation_is_a_noop_on_cpu(monkeypatch):
     # CPU-recommended + default backend already CPU -> nothing to place.
     if jax.default_backend() == "cpu":
         assert dev.resolve_device(dev.AUTO, _res(ns=11, mpol=6, ntor=0)) is None
+
+
+def test_synthesis_policy_uses_measured_hardware_defaults(monkeypatch):
+    resolution = _res(ns=101, mpol=18, ntor=24, nfp=4)
+    target = SimpleNamespace(platform="cpu")
+    monkeypatch.setattr(solver, "_placement_device", lambda *_: target)
+    monkeypatch.setattr(solver.platform, "machine", lambda: "x86_64")
+    assert not solver._resolve_use_fft(None, "cpu", resolution)
+    monkeypatch.setattr(solver.platform, "machine", lambda: "arm64")
+    assert solver._resolve_use_fft(None, "cpu", resolution)
+    target.platform = "gpu"
+    assert solver._resolve_use_fft(None, "gpu", resolution)
+    assert not solver._resolve_use_fft(
+        None, "gpu", _res(ns=50, mpol=8, ntor=8, nfp=2)
+    )
+    assert solver._resolve_use_fft(False, "gpu", resolution) is False
+    assert solver._resolve_use_fft(True, "cpu", resolution) is True
+
+
+def test_synthesis_policy_respects_active_default_device(monkeypatch):
+    monkeypatch.setattr(solver.platform, "machine", lambda: "x86_64")
+    resolution = _res(ns=101, mpol=18, ntor=24, nfp=4)
+    with jax.default_device(jax.devices("cpu")[0]):
+        assert not solver._resolve_use_fft(None, None, resolution)
 
 
 def test_auto_gpu_recommendation_without_accelerator(monkeypatch):

--- a/tests/test_fourier_transforms.py
+++ b/tests/test_fourier_transforms.py
@@ -12,6 +12,7 @@ during the port:
 from __future__ import annotations
 
 import jax
+import jax.numpy as jnp
 
 jax.config.update("jax_enable_x64", True)
 
@@ -25,6 +26,7 @@ from vmex.core.nyquist import (
     wrout_sin_coeffs,
 )
 from vmex.core.transforms import (
+    _fourier_to_real_fft,
     fourier_to_real,
     real_to_fourier,
     symforce_split,
@@ -141,6 +143,59 @@ def test_lasym_nestor_surface_analysis_preserves_mode_signs():
     np.testing.assert_allclose(
         actual_sin, sin_coefficients, rtol=0.0, atol=roundtrip_atol
     )
+
+
+def test_synthesis_accepts_nyquist_extended_trig_tables():
+    """WOUT evaluates main-mode coefficients on Nyquist-extended grids."""
+    base = Resolution(
+        mpol=6, ntor=3, ntheta=22, nzeta=16, nfp=3, lasym=False, ns=NS
+    )
+    extended = Resolution(
+        mpol=9, ntor=8, ntheta=22, nzeta=16, nfp=3, lasym=False, ns=NS
+    )
+    modes = mode_table(base.mpol, base.ntor)
+    rng = np.random.default_rng(4)
+    coefficient_cos = rng.standard_normal((NS, modes.mnmax))
+    coefficient_sin = rng.standard_normal((NS, modes.mnmax))
+    kwargs = dict(modes=modes, derivatives=("value", "dtheta", "dzeta"))
+    actual = _fourier_to_real_fft(
+        coefficient_cos, coefficient_sin, trig=trig_tables(extended), **kwargs
+    )
+    expected = fourier_to_real(
+        coefficient_cos, coefficient_sin, trig=trig_tables(base), **kwargs
+    )
+    for left, right in zip(actual, expected):
+        np.testing.assert_allclose(left, right, rtol=RTOL, atol=1e-12)
+
+
+def test_fft_and_dense_synthesis_match_through_ad():
+    """The fast primal and lower-memory implicit path have matching AD."""
+    resolution = Resolution(
+        mpol=4, ntor=2, ntheta=16, nzeta=12, nfp=3, lasym=True, ns=NS
+    )
+    modes = mode_table(resolution.mpol, resolution.ntor)
+    trig = trig_tables(resolution)
+    rng = np.random.default_rng(5)
+    shape = (NS, modes.mnmax)
+    primals = tuple(jnp.asarray(rng.standard_normal(shape)) for _ in range(2))
+    tangents = tuple(jnp.asarray(rng.standard_normal(shape)) for _ in range(2))
+
+    def synthesize(c, s, *, use_fft):
+        transform = _fourier_to_real_fft if use_fft else fourier_to_real
+        return transform(c, s, modes=modes, trig=trig)
+
+    fast = lambda c, s: synthesize(c, s, use_fft=True)  # noqa: E731
+    dense = lambda c, s: synthesize(c, s, use_fft=False)  # noqa: E731
+    values, tangent = jax.jvp(fast, primals, tangents)
+    dense_values, dense_tangent = jax.jvp(dense, primals, tangents)
+    for left, right in zip(values + tangent, dense_values + dense_tangent):
+        np.testing.assert_allclose(left, right, rtol=2e-13, atol=2e-12)
+    cotangent = tuple(jnp.asarray(rng.standard_normal(x.shape)) for x in values)
+    _, pullback = jax.vjp(fast, *primals)
+    adjoint = pullback(cotangent)
+    lhs = sum(jnp.vdot(x, y) for x, y in zip(tangent, cotangent))
+    rhs = sum(jnp.vdot(x, y) for x, y in zip(tangents, adjoint))
+    np.testing.assert_allclose(lhs, rhs, rtol=2e-13, atol=2e-12)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -12,7 +12,7 @@ import pytest
 
 from vmex.core import device as device_policy
 from vmex.core import implicit as im
-from vmex.core import freeboundary, multigrid, solver
+from vmex.core import freeboundary, multigrid, optimize, solver
 from vmex.core.input import VmecInput
 from vmex.core.mgrid import MgridField
 from vmex.core.wout import wout_from_state
@@ -469,3 +469,24 @@ def test_explicit_implicit_gradient_cpu_gpu_parity():
     assert {_platform(x) for x in jax.tree.leaves(gpu_tree)} == {"gpu"}
     np.testing.assert_allclose(gpu_value, cpu_value, rtol=1e-11)
     np.testing.assert_allclose(gpu_gradient, cpu_gradient, rtol=2e-7, atol=1e-12)
+
+
+def test_scalarized_profile_gradient_cpu_gpu_parity():
+    """The bounded-storage DMerc/D_R/<J.B> optimizer uses either device."""
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    terms = [
+        (optimize.mercier_stability_residual, 0.0, 1.0),
+        (optimize.glasser_stability_residual, 0.0, 1.0),
+        (optimize.jdotb_residual, 0.0, 1.0e-6),
+    ]
+    x0 = optimize.pack_boundary(inp, 1)
+    results = {
+        platform: optimize.minimize(
+            terms, inp, max_mode=1, device=platform,
+            bounds=list(zip(x0, x0)))
+        for platform in ("cpu", "gpu")
+    }
+    np.testing.assert_allclose(
+        results["gpu"].cost, results["cpu"].cost, rtol=1e-11)
+    np.testing.assert_allclose(
+        results["gpu"].jac, results["cpu"].jac, rtol=2e-7, atol=1e-12)

--- a/tests/test_multigrid_ladder.py
+++ b/tests/test_multigrid_ladder.py
@@ -253,6 +253,19 @@ def test_ladder_skips_decreasing_stages():
                                rtol=5e-12)
 
 
+def test_ladder_can_release_distinct_stage_caches(monkeypatch):
+    """One-shot ladders may discard a completed grid's in-memory executable."""
+    cleared = []
+    monkeypatch.setattr(multigrid.jax, "clear_caches", lambda: cleared.append(1))
+    monkeypatch.setattr(multigrid.gc, "collect", lambda: 0)
+    multigrid.solve_multigrid(
+        _load_input("cth_like_fixed_bdy"), ns_array=[5, 9],
+        ftol_array=[1e-30], niter_array=[1], raise_on_max_iterations=False,
+        release_stage_cache=True,
+    )
+    assert cleared == [1]
+
+
 def test_ladder_forwards_explicit_2d_preconditioner(monkeypatch):
     seen = []
     marker = object()

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -380,6 +380,24 @@ def test_least_squares_implicit_smoke(solovev_eq):
     assert abs(aspect1 - 4.0) < abs(aspect0 - 4.0)
 
 
+def test_minimize_scalarized_implicit_smoke(solovev_eq):
+    """L-BFGS-B lowers the same cost with a finite reverse gradient."""
+    jax.config.update("jax_disable_jit", False)
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    x0 = opt.pack_boundary(inp, 1)
+    cost0 = 0.5 * (float(opt.aspect_ratio(
+        solovev_eq.state, solovev_eq.runtime)) - 4.0) ** 2
+    bounds = list(zip(x0 - 0.5, x0 + 0.5))
+    res = opt.minimize(
+        [(opt.aspect_ratio, 4.0, 1.0)], inp, max_mode=1,
+        bounds=bounds, options={"maxiter": 1})
+    assert res.cost < cost0
+    assert np.isfinite(res.optimality)
+    assert np.all(np.isfinite(res.jac))
+    assert np.all(res.x >= x0 - 0.5) and np.all(res.x <= x0 + 0.5)
+    assert isinstance(res.input, VmecInput)
+
+
 def test_least_squares_implicit_jac_chunking(solovev_eq):
     """The R17.1 chunked implicit Jacobian matches the unchunked one.
 

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -408,10 +408,16 @@ def test_least_squares_implicit_jac_chunking(solovev_eq):
                                    err_msg=f"chunk={chunk!r}")
 
 
+def test_auto_jac_chunk_stays_bounded_with_large_device(monkeypatch):
+    """A reported accelerator budget must not turn ``auto`` into one vmap."""
+    monkeypatch.setattr(opt, "auto_chunk_size", lambda dim: dim)
+    assert opt._auto_jac_chunk(120) == 11
+
+
 def test_least_squares_implicit_jac_solver_block(solovev_eq):
     """The R25.2 block-tridiagonal Jacobian matches the per-dof GMRES one.
 
-    ``jac_solver="block"`` (default) assembles the raw force Jacobian's
+    ``jac_solver="block"`` assembles the raw force Jacobian's
     radial blocks by colored jvp probes, factors once
     (:func:`solvax.block_thomas_factor`) and backsolves every dof column,
     then certifies each column with a short warm-started GMRES pass against
@@ -425,8 +431,11 @@ def test_least_squares_implicit_jac_solver_block(solovev_eq):
                             jac_solver="gmres", max_nfev=1)
     got = opt.least_squares(obj, inp, max_mode=1, jac="implicit",
                             jac_solver="block", max_nfev=1)
+    reverse = opt.least_squares(obj, inp, max_mode=1, jac="implicit",
+                                jac_solver="reverse", max_nfev=1)
     assert got.jac.shape == ref.jac.shape
     np.testing.assert_allclose(got.jac, ref.jac, rtol=1e-6, atol=1e-8)
+    np.testing.assert_allclose(reverse.jac, ref.jac, rtol=1e-6, atol=1e-8)
     with pytest.raises(ValueError, match="jac_solver"):
         opt.least_squares(obj, inp, max_mode=1, jac="implicit",
                           jac_solver="svd", max_nfev=1)

--- a/tests/test_optimize_penalty.py
+++ b/tests/test_optimize_penalty.py
@@ -107,6 +107,31 @@ def test_implicit_lane_fun_penalty_path(monkeypatch, capsys):
     np.testing.assert_allclose(res.x, opt.pack_boundary(inp, 1))  # stayed at x0
 
 
+def test_minimize_penalty_path(monkeypatch, capsys):
+    """A failed scalarized trial reuses the last finite reverse gradient."""
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    real = im._host_solve
+    calls = {"new": 0, "poisoned": 0}
+
+    def flaky(cfg, params):
+        hit = im._LAST_SOLVE.get(cfg)
+        if hit is None or hit[0] != im._params_key(params):
+            calls["new"] += 1
+            if calls["new"] >= 2:
+                calls["poisoned"] += 1
+                raise _boom()
+        return real(cfg, params)
+
+    monkeypatch.setattr(im, "_host_solve", flaky)
+    res = opt.minimize(
+        OBJECTIVE, inp, max_mode=1, verbose=1,
+        options={"maxiter": 2, "maxls": 3})
+    out = capsys.readouterr().out
+    assert calls["poisoned"] >= 1
+    assert "trial solve/gradient failed" in out
+    assert np.isfinite(res.cost)
+
+
 def test_implicit_lane_jac_fallback_and_diagnostic_resolve(monkeypatch, capsys):
     """jac='implicit': failed Jacobian reuses the last valid one; final
     diagnostic re-solve falls back to a cold solve when the hot seed fails.

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -233,12 +233,13 @@ def test_glasser_stability_residual_is_smooth_upper_bound(shaped_eq):
 
 
 def test_least_squares_accepts_implicit_stability_terms():
-    """One optimizer evaluation builds DMerc/D_R/<J.B> rows and Jacobian."""
+    """Profile scalarization matches the Gauss--Newton cost and gradient."""
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    terms = [(opt.mercier_stability_residual, 0.0, 1.0),
+             (opt.glasser_stability_residual, 0.0, 1.0),
+             (opt.jdotb_residual, 0.0, 1.0e-6)]
     result = opt.least_squares(
-        [(opt.mercier_stability_residual, 0.0, 1.0),
-         (opt.glasser_stability_residual, 0.0, 1.0),
-         (opt.jdotb_residual, 0.0, 1.0e-6)],
+        terms,
         inp,
         max_mode=1,
         jac="implicit",
@@ -247,6 +248,12 @@ def test_least_squares_accepts_implicit_stability_terms():
     assert result.nfev == 1
     assert np.isfinite(result.cost)
     assert np.all(np.isfinite(result.jac))
+    x0 = opt.pack_boundary(inp, 1)
+    scalar = opt.minimize(
+        terms, inp, max_mode=1, bounds=list(zip(x0, x0)))
+    np.testing.assert_allclose(scalar.cost, result.cost, rtol=1e-12)
+    np.testing.assert_allclose(
+        scalar.jac, result.jac.T @ result.fun, rtol=2e-5, atol=1e-8)
 
 
 @pytest.mark.full

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -579,6 +579,7 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
             verbose=verbose,
             emit=emit,
             device=None if args.device == "none" else args.device,
+            release_stage_cache=True,
         )
     solve_s = time.perf_counter() - t1
 

--- a/vmex/core/forces.py
+++ b/vmex/core/forces.py
@@ -59,6 +59,7 @@ from .fourier import ModeTable, TrigTables
 from .geometry import HalfMeshJacobian, RealSpaceGeometry, sqrt_s_half_mesh
 from .transforms import (
     SpectralForce,
+    _fourier_to_real_fft,
     fourier_to_real,
     register_pytree_dataclass as _register,
     symforce_split,
@@ -628,6 +629,7 @@ def constraint_force(
     signgs: int,
     rcon0: Array | None = None,
     zcon0: Array | None = None,
+    use_fft: bool = False,
 ) -> tuple[Array, Array, Array, Array, Array]:
     """Spectral-condensation constraint force pipeline (funct3d.f + alias.f).
 
@@ -681,7 +683,8 @@ def constraint_force(
         ],
         axis=0,
     )
-    (value,) = fourier_to_real(
+    synthesize = _fourier_to_real_fft if use_fft else fourier_to_real
+    (value,) = synthesize(
         coeff_cos,
         coeff_sin,
         modes=modes,
@@ -745,6 +748,7 @@ def mhd_forces(
     signgs: int,
     rcon0: Array | None = None,
     zcon0: Array | None = None,
+    use_fft: bool = False,
 ) -> RealSpaceForces:
     """Assemble all real-space force kernels (funct3d.f force stage).
 
@@ -784,6 +788,7 @@ def mhd_forces(
         signgs=signgs,
         rcon0=rcon0,
         zcon0=zcon0,
+        use_fft=use_fft,
     )
 
     s = jnp.asarray(s)

--- a/vmex/core/geometry.py
+++ b/vmex/core/geometry.py
@@ -38,7 +38,11 @@ import numpy as np
 import jax.numpy as jnp
 
 from .fourier import ModeTable, TrigTables
-from .transforms import fourier_to_real, register_pytree_dataclass as _register
+from .transforms import (
+    _fourier_to_real_fft,
+    fourier_to_real,
+    register_pytree_dataclass as _register,
+)
 
 __all__ = [
     "RealSpaceGeometry",
@@ -204,6 +208,7 @@ def real_space_geometry(
     modes: ModeTable,
     trig: TrigTables,
     s: Array,
+    use_fft: bool = False,
 ) -> RealSpaceGeometry:
     """Synthesize the VMEC even-m/odd-m geometry channels from coefficients.
 
@@ -223,6 +228,9 @@ def real_space_geometry(
         (:func:`apply_lambda_axis_closure`).
     s:
         Full-mesh radial grid, shape ``(ns,)`` (uniform, ``s in [0, 1]``).
+    use_fft:
+        Use separable toroidal FFT synthesis; False retains the real dense
+        contraction used by the high-column implicit Jacobian.
 
     Returns
     -------
@@ -249,7 +257,8 @@ def real_space_geometry(
     # single odd_m_sqrt_s=True synthesis serves all three parity subsets.
     batched_cos = coeff_cos[None, ...] * mask_stack[:, None, None, :]
     batched_sin = coeff_sin[None, ...] * mask_stack[:, None, None, :]
-    value, dtheta, dzeta = fourier_to_real(
+    synthesize = _fourier_to_real_fft if use_fft else fourier_to_real
+    value, dtheta, dzeta = synthesize(
         batched_cos,
         batched_sin,
         modes=modes,

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -312,6 +312,7 @@ def _template_runtime(cfg: ImplicitConfig) -> SolverRuntime:
     return prepare_runtime(
         cfg.inp, cfg.resolution, ftol=cfg.ftol,
         max_iterations=cfg.max_iterations, lconm1=cfg.lconm1,
+        use_fft=False,
     )
 
 
@@ -750,6 +751,7 @@ def residual_fn(cfg: ImplicitConfig, frozen: SpectralState,
             fields=fields, R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
             modes=rt_p.modes, trig=rt_p.trig, s=s, phipf=setup.phipf,
             tcon=tcon, signgs=setup.signgs, rcon0=rt_p.rcon0, zcon0=rt_p.zcon0,
+            use_fft=False,
         )
         spectral = spectral_mhd_forces(
             forces, mpol=cfg.resolution.mpol, ntor=cfg.resolution.ntor,
@@ -896,12 +898,12 @@ def _host_solve(cfg: ImplicitConfig, params: ImplicitParams) -> SolveResult:
         run = lambda init: solve_multigrid(  # noqa: E731
             inp2, ns_array=ns_arr, ftol_array=ftol_arr, mode=cfg.mode,
             lconm1=cfg.lconm1, raise_on_max_iterations=False,
-            initial_state=init)
+            initial_state=init, use_fft=False)
     else:
         run = lambda init: solve(  # noqa: E731
             inp2, cfg.resolution, ftol=cfg.ftol,
             max_iterations=cfg.max_iterations, mode=cfg.mode,
-            lconm1=cfg.lconm1, initial_state=init)
+            lconm1=cfg.lconm1, initial_state=init, use_fft=False)
     # Seed ladder: perturbation prediction -> plain hot restart -> cold.
     # A bad warm seed must not fail the trial (only the initial guess is at
     # stake — every rung converges to the same fixed point).

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -34,11 +34,13 @@ host round-trips of traced values.
 
 from __future__ import annotations
 
+import gc
 from dataclasses import replace
 from typing import Any
 
 import numpy as np
 
+import jax
 import jax.numpy as jnp
 
 from .device import AUTO, _placement_device, _put_numeric_leaves, device_context
@@ -48,7 +50,7 @@ from .input import VmecInput
 from .preconditioner_2d import Prec2DConfig
 from .solver import (
     SolveResult, SpectralState, _finalize, _result_from_carry, _solve_stage,
-    hot_restart_state, prepare_runtime, resolution_from_input,
+    _resolve_use_fft, hot_restart_state, prepare_runtime, resolution_from_input,
     runtime_with_baselines,
 )
 from .transforms import odd_m_sqrt_s_scaling
@@ -198,6 +200,8 @@ def solve_multigrid(
     prec2d: Prec2DConfig | None = None,
     device: Any = AUTO,
     raise_on_max_iterations: bool = True,
+    use_fft: bool | None = None,
+    release_stage_cache: bool = False,
 ) -> SolveResult:
     """Fixed-boundary multigrid solve over the ``NS_ARRAY`` ladder.
 
@@ -245,6 +249,15 @@ def solve_multigrid(
     follows JAX placement.  Auto never overrides an active JAX device or
     platform selection.
 
+    ``use_fft`` has the same measured-hardware default and implicit-AD role as in
+    :func:`vmex.core.solver.solve`.
+
+    ``release_stage_cache=True`` clears JAX's in-memory compilation/staging
+    caches between distinct radial grids. This lowers peak RSS for a one-shot
+    high-resolution ladder while leaving the persistent on-disk cache intact.
+    It is false by default so repeated library solves retain warm executables;
+    the standalone CLI enables it.
+
     Returns the final stage's :class:`~vmex.core.solver.SolveResult`.
     """
     ns_arr = np.atleast_1d(np.asarray(
@@ -276,12 +289,13 @@ def solve_multigrid(
             continue
         ns_min = nsval
         resolution = resolution_from_input(inp, ns=nsval)
+        stage_use_fft = _resolve_use_fft(use_fft, device, resolution)
         rt = prepare_runtime(
             inp, resolution, ftol=float(ftol_arr[igrid]),
             max_iterations=int(niter_arr[igrid]), lconm1=lconm1,
             time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
             precon_type=precon_type, prec2d_threshold=prec2d_threshold,
-            prec2d=prec2d,
+            prec2d=prec2d, use_fft=stage_use_fft,
         )
         if state is not None and int(state.R_cos.shape[0]) != nsval:
             state = interpolate_state(state, ns_fine=nsval, modes=rt.modes)
@@ -291,12 +305,13 @@ def solve_multigrid(
                 state = hot_restart_state(rt, state)
             # funct3d.f: rcon0/zcon0 are set from the state at iter2 == iter1,
             # i.e. from THIS stage's starting state, not the interior guess.
-            rt = runtime_with_baselines(rt, state)
+            rt = runtime_with_baselines(rt, state, use_fft=stage_use_fft)
         with device_context(device, resolution):
             carry = _solve_stage(
                 rt, state, mode=mode, verbose=verbose, emit=emit,
                 # the eqsolve.f axis re-guess applies to the fresh interior guess
                 try_axis_reguess=first_executed and state is None,
+                use_fft=stage_use_fft,
             )
         first_executed = False
         ier = int(carry.ier)
@@ -306,6 +321,16 @@ def solve_multigrid(
                 and not (ier == MORE_ITER_FLAG and not raise_on_max_iterations)):
             _finalize(carry, rt)  # raises the typed error for this stage
         state = carry.state
+        future = ns_arr[igrid + 1:]
+        executable = future[future >= nsval]
+        if (
+            release_stage_cache
+            and executable.size
+            and int(executable[0]) != nsval
+        ):
+            jax.block_until_ready(carry)
+            jax.clear_caches()
+            gc.collect()
 
     if int(carry.ier) == MORE_ITER_FLAG and not raise_on_max_iterations:
         return _result_from_carry(carry, rt)

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -23,6 +23,9 @@ Simsopt-style vocabulary for the QA/QH/QP/QI examples on the pure new core:
 - :func:`least_squares` — a thin :func:`scipy.optimize.least_squares` driver
   over boundary Fourier dofs (:func:`pack_boundary`/:func:`unpack_boundary`),
   taking simsopt-style ``(callable, target, weight)`` terms.
+- :func:`minimize` — the same residual definition scalarized as
+  ``0.5 * sum(residual**2)`` and minimized with L-BFGS-B, so one reverse
+  implicit adjoint supplies the gradient without a dense residual Jacobian.
 
 Helicity conventions (match legacy/simsopt exactly)
 ---------------------------------------------------
@@ -157,6 +160,7 @@ __all__ = [
     "pack_boundary",
     "unpack_boundary",
     "least_squares",
+    "minimize",
     "RedlBootstrapMismatch",  # noqa: F822 - provided lazily by __getattr__ below
 ]
 
@@ -1406,6 +1410,64 @@ def least_squares(
     return result
 
 
+def minimize(
+    objective_terms: Sequence[tuple[Callable, float, float]],
+    inp: VmecInput,
+    *,
+    max_mode: int | Sequence[int] = 1,
+    x0: np.ndarray | None = None,
+    current_dofs: int | None = None,
+    hot_restart: bool = True,
+    device: Any = AUTO,
+    solve_kwargs: dict | None = None,
+    verbose: int = 0,
+    method: str = "L-BFGS-B",
+    **scipy_kwargs,
+):
+    """Minimize the scalarized residual norm with one adjoint per gradient.
+
+    The objective is exactly ``0.5 * sum(rows**2)``, with ``rows`` defined by
+    :func:`least_squares`.  Unlike Gauss--Newton least squares, a reverse
+    gradient of this scalar needs one matrix-free implicit adjoint and never
+    forms the vector residual Jacobian or its dense radial block factors.
+    This is the bounded-storage path for profile objectives such as ``DMerc``,
+    ``jdotb``, and Glasser ``D_R``.  It changes the optimization algorithm,
+    not the objective or its unconstrained minimizers, and is therefore
+    opt-in; :func:`least_squares` retains all existing defaults.
+
+    ``method`` and remaining keywords are passed to
+    :func:`scipy.optimize.minimize` (default ``"L-BFGS-B"``; use ``bounds=``
+    and ``options={"maxiter": ...}`` in the usual scipy form).  All objective
+    terms must support ``jac="implicit"`` as documented by
+    :func:`least_squares`.  Plain state hot restarts are used because the
+    first-order perturbation warm start requires the forward state-response
+    columns that this lower-storage path deliberately avoids.
+    """
+    modes_schedule = ([int(max_mode)] if np.isscalar(max_mode)
+                      else [int(m) for m in max_mode])
+    if len(modes_schedule) > 1:
+        if x0 is not None:
+            raise ValueError("x0 cannot be combined with a max_mode schedule")
+        stage_results = []
+        current = inp
+        for mm in modes_schedule:
+            result = minimize(
+                objective_terms, current, max_mode=mm,
+                current_dofs=current_dofs, hot_restart=hot_restart,
+                device=device, solve_kwargs=solve_kwargs, verbose=verbose,
+                method=method, **scipy_kwargs)
+            stage_results.append(result)
+            current = result.input
+        result.stage_results = stage_results
+        return result
+    return _least_squares_implicit(
+        objective_terms, inp, max_mode=modes_schedule[0], x0=x0,
+        current_dofs=current_dofs, jac_solver="reverse", recycle=False,
+        warm_start=("state" if hot_restart else None),
+        solve_kwargs=dict(solve_kwargs or {}), device=device, verbose=verbose,
+        minimize_method=method, **scipy_kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Implicit-gradient mode (vmex.core.implicit wiring)
 # ---------------------------------------------------------------------------
@@ -1457,6 +1519,7 @@ def _least_squares_implicit(
     solve_kwargs: dict,
     device: Any = AUTO,
     verbose: int = 0,
+    minimize_method: str | None = None,
     **scipy_kwargs,
 ):
     """Single-stage boundary least squares with implicit-gradient Jacobians.
@@ -1565,6 +1628,12 @@ def _least_squares_implicit(
         return term_rows(state, imp.runtime_from_params(params, cfg))
 
     rows_jit = jax.jit(residual_rows)
+
+    def scalar_loss(x: jnp.ndarray) -> jnp.ndarray:
+        rows = residual_rows(x)
+        return 0.5 * jnp.vdot(rows, rows)
+
+    value_grad_jit = jax.jit(jax.value_and_grad(scalar_loss))
 
     # The evolved-dof mask is a *structural* per-config constant; fetch it
     # once (first host solve, cached in implicit._MASK_CACHE) so the Jacobian
@@ -1981,8 +2050,37 @@ def _least_squares_implicit(
         except Exception:  # the seed itself does not converge -> fun raises clearly
             pass
 
-    result = scipy.optimize.least_squares(fun, np.asarray(x0, dtype=float),
-                                          jac=jac_fn, **scipy_kwargs)
+    if minimize_method is None:
+        result = scipy.optimize.least_squares(
+            fun, np.asarray(x0, dtype=float), jac=jac_fn, **scipy_kwargs)
+    else:
+        def value_and_grad(x: np.ndarray):
+            try:
+                value, grad = value_grad_jit(_place(x))
+                value = float(jax.device_get(value))
+                grad = np.asarray(jax.device_get(grad), dtype=float)
+            except Exception as exc:
+                if holder.get("last_grad") is None:
+                    raise
+                if verbose:
+                    print(f"[minimize] trial solve/gradient failed: {exc}")
+                return 1.0e12, holder["last_grad"]
+            if np.isfinite(value) and np.all(np.isfinite(grad)):
+                holder["last_grad"] = grad
+                if verbose:
+                    print(f"[minimize] cost = {value:.6e}")
+                return value, grad
+            if holder.get("last_grad") is None:
+                raise FloatingPointError("non-finite initial objective or gradient")
+            return 1.0e12, holder["last_grad"]
+
+        result = scipy.optimize.minimize(
+            value_and_grad, np.asarray(x0, dtype=float), jac=True,
+            method=minimize_method, **scipy_kwargs)
+        if "jac" not in result:  # scipy may skip evaluation if every dof is fixed
+            result.fun, result.jac = value_and_grad(result.x)
+        result.cost = float(result.fun)
+        result.optimality = float(np.linalg.norm(result.jac, ord=np.inf))
     result.input = unpack_boundary(inp, result.x[:nboundary], max_mode)
     if k_cur:
         result.input = _apply_current(result.input, result.x[nboundary:],

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -203,6 +203,11 @@ class Equilibrium:
         )
 
 
+def _auto_jac_chunk(dim: int) -> int:
+    """Bound device-aware batching by the conservative square-root policy."""
+    return min(int(auto_chunk_size(dim)), int(np.ceil(np.sqrt(dim))))
+
+
 def solve_equilibrium(
     inp: VmecInput,
     *,
@@ -1151,7 +1156,7 @@ def least_squares(
     current_dofs: int | None = None,
     jac: str | None = None,
     jac_chunk_size: int | str | None = "auto",
-    jac_solver: str = "block",
+    jac_solver: str = "auto",
     recycle: bool = False,
     hot_restart: bool = True,
     warm_start: str | None = "perturbation",
@@ -1228,19 +1233,18 @@ def least_squares(
     ``readin.f`` delta rotation.
     ``jac_chunk_size`` (R17.1 memory knob, ``jac="implicit"`` only) chunks the
     per-dof Jacobian columns via :func:`solvax.chunk_map`: ``"auto"`` (default)
-    lets :func:`solvax.auto_chunk_size` pick a memory-bounded width (the
-    largest block that fits the device budget on GPU, a sqrt-balanced width on
-    CPU) so peak Jacobian memory is ``m0 + m1*chunk`` instead of scaling with
-    the full dof count; an ``int`` fixes that many boundary dofs at a time; and
-    ``None`` forces one wide ``vmap`` over all dofs (the pre-R17.1 behavior,
-    fastest but peak memory O(dofs)).  The column blocks are mathematically
-    independent, so the assembled Jacobian is identical to float64 round-off
-    (~1e-15) across chunk sizes.  It is inert for ``jac=None`` (scipy computes
-    the finite-difference Jacobian itself).
+    uses SOLVAX's device-aware width capped by a conservative square-root
+    width, so an accelerator memory report cannot expand the full probe batch;
+    an ``int`` fixes that many boundary dofs at a time; and ``None`` forces one
+    wide ``vmap`` over all dofs. The column blocks are mathematically
+    independent, so the assembled Jacobian is identical to float64 round-off.
+    It is inert for ``jac=None``.
 
-    ``jac_solver`` (plan R25.2, ``jac="implicit"`` only) selects the linear
-    solver behind the per-dof implicit-Jacobian columns.  ``"block"``
-    (default) amortizes one block-tridiagonal factorization of the *raw*
+    ``jac_solver`` (``jac="implicit"`` only) selects the implicit-Jacobian
+    direction. ``"auto"`` (default) uses one matrix-free reverse solve for a
+    scalar residual and the ``"block"`` path below otherwise. ``"reverse"``
+    requests one reverse solve per residual row. ``"block"``
+    amortizes one block-tridiagonal factorization of the *raw*
     force Jacobian — whose radial coupling is exactly nearest-neighbor, so
     ns dense ``(3*mn, 3*mn)`` blocks assembled by 3-colored ``jax.jvp``
     probes capture it completely at a cost independent of the dof count —
@@ -1447,7 +1451,7 @@ def _least_squares_implicit(
     x0: np.ndarray | None,
     current_dofs: int | None = None,
     jac_chunk_size: int | str | None = "auto",
-    jac_solver: str = "block",
+    jac_solver: str = "auto",
     recycle: bool = False,
     warm_start: str | None = "perturbation",
     solve_kwargs: dict,
@@ -1464,13 +1468,11 @@ def _least_squares_implicit(
     :func:`~vmex.core.implicit.runtime_from_params` -> the stacked
     objective rows: one warm host solve per trial ``x``.  ``jac`` computes
     the exact residual Jacobian by *forward* implicit differentiation:
-    by default (``jac_solver="block"``, see ``jacobian_rows_block``) one
-    amortized block-tridiagonal factorization backsolves every boundary-dof
-    column at once; ``jac_solver="gmres"`` (see ``jacobian_rows``) runs one
-    preconditioned GMRES per boundary dof, batched.  Either way this is far
-    below one full equilibrium solve per dof (finite differences) while
-    keeping the full pointwise Gauss-Newton residual geometry.  Both are
-    jit-compiled once per stage.
+    with one reverse adjoint for a scalar residual (``jac_solver="auto"``);
+    vector residuals use one amortized block-tridiagonal factorization
+    (``jacobian_rows_block``), while ``jac_solver="gmres"`` keeps the
+    per-boundary-dof fallback. All paths retain the full pointwise
+    Gauss-Newton residual geometry and are jit-compiled once per stage.
 
     The residual and Jacobian graphs run on the device chosen by
     :func:`vmex.core.device.resolve_implicit_device` — the CPU by default,
@@ -1608,7 +1610,7 @@ def _least_squares_implicit(
     # R17.1 memory knob: chunk_size None == one wide vmap (current behavior),
     # an int / "auto" caps peak Jacobian memory at that many dofs at a time.
     if jac_chunk_size == "auto":
-        chunk = int(auto_chunk_size(ndof))
+        chunk = _auto_jac_chunk(ndof)
     elif jac_chunk_size is None or isinstance(jac_chunk_size, int):
         chunk = jac_chunk_size
     else:
@@ -1710,10 +1712,7 @@ def _least_squares_implicit(
     probe_color = jnp.asarray(np.repeat(np.arange(3), m_block))
     probe_field = jnp.asarray(np.tile(np.repeat(np.arange(n_act), mn_state), 3))
     probe_col = jnp.asarray(np.tile(np.tile(np.arange(mn_state), n_act), 3))
-    if jac_chunk_size == "auto":
-        probe_chunk = int(auto_chunk_size(3 * m_block))
-    else:
-        probe_chunk = chunk
+    probe_chunk = chunk
 
     def _pack(t) -> jnp.ndarray:
         """SpectralState -> (ns, m_block): active fields side by side."""
@@ -1854,16 +1853,18 @@ def _least_squares_implicit(
         cols = cols.reshape((nchunks * csize,) + cols.shape[2:])[:ndof]
         return jnp.transpose(cols), C, U
 
-    if jac_solver not in ("block", "gmres"):
+    if jac_solver not in ("auto", "block", "gmres", "reverse"):
         raise ValueError(
-            f"jac_solver must be 'block' or 'gmres', got {jac_solver!r}")
+            "jac_solver must be 'auto', 'block', 'gmres', or 'reverse', "
+            f"got {jac_solver!r}")
     if recycle:
         jac_impl = jacobian_rows_recycled  # opt-in R25.3 experiment wins
-    elif jac_solver == "block":
+    elif jac_solver in ("auto", "block"):
         jac_impl = jacobian_rows_block
     else:
         jac_impl = jacobian_rows
     jac_jit = jax.jit(jac_impl)
+    reverse_jit = jax.jit(jax.jacrev(residual_rows))
 
     holder: dict[str, Any] = {"nres": None, "lin": None}
     if recycle:
@@ -1937,7 +1938,19 @@ def _least_squares_implicit(
 
     def jac_fn(x: np.ndarray) -> np.ndarray:
         try:
-            if recycle:
+            reverse = (
+                not recycle
+                and (
+                    jac_solver == "reverse"
+                    or (jac_solver == "auto" and holder["nres"] == 1)
+                )
+            )
+            if reverse:
+                jac = np.asarray(
+                    jax.device_get(reverse_jit(_place(x))), dtype=float
+                )
+                holder["lin"] = None
+            elif recycle:
                 rows, C, U = jac_jit(_place(x), *holder["recycle"])
                 holder["recycle"] = (C, U)  # deflate the next jac evaluation
                 jac = np.asarray(jax.device_get(rows), dtype=float)

--- a/vmex/core/setup.py
+++ b/vmex/core/setup.py
@@ -917,6 +917,7 @@ def run_setup(
     *,
     lconm1: bool = True,
     infer_axis_if_missing: bool = True,
+    use_fft: bool = False,
 ) -> RunSetup:
     """Build the complete pre-iteration setup for one radial resolution.
 
@@ -973,7 +974,7 @@ def run_setup(
                 modes=modes, lthreed=bool(resolution.lthreed),
                 lasym=bool(resolution.lasym), lconm1=bool(lconm1),
             ),
-            modes=modes, trig=trig, s=grids.s_full,
+            modes=modes, trig=trig, s=grids.s_full, use_fft=use_fft,
         )
         axis = guess_axis(geom, s=grids.s_full, trig=trig, signgs=boundary.signgs)
         raxis_c, raxis_s, zaxis_c, zaxis_s = axis

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -61,6 +61,7 @@ from dataclasses import dataclass, fields as dataclass_fields, is_dataclass, rep
 from typing import Any, Callable
 
 import functools
+import platform
 
 import numpy as np
 
@@ -125,7 +126,12 @@ _harden_compilation_cache()
 import jax.numpy as jnp
 from jax import lax
 
-from .device import AUTO, device_context
+from .device import (
+    AUTO,
+    GPU_MAX_SPECTRAL_MODES,
+    _placement_device,
+    device_context,
+)
 from .errors import (
     BAD_JACOBIAN_FLAG, JAC75_FLAG, MISC_ERROR_FLAG, MORE_ITER_FLAG,
     NONFINITE_FLAG, NORM_TERM_FLAG, SUCCESSFUL_TERM_FLAG,
@@ -549,7 +555,9 @@ def _physical_coefficients(state: SpectralState, *, modes, lthreed, lasym, lconm
     return R_cos, R_sin, Z_cos, Z_sin
 
 
-def _geometry(state: SpectralState, rt: SolverRuntime):
+def _geometry(
+    state: SpectralState, rt: SolverRuntime, *, use_fft: bool = False
+):
     """Constrained state -> physical coefficients + real-space geometry."""
     setup = rt.setup
     R_cos, R_sin, Z_cos, Z_sin = _physical_coefficients(
@@ -560,7 +568,7 @@ def _geometry(state: SpectralState, rt: SolverRuntime):
     geometry = real_space_geometry(
         R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
         lambda_cos=state.L_cos, lambda_sin=lambda_sin,
-        modes=rt.modes, trig=rt.trig, s=setup.s_full,
+        modes=rt.modes, trig=rt.trig, s=setup.s_full, use_fft=use_fft,
     )
     return (R_cos, R_sin, Z_cos, Z_sin), geometry
 
@@ -603,6 +611,7 @@ def prepare_runtime(
     lconm1: bool = True, setup: RunSetup | None = None,
     precon_type: str | None = None, prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
+    use_fft: bool = False,
 ) -> SolverRuntime:
     """Build the static solver context from an input file or a RunSetup.
 
@@ -629,7 +638,9 @@ def prepare_runtime(
         if resolution is None:
             resolution = resolution_from_input(inp)
         if setup is None:
-            setup = run_setup(inp, resolution, lconm1=lconm1)
+            setup = run_setup(
+                inp, resolution, lconm1=lconm1, use_fft=use_fft
+            )
         defaults = dict(ftol=float(inp.ftol_array[0]), niter=int(inp.niter_array[0]),
                         delt=float(inp.delt), tcon0=float(inp.tcon0),
                         gamma=float(inp.gamma), nstep=int(inp.nstep))
@@ -646,7 +657,9 @@ def prepare_runtime(
         rcon0=jnp.zeros(()), zcon0=jnp.zeros(()),  # placeholder, replaced below
         prec2d=_resolve_prec2d(source, prec2d, precon_type, prec2d_threshold),
     )
-    rcon0, zcon0 = _constraint_baselines(_initial_state(setup), rt)
+    rcon0, zcon0 = _constraint_baselines(
+        _initial_state(setup), rt, use_fft=use_fft
+    )
     return replace(rt, rcon0=rcon0, zcon0=zcon0)
 
 
@@ -688,7 +701,9 @@ def hot_restart_state(rt: SolverRuntime, state: SpectralState) -> SpectralState:
     )
 
 
-def runtime_with_baselines(rt: SolverRuntime, state: SpectralState) -> SolverRuntime:
+def runtime_with_baselines(
+    rt: SolverRuntime, state: SpectralState, *, use_fft: bool = False
+) -> SolverRuntime:
     """Rebind ``rcon0/zcon0`` to a new starting state (``funct3d.f``).
 
     VMEC2000 sets the constraint baselines from the *current* state whenever
@@ -700,19 +715,24 @@ def runtime_with_baselines(rt: SolverRuntime, state: SpectralState) -> SolverRun
     and hence the converged equilibrium — is subtly wrong (observed as a
     ~1e-8 relative ``wb`` shift on the nfp4_QH ladder).
     """
-    rcon0, zcon0 = _constraint_baselines(state, rt)
+    rcon0, zcon0 = _constraint_baselines(state, rt, use_fft=use_fft)
     return replace(rt, rcon0=rcon0, zcon0=zcon0)
 
 
-def _constraint_baselines(state: SpectralState, rt: SolverRuntime):
+def _constraint_baselines(
+    state: SpectralState, rt: SolverRuntime, *, use_fft: bool = False
+):
     """One-time ``rcon0/zcon0 = s * rcon(ns)`` (funct3d.f, iter2 == iter1)."""
-    (R_cos, R_sin, Z_cos, Z_sin), geometry = _geometry(state, rt)
+    (R_cos, R_sin, Z_cos, Z_sin), geometry = _geometry(
+        state, rt, use_fft=use_fft
+    )
     ns = int(rt.setup.s_full.shape[0])
     _, _, _, rcon0, zcon0 = constraint_force(
         R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
         geometry=geometry, modes=rt.modes, trig=rt.trig, s=rt.setup.s_full,
         tcon=jnp.zeros((ns,), dtype=rt.setup.s_full.dtype),
         signgs=rt.setup.signgs,
+        use_fft=use_fft,
     )
     return rcon0, zcon0
 
@@ -772,6 +792,7 @@ def _force_pipeline(
     cache: PreconditionerCache, rt: SolverRuntime,
     iteration: Array, fsqz_previous: Array,
     collect_health: bool = False,
+    use_fft: bool = False,
 ) -> tuple[Any, Any, ForcePipelineHealth]:
     """MHD forces -> residue.f90 chain -> scalfor/faclam preconditioning.
 
@@ -795,6 +816,7 @@ def _force_pipeline(
         R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
         modes=rt.modes, trig=rt.trig, s=s, phipf=setup.phipf,
         tcon=cache.tcon, signgs=setup.signgs, rcon0=rt.rcon0, zcon0=rt.zcon0,
+        use_fft=use_fft,
     )
     if rt.lfreeb:
         # forces.f (ivac >= 1): vacuum-pressure edge force.  funct3d.f builds
@@ -950,6 +972,7 @@ def _evaluate(
     iter_last_reset: Array, fsqz_previous: Array, rt: SolverRuntime,
     fsq_rz_previous: Array | None = None,
     *, collect_health: bool = False,
+    use_fft: bool = False,
 ) -> _EvalResult:
     """One funct3d.f pass (fixed boundary), pure and jit-friendly.
 
@@ -969,7 +992,9 @@ def _evaluate(
     ns = int(s.shape[0])
     hs = setup.hs
 
-    (R_cos, R_sin, Z_cos, Z_sin), geometry = _geometry(state, rt)
+    (R_cos, R_sin, Z_cos, Z_sin), geometry = _geometry(
+        state, rt, use_fft=use_fft
+    )
     jacobian = half_mesh_jacobian(geometry, s=s)
     jac_changed = jacobian.jacobian_sign_changed
 
@@ -1040,7 +1065,7 @@ def _evaluate(
         geometry=geometry, jacobian=jacobian, metrics=metrics, fields=fields,
         R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
         cache=cache, rt=rt, iteration=iteration, fsqz_previous=fsqz_previous,
-        collect_health=collect_health,
+        collect_health=collect_health, use_fft=use_fft,
     )
     if rt.lfreeb:
         # residue.f90 medge rule: the edge rows join fsqr/fsqz only when
@@ -1160,7 +1185,7 @@ def _evaluation_is_finite(result: _EvalResult) -> Array:
 
 
 def reguess_initial_axis(
-    rt: SolverRuntime, state: SpectralState
+    rt: SolverRuntime, state: SpectralState, *, use_fft: bool = False
 ) -> tuple[SolverRuntime, SpectralState, tuple[Array, Array, Array, Array]]:
     """Apply the VMEC2000 first-bad-Jacobian magnetic-axis retry.
 
@@ -1169,7 +1194,7 @@ def reguess_initial_axis(
     constraint baselines to that state (``funct3d.f: iter2 == iter1``).
     """
     setup = rt.setup
-    _, geometry = _geometry(state, rt)
+    _, geometry = _geometry(state, rt, use_fft=use_fft)
     axis = guess_axis(
         geometry, s=setup.s_full, trig=rt.trig, signgs=setup.signgs
     )
@@ -1191,7 +1216,9 @@ def reguess_initial_axis(
         R_cos=arrays[0], R_sin=arrays[1], Z_cos=arrays[2], Z_sin=arrays[3],
         L_cos=arrays[4], L_sin=arrays[5],
     )
-    rt = runtime_with_baselines(replace(rt, setup=new_setup), state)
+    rt = runtime_with_baselines(
+        replace(rt, setup=new_setup), state, use_fft=use_fft
+    )
     return rt, state, axis
 
 
@@ -1202,6 +1229,7 @@ def _make_body(
     rt: SolverRuntime,
     *,
     evaluation_state: SpectralState | None = None,
+    use_fft: bool = False,
 ) -> Callable[[_LoopCarry], _LoopCarry]:
     """Build the traced single-iteration body shared by both lanes.
 
@@ -1223,7 +1251,7 @@ def _make_body(
         # ---- funct3d (evolve.f) -------------------------------------------
         state_e1 = carry.state if evaluation_state is None else evaluation_state
         e1 = _evaluate(state_e1, carry.cache, it, carry.iter1, carry.fsqz, rt,
-                       carry.fsqr + carry.fsqz)
+                       carry.fsqr + carry.fsqz, use_fft=use_fft)
         jac1 = e1.jacobian_sign_changed
         nonfinite1 = (~jac1) & (~_evaluation_is_finite(e1))
         # On irst=2 funct3d skips residue: the module residuals stay stale.
@@ -1269,7 +1297,10 @@ def _make_body(
         # Re-evaluate at the restored state (TimeStepControl calls funct3d).
         e2 = lax.cond(
             restart,
-            lambda args: _evaluate(args[0], args[1], it, it, args[2], rt, args[3]),
+            lambda args: _evaluate(
+                args[0], args[1], it, it, args[2], rt, args[3],
+                use_fft=use_fft,
+            ),
             lambda args: e1,
             (state_r, e1.cache, fsqz_c, fsqr_c + fsqz_c),
         )
@@ -1563,13 +1594,49 @@ def _block_lane(carry: _LoopCarry, rt: SolverRuntime) -> _LoopCarry:
     return lax.scan(lambda cc, _: (body(cc), None), carry, None, length=BLOCK_SIZE)[0]
 
 
+@jax.jit
+def _while_lane_fft(carry: _LoopCarry, rt: SolverRuntime) -> _LoopCarry:
+    """Whole-solve lane using separable Fourier synthesis."""
+    body = _make_body(rt, use_fft=True)
+    return lax.while_loop(lambda c: jnp.logical_not(c.done), body, carry)
+
+
+@functools.partial(jax.jit, donate_argnums=(0,))
+def _block_lane_fft(carry: _LoopCarry, rt: SolverRuntime) -> _LoopCarry:
+    """Donated CLI block using separable Fourier synthesis."""
+    body = _make_body(rt, use_fft=True)
+    return lax.scan(
+        lambda cc, _: (body(cc), None), carry, None, length=BLOCK_SIZE
+    )[0]
+
+
+def _resolve_use_fft(
+    use_fft: bool | None, device: Any, resolution: Resolution
+) -> bool:
+    """Select the measured synthesis kernel without environment routing."""
+    if use_fft is not None:
+        return bool(use_fft)
+    if int(resolution.mnmax) <= GPU_MAX_SPECTRAL_MODES:
+        return False
+    target = _placement_device(device, resolution)
+    if target is None:
+        target = jax.config.jax_default_device
+    backend = (
+        getattr(target, "platform", None)
+        if target is not None
+        else jax.default_backend()
+    )
+    return backend != "cpu" or platform.machine().lower() in ("arm64", "aarch64")
+
+
 def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
-              ijacob: int, verbose: bool, emit) -> _LoopCarry:
+              ijacob: int, verbose: bool, emit,
+              use_fft: bool = False) -> _LoopCarry:
     """Run the iteration loop in the requested lane; return the final carry."""
     carry = _initial_carry(state0, rt, ijacob=ijacob)
 
     if mode == "jit":
-        return _while_lane(carry, rt)
+        return (_while_lane_fft if use_fft else _while_lane)(carry, rt)
 
     if mode != "cli":
         raise ValueError(f"unknown mode {mode!r}; expected 'cli' or 'jit'")
@@ -1587,8 +1654,9 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
 
     printed: set[int] = set()
     max_passes = rt.max_iterations + 200
+    lane = _block_lane_fft if use_fft else _block_lane
     for _ in range(max_passes):
-        carry = _block_lane(carry, rt)
+        carry = lane(carry, rt)
         done = bool(carry.done)
         upto = int(carry.iteration) if done else int(carry.iteration) - 1
         if verbose:
@@ -1601,7 +1669,8 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
 
 def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
                  mode: str, verbose: bool, emit,
-                 try_axis_reguess: bool = True) -> _LoopCarry:
+                 try_axis_reguess: bool = True,
+                 use_fft: bool = False) -> _LoopCarry:
     """Run one solve at a fixed runtime, with the eqsolve.f axis-retry.
 
     ``state0=None`` starts from the runtime's ``profil3d.f`` interior guess.
@@ -1613,7 +1682,10 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
     setup = rt.setup
     if state0 is None:
         state0 = _initial_state(setup)
-    carry = _run_loop(state0, rt, mode=mode, ijacob=0, verbose=verbose, emit=emit)
+    carry = _run_loop(
+        state0, rt, mode=mode, ijacob=0, verbose=verbose, emit=emit,
+        use_fft=use_fft,
+    )
 
     # eqsolve.f: on a first-iteration Jacobian sign change with ijacob == 0,
     # re-guess the axis from the current geometry and restart once.
@@ -1622,9 +1694,11 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
         if verbose:
             emit(" INITIAL JACOBIAN CHANGED SIGN!")
             emit(" TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS")
-        rt, state0, _axis = reguess_initial_axis(rt, state0)
+        rt, state0, _axis = reguess_initial_axis(
+            rt, state0, use_fft=use_fft
+        )
         carry = _run_loop(state0, rt, mode=mode, ijacob=1, verbose=verbose,
-                          emit=emit)
+                          emit=emit, use_fft=use_fft)
     return carry
 
 
@@ -1672,6 +1746,7 @@ def solve(
     device: Any = AUTO,
     precon_type: str | None = None, prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
+    use_fft: bool | None = None,
 ) -> SolveResult:
     """Single-grid fixed-boundary solve (VMEC2000 ``eqsolve.f``).
 
@@ -1708,6 +1783,12 @@ def solve(
     follow JAX placement.  The automatic policy never overrides an active
     ``jax.default_device`` context or user-pinned JAX platform.
 
+    ``use_fft=None`` (default) selects separable FFT only above 512 modes on
+    accelerators and ARM CPUs; smaller problems and x86 CPUs retain the dense
+    real contraction. Explicit ``True``/``False`` always wins. The implicit
+    API sets it False internally so its equilibrium and Jacobian share one
+    lower-memory real-contraction executable.
+
     ``precon_type`` (``"NONE"`` default) with a finite ``prec2d_threshold`` —
     or an explicit ``prec2d``
     :class:`~vmex.core.preconditioner_2d.Prec2DConfig` — switches on the
@@ -1718,11 +1799,17 @@ def solve(
     stiff cases (high beta/aspect/mode-number) in far fewer iterations.  The
     default (``NONE``) path is byte-identical to the 1D-only solver.
     """
+    if resolution is None and isinstance(source, VmecInput):
+        resolution = resolution_from_input(source)
+    if resolution is None:
+        raise ValueError("solve(RunSetup) requires a Resolution")
+    use_fft_resolved = _resolve_use_fft(use_fft, device, resolution)
     rt = prepare_runtime(
         source, resolution, ftol=ftol, max_iterations=max_iterations,
         time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
         lconm1=lconm1, precon_type=precon_type,
         prec2d_threshold=prec2d_threshold, prec2d=prec2d,
+        use_fft=use_fft_resolved,
     )
     if initial_state is not None:
         ns, mnmax = rt.resolution.ns, rt.modes.mnmax
@@ -1733,7 +1820,12 @@ def solve(
                 "vmex.core.multigrid.interpolate_state first"
             )
         initial_state = hot_restart_state(rt, initial_state)
-        rt = runtime_with_baselines(rt, initial_state)  # funct3d.f iter2==iter1
+        rt = runtime_with_baselines(
+            rt, initial_state, use_fft=use_fft_resolved
+        )  # funct3d.f iter2==iter1
     with device_context(device, rt.resolution):
-        carry = _solve_stage(rt, initial_state, mode=mode, verbose=verbose, emit=emit)
+        carry = _solve_stage(
+            rt, initial_state, mode=mode, verbose=verbose, emit=emit,
+            use_fft=use_fft_resolved,
+        )
     return _finalize(carry, rt)

--- a/vmex/core/transforms.py
+++ b/vmex/core/transforms.py
@@ -15,10 +15,12 @@ VMEC2000 counterparts
 
 Structure
 ---------
-All transforms are two-stage DFTs expressed as batched matrix products
-(theta stage then zeta stage, or mode-stacked phase tables), pure ``jax.numpy``
-with ``Precision.HIGHEST``, no host round-trips, and jit-friendly: the trig
-tables and mode tables are static (NumPy) trace-time constants.
+Production geometry synthesis can use a batched toroidal FFT followed by a
+poloidal contraction (with a dense-DFT fallback for undersampled grids).
+The solver selects it on measured winning hardware; the public dense synthesis
+is retained for x86 CPUs and high-column implicit AD. Force projection uses the
+reverse two-stage order. All paths are pure ``jax.numpy``, have no host
+round-trips, and are jit-friendly.
 
 Naming: variables use physical names with the VMEC2000 Fortran name recorded
 in docstrings/comments (e.g. ``force_R`` for ``armn``, ``force_R_cc`` for
@@ -184,6 +186,122 @@ def _phase_pair(modes: ModeTable, trig: TrigTables, derivative: str) -> tuple[np
     return cos_phase, sin_phase
 
 
+def _packed_toroidal_coefficients(
+    coefficient_cos: Array, coefficient_sin: Array, modes: ModeTable
+) -> tuple[Array, Array, Array, Array]:
+    """Repack signed helical modes into separable cos/sin theta-zeta blocks."""
+    mpol = int(np.max(np.asarray(modes.m))) + 1
+    ntor = int(np.max(np.abs(np.asarray(modes.n)))) if modes.mnmax else 0
+    split = ntor + 1
+    cos0 = coefficient_cos[..., :split][..., None, :]
+    sin0 = coefficient_sin[..., :split][..., None, :]
+    shape = (*coefficient_cos.shape[:-1], mpol - 1, 2 * ntor + 1)
+    cos_rest = coefficient_cos[..., split:].reshape(shape)
+    sin_rest = coefficient_sin[..., split:].reshape(shape)
+
+    cos_neg = cos_rest[..., :ntor][..., ::-1]
+    sin_neg = sin_rest[..., :ntor][..., ::-1]
+    cos_pos = cos_rest[..., ntor + 1 :]
+    sin_pos = sin_rest[..., ntor + 1 :]
+    cos_zero = cos_rest[..., ntor : ntor + 1]
+    sin_zero = sin_rest[..., ntor : ntor + 1]
+
+    theta_cos_cos = jnp.concatenate(
+        [cos_zero, cos_neg + cos_pos], axis=-1
+    )
+    theta_cos_sin = jnp.concatenate(
+        [jnp.zeros_like(sin_zero), sin_neg - sin_pos], axis=-1
+    )
+    theta_sin_cos = jnp.concatenate(
+        [sin_zero, sin_neg + sin_pos], axis=-1
+    )
+    theta_sin_sin = jnp.concatenate(
+        [jnp.zeros_like(cos_zero), cos_pos - cos_neg], axis=-1
+    )
+
+    zero = jnp.zeros_like(cos0)
+    sin0_zeta = jnp.concatenate(
+        [jnp.zeros_like(sin0[..., :1]), -sin0[..., 1:]], axis=-1
+    )
+    return tuple(
+        jnp.concatenate([axis, rest], axis=-2)
+        for axis, rest in (
+            (cos0, theta_cos_cos),
+            (sin0_zeta, theta_cos_sin),
+            (zero, theta_sin_cos),
+            (zero, theta_sin_sin),
+        )
+    )
+
+
+def _toroidal_synthesis(
+    coefficient_cos: Array, coefficient_sin: Array, trig: TrigTables
+) -> Array:
+    """Evaluate one real toroidal Fourier series, using an FFT when unaliased."""
+    nzeta = int(np.shape(trig.cosnv)[0])
+    n_modes = int(coefficient_cos.shape[-1])
+    ntor = n_modes - 1
+    if ntor <= (nzeta - 1) // 2:
+        factors = jnp.full((n_modes,), nzeta / 2, dtype=coefficient_cos.dtype)
+        factors = factors.at[0].set(nzeta)
+        spectrum = (
+            factors * jnp.asarray(trig.nscale[:n_modes])
+            * (coefficient_cos - 1j * coefficient_sin)
+        )
+        spectrum = jnp.pad(
+            spectrum,
+            [(0, 0)] * (spectrum.ndim - 1)
+            + [(0, nzeta // 2 + 1 - n_modes)],
+        )
+        return jnp.fft.irfft(spectrum, n=nzeta, axis=-1)
+    return (
+        _einsum("...mn,kn->...mk", coefficient_cos, trig.cosnv[:, :n_modes])
+        + _einsum("...mn,kn->...mk", coefficient_sin, trig.sinnv[:, :n_modes])
+    )
+
+
+def _fast_synthesis(
+    coefficient_cos: Array,
+    coefficient_sin: Array,
+    modes: ModeTable,
+    trig: TrigTables,
+    derivatives: tuple[str, ...],
+) -> tuple[Array, ...]:
+    """Use separable FFT synthesis without expanding mode-stacked phases."""
+    a_cos, a_sin, b_cos, b_sin = _packed_toroidal_coefficients(
+        coefficient_cos, coefficient_sin, modes
+    )
+    a = _toroidal_synthesis(a_cos, a_sin, trig)
+    b = _toroidal_synthesis(b_cos, b_sin, trig)
+    mpol = int(a.shape[-2])
+    theta = {
+        "value": (trig.cosmu[:, :mpol], trig.sinmu[:, :mpol]),
+        "dtheta": (trig.sinmum[:, :mpol], trig.cosmum[:, :mpol]),
+    }
+    fields: list[Array] = []
+    for derivative in derivatives:
+        if derivative == "dzeta":
+            frequency = (
+                jnp.arange(a_cos.shape[-1], dtype=coefficient_cos.dtype)
+                * float(trig.nfp)
+            )
+            a_d = _toroidal_synthesis(frequency * a_sin, -frequency * a_cos, trig)
+            b_d = _toroidal_synthesis(frequency * b_sin, -frequency * b_cos, trig)
+            cosmu, sinmu = trig.cosmu[:, :mpol], trig.sinmu[:, :mpol]
+        elif derivative in theta:
+            a_d, b_d = a, b
+            cosmu, sinmu = theta[derivative]
+        else:
+            raise ValueError(
+                f"Unknown derivative {derivative!r}; expected one of {_DERIVATIVES}"
+            )
+        fields.append(
+            _einsum("...mk,im->...ik", a_d, cosmu)
+            + _einsum("...mk,im->...ik", b_d, sinmu)
+        )
+    return tuple(fields)
+
+
 # ---------------------------------------------------------------------------
 # Fourier -> real space (totzsps/totzspa)
 # ---------------------------------------------------------------------------
@@ -269,6 +387,51 @@ def fourier_to_real(
         phase = jnp.asarray(np.concatenate([cos_phase, sin_phase], axis=0))
         fields.append(_einsum("...k,kij->...ij", coeff, phase))
     return tuple(fields)
+
+
+def _fourier_to_real_fft(
+    coefficient_cos: Array,
+    coefficient_sin: Array,
+    *,
+    modes: ModeTable,
+    trig: TrigTables,
+    derivatives: Sequence[str] = _DERIVATIVES,
+    internal_coeffs: bool = False,
+    odd_m_sqrt_s: bool = False,
+    s: Array | None = None,
+) -> tuple[Array, ...]:
+    """Internal separable-FFT variant of :func:`fourier_to_real`."""
+    coeff_cos = jnp.asarray(coefficient_cos)
+    coeff_sin = jnp.asarray(coefficient_sin)
+    if coeff_cos.ndim < 2 or coeff_sin.ndim < 2:
+        raise ValueError("Expected coefficient arrays with shape (..., ns, mnmax)")
+    if coeff_cos.shape != coeff_sin.shape:
+        raise ValueError("coefficient_cos and coefficient_sin must have the same shape")
+    if int(coeff_cos.shape[-1]) != modes.mnmax:
+        raise ValueError("Mode count mismatch between coefficients and mode table")
+
+    if not internal_coeffs:
+        scale = jnp.asarray(
+            physical_to_internal_scale(modes, trig), dtype=coeff_cos.dtype
+        )
+        scale = scale.reshape((1,) * (coeff_cos.ndim - 1) + (modes.mnmax,))
+        coeff_cos = coeff_cos * scale
+        coeff_sin = coeff_sin * scale
+    if odd_m_sqrt_s:
+        ns = int(coeff_cos.shape[-2])
+        if s is None:
+            s = _default_radial_grid(ns, coeff_cos.dtype)
+        mpol = int(np.max(np.asarray(modes.m))) + 1
+        scalxc = odd_m_sqrt_s_scaling(s, mpol).astype(coeff_cos.dtype)
+        scalxc_mn = scalxc[:, np.asarray(modes.m, dtype=np.int64)]
+        scalxc_mn = scalxc_mn.reshape(
+            (1,) * (coeff_cos.ndim - 2) + scalxc_mn.shape
+        )
+        coeff_cos = coeff_cos * scalxc_mn
+        coeff_sin = coeff_sin * scalxc_mn
+    return _fast_synthesis(
+        coeff_cos, coeff_sin, modes, trig, tuple(derivatives)
+    )
 
 
 def real_to_fourier(


### PR DESCRIPTION
## Summary

Add an opt-in bounded-storage optimization path for vector physics profiles.
`optimize.minimize(...)` uses the same `(objective, target, weight)` rows as
`least_squares`, scalarizes them as `0.5 * ||r||²`, and supplies L-BFGS-B with
one exact matrix-free reverse implicit gradient.

This PR is stacked on #76 because it relies on that PR's direction-adaptive
implicit path and high-resolution profiler.

## Goals

- Make high-resolution DMerc, Glasser `D_R`, and `<J.B>` optimization possible
  without constructing their complete residual Jacobian.
- Bound optimizer linear-algebra storage independently of the number of
  profile samples and boundary degrees of freedom.
- Preserve existing `least_squares` behavior and Gauss--Newton defaults.
- Retain bounds, current-profile degrees of freedom, staged `max_mode`,
  hot restarts, typed failure recovery, explicit CPU/GPU placement, and
  research-grade documentation.
- Validate that the scalar reverse gradient is the same derivative as
  `J.T @ r`, and measure the collaborator's supplied high-resolution HSX case.

## Achieved so far

- Added `optimize.minimize(...)`, defaulting to scipy L-BFGS-B.
- The objective remains exactly the existing least-squares cost; only the step
  model changes from trust-region Gauss--Newton to limited-memory
  quasi-Newton.
- Each gradient uses one reverse implicit adjoint. The block-Jacobian
  assembly/factorization path is not compiled or executed.
- Existing public `least_squares(...)` code paths and defaults are unchanged.
- Bounds, staged mode schedules, current-profile degrees of freedom, ordinary
  state hot restarts, explicit `device=`, and failed-trial penalties are
  retained.
- Combined DMerc / `D_R` / `<J.B>` validation on Solovev:
  scalar cost agrees with the stacked least-squares cost to `1e-12`; the
  reverse gradient agrees with `J.T @ r` within the existing implicit-solve
  tolerance.
- Explicit office CPU/GPU profile-gradient norms agree to approximately
  `3e-16` relative without platform-selection environment variables.
- The exact supplied `ns=101, mpol=18, ntor=24` HSX deck completes one
  combined DMerc / `D_R` / `<J.B>` gradient in 2881.31 s / 15.250 GiB:
  120 finite components, norm `2.4348168757777485e12`, SHA-256
  `7f05873ba0f657249a6b0be4abfd1ec5112d40276dd76a5a2f972e1f036b0b0c`,
  and the same 2737-iteration equilibrium.
- Updated the high-resolution profiler, README, optimization guide, module
  documentation, and changelog.

## Validation completed

- targeted optimization/stability/penalty suite: `39 passed, 1 skipped`;
- new focused gates: `3 passed`;
- complete local non-`full` suite:
  `707 passed, 39 skipped, 2 xfailed`;
- planned full DMerc / `D_R` / `<J.B>` AD cases:
  `3 passed, 34 deselected`;
- Ruff: passed;
- mypy: passed;
- strict Sphinx (`-W --keep-going`): passed;
- wheel and sdist build: passed;
- fresh-process Solovev stability profile:
  - office CPU: 27.39 s, finite 2-dof gradient;
  - RTX A4000: 34.89 s, finite 2-dof gradient;
  - relative gradient-norm difference: approximately `3e-16`.
- exact-head RTX A4000 GPU-CI profile-gradient test:
  `1 passed` in 104.47 s, with no JAX platform-selection environment
  variable;
- exact supplied-HSX CPU stability profile: finite in 2881.31 s /
  15.250 GiB, where the direct vector block path exceeded 39 GiB.
- final required PR CI:
  [18 jobs passed](https://github.com/uwplasma/vmex/actions/runs/30082855216),
  including strict build/lint/docs, all physics/gradient shards, and the
  aggregate `>=95%` coverage gate;
- the former 431-test catch-all was split without changing its test set:
  collection-set equality is exact (472 parameterized nodes); local shard c
  passed `216 passed, 11 skipped` and shard e passed
  `217 passed, 29 skipped`; independent hosted copies passed in 15:56 and
  3:34;
- production-code head before the final CI-only split:
  [32 jobs passed](https://github.com/rogeriojorge/vmec_jax/actions/runs/30077540268).
- final exact-head full/nightly matrix:
  [33 jobs passed](https://github.com/rogeriojorge/vmec_jax/actions/runs/30083264462),
  including the 93-minute mirror-beta observables shard.

## User impact

There is no default behavior change. Existing users of `least_squares` retain
the same residuals, Jacobians, trust-region steps, warm starts, and results.
Users must explicitly call `optimize.minimize` to select the lower-storage
quasi-Newton algorithm.

## Remaining before merge

- rebase onto the target branch after #76 merges so reviewers see only this
  additive optimizer change.

## Deliberate limitation

This avoids the dense block path for scalarized objectives; it does not make
the exact vector residual Jacobian lower-storage. SOLVAX #39 addresses
checkpointed factor storage, but VMEX still needs a row/segment derivative
generator or a stronger multilevel matrix-free solver before a direct
high-mode Gauss--Newton Jacobian is memory-competitive. The 15.250 GiB HSX
result also shows that scalarization bounds optimizer/Jacobian storage, not
the compiled diagnostic-adjoint working set.

## Final forward-integrated validation (2026-07-24)

Current head `697d3e33` differs from validated head `a7d52cca` only in `.github/workflows/ci.yml`; VMEX source, tests, and documentation are identical. That tree passed the complete local suite (**753 passed, 92 skipped, 2 xfailed**) and the ordinary-discovery office A4000 gate (**10 passed**) with no JAX platform-selection environment variable. Two fresh full supplied-HSX solves completed in **224.64 s / 1.708 GiB** and **218.94 s / 1.569 GiB**, produced byte-identical WOUTs, and retained `1e-11`-scale VMEC2000 parity. This verifies compatibility with the complete forward-performance, free-boundary, mirror, LASYM, diagnostic, and device stack.

Exact-head required CI passed all **18 jobs**, including the ≥95% coverage gate ([run 30101427366](https://github.com/uwplasma/vmex/actions/runs/30101427366)). The PR remains draft only because it must be rebased after #76 merges so its review diff contains the bounded-storage optimizer rather than the stacked performance changes.

Final exact-head manual matrix passed all **34 jobs** ([run 30101437203](https://github.com/rogeriojorge/vmec_jax/actions/runs/30101437203)), including the bounded core/free-boundary split and the 89-minute mirror-beta observables shard.