### PR TITLE
Add opt-in native force projection and structured AD primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,14 +141,14 @@ jobs:
   parity:
     name: Parity suite ${{ matrix.shard }} (goldens, coverage)
     runs-on: ubuntu-latest
-    # Headroom for slow shared runners: the golden solves run ~15-20 min on a
-    # healthy runner but tip over a tighter limit on a slow one (the suite
-    # content is unchanged). 35 absorbs that variance without masking a hang.
+    # The former 431-test catch-all passed in 15-20 min on healthy runners but
+    # repeatedly lost slow shared runners. Shards c/e preserve its exact test
+    # set with enough headroom to distinguish runner variance from a hang.
     timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
-        shard: [a, b, c, d]
+        shard: [a, b, c, d, e]
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -181,7 +181,7 @@ jobs:
           print("golden dir:", mod.resolve_golden_dir())
           EOF
 
-      # Four shards, each well under the 10-min budget.  The xdist dist MODE is
+      # Five bounded shards.  The xdist dist MODE is
       # chosen PER SHARD by whether its modules share an expensive fixture:
       #   * loadscope groups a whole module onto ONE worker, so module-scoped
       #     equilibrium fixtures (omnigenity qi_eq/tok_eq, bootstrap eq,
@@ -201,11 +201,12 @@ jobs:
       #   a = heaviest solver-golden modules, including all free-boundary
       #       modules so their JAX caches leave with this bounded shard instead
       #       of accumulating in the catch-all worker processes;
-      #   c = everything else, incl. omnigenity/turbulence/bootstrap/stability.
+      #   c = the slow fixture-sharing modules from the former catch-all;
+      #   e = the remaining catch-all modules.
       # Together they cover the whole non-gradient, non-example core suite once;
       # the separate mirror matrix owns tests/mirror. Therefore
       # every test file appears in exactly one shard (coverage gate combines
-      # a+b+c+d), so coverage is invariant under this reshuffle.
+      # a+b+c+d+e), so coverage is invariant under this reshuffle.
       - name: Run parity shard ${{ matrix.shard }} with coverage
         env:
           JAX_ENABLE_X64: "1"
@@ -221,6 +222,17 @@ jobs:
           B_FILES="tests/test_golden_digests.py \
                    tests/test_bootstrap.py \
                    tests/test_wout_golden.py"
+          C_FILES="tests/test_input_profiles.py \
+                   tests/test_setup.py \
+                   tests/test_profiles.py \
+                   tests/test_omnigenity.py \
+                   tests/test_implicit_multi_rhs.py \
+                   tests/test_parallel.py \
+                   tests/test_optimize_penalty.py \
+                   tests/test_lgradb.py \
+                   tests/test_package_api.py \
+                   tests/test_stability.py \
+                   tests/test_multigrid_interp.py"
           D_FILES="tests/test_optimize.py"
           if [ "${{ matrix.shard }}" = "a" ]; then
             pytest -q -n 4 --dist loadscope $A_FILES --durations=15 --cov=vmex --cov-report=term
@@ -228,8 +240,10 @@ jobs:
             pytest -q -n 4 --dist load $B_FILES --durations=15 --cov=vmex --cov-report=term
           elif [ "${{ matrix.shard }}" = "d" ]; then
             pytest -q -n 4 --dist load $D_FILES --durations=15 --cov=vmex --cov-report=term
+          elif [ "${{ matrix.shard }}" = "c" ]; then
+            pytest -q -n 4 --dist loadscope $C_FILES --durations=15 --cov=vmex --cov-report=term
           else
-            IGNORES=$(for f in $A_FILES $B_FILES $D_FILES; do echo "--ignore=$f"; done)
+            IGNORES=$(for f in $A_FILES $B_FILES $C_FILES $D_FILES; do echo "--ignore=$f"; done)
             pytest -q -n 4 --dist loadscope tests \
               --ignore=tests/mirror \
               --ignore=tests/test_implicit_grad.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
 
       - name: Combine shards and enforce the gate
         run: |
-          coverage combine coverage.parity-a coverage.parity-b coverage.parity-c coverage.parity-d coverage.gradient-a coverage.gradient-b coverage.gradient-c coverage.examples
+          coverage combine coverage.parity-a coverage.parity-b coverage.parity-c coverage.parity-d coverage.parity-e coverage.gradient-a coverage.gradient-b coverage.gradient-c coverage.examples
           # The mirror release audit reaches 95% only after appending nightly
           # fixed/free adjoint tests. The fast core artifacts intentionally
           # exclude those tests, so do not mix a partial mirror number into

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -49,7 +49,9 @@ jobs:
           PY
 
       - name: Run focused placement, solve, and gradient checks
-        run: pytest -q tests/test_gpu_ci.py tests/test_device.py tests/test_implicit_device.py --durations=0
+        run: |
+          pytest -q tests/test_gpu_ci.py tests/test_device.py \
+            tests/test_implicit_device.py tests/test_native_force.py --durations=0
 
       - name: Audit all physics gradients on CPU and GPU
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
 ## [Unreleased]
 
 ### Added
+- **Bounded-storage profile optimization.** `optimize.minimize` scalarizes the
+  existing least-squares rows and uses L-BFGS-B with one matrix-free reverse
+  adjoint per gradient, avoiding dense residual Jacobians for high-resolution
+  `DMerc`, `jdotb`, and Glasser `D_R` campaigns without changing defaults.
 - **High-resolution resource profiler.**
   `benchmarks/profile_high_resolution.py` records fresh-process implicit
   Jacobian checksums and per-resolution mirror wall/RSS scaling without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
 ## [Unreleased]
 
 ### Added
+- **Opt-in native force projection.** Source builds can provide a CPU JAX-FFI
+  kernel for the fused weighted theta/zeta force projection with explicit
+  `threads=` control and compiler-reusable scratch. Exact pure-JAX JVP/VJP
+  rules preserve implicit gradients; the portable JAX backend remains the
+  default and the GPU path.
+- **Structured free-boundary primitive.**
+  `NestorBorderedOperator` supplies matrix-free coupled plasma/vacuum action,
+  exact transpose, Schur action, and block inversion without changing the
+  host NESTOR or solver defaults.
 - **Bounded-storage profile optimization.** `optimize.minimize` scalarizes the
   existing least-squares rows and uses L-BFGS-B with one matrix-free reverse
   adjoint per gradient, avoiding dense residual Jacobians for high-resolution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
   implicit-gradient parity without JAX platform environment variables.
 
 ### Changed
+- **Measured high-mode synthesis.** Above 512 modes on accelerators and ARM
+  CPUs, equilibrium solves now repack signed helical modes into toroidal FFTs
+  plus a short poloidal contraction; smaller decks retain the dense lane
+  after routine M4 timing. The exact supplied HSX run on an Apple M4 falls
+  from
+  676.46 s / 3.896 GiB to
+  206.56 s / 1.634 GiB without changing convergence or WOUT parity. The
+  dense real contraction remains the x86 CPU default after it beat the FFT
+  path 413.24 s to 570.47 s on the office Xeon; explicit `use_fft` wins.
+  The one-shot CLI releases completed radial-stage executables; library
+  calls retain them by default. Implicit AD keeps the established real
+  contraction to avoid complex batched tangent storage.
+- **Direction-adaptive implicit Jacobians.** Scalar least-squares residuals
+  now use one matrix-free reverse adjoint by default, avoiding the dense
+  high-mode block assembly; vector residuals retain the exact block path.
+  Automatic probe chunks are capped by the conservative square-root width.
 - **Mirror-specific device policy.** Fixed/free-boundary mirror solves and
   beta scans now accept the common `device=` contract and default to CPU for
   their measured host-SciPy/JAX callback workload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once past 1.0.
 ## [Unreleased]
 
 ### Added
+- **High-resolution resource profiler.**
+  `benchmarks/profile_high_resolution.py` records fresh-process implicit
+  Jacobian checksums and per-resolution mirror wall/RSS scaling without
+  hardware-selection environment variables.
 - **Explicit device selection.** Forward, free-boundary, implicit, and CLI
   solve paths accept public CPU/GPU/JAX placement controls: omitted or
   `"auto"` retains VMEX's measured policy, `None` follows JAX, and explicit

--- a/README.md
+++ b/README.md
@@ -433,6 +433,23 @@ objective at a stiff weight:
 - lower the aspect ratio to 4.8 at fixed iota;
 - push the Mercier criterion `DMerc` toward stability at ⟨β⟩ ≈ 1.25%.
 
+High-resolution vector profiles can use `opt.minimize(...)` with the same
+`(objective, target, weight)` terms. It minimizes the identical squared
+residual cost with L-BFGS-B and one matrix-free reverse adjoint per gradient,
+avoiding the dense residual Jacobian used by Gauss–Newton:
+
+```python
+result = opt.minimize(
+    [(opt.mercier_stability_residual, 0.0, 1.0),
+     (opt.glasser_stability_residual, 0.0, 1.0),
+     (opt.jdotb_residual, 0.0, 1e-6)],
+    inp, max_mode=5, bounds=bounds, options={"maxiter": 100},
+)
+```
+
+This bounded-storage optimizer is opt-in because its quasi-Newton steps differ
+from `least_squares`; existing defaults and objective minima are unchanged.
+
 The first four use the implicit adjoint (`jac="implicit"`). The published
 `DMerc` showcase deliberately preserves its legacy host-side reporting lane
 and finite-difference baseline at `max_mode` 2. New campaigns can instead use

--- a/README.md
+++ b/README.md
@@ -195,6 +195,17 @@ CPU, single thread; `benchmarks/baseline.json`; reproduce with
   GMRES path was over 5× slower without finishing. Scalar objectives now
   default to one matrix-free reverse adjoint and avoid that block assembly;
   reducing block storage for high-mode vector objectives remains open work.
+- **Native CPU force projection (experimental)** — source builds attempt an
+  optional JAX-FFI extension that fuses the weighted theta/zeta force
+  projection and reuses compiler-managed scratch. It is never selected
+  implicitly: pass `force_backend="native", threads=N` to `solve`,
+  `solve_multigrid`, or the implicit API. The default `force_backend="jax"`
+  remains portable across CPU, GPU, and TPU; GPU execution currently uses
+  that pure-JAX path because there is no native CUDA handler yet.
+  On the full supplied HSX deck, eight native threads took 215.37 s /
+  1.63 GiB versus recent JAX controls at 218.94–224.64 s /
+  1.57–1.71 GiB, with unchanged 2737-iteration convergence and VMEC2000
+  parity. This modest 2–4% result does not close the VMEC++ gap.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -164,15 +164,33 @@ CPU, single thread; `benchmarks/baseline.json`; reproduce with
   858-mode HSX case was instead 3.44× slower than CPU. The measured device
   policy therefore keeps both small-work and very-high-mode stages on CPU,
   while explicit placement always wins.
-- **Memory** — the bundled warm cases peak at 0.6–3.3 GB, but that is not a
-  high-resolution upper bound. The supplied `ns=101`, `mpol=18`, `ntor=24`
-  HSX deck used 3.90 GiB in a fresh CPU VMEX process versus 380 MiB in VMEC++
-  and 265 MiB in one-radial-process VMEC2000.
+- **High resolution** — on Apple Silicon, separable toroidal FFT synthesis
+  cuts the supplied
+  `ns=101`, `mpol=18`, `ntor=24` HSX deck from 676.46 s / 3.90 GiB to
+  206.56 s / 1.63 GiB in a fresh CPU VMEX CLI process; the CLI releases
+  completed radial-stage executables while the reusable library API retains
+  them by default. Convergence and VMEC2000 parity are unchanged. That is
+  faster than the measured
+  one-thread VMEC++ control (449.79 s), though ten-thread VMEC++ remains
+  faster and smaller (92.03 s / 380 MiB); one-radial-process VMEC2000
+  took 1154.82 s / 265 MiB.
+  The measured default selects this kernel only above 512 modes on ARM CPUs
+  and accelerators. Smaller problems retain the established dense lane (FFT
+  was slower on three routine M4 decks and only marginally faster warm at
+  128 modes); x86 CPUs also remain dense because FFT was slower.
+  Dense synthesis with CLI stage-cache release took 413.24 s /
+  4.04 GiB on the office Xeon, versus 570.47 s for FFT and the previous
+  cache-retaining dense baseline of 426.94 s / 6.52 GiB (3.2% faster and
+  38.0% lower peak RSS). `use_fft=True` or `False` remains an explicit
+  library override.
   Column chunking bounds simultaneous design probes, while the implicit
   block factors still scale as `O(ns * m_block²)`; an `ns=201` one-Jacobian
-  measurement used 4.11 GiB. A candidate chunk schedule that raised RSS by
-  36.7% was rejected, and the lower-memory GMRES path was over 5× slower
-  without finishing. Reducing the block-factor storage remains open work.
+  measurement used 4.11 GiB. The implicit callback deliberately retains the
+  real dense transform: complex FFT tangents exceeded 10 GiB. A candidate
+  chunk schedule that raised RSS by 36.7% was rejected, and the lower-memory
+  GMRES path was over 5× slower without finishing. Scalar objectives now
+  default to one matrix-free reverse adjoint and avoid that block assembly;
+  reducing block storage for high-mode vector objectives remains open work.
 
 ## Features
 
@@ -388,8 +406,8 @@ These campaigns need implicit gradients. Finite differences stall at the
 axisymmetric seed of the QH target (a saddle point) and land in a worse basin
 for QP. Three measured optimizations keep each campaign in the minutes range:
 
-- the residual Jacobian uses a block-tridiagonal factorization of the force
-  linearization (33× faster than per-dof GMRES);
+- scalar residuals use one reverse adjoint; vector residual Jacobians use a
+  block-tridiagonal factorization (33× faster than per-dof GMRES);
 - each trial equilibrium starts from a first-order perturbation prediction
   (3.7× fewer solver iterations);
 - a converged-state memo avoids re-solving the point the residual just

--- a/benchmarks/profile_high_resolution.py
+++ b/benchmarks/profile_high_resolution.py
@@ -33,20 +33,25 @@ def _implicit(args) -> dict:
     if args.input is None:
         raise ValueError("--input is required for the implicit case")
     inp = VmecInput.from_file(args.input)
-    result = opt.least_squares(
-        [(opt.aspect_ratio, args.aspect_target, 1.0)],
-        inp,
-        max_mode=args.max_mode,
-        jac="implicit",
-        jac_solver=args.jac_solver,
-        jac_chunk_size=args.jac_chunk,
-        max_nfev=1,
-        ftol=1e-9,
-        xtol=1e-10,
-        device=args.device,
-    )
+    terms = ([(opt.aspect_ratio, args.aspect_target, 1.0)]
+             if args.implicit_objective == "aspect" else
+             [(opt.mercier_stability_residual, 0.0, 1.0),
+              (opt.glasser_stability_residual, 0.0, 1.0),
+              (opt.jdotb_residual, 0.0, 1.0e-6)])
+    if args.optimizer == "minimize":
+        x0 = opt.pack_boundary(inp, args.max_mode)
+        result = opt.minimize(
+            terms, inp, max_mode=args.max_mode, device=args.device,
+            bounds=list(zip(x0, x0)))
+    else:
+        result = opt.least_squares(
+            terms, inp, max_mode=args.max_mode, jac="implicit",
+            jac_solver=args.jac_solver, jac_chunk_size=args.jac_chunk,
+            max_nfev=1, ftol=1e-9, xtol=1e-10, device=args.device)
     jac = np.asarray(result.jac, dtype=np.float64)
     return {
+        "optimizer": args.optimizer,
+        "objective": args.implicit_objective,
         "jac_solver": args.jac_solver,
         "ns_array": np.asarray(inp.ns_array).tolist(),
         "mpol": int(inp.mpol),
@@ -132,6 +137,14 @@ def main() -> None:
     parser.add_argument("--input")
     parser.add_argument("--max-mode", type=int, default=5)
     parser.add_argument("--aspect-target", type=float, default=8.0)
+    parser.add_argument(
+        "--implicit-objective", choices=("aspect", "stability"),
+        default="aspect",
+    )
+    parser.add_argument(
+        "--optimizer", choices=("least-squares", "minimize"),
+        default="least-squares",
+    )
     parser.add_argument(
         "--jac-solver", choices=("auto", "block", "gmres", "reverse"),
         default="auto",

--- a/benchmarks/profile_high_resolution.py
+++ b/benchmarks/profile_high_resolution.py
@@ -42,17 +42,25 @@ def _implicit(args) -> dict:
         x0 = opt.pack_boundary(inp, args.max_mode)
         result = opt.minimize(
             terms, inp, max_mode=args.max_mode, device=args.device,
+            solve_kwargs={
+                "force_backend": args.force_backend, "threads": args.threads
+            },
             bounds=list(zip(x0, x0)))
     else:
         result = opt.least_squares(
             terms, inp, max_mode=args.max_mode, jac="implicit",
             jac_solver=args.jac_solver, jac_chunk_size=args.jac_chunk,
-            max_nfev=1, ftol=1e-9, xtol=1e-10, device=args.device)
+            max_nfev=1, ftol=1e-9, xtol=1e-10, device=args.device,
+            solve_kwargs={
+                "force_backend": args.force_backend, "threads": args.threads
+            })
     jac = np.asarray(result.jac, dtype=np.float64)
     return {
         "optimizer": args.optimizer,
         "objective": args.implicit_objective,
         "jac_solver": args.jac_solver,
+        "force_backend": args.force_backend,
+        "threads": args.threads,
         "ns_array": np.asarray(inp.ns_array).tolist(),
         "mpol": int(inp.mpol),
         "ntor": int(inp.ntor),
@@ -146,10 +154,13 @@ def main() -> None:
         default="least-squares",
     )
     parser.add_argument(
-        "--jac-solver", choices=("auto", "block", "gmres", "reverse"),
+        "--jac-solver",
+        choices=("auto", "block", "gmres", "reverse"),
         default="auto",
     )
     parser.add_argument("--jac-chunk", default="auto")
+    parser.add_argument("--force-backend", choices=("jax", "native"), default="jax")
+    parser.add_argument("--threads", type=int, default=1)
     parser.add_argument("--ns", type=int, default=5)
     parser.add_argument("--nxi", type=int, default=7)
     parser.add_argument("--elements", type=int, default=4)

--- a/benchmarks/profile_high_resolution.py
+++ b/benchmarks/profile_high_resolution.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+"""Fresh-process resource profiles for implicit AD and mirror scaling."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import resource
+import sys
+import time
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+
+def _peak_rss_gib() -> float:
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    peak_bytes = peak if platform.system() == "Darwin" else peak * 1024
+    return peak_bytes / 2**30
+
+
+def _implicit(args) -> dict:
+    from vmex.core import optimize as opt
+    from vmex.core.input import VmecInput
+
+    if args.input is None:
+        raise ValueError("--input is required for the implicit case")
+    inp = VmecInput.from_file(args.input)
+    result = opt.least_squares(
+        [(opt.aspect_ratio, args.aspect_target, 1.0)],
+        inp,
+        max_mode=args.max_mode,
+        jac="implicit",
+        jac_solver=args.jac_solver,
+        jac_chunk_size=args.jac_chunk,
+        max_nfev=1,
+        ftol=1e-9,
+        xtol=1e-10,
+        device=args.device,
+    )
+    jac = np.asarray(result.jac, dtype=np.float64)
+    return {
+        "ns_array": np.asarray(inp.ns_array).tolist(),
+        "mpol": int(inp.mpol),
+        "ntor": int(inp.ntor),
+        "jac_shape": list(jac.shape),
+        "jac_finite": bool(np.all(np.isfinite(jac))),
+        "jac_norm": float(np.linalg.norm(jac)),
+        "jac_sha256": hashlib.sha256(jac.tobytes()).hexdigest(),
+        "solve_stats": result.solve_stats,
+    }
+
+
+def _external_mirror_field(points):
+    points = jnp.asarray(points)
+    x, y, z = jnp.moveaxis(points, -1, 0)
+    curvature = 0.02
+    return jnp.stack(
+        (-curvature * x * z,
+         -curvature * y * z,
+         0.08 + curvature * (z**2 - 0.5 * (x**2 + y**2))),
+        axis=-1,
+    )
+
+
+def _mirror(args) -> dict:
+    from vmex.mirror import (
+        MirrorBoundary,
+        MirrorConfig,
+        MirrorResolution,
+        SplineMirrorDiscretization,
+        solve_beta_scan,
+    )
+
+    config = MirrorConfig(
+        resolution=MirrorResolution(ns=args.ns, mpol=0, nxi=args.nxi),
+        z_min=-0.8,
+        z_max=0.8,
+        ftol=1e-12,
+        max_iterations=args.max_iterations,
+    )
+    source_grid = config.build_grid()
+    discretization = SplineMirrorDiscretization.build_cgl(
+        config, elements=args.elements)
+    grid = discretization.grid
+    on_axis = 0.08 + 0.02 * jnp.asarray(grid.z) ** 2
+    center = grid.nxi // 2
+    flux = 0.5 * on_axis[center] * 0.25**2
+    boundary = discretization.fit_boundary(
+        MirrorBoundary.from_axis_field(flux, on_axis, grid), source_grid)
+    betas = jnp.asarray([float(value) for value in args.betas.split(",")])
+    results = solve_beta_scan(
+        boundary,
+        discretization,
+        config,
+        _external_mirror_field,
+        betas,
+        axial_flux_derivative=flux,
+        reference_field=float(on_axis[center]),
+        exterior_ntheta=args.exterior_ntheta,
+        exterior_order=8,
+        device=args.device,
+    )
+    return {
+        "resolution": {
+            "ns": args.ns,
+            "nxi": args.nxi,
+            "elements": args.elements,
+            "exterior_ntheta": args.exterior_ntheta,
+        },
+        "betas": np.asarray(betas).tolist(),
+        "converged": [bool(result.converged) for result in results],
+        "iterations": [int(result.iterations) for result in results],
+        "variational_max": [
+            float(result.variational_max) for result in results],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("case", choices=("implicit", "mirror"))
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--out")
+    parser.add_argument("--input")
+    parser.add_argument("--max-mode", type=int, default=5)
+    parser.add_argument("--aspect-target", type=float, default=8.0)
+    parser.add_argument("--jac-solver", choices=("block", "gmres"),
+                        default="block")
+    parser.add_argument("--jac-chunk", default="auto")
+    parser.add_argument("--ns", type=int, default=5)
+    parser.add_argument("--nxi", type=int, default=7)
+    parser.add_argument("--elements", type=int, default=4)
+    parser.add_argument("--exterior-ntheta", type=int, default=8)
+    parser.add_argument("--betas", default="0,0.1")
+    parser.add_argument("--max-iterations", type=int, default=500)
+    args = parser.parse_args()
+    if args.device == "none":
+        args.device = None
+    if args.jac_chunk != "auto":
+        args.jac_chunk = int(args.jac_chunk)
+
+    started = time.perf_counter()
+    payload = (_implicit(args) if args.case == "implicit" else _mirror(args))
+    record = {
+        "case": args.case,
+        "device": None if args.device is None else str(args.device),
+        "jax": jax.__version__,
+        "devices": [str(device) for device in jax.devices()],
+        "wall_s": time.perf_counter() - started,
+        "peak_rss_gib": _peak_rss_gib(),
+        **payload,
+    }
+    text = json.dumps(record, indent=2, sort_keys=True)
+    print(text, flush=True)
+    if args.out:
+        Path(args.out).write_text(text + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/profile_high_resolution.py
+++ b/benchmarks/profile_high_resolution.py
@@ -47,6 +47,7 @@ def _implicit(args) -> dict:
     )
     jac = np.asarray(result.jac, dtype=np.float64)
     return {
+        "jac_solver": args.jac_solver,
         "ns_array": np.asarray(inp.ns_array).tolist(),
         "mpol": int(inp.mpol),
         "ntor": int(inp.ntor),
@@ -131,8 +132,10 @@ def main() -> None:
     parser.add_argument("--input")
     parser.add_argument("--max-mode", type=int, default=5)
     parser.add_argument("--aspect-target", type=float, default=8.0)
-    parser.add_argument("--jac-solver", choices=("block", "gmres"),
-                        default="block")
+    parser.add_argument(
+        "--jac-solver", choices=("auto", "block", "gmres", "reverse"),
+        default="auto",
+    )
     parser.add_argument("--jac-chunk", default="auto")
     parser.add_argument("--ns", type=int, default=5)
     parser.add_argument("--nxi", type=int, default=7)

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -493,9 +493,11 @@ Forward-mode Jacobians for least squares (block-tridiagonal)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The adjoint above is the right tool for *one* scalar objective and many
-parameters. A least-squares optimizer needs the opposite object — the full
-residual Jacobian over all boundary dofs — which is computed in **forward**
-mode: per dof tangent :math:`t_j`, the state response is
+parameters. ``jac_solver="auto"`` therefore uses that reverse path for a
+scalar least-squares residual: one matrix-free solve, with no dense angular
+block assembly. Vector residuals need the full Jacobian over all boundary
+dofs, which the automatic policy computes in **forward** mode. Per dof
+tangent :math:`t_j`, the state response is
 
 .. math::
 
@@ -503,7 +505,7 @@ mode: per dof tangent :math:`t_j`, the state response is
           \frac{\partial F}{\partial p}\, t_j ,
 
 one linear solve per dof. Rather than running an independent GMRES per
-column, the default path (``jac_solver="block"``) exploits a structural
+column, the vector-residual path (``jac_solver="block"``) exploits a structural
 fact: in the **raw** force formulation the radial coupling of
 :math:`\partial F/\partial z` is exactly nearest-neighbor (the
 finite-difference stencil in :math:`s`), so the operator is *exactly*

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -49,6 +49,17 @@ tables are built in :mod:`vmex.core.fourier` and the transforms
 ``dot_general`` matmuls in :mod:`vmex.core.transforms` — GEMM-friendly
 and XLA-fusable while matching VMEC2000 normalization exactly.
 
+Source builds may also provide the opt-in ``force_backend="native"`` CPU
+projection. Its JAX-FFI handler fuses the two analysis stages, parallelizes
+over surface/mode work with explicit ``threads=``, and uses an XLA-owned
+scratch result that the allocator can reuse between calls. The primal handler
+is value-only; a custom JVP evaluates the exact pure-JAX linearization, so
+forward and transpose/reverse AD retain the portable implementation. This
+also defines the accelerator policy: the ordinary ``"jax"`` backend is the
+unchanged default on every platform, and is currently the only GPU path. A
+native GPU implementation would require a separate CUDA FFI target rather
+than calling the host kernel on device buffers.
+
 Geometry pipeline
 ~~~~~~~~~~~~~~~~~
 
@@ -352,6 +363,15 @@ ESSOS/SIMSOPT Biot--Savart object or any ``xyz -> B`` callable.  The resulting
 table and its current scale remain JAX-differentiable; tabulation itself does
 not retain coil-geometry derivatives.  Direct, interpolation-free ESSOS coil
 derivatives use the virtual-casing residual below. vmex carries no coil code.
+
+For future differentiation of the coupled equilibrium,
+:class:`vmex.core.freeboundary_linear.NestorBorderedOperator` represents its
+linearization as ``[[A, B], [C, D]]`` with matrix-free plasma, vacuum, and
+edge-coupling actions. It supplies the exact generated transpose, the Schur
+action :math:`D-C A^{-1}B`, and a block inverse. This is a tested linear
+algebra primitive only: the host-driven NESTOR cadence above has not yet been
+connected to these blocks and is not currently an implicit free-boundary
+adjoint.
 
 Differentiable free boundary (virtual casing)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -364,14 +364,17 @@ table and its current scale remain JAX-differentiable; tabulation itself does
 not retain coil-geometry derivatives.  Direct, interpolation-free ESSOS coil
 derivatives use the virtual-casing residual below. vmex carries no coil code.
 
-For future differentiation of the coupled equilibrium,
 :class:`vmex.core.freeboundary_linear.NestorBorderedOperator` represents its
 linearization as ``[[A, B], [C, D]]`` with matrix-free plasma, vacuum, and
-edge-coupling actions. It supplies the exact generated transpose, the Schur
-action :math:`D-C A^{-1}B`, and a block inverse. This is a tested linear
-algebra primitive only: the host-driven NESTOR cadence above has not yet been
-connected to these blocks and is not currently an implicit free-boundary
-adjoint.
+edge-coupling actions. :func:`~vmex.core.freeboundary_linear.linearize_nestor_coupling`
+builds those four actions directly from a live plasma residual and NESTOR's
+unsolved ``A(x) q - b(x)`` equation; :class:`~vmex.core.vacuum.VacuumSolver`
+exposes that equation through ``assemble`` without nesting a potential solve.
+The operator supplies the exact generated transpose, the Schur action
+:math:`D-C A^{-1}B`, and a block inverse. The live LASYM NESTOR blocks are
+tested against the complete coupled JVP/VJP. The host-driven cadence above is
+not yet replaced by a coupled Newton solve, so this foundation is not yet a
+public implicit free-boundary adjoint.
 
 Differentiable free boundary (virtual casing)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -552,3 +555,10 @@ Jacobian phase of the benchmark optimization step (see
 :doc:`optimization`). The same per-dof responses :math:`dz_j` double as a
 first-order perturbation warm start for the optimizer's next trial solves —
 the DESC-style ``eq.perturb`` pattern — making the linearization pay twice.
+
+A separate width-three nonlinear kernel reproduces the full raw residual on
+axis, interior, edge, symmetric, and LASYM rows. A measured attempt to stream
+its generated rows directly into the SOLVAX factor was rejected: sequential
+rows exceeded 10.6 minutes on the ``ns=201`` HSX gate, while eight-row batches
+exceeded 5.1 GiB and 6.7 minutes before completion. The proven three-color
+assembler therefore remains in production; see :doc:`performance`.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -68,6 +68,9 @@ Free boundary
 .. automodule:: vmex.core.freeboundary
    :members:
 
+.. automodule:: vmex.core.freeboundary_linear
+   :members:
+
 .. automodule:: vmex.core.freeboundary_diff
    :members:
 

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -52,11 +52,44 @@ Two gradient modes share the same term list.  ``jac=None`` uses scipy
 freedom per Jacobian, works with *every* objective.  ``jac="implicit"``
 computes the exact residual Jacobian by implicit differentiation (one
 amortized linear-algebra pass instead of ~2N solves) and requires traceable
-terms and a stellarator-symmetric fixed-boundary problem — the
+terms and a fixed-boundary problem — the
 compatibility table is in :doc:`objectives`.  ``current_dofs=k``
 additionally frees the first ``k`` current-profile (``AC``) coefficients
 plus ``CURTOR`` in either mode — the dof set of the self-consistent
 bootstrap objective.
+
+Bounded-storage profile optimization
+------------------------------------
+
+Vector profile objectives normally require their complete residual Jacobian
+for a Gauss--Newton step.  At high Fourier resolution those radial
+block-tridiagonal factors can dominate memory.  :func:`~vmex.core.optimize.minimize`
+instead minimizes the identical scalar cost
+
+.. math::
+
+   \Phi(p) = \frac{1}{2}\sum_i r_i(p)^2
+
+with scipy L-BFGS-B.  Reverse implicit differentiation evaluates
+``grad(Phi)`` with one matrix-free adjoint, independent of the number of
+profile samples, and does not form the dense residual Jacobian:
+
+.. code-block:: python
+
+   result = opt.minimize(
+       [(opt.mercier_stability_residual, 0.0, 1.0),
+        (opt.glasser_stability_residual, 0.0, 1.0),
+        (opt.jdotb_residual, 0.0, 1e-6)],
+       inp, max_mode=5,
+       bounds=bounds,
+       options={"maxiter": 100})
+
+This is opt-in because it changes the step model from Gauss--Newton
+trust-region to limited-memory quasi-Newton, although the objective and its
+unconstrained minimizers are unchanged.  Existing
+:func:`~vmex.core.optimize.least_squares` behavior is unaffected.  Plain
+state hot restarts remain enabled; the perturbation warm start is unavailable
+because it would require the forward state-response columns this path avoids.
 
 Single-call ESS optimization (the recommended pattern)
 ------------------------------------------------------

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -253,6 +253,9 @@ default:
   column to the same ``adjoint_tol`` as the old path.  Measured: the warm
   Jacobian phase drops 20.35 s to 0.61 s (**33x**); ``jac_solver="gmres"``
   (one preconditioned GMRES per dof) remains as a fallback.
+  A true width-three nonlinear row kernel is parity-tested, but its direct
+  streamed SOLVAX assembly is not selected: the high-resolution HSX resource
+  gate was slower and used more peak memory than this three-color path.
 - **Converged-state memo.**  scipy's trust-region drivers call ``jac(x)``
   at exactly the ``x`` that ``fun(x)`` just converged; a one-entry
   params-keyed memo removes that redundant solve per accepted iterate, and

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -206,8 +206,12 @@ default:
    Reproduce the campaign numbers with the two
    ``examples/optimization/QA_optimization*.py`` scripts.
 
-- **Block-tridiagonal Jacobian factorization** (``jac_solver="block"``,
-  default).  The raw force Jacobian ``dF/dz`` is *exactly*
+- **Direction-adaptive Jacobians** (``jac_solver="auto"``, default). A scalar
+  residual uses one matrix-free reverse adjoint and never assembles dense
+  angular blocks. Vector residuals use the block path below; ``"reverse"``
+  and ``"block"`` remain explicit controls.
+- **Block-tridiagonal Jacobian factorization** (``jac_solver="block"``).
+  The raw force Jacobian ``dF/dz`` is *exactly*
   block-tridiagonal in radius (nearest-neighbor coupling; verified to
   1e-14), so ``ns`` dense ``(3mn, 3mn)`` blocks are assembled with
   3-colored ``jax.jvp`` probes — a cost independent of the dof count —
@@ -231,10 +235,10 @@ default:
   hot restart hit a Jacobian-sign failure.  ``"state"`` (plain hot restart)
   and ``None`` are the fallbacks; all three converge to identical fixed
   points.
-- **Memory** stays bounded by column chunking
-  (``jac_chunk_size="auto"``, the same knob DESC exposes): peak Jacobian
-  memory is ``m0 + m1*chunk`` instead of scaling with the dof count, and
-  the chunked columns are identical to float64 round-off.
+- **Memory** stays bounded by column chunking. ``jac_chunk_size="auto"`` caps
+  SOLVAX's device-aware choice by the square-root width, so accelerator
+  capacity cannot accidentally request one full probe ``vmap``. Chunked
+  columns are identical to float64 round-off.
 - **Krylov recycling** (``recycle=True``) carries a GCROT deflation space
   across the per-dof solves.  It is **off by default for a measured
   reason**: solvax v0.1's FIFO recycle space *slows* warm-started columns

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -376,6 +376,41 @@ Explicit ``use_fft=True`` or ``use_fft=False`` always wins. Implicit AD
 retains the dense lanes and their existing checksum/storage gate. The shared
 runtime pytree is unchanged.
 
+Native projection experiment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Source builds attempt a CPU JAX-FFI force-projection extension. It is
+deliberately opt-in and leaves all solver defaults unchanged::
+
+   result = solve_multigrid(
+       inp, force_backend="native", threads=8, device="cpu"
+   )
+
+The handler fuses the weighted poloidal and toroidal projection and uses
+compiler-owned reusable scratch. Its exact JVP/VJP is the pure-JAX
+linearization, so implicit gradients remain portable. At the supplied-HSX
+projection shape (``ns=101, mpol=18, ntor=24``), the isolated warm M4 result
+was 8.21 ms for JAX, 8.22 ms for four native threads, and 6.99 ms for eight
+threads; cold execution fell from 122.8 ms to 22.5 ms at eight threads.
+These are microkernel numbers, not an end-to-end VMEC++ parity claim. The
+default remains JAX, and GPUs use it: a safe native CUDA version needs a
+separate device handler.
+
+The fresh five-stage HSX solve with eight native threads took 215.37 s /
+1.63 GiB and the same 2737 final-stage iterations. Recent JAX controls took
+218.94--224.64 s / 1.57--1.71 GiB, so the end-to-end gain is only about
+2--4% and RSS is unchanged within run-to-run variation. The native WOUT
+remains at VMEC2000 parity (relative L2: ``rmnc 1.62e-11``,
+``zmns 1.00e-10``, ``bmnc 2.61e-11``, ``iotaf 5.64e-10``). This backend is
+therefore a small measured CPU option, not closure of the ten-thread VMEC++
+runtime or memory gap.
+
+The high-resolution profiler accepts the backend controls::
+
+   python benchmarks/profile_high_resolution.py implicit \
+       --input input.case --force-backend native --threads 8 \
+       --jac-solver block --device cpu
+
 The one-shot fixed-boundary CLI additionally calls JAX's public
 ``clear_caches`` between distinct radial grids. This clears in-memory
 compilation/staging entries while VMEX's persistent on-disk compilation cache

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -461,6 +461,19 @@ wall time to 284.69 s, but increased peak RSS by 8.6 % to 4.833 GiB as the
 allocator retained loop intermediates into factorization.  It was also rejected:
 lower storage must be demonstrated end to end, not inferred from one live array.
 
+A sixth experiment differentiated a genuinely local nonlinear raw-force
+kernel containing exactly three full surfaces. The kernel itself matches the
+global nonlinear residual to ``2e-12`` on axis/interior/edge rows for both
+stellarator symmetry and LASYM. Connecting its rows to the same checkpointed
+SOLVAX block-Thomas solve nevertheless failed the end-to-end resource gate:
+one-row streaming was stopped after 10.6 minutes (versus the 352.73 s /
+4.450 GiB baseline), and an eight-row batch was stopped after 6.7 minutes
+when live RSS exceeded 5.1 GiB. Both retained the exact small-case Jacobian,
+but XLA compilation/allocator retention plus the unchanged dense block bands
+and factors erased the local-temporary saving. The local kernel remains as a
+tested foundation; the production assembler remains the faster three-color
+path until the factor representation itself becomes lower-storage.
+
 The same profiler isolates one free-boundary mirror resolution per process:
 
 .. code-block:: bash

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -362,6 +362,41 @@ the baseline) but did not finish one Jacobian in 30m08s, over five times the
 block wall. A lower-storage factorization or a measured resolution-aware
 solver policy is still needed.
 
+``benchmarks/profile_high_resolution.py`` makes that gate reusable on any
+input without hardware-selection environment variables:
+
+.. code-block:: bash
+
+   python benchmarks/profile_high_resolution.py implicit \
+       --input /path/to/input.HSX_QHS_vacuum_ns201 \
+       --max-mode 5 --device cpu --out implicit.json
+
+It records the input resolution, devices, wall time, peak RSS, solve count,
+and the complete Jacobian's finiteness, norm, and SHA-256.  On the case above,
+the unmodified float64 path repeated in 355.25 s with the established
+``74.70287727265259`` norm and checksum.  Three dtype-only lower-storage
+factorizations were rejected: demanding HSX Jacobians became non-finite, or a
+regularized approximate factor took over twice the baseline wall time.
+Low precision is therefore not a safe drop-in replacement; future work must
+change the representation or measured solver policy while preserving this
+gate.
+
+The same profiler isolates one free-boundary mirror resolution per process:
+
+.. code-block:: bash
+
+   python benchmarks/profile_high_resolution.py mirror \
+       --ns 5 --nxi 7 --elements 4 --exterior-ntheta 8 \
+       --betas 0,0.1,0.5 --device cpu --out mirror-coarse.json
+   python benchmarks/profile_high_resolution.py mirror \
+       --ns 9 --nxi 17 --elements 9 --exterior-ntheta 16 \
+       --betas 0,0.1,0.5 --device cpu --out mirror-fine.json
+
+This separates intrinsic fine-grid storage from cross-resolution process
+history.  The combined three-resolution nightly node passes, but takes about
+85 minutes and peaked at 11.04 GiB on the office host; it remains
+manual/nightly coverage rather than a required PR check.
+
 The existing optimization controls remain useful within that limitation:
 
 - The optimization Jacobian is column-chunked (``jac_chunk_size="auto"``, the

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -374,12 +374,19 @@ input without hardware-selection environment variables:
 It records the input resolution, devices, wall time, peak RSS, solve count,
 and the complete Jacobian's finiteness, norm, and SHA-256.  On the case above,
 the unmodified float64 path repeated in 355.25 s with the established
-``74.70287727265259`` norm and checksum.  Three dtype-only lower-storage
-factorizations were rejected: demanding HSX Jacobians became non-finite, or a
-regularized approximate factor took over twice the baseline wall time.
+``74.70287727265259`` norm and checksum.  Four small lower-storage candidates
+were rejected: float32 bands/factors and row scaling made this demanding HSX
+Jacobian non-finite, while a regularized scaled factor took over twice the
+baseline wall time.
 Low precision is therefore not a safe drop-in replacement; future work must
 change the representation or measured solver policy while preserving this
 gate.
+
+A fifth experiment streamed the three radial probe colors instead of retaining
+their complete response tensor.  It preserved the norm and checksum and reduced
+wall time to 284.69 s, but increased peak RSS by 8.6 % to 4.833 GiB as the
+allocator retained loop intermediates into factorization.  It was also rejected:
+lower storage must be demonstrated end to end, not inferred from one live array.
 
 The same profiler isolates one free-boundary mirror resolution per process:
 
@@ -392,10 +399,33 @@ The same profiler isolates one free-boundary mirror resolution per process:
        --ns 9 --nxi 17 --elements 9 --exterior-ntheta 16 \
        --betas 0,0.1,0.5 --device cpu --out mirror-fine.json
 
-This separates intrinsic fine-grid storage from cross-resolution process
-history.  The combined three-resolution nightly node passes, but takes about
-85 minutes and peaked at 11.04 GiB on the office host; it remains
-manual/nightly coverage rather than a required PR check.
+Fresh office CPU processes gave:
+
+.. list-table::
+   :header-rows: 1
+
+   * - ``(ns, nxi, elements, ntheta)``
+     - iterations by beta
+     - wall (s)
+     - peak RSS (GiB)
+   * - ``(5, 7, 4, 8)``
+     - 5 / 8 / 10
+     - 16.67
+     - 2.359
+   * - ``(7, 13, 7, 12)``
+     - 42 / 43 / 44
+     - 1457.30
+     - 4.506
+   * - ``(9, 17, 9, 16)``
+     - 42 / 44 / 45
+     - 3351.74
+     - 8.085
+
+All beta points converged with variational maxima below ``2e-13``.  Isolating
+the fine process lowers the previous combined 11.04 GiB peak by 26.8 %, but
+its 8.085 GiB peak is still 3.43 times the coarse result.  Allocator history
+therefore explains part, not all, of the scaling gap.  This 56-minute fine
+case remains manual/nightly coverage rather than a required PR check.
 
 The existing optimization controls remain useful within that limitation:
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -327,17 +327,21 @@ Peak resident memory is 0.6–1.5 GB on most bundled rows and about 3.3 GB on
 the largest bundled multigrid deck, but those figures are not a
 high-resolution upper bound. The spectral state is small; compiled transform
 graphs and implicit block factors are not. On the supplied HSX
-``ns=101, mpol=18, ntor=24`` deck, a fresh Apple-M4 CPU VMEX process took
-676.46 s and 3.896 GiB maximum RSS. VMEC++ with ten threads took 92.03 s and
-380.0 MiB on the same host; one-radial-process VMEC2000 took 1154.82 s and
-265.0 MiB. A one-thread VMEC++ control took 449.79 s and 445.1 MiB, so its
-advantage is not only thread parallelism: it remained 1.50x faster than VMEX
-and used 8.96x less RSS. VMEX was 1.71x faster than this VMEC2000 run but used
-15.05x its RSS. The VMEX state nevertheless matches VMEC2000 to near
-floating-point accuracy, so this is a performance/storage gap rather than a
-convergence or equilibrium-accuracy failure.
+``ns=101, mpol=18, ntor=24`` deck, replacing the full mode-stacked synthesis
+with a separable toroidal FFT reduced a fresh Apple-M4 CPU VMEX run from
+676.46 s / 3.896 GiB to 206.56 s / 1.634 GiB. The final 2737-iteration path,
+residuals, and energy are unchanged.
 
-Explicit CPU and GPU runs of the same deck on the office host converged in
+VMEC++ with ten threads took 92.03 s and 380.0 MiB on the same host;
+one-radial-process VMEC2000 took 1154.82 s and 265.0 MiB. A one-thread
+VMEC++ control took 449.79 s and 445.1 MiB. VMEX is therefore now 2.18x
+faster than one-thread VMEC++ and 5.61x faster than VMEC2000 on this deck,
+while ten-thread VMEC++ remains 2.24x faster and uses about one quarter the
+RSS. The remaining storage gap is substantive even though the VMEX state
+matches VMEC2000 to near floating-point accuracy.
+
+Before the separable-transform change, explicit CPU and GPU runs of the same
+deck on the office host converged in
 the same 2737 final-stage iterations.  With the GPU persistent cache already
 populated, CPU took 426.94 s and 6.52 GiB host RSS; the RTX A4000 took
 1468.07 s and 5.40 GiB.  CPU was therefore 3.44x faster, while cached GPU
@@ -346,7 +350,41 @@ were ``5.20e-11`` for ``rmnc``, ``3.27e-10`` for ``zmns``, ``9.76e-11`` for
 ``bmnc``, and ``6.54e-11`` for core iota.  An empty-cache GPU process took
 1596.01 s and 6.98 GiB.  These measurements show both that explicit GPU
 placement is correct and that it is not automatically faster for a
-high-mode CLI run.
+high-mode CLI run. This is a pre-change baseline; the updated CPU/GPU result
+must be recorded before changing the measured automatic device cutoff.
+
+The new synthesis repacks the signed helical coefficients into separable
+theta/zeta blocks, evaluates zeta with ``jax.numpy.fft.irfft``, and
+performs a short real poloidal contraction. Undersampled toroidal grids fall
+back to the established dense DFT. The implicit callback also retains the
+dense-real path: a direct FFT tangent expanded complex Jacobian probe batches
+past 10 GiB RSS, and compiling fast primal plus dense tangent representations
+in one process exceeded 7 GiB. Fixed-boundary
+:func:`~vmex.core.solver.solve` and
+:func:`~vmex.core.multigrid.solve_multigrid` select separate FFT lanes only
+above 512 modes on accelerators and ARM CPUs. Smaller problems retain the
+dense-real lane: on the M4, FFT was 38--88% slower warm on three 5--8-mode
+routine decks and its 8% warm win at 128 modes came with a 13% first-solve
+loss. At 162 modes, both lanes reached the supplied 10,000-iteration cap with
+near-zero residuals, but dense was 4.3% faster (279.55 s versus 291.69 s).
+x86 CPUs also remain dense. This is a measured default: on the office Xeon
+the exact FFT run took 570.47 s,
+while dense synthesis with stage-cache release took 413.24 s / 4.04 GiB
+(3.2% faster and 38.0% lower peak RSS than the prior cache-retaining dense
+baseline of 426.94 s / 6.52 GiB).
+Explicit ``use_fft=True`` or ``use_fft=False`` always wins. Implicit AD
+retains the dense lanes and their existing checksum/storage gate. The shared
+runtime pytree is unchanged.
+
+The one-shot fixed-boundary CLI additionally calls JAX's public
+``clear_caches`` between distinct radial grids. This clears in-memory
+compilation/staging entries while VMEX's persistent on-disk compilation cache
+remains available. On the exact deck it changed 205.97 s / 2.970 GiB to
+206.56 s / 1.634 GiB (0.3% wall-time cost, 45.0% lower peak RSS) with
+identical geometry, iteration count, residuals, and energy. Library
+:func:`~vmex.core.multigrid.solve_multigrid` retains warm stage executables by
+default for scans and repeated solves; ``release_stage_cache=True`` opts into
+the one-shot policy.
 
 Column chunking bounds simultaneous design-variable probes, not the dominant
 dense ``O(ns * m_block**2)`` block bands and factors. On an exact
@@ -429,8 +467,11 @@ case remains manual/nightly coverage rather than a required PR check.
 
 The existing optimization controls remain useful within that limitation:
 
+- Scalar objectives default to one matrix-free reverse adjoint
+  (``jac_solver="auto"``), avoiding dense block assembly entirely.
 - The optimization Jacobian is column-chunked (``jac_chunk_size="auto"``, the
-  same knob DESC exposes), limiting the simultaneous probe batch.
+  device-aware choice conservatively capped at a square-root width), limiting
+  the simultaneous probe batch for vector objectives.
 - Factoring the residual and field pipelines into reusable compiled
   sub-computations cut the implicit-gradient compile ~20% in memory and ~21% in
   wall time, bit-identically (R16).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["setuptools", "wheel", "packaging"]
+# Compile the optional FFI against VMEX's minimum JAX ABI; newer JAX releases
+# accept that handler version, while a newer handler cannot load on JAX 0.4.x.
+requires = ["setuptools", "wheel", "packaging", "jax==0.4.38", "pybind11>=2.12"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pybind11
+from setuptools import Extension, setup
+
+try:
+    from jax import ffi
+except ImportError:  # JAX 0.4.x
+    from jax.extend import ffi
+
+
+setup(
+    ext_modules=[
+        Extension(
+            "vmex._force_ffi",
+            ["vmex/native/force_ffi.cc"],
+            include_dirs=[ffi.include_dir(), pybind11.get_include()],
+            language="c++",
+            extra_compile_args=["-std=c++17"],
+            optional=True,
+        )
+    ]
+)

--- a/tests/test_cli_device.py
+++ b/tests/test_cli_device.py
@@ -36,6 +36,7 @@ def test_fixed_boundary_cli_forwards_device(monkeypatch, tmp_path, choice, expec
     monkeypatch.setattr(multigrid, "solve_multigrid", fake_solve)
     assert cli._solve_input_file(args, tmp_path / "input.case", tmp_path, emit=print) == 0
     assert seen["device"] == expected
+    assert seen["release_stage_cache"] is True
 
 
 def test_free_boundary_cli_forwards_device(monkeypatch, tmp_path):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -15,7 +15,7 @@ import numpy as np
 import pytest
 
 from vmex.core import device as dev
-from vmex.core import freeboundary, multigrid
+from vmex.core import freeboundary, multigrid, solver
 from vmex.core.fourier import Resolution
 
 
@@ -89,6 +89,30 @@ def test_auto_cpu_recommendation_is_a_noop_on_cpu(monkeypatch):
     # CPU-recommended + default backend already CPU -> nothing to place.
     if jax.default_backend() == "cpu":
         assert dev.resolve_device(dev.AUTO, _res(ns=11, mpol=6, ntor=0)) is None
+
+
+def test_synthesis_policy_uses_measured_hardware_defaults(monkeypatch):
+    resolution = _res(ns=101, mpol=18, ntor=24, nfp=4)
+    target = SimpleNamespace(platform="cpu")
+    monkeypatch.setattr(solver, "_placement_device", lambda *_: target)
+    monkeypatch.setattr(solver.platform, "machine", lambda: "x86_64")
+    assert not solver._resolve_use_fft(None, "cpu", resolution)
+    monkeypatch.setattr(solver.platform, "machine", lambda: "arm64")
+    assert solver._resolve_use_fft(None, "cpu", resolution)
+    target.platform = "gpu"
+    assert solver._resolve_use_fft(None, "gpu", resolution)
+    assert not solver._resolve_use_fft(
+        None, "gpu", _res(ns=50, mpol=8, ntor=8, nfp=2)
+    )
+    assert solver._resolve_use_fft(False, "gpu", resolution) is False
+    assert solver._resolve_use_fft(True, "cpu", resolution) is True
+
+
+def test_synthesis_policy_respects_active_default_device(monkeypatch):
+    monkeypatch.setattr(solver.platform, "machine", lambda: "x86_64")
+    resolution = _res(ns=101, mpol=18, ntor=24, nfp=4)
+    with jax.default_device(jax.devices("cpu")[0]):
+        assert not solver._resolve_use_fft(None, None, resolution)
 
 
 def test_auto_gpu_recommendation_without_accelerator(monkeypatch):

--- a/tests/test_fourier_transforms.py
+++ b/tests/test_fourier_transforms.py
@@ -12,6 +12,7 @@ during the port:
 from __future__ import annotations
 
 import jax
+import jax.numpy as jnp
 
 jax.config.update("jax_enable_x64", True)
 
@@ -25,6 +26,7 @@ from vmex.core.nyquist import (
     wrout_sin_coeffs,
 )
 from vmex.core.transforms import (
+    _fourier_to_real_fft,
     fourier_to_real,
     real_to_fourier,
     symforce_split,
@@ -141,6 +143,59 @@ def test_lasym_nestor_surface_analysis_preserves_mode_signs():
     np.testing.assert_allclose(
         actual_sin, sin_coefficients, rtol=0.0, atol=roundtrip_atol
     )
+
+
+def test_synthesis_accepts_nyquist_extended_trig_tables():
+    """WOUT evaluates main-mode coefficients on Nyquist-extended grids."""
+    base = Resolution(
+        mpol=6, ntor=3, ntheta=22, nzeta=16, nfp=3, lasym=False, ns=NS
+    )
+    extended = Resolution(
+        mpol=9, ntor=8, ntheta=22, nzeta=16, nfp=3, lasym=False, ns=NS
+    )
+    modes = mode_table(base.mpol, base.ntor)
+    rng = np.random.default_rng(4)
+    coefficient_cos = rng.standard_normal((NS, modes.mnmax))
+    coefficient_sin = rng.standard_normal((NS, modes.mnmax))
+    kwargs = dict(modes=modes, derivatives=("value", "dtheta", "dzeta"))
+    actual = _fourier_to_real_fft(
+        coefficient_cos, coefficient_sin, trig=trig_tables(extended), **kwargs
+    )
+    expected = fourier_to_real(
+        coefficient_cos, coefficient_sin, trig=trig_tables(base), **kwargs
+    )
+    for left, right in zip(actual, expected):
+        np.testing.assert_allclose(left, right, rtol=RTOL, atol=1e-12)
+
+
+def test_fft_and_dense_synthesis_match_through_ad():
+    """The fast primal and lower-memory implicit path have matching AD."""
+    resolution = Resolution(
+        mpol=4, ntor=2, ntheta=16, nzeta=12, nfp=3, lasym=True, ns=NS
+    )
+    modes = mode_table(resolution.mpol, resolution.ntor)
+    trig = trig_tables(resolution)
+    rng = np.random.default_rng(5)
+    shape = (NS, modes.mnmax)
+    primals = tuple(jnp.asarray(rng.standard_normal(shape)) for _ in range(2))
+    tangents = tuple(jnp.asarray(rng.standard_normal(shape)) for _ in range(2))
+
+    def synthesize(c, s, *, use_fft):
+        transform = _fourier_to_real_fft if use_fft else fourier_to_real
+        return transform(c, s, modes=modes, trig=trig)
+
+    fast = lambda c, s: synthesize(c, s, use_fft=True)  # noqa: E731
+    dense = lambda c, s: synthesize(c, s, use_fft=False)  # noqa: E731
+    values, tangent = jax.jvp(fast, primals, tangents)
+    dense_values, dense_tangent = jax.jvp(dense, primals, tangents)
+    for left, right in zip(values + tangent, dense_values + dense_tangent):
+        np.testing.assert_allclose(left, right, rtol=2e-13, atol=2e-12)
+    cotangent = tuple(jnp.asarray(rng.standard_normal(x.shape)) for x in values)
+    _, pullback = jax.vjp(fast, *primals)
+    adjoint = pullback(cotangent)
+    lhs = sum(jnp.vdot(x, y) for x, y in zip(tangent, cotangent))
+    rhs = sum(jnp.vdot(x, y) for x, y in zip(tangents, adjoint))
+    np.testing.assert_allclose(lhs, rhs, rtol=2e-13, atol=2e-12)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_freeboundary.py
+++ b/tests/test_freeboundary.py
@@ -41,6 +41,7 @@ import jax.numpy as jnp  # noqa: E402
 from vmex.core import freeboundary as FB  # noqa: E402
 from vmex.core import vacuum as V  # noqa: E402
 from vmex.core.errors import MgridNotFoundError, VmecJacobianError  # noqa: E402
+from vmex.core.freeboundary_linear import linearize_nestor_coupling  # noqa: E402
 from vmex.core.input import VmecInput  # noqa: E402
 from vmex.core.mgrid import MgridField, read_mgrid  # noqa: E402
 from vmex.core.solver import (  # noqa: E402
@@ -111,6 +112,11 @@ def test_nestor_skip_branch_matches_full_solve(ab_inputs):
     potvac, mode_matrix, bvec_nonsing, rhs, gsource, grpmn = solver.full(
         boundary, jnp.asarray(bexni)
     )
+    assembled = solver.assemble(boundary, jnp.asarray(bexni))
+    for actual, expected in zip(
+        assembled, (mode_matrix, rhs, bvec_nonsing, gsource, grpmn), strict=True
+    ):
+        np.testing.assert_allclose(actual, expected, rtol=0.0, atol=0.0)
     for name, arr in (("potvac", potvac), ("rhs", rhs), ("mode_matrix", mode_matrix),
                       ("grpmn", grpmn), ("gsource", gsource)):
         a = np.asarray(arr)
@@ -122,6 +128,83 @@ def test_nestor_skip_branch_matches_full_solve(ab_inputs):
     )
     np.testing.assert_allclose(np.asarray(potvac_skip), np.asarray(potvac), rtol=1e-12, atol=1e-14)
     np.testing.assert_allclose(np.asarray(rhs_skip), np.asarray(rhs), rtol=1e-12, atol=1e-14)
+
+
+def test_live_nestor_blocks_match_coupled_residual_jvp_and_vjp():
+    """The bordered blocks come from a live, small LASYM NESTOR equation."""
+    basis = V.vacuum_basis(
+        mf=1, nf=0, ntheta3=6, nzeta=1, nfp=1, lasym=True,
+        wint=np.full((6,), 1.0 / 6.0),
+    )
+    theta = jnp.asarray(basis.theta).reshape((6, 1))
+    zero = jnp.zeros_like(theta)
+    a = 0.3
+    boundary0 = V.VacuumBoundary(
+        R=2.0 + a * jnp.cos(theta) + 0.02 * jnp.sin(theta),
+        Z=a * jnp.sin(theta) + 0.01 * jnp.cos(theta),
+        Ru=-a * jnp.sin(theta) + 0.02 * jnp.cos(theta),
+        Zu=a * jnp.cos(theta) - 0.01 * jnp.sin(theta),
+        Rv=zero, Zv=zero,
+        ruu=-a * jnp.cos(theta) - 0.02 * jnp.sin(theta),
+        zuu=-a * jnp.sin(theta) - 0.01 * jnp.cos(theta),
+        ruv=zero, zuv=zero, rvv=zero, zvv=zero,
+    )
+    solver = V.make_vacuum_solver(basis, signgs=-1)
+    bexni = jnp.full((6, 1), 0.05)
+
+    def boundary(x):
+        scale, twist = 1.0 + 1e-4 * x[0], 1e-4 * x[1]
+        fields = {}
+        for r_name, z_name in (
+            ("R", "Z"), ("Ru", "Zu"), ("Rv", "Zv"),
+            ("ruu", "zuu"), ("ruv", "zuv"), ("rvv", "zvv"),
+        ):
+            r, z = getattr(boundary0, r_name), getattr(boundary0, z_name)
+            fields[r_name] = scale * r + twist * z
+            fields[z_name] = scale * z - twist * r
+        return dataclasses.replace(boundary0, **fields)
+
+    def vacuum_system(x):
+        matrix, rhs, *_ = solver.assemble(boundary(x), bexni)
+        return matrix, rhs
+
+    def plasma_residual(x, q):
+        b = boundary(x)
+        guu = b.Ru * b.Ru + b.Zu * b.Zu
+        guv = b.Ru * b.Rv + b.Zu * b.Zv
+        gvv = b.Rv * b.Rv + b.Zv * b.Zv + b.R * b.R
+        bsq, *_ = V.vacuum_channels(
+            basis=basis, potvac=q, bexu=jnp.full_like(b.R, 0.02),
+            bexv=0.1 * b.R, guu=guu, guv=guv, gvv=gvv,
+        )
+        return jnp.asarray([jnp.mean(bsq), jnp.mean(bsq * b.R)])
+
+    x0 = jnp.zeros((2,), dtype=jnp.float64)
+    q0, *_ = solver.full(boundary0, bexni)
+    op = linearize_nestor_coupling(plasma_residual, vacuum_system, x0, q0)
+
+    def coupled(value):
+        x, q = value[:2], value[2:]
+        matrix, rhs = vacuum_system(x)
+        return jnp.concatenate((plasma_residual(x, q), matrix @ q - rhs))
+
+    base = jnp.concatenate((x0, q0))
+    tangent = jnp.linspace(-0.2, 0.3, base.size)
+    cotangent = jnp.linspace(0.1, -0.1, base.size)
+    expected = jax.jvp(coupled, (base,), (tangent,))[1]
+    np.testing.assert_allclose(op(tangent), expected, rtol=2e-12, atol=2e-12)
+    _, pullback = jax.vjp(coupled, base)
+    np.testing.assert_allclose(
+        op.transpose(cotangent), pullback(cotangent)[0],
+        rtol=2e-12, atol=2e-12,
+    )
+    for value in (
+        op.plasma(jnp.ones_like(x0)),
+        op.vacuum_to_plasma(jnp.ones_like(q0)),
+        op.plasma_to_vacuum(jnp.ones_like(x0)),
+        op.vacuum(jnp.ones_like(q0)),
+    ):
+        assert float(jnp.linalg.norm(value)) > 0.0
 
 
 def test_vacuum_first_call_diagnostics(ab_inputs):

--- a/tests/test_freeboundary_linear.py
+++ b/tests/test_freeboundary_linear.py
@@ -1,0 +1,49 @@
+"""Coupled plasma/NESTOR bordered-operator tests."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from vmex.core.freeboundary_linear import NestorBorderedOperator
+
+
+def _operator():
+    a = jnp.asarray([[4.0, 1.0, 0.0], [1.0, 3.0, 0.5], [0.0, 0.5, 2.0]])
+    b = jnp.asarray([[0.2, 0.0], [0.1, -0.3], [0.0, 0.4]])
+    c = jnp.asarray([[0.5, 0.1, 0.0], [0.0, -0.2, 0.6]])
+    d = jnp.asarray([[2.0, 0.2], [0.2, 1.5]])
+    op = NestorBorderedOperator(
+        lambda x: a @ x, lambda q: b @ q,
+        lambda x: c @ x, lambda q: d @ q, 3, 2,
+    )
+    return op, jnp.block([[a, b], [c, d]]), a, b, c, d
+
+
+def test_nestor_bordered_value_transpose_jvp_and_vjp():
+    op, dense, *_ = _operator()
+    x = jnp.arange(5.0)
+    tangent = jnp.linspace(-0.3, 0.4, 5)
+    with jax.disable_jit(False):
+        value, jvp = jax.jit(
+            lambda y, dy: jax.jvp(op, (y,), (dy,))
+        )(x, tangent)
+    np.testing.assert_allclose(value, dense @ x, atol=1e-14)
+    np.testing.assert_allclose(jvp, dense @ tangent, atol=1e-14)
+    np.testing.assert_allclose(op.transpose(x), dense.T @ x, atol=1e-14)
+    grad = jax.grad(lambda y: jnp.sum(op(y) ** 2))(x)
+    np.testing.assert_allclose(grad, 2.0 * dense.T @ dense @ x, atol=1e-13)
+
+
+def test_nestor_schur_and_block_inverse():
+    op, dense, a, b, c, d = _operator()
+    a_solve = lambda x: jnp.linalg.solve(a, x)  # noqa: E731
+    schur_dense = d - c @ jnp.linalg.solve(a, b)
+    schur_solve = lambda x: jnp.linalg.solve(schur_dense, x)  # noqa: E731
+    q = jnp.asarray([0.3, -0.1])
+    np.testing.assert_allclose(op.schur(a_solve)(q), schur_dense @ q, atol=1e-14)
+    rhs = jnp.arange(1.0, 6.0)
+    with jax.disable_jit(False):
+        actual = jax.jit(op.preconditioner(a_solve, schur_solve))(rhs)
+    np.testing.assert_allclose(actual, jnp.linalg.solve(dense, rhs), atol=1e-13)

--- a/tests/test_freeboundary_linear.py
+++ b/tests/test_freeboundary_linear.py
@@ -6,7 +6,9 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from vmex.core.freeboundary_linear import NestorBorderedOperator
+from vmex.core.freeboundary_linear import (
+    NestorBorderedOperator, linearize_nestor_coupling,
+)
 
 
 def _operator():
@@ -47,3 +49,33 @@ def test_nestor_schur_and_block_inverse():
     with jax.disable_jit(False):
         actual = jax.jit(op.preconditioner(a_solve, schur_solve))(rhs)
     np.testing.assert_allclose(actual, jnp.linalg.solve(dense, rhs), atol=1e-13)
+
+
+def test_live_nestor_factory_differentiates_all_four_blocks():
+    x0 = jnp.asarray([0.2, -0.3])
+    q0 = jnp.asarray([0.4, 0.1])
+
+    def plasma_residual(x, q):
+        return jnp.asarray([x[0] ** 2 + q[0] * q[1], x[1] + q[1] ** 2])
+
+    def vacuum_system(x):
+        matrix = jnp.asarray([[2.0 + x[0], x[1]], [x[1], 1.5 - x[0]]])
+        return matrix, jnp.asarray([1.0 + x[1], -0.2 + x[0]])
+
+    op = linearize_nestor_coupling(plasma_residual, vacuum_system, x0, q0)
+
+    def coupled(value):
+        x, q = value[:2], value[2:]
+        matrix, rhs = vacuum_system(x)
+        return jnp.concatenate((plasma_residual(x, q), matrix @ q - rhs))
+
+    base = jnp.concatenate((x0, q0))
+    dense = jax.jacfwd(coupled)(base)
+    np.testing.assert_allclose(jax.jacfwd(op)(jnp.zeros_like(base)), dense, atol=1e-14)
+    blocks = (
+        jax.jacfwd(op.plasma)(jnp.zeros_like(x0)),
+        jax.jacfwd(op.vacuum_to_plasma)(jnp.zeros_like(q0)),
+        jax.jacfwd(op.plasma_to_vacuum)(jnp.zeros_like(x0)),
+        jax.jacfwd(op.vacuum)(jnp.zeros_like(q0)),
+    )
+    assert all(float(jnp.linalg.norm(block)) > 0.0 for block in blocks)

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -12,7 +12,7 @@ import pytest
 
 from vmex.core import device as device_policy
 from vmex.core import implicit as im
-from vmex.core import freeboundary, multigrid, solver
+from vmex.core import freeboundary, multigrid, optimize, solver
 from vmex.core.input import VmecInput
 from vmex.core.mgrid import MgridField
 from vmex.core.wout import wout_from_state
@@ -469,3 +469,24 @@ def test_explicit_implicit_gradient_cpu_gpu_parity():
     assert {_platform(x) for x in jax.tree.leaves(gpu_tree)} == {"gpu"}
     np.testing.assert_allclose(gpu_value, cpu_value, rtol=1e-11)
     np.testing.assert_allclose(gpu_gradient, cpu_gradient, rtol=2e-7, atol=1e-12)
+
+
+def test_scalarized_profile_gradient_cpu_gpu_parity():
+    """The bounded-storage DMerc/D_R/<J.B> optimizer uses either device."""
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    terms = [
+        (optimize.mercier_stability_residual, 0.0, 1.0),
+        (optimize.glasser_stability_residual, 0.0, 1.0),
+        (optimize.jdotb_residual, 0.0, 1.0e-6),
+    ]
+    x0 = optimize.pack_boundary(inp, 1)
+    results = {
+        platform: optimize.minimize(
+            terms, inp, max_mode=1, device=platform,
+            bounds=list(zip(x0, x0)))
+        for platform in ("cpu", "gpu")
+    }
+    np.testing.assert_allclose(
+        results["gpu"].cost, results["cpu"].cost, rtol=1e-11)
+    np.testing.assert_allclose(
+        results["gpu"].jac, results["cpu"].jac, rtol=2e-7, atol=1e-12)

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -210,6 +210,26 @@ def test_runtime_from_params_matches_run_setup(case):
                                rtol=0.0, atol=1e-15, err_msg=f"{name}: zcon0")
 
 
+@pytest.mark.parametrize("source", [0, 5, 9])
+def test_raw_residual_jvp_is_exactly_nearest_neighbor(solovev, source):
+    """A one-surface tangent has no raw-force response beyond adjacent rows."""
+    _, _, cfg, p0, state, _, mask = solovev
+    P = im._dof_projector(cfg, mask)
+    z_star = P(state)
+    tangent = jax.tree.map(
+        lambda active: jnp.zeros_like(active).at[source].set(active[source]),
+        mask,
+    )
+    F = im.residual_fn(cfg, state, mask, formulation="raw")
+    response = jax.jvp(lambda z: F(z, p0), (z_star,), (tangent,))[1]
+    keep = jnp.abs(jnp.arange(cfg.resolution.ns) - source) <= 1
+    local_max = 0.0
+    for value in jax.tree.leaves(response):
+        assert float(jnp.max(jnp.abs(jnp.where(keep[:, None], 0.0, value)))) == 0.0
+        local_max = max(local_max, float(jnp.max(jnp.abs(value[keep]))))
+    assert local_max > 0.0
+
+
 # ---------------------------------------------------------------------------
 # 2. the implicit residual vanishes at the converged fixed point
 # ---------------------------------------------------------------------------

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -230,6 +230,47 @@ def test_raw_residual_jvp_is_exactly_nearest_neighbor(solovev, source):
     assert local_max > 0.0
 
 
+def test_three_surface_raw_kernel_matches_global_nonlinear_rows(case):
+    """The local nonlinear chain reproduces every row with a complete halo."""
+    _, _, cfg, p0, state, rt, mask = case
+    ns = cfg.resolution.ns
+    P = im._dof_projector(cfg, mask)
+    edge = im._edge_mask(cfg)
+    z_star = P(state)
+    key = jax.random.key(13)
+    noise = jax.tree.map(
+        lambda a: 1e-5 * a * jax.random.normal(
+            key, a.shape, dtype=jnp.asarray(a).dtype
+        ),
+        mask,
+    )
+    z = jax.tree.map(jnp.add, z_star, noise)
+    x = im._assemble(z, rt, state, P, edge)
+    full = im.residual_fn(cfg, state, mask, formulation="raw")(z, p0)
+
+    segments = ((0, (0, 1)), (max(0, ns // 2 - 1), (1,)), (ns - 3, (1, 2)))
+    for start, rows in segments:
+        window = jax.tree.map(lambda a: a[start:start + 3], x)
+        local = im._raw_residual_segment(
+            window, rt, jnp.asarray(start), axis_closure=(start == 0)
+        )
+        embedded = jax.tree.map(
+            lambda a, whole: jnp.zeros_like(whole).at[start:start + 3].set(a),
+            local, full,
+        )
+        projected = P(embedded)
+        for name, actual, expected in zip(
+            im._STATE_FIELDS, jax.tree.leaves(projected),
+            jax.tree.leaves(full), strict=True
+        ):
+            np.testing.assert_allclose(
+                np.asarray(actual)[start + np.asarray(rows)],
+                np.asarray(expected)[start + np.asarray(rows)],
+                rtol=2e-12, atol=2e-12,
+                err_msg=f"{name}, segment {start}, local rows {rows}",
+            )
+
+
 # ---------------------------------------------------------------------------
 # 2. the implicit residual vanishes at the converged fixed point
 # ---------------------------------------------------------------------------

--- a/tests/test_multigrid_ladder.py
+++ b/tests/test_multigrid_ladder.py
@@ -253,6 +253,19 @@ def test_ladder_skips_decreasing_stages():
                                rtol=5e-12)
 
 
+def test_ladder_can_release_distinct_stage_caches(monkeypatch):
+    """One-shot ladders may discard a completed grid's in-memory executable."""
+    cleared = []
+    monkeypatch.setattr(multigrid.jax, "clear_caches", lambda: cleared.append(1))
+    monkeypatch.setattr(multigrid.gc, "collect", lambda: 0)
+    multigrid.solve_multigrid(
+        _load_input("cth_like_fixed_bdy"), ns_array=[5, 9],
+        ftol_array=[1e-30], niter_array=[1], raise_on_max_iterations=False,
+        release_stage_cache=True,
+    )
+    assert cleared == [1]
+
+
 def test_ladder_forwards_explicit_2d_preconditioner(monkeypatch):
     seen = []
     marker = object()

--- a/tests/test_native_force.py
+++ b/tests/test_native_force.py
@@ -1,0 +1,180 @@
+"""Value and derivative parity for the opt-in native force projection."""
+
+from __future__ import annotations
+
+import dataclasses
+import types
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from vmex.core.fourier import Resolution, trig_tables
+from vmex.core import implicit as im
+from vmex.core.input import VmecInput
+from vmex.core.multigrid import solve_multigrid
+from vmex.core.native_force import (
+    _NAMES, native_force_available, project_force, require_native_cpu,
+)
+from vmex.core.transforms import tomnspa, tomnsps
+
+
+def _case(*, lasym=False):
+    resolution = Resolution(
+        mpol=4, ntor=2, ntheta=16, nzeta=12, nfp=3, lasym=lasym, ns=6
+    )
+    trig = trig_tables(resolution)
+    rng = np.random.default_rng(7)
+    shape = (resolution.ns, trig.ntheta3, resolution.nzeta)
+    kernels = {
+        f"{name}_{parity}": jnp.asarray(rng.standard_normal(shape))
+        for name in _NAMES for parity in ("even", "odd")
+    }
+    return resolution, trig, kernels
+
+
+@pytest.mark.skipif(not native_force_available(), reason="native extension not built")
+@pytest.mark.parametrize("asym", [False, True])
+@pytest.mark.parametrize("include_edge", [False, True])
+@pytest.mark.parametrize("threads", [1, 2])
+def test_native_force_matches_public_jax(asym, include_edge, threads):
+    resolution, trig, kernels = _case(lasym=asym)
+    reference = (tomnspa if asym else tomnsps)(
+        **kernels, mpol=resolution.mpol, ntor=resolution.ntor,
+        trig=trig, include_edge=include_edge,
+    )
+    def compiled():
+        result = project_force(
+            kernels, mpol=resolution.mpol, ntor=resolution.ntor, trig=trig,
+            include_edge=include_edge, asym=asym, backend="native", threads=threads,
+        )
+        return tuple(value for value in dataclasses.astuple(result) if value is not None)
+
+    with jax.disable_jit(False), jax.default_device(jax.devices("cpu")[0]):
+        actual = jax.jit(compiled)()
+    expected = tuple(
+        value for value in dataclasses.astuple(reference) if value is not None
+    )
+    for value, target in zip(actual, expected, strict=True):
+        np.testing.assert_allclose(value, target, rtol=2e-13, atol=2e-12)
+
+
+@pytest.mark.skipif(not native_force_available(), reason="native extension not built")
+@pytest.mark.parametrize("asym", [False, True])
+def test_native_force_jvp_and_transpose(asym):
+    resolution, trig, kernels = _case(lasym=asym)
+
+    def projected(scale, backend):
+        scaled = jax.tree.map(lambda value: scale * value, kernels)
+        scaled_trig = dataclasses.replace(trig, **{
+            name: scale * getattr(trig, name)
+            for name in (
+                "cosmui", "sinmui", "cosmumi", "sinmumi",
+                "cosnv", "sinnv", "cosnvn", "sinnvn",
+            )
+        })
+        result = project_force(
+            scaled, mpol=resolution.mpol, ntor=resolution.ntor, trig=scaled_trig,
+            asym=asym, backend=backend, threads=2,
+        )
+        return jnp.stack([
+            value for value in dataclasses.astuple(result) if value is not None
+        ])
+
+    with jax.disable_jit(False), jax.default_device(jax.devices("cpu")[0]):
+        value, tangent = jax.jvp(
+            lambda scale: projected(scale, "native"), (1.0,), (0.25,)
+        )
+        reference, reference_tangent = jax.jvp(
+            lambda scale: projected(scale, "jax"), (1.0,), (0.25,)
+        )
+        gradient = jax.grad(
+            lambda scale: jnp.sum(projected(scale, "native") ** 2)
+        )(1.0)
+        reference_gradient = jax.grad(
+            lambda scale: jnp.sum(projected(scale, "jax") ** 2)
+        )(1.0)
+    np.testing.assert_allclose(value, reference, rtol=2e-13, atol=2e-12)
+    np.testing.assert_allclose(tangent, reference_tangent, rtol=2e-13, atol=2e-12)
+    np.testing.assert_allclose(
+        gradient, reference_gradient, rtol=2e-13, atol=2e-11
+    )
+
+
+def test_force_backend_validation():
+    resolution, trig, kernels = _case()
+    with pytest.raises(ValueError, match="backend"):
+        project_force(
+            kernels, mpol=resolution.mpol, ntor=resolution.ntor,
+            trig=trig, backend="cuda",
+        )
+    with pytest.raises(ValueError, match="threads"):
+        project_force(
+            kernels, mpol=resolution.mpol, ntor=resolution.ntor,
+            trig=trig, threads=0,
+        )
+
+
+@pytest.mark.gpu
+def test_native_backend_rejects_gpu_placement():
+    try:
+        jax.devices("gpu")
+    except RuntimeError:
+        pytest.skip("GPU unavailable")
+    resolution, _, _ = _case()
+    with pytest.raises(ValueError, match="CPU-only"):
+        require_native_cpu("gpu", resolution)
+
+
+def test_native_implicit_forward_uses_cpu(monkeypatch):
+    inp = VmecInput.from_file("examples/data/input.solovev")
+    cfg = im.make_config(inp, force_backend="native")
+    seen = {}
+
+    def solve_stub(*args, **kwargs):
+        seen["device"] = kwargs["device"]
+        return types.SimpleNamespace(converged=True, iterations=0, state=None)
+
+    monkeypatch.setattr(im, "solve", solve_stub)
+    im._host_solve(cfg, im.params_from_input(inp, device="cpu"))
+    assert seen["device"] == "cpu"
+
+
+@pytest.mark.skipif(not native_force_available(), reason="native extension not built")
+def test_native_fixed_boundary_matches_default():
+    inp = VmecInput.from_file("examples/data/input.solovev")
+    with jax.disable_jit(False), jax.default_device(jax.devices("cpu")[0]):
+        reference = solve_multigrid(inp, mode="jit")
+        actual = solve_multigrid(
+            inp, mode="jit", force_backend="native", threads=2
+        )
+    assert actual.iterations == reference.iterations
+    for field in dataclasses.fields(reference.state):
+        np.testing.assert_allclose(
+            getattr(actual.state, field.name),
+            getattr(reference.state, field.name),
+            rtol=2e-13,
+            atol=6e-14,
+        )
+
+
+@pytest.mark.full
+@pytest.mark.skipif(not native_force_available(), reason="native extension not built")
+def test_native_implicit_gradient_matches_jax():
+    inp = VmecInput.from_file("examples/data/input.solovev")
+    params = im.params_from_input(inp, device="cpu")
+
+    def gradient(backend):
+        return jax.grad(
+            lambda p: im.run(
+                inp, p, force_backend=backend, threads=2, device="cpu"
+            ).wb
+        )(params)
+
+    reference = gradient("jax")
+    actual = gradient("native")
+    for expected, value in zip(
+        jax.tree.leaves(reference), jax.tree.leaves(actual), strict=True
+    ):
+        np.testing.assert_allclose(value, expected, rtol=3e-10, atol=3e-11)

--- a/tests/test_native_force.py
+++ b/tests/test_native_force.py
@@ -10,6 +10,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+from vmex.core import native_force as nf
 from vmex.core.fourier import Resolution, trig_tables
 from vmex.core import implicit as im
 from vmex.core.input import VmecInput
@@ -20,9 +21,10 @@ from vmex.core.native_force import (
 from vmex.core.transforms import tomnspa, tomnsps
 
 
-def _case(*, lasym=False):
+def _case(*, lasym=False, ntor=2):
     resolution = Resolution(
-        mpol=4, ntor=2, ntheta=16, nzeta=12, nfp=3, lasym=lasym, ns=6
+        mpol=4, ntor=ntor, ntheta=16, nzeta=12 if ntor else 1,
+        nfp=3, lasym=lasym, ns=6,
     )
     trig = trig_tables(resolution)
     rng = np.random.default_rng(7)
@@ -32,6 +34,26 @@ def _case(*, lasym=False):
         for name in _NAMES for parity in ("even", "odd")
     }
     return resolution, trig, kernels
+
+
+@pytest.mark.parametrize("asym", [False, True])
+@pytest.mark.parametrize("ntor", [0, 2])
+def test_jax_force_projector_matches_public(asym, ntor):
+    resolution, trig, kernels = _case(lasym=asym, ntor=ntor)
+    expected = (tomnspa if asym else tomnsps)(
+        **kernels, mpol=resolution.mpol, ntor=ntor, trig=trig,
+    )
+    actual = project_force(
+        kernels, mpol=resolution.mpol, ntor=ntor, trig=trig,
+        asym=asym, backend="jax",
+    )
+    for value, target in zip(
+        dataclasses.astuple(actual), dataclasses.astuple(expected), strict=True
+    ):
+        if target is None:
+            assert value is None
+        else:
+            np.testing.assert_allclose(value, target, rtol=2e-13, atol=2e-12)
 
 
 @pytest.mark.skipif(not native_force_available(), reason="native extension not built")
@@ -113,6 +135,91 @@ def test_force_backend_validation():
         project_force(
             kernels, mpol=resolution.mpol, ntor=resolution.ntor,
             trig=trig, threads=0,
+        )
+
+
+def test_native_ffi_wrapper_shape_and_jvp(monkeypatch):
+    from vmex.core.forces import RealSpaceForces, spectral_mhd_forces
+
+    resolution, trig, kernels = _case()
+    seen = {}
+
+    def ffi_call(_name, specs, **_kwargs):
+        def call(*args, **attrs):
+            seen.update(attrs)
+            return tuple(jnp.zeros(spec.shape, args[0].dtype) for spec in specs)
+        return call
+
+    monkeypatch.setattr(nf, "_force_ffi", object())
+    monkeypatch.setattr(nf.ffi, "ffi_call", ffi_call)
+
+    def projected(scale, backend):
+        result = project_force(
+            jax.tree.map(lambda value: scale * value, kernels),
+            mpol=resolution.mpol, ntor=resolution.ntor, trig=trig,
+            backend=backend, threads=99,
+        )
+        return jnp.stack([
+            value for value in dataclasses.astuple(result) if value is not None
+        ])
+
+    value, tangent = jax.jvp(
+        lambda scale: projected(scale, "native"), (1.0,), (0.25,)
+    )
+    reference_tangent = jax.jvp(
+        lambda scale: projected(scale, "jax"), (1.0,), (0.25,)
+    )[1]
+    np.testing.assert_array_equal(value, 0.0)
+    np.testing.assert_allclose(tangent, reference_tangent, rtol=2e-13, atol=2e-12)
+    assert seen["threads"] == resolution.ns * resolution.mpol
+    spectral_mhd_forces(
+        RealSpaceForces(**kernels), mpol=resolution.mpol,
+        ntor=resolution.ntor, trig=trig, backend="native",
+    )
+    asym_resolution, asym_trig, asym_kernels = _case(lasym=True)
+    spectral_mhd_forces(
+        RealSpaceForces(**asym_kernels), mpol=asym_resolution.mpol,
+        ntor=asym_resolution.ntor, trig=asym_trig, backend="native",
+    )
+
+
+def test_native_cpu_guard_and_public_entry_points(monkeypatch):
+    from vmex.core.freeboundary import solve_free_boundary
+    from vmex.core.multigrid import solve_free_boundary_multigrid
+    from vmex.core import optimize as opt
+    from vmex.core.solver import solve
+
+    inp = VmecInput.from_file("examples/data/input.solovev")
+    resolution, _, _ = _case()
+    require_native_cpu("cpu", resolution)
+    with jax.default_device(jax.devices("cpu")[0]):
+        require_native_cpu(None, resolution)
+
+    class GuardReached(Exception):
+        pass
+
+    def stop(*_args):
+        raise GuardReached
+
+    monkeypatch.setattr(nf, "require_native_cpu", stop)
+    calls = (
+        lambda: solve(inp, force_backend="native"),
+        lambda: solve_multigrid(inp, force_backend="native"),
+        lambda: solve_free_boundary(inp, force_backend="native"),
+        lambda: im.run(inp, force_backend="native"),
+        lambda: opt.least_squares(
+            [], inp, max_mode=0, jac="implicit",
+            solve_kwargs={"force_backend": "native"},
+        ),
+    )
+    for call in calls:
+        with pytest.raises(GuardReached):
+            call()
+
+    freeb = VmecInput.from_file("examples/data/input.cth_like_free_bdy")
+    with pytest.raises(GuardReached):
+        solve_free_boundary_multigrid(
+            freeb, external_field=object(), force_backend="native",
         )
 
 

--- a/tests/test_native_force.py
+++ b/tests/test_native_force.py
@@ -124,7 +124,7 @@ def test_native_force_jvp_and_transpose(asym):
     )
 
 
-def test_force_backend_validation():
+def test_force_backend_validation(monkeypatch):
     resolution, trig, kernels = _case()
     with pytest.raises(ValueError, match="backend"):
         project_force(
@@ -135,6 +135,12 @@ def test_force_backend_validation():
         project_force(
             kernels, mpol=resolution.mpol, ntor=resolution.ntor,
             trig=trig, threads=0,
+        )
+    monkeypatch.setattr(nf, "_force_ffi", None)
+    with pytest.raises(RuntimeError, match="not available"):
+        project_force(
+            kernels, mpol=resolution.mpol, ntor=resolution.ntor,
+            trig=trig, backend="native",
         )
 
 
@@ -184,16 +190,32 @@ def test_native_ffi_wrapper_shape_and_jvp(monkeypatch):
 
 
 def test_native_cpu_guard_and_public_entry_points(monkeypatch):
+    from vmex.core import device as device_module
     from vmex.core.freeboundary import solve_free_boundary
     from vmex.core.multigrid import solve_free_boundary_multigrid
     from vmex.core import optimize as opt
-    from vmex.core.solver import solve
+    from vmex.core.setup import run_setup
+    from vmex.core.solver import prepare_runtime, resolution_from_input, solve
 
     inp = VmecInput.from_file("examples/data/input.solovev")
     resolution, _, _ = _case()
     require_native_cpu("cpu", resolution)
     with jax.default_device(jax.devices("cpu")[0]):
         require_native_cpu(None, resolution)
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            device_module, "_placement_device",
+            lambda *_args: types.SimpleNamespace(platform="gpu"),
+        )
+        with pytest.raises(ValueError, match="CPU-only"):
+            require_native_cpu(None, resolution)
+
+    input_resolution = resolution_from_input(inp)
+    setup = run_setup(inp, input_resolution)
+    with pytest.raises(ValueError, match="force_backend"):
+        prepare_runtime(setup, input_resolution, force_backend="cuda")
+    with pytest.raises(ValueError, match="threads"):
+        prepare_runtime(setup, input_resolution, threads=0)
 
     class GuardReached(Exception):
         pass

--- a/tests/test_native_force.py
+++ b/tests/test_native_force.py
@@ -83,6 +83,29 @@ def test_native_force_matches_public_jax(asym, include_edge, threads):
 
 
 @pytest.mark.skipif(not native_force_available(), reason="native extension not built")
+def test_native_force_float32_with_float64_tables():
+    resolution, trig, kernels = _case()
+    kernels = jax.tree.map(lambda value: value.astype(jnp.float32), kernels)
+    with jax.default_device(jax.devices("cpu")[0]):
+        expected = project_force(
+            kernels, mpol=resolution.mpol, ntor=resolution.ntor,
+            trig=trig, backend="jax",
+        )
+        actual = project_force(
+            kernels, mpol=resolution.mpol, ntor=resolution.ntor,
+            trig=trig, backend="native",
+        )
+    for value, target in zip(
+        dataclasses.astuple(actual), dataclasses.astuple(expected), strict=True
+    ):
+        if value is None:
+            assert target is None
+            continue
+        assert value.dtype == jnp.float32
+        np.testing.assert_allclose(value, target, rtol=2e-6, atol=2e-6)
+
+
+@pytest.mark.skipif(not native_force_available(), reason="native extension not built")
 @pytest.mark.parametrize("asym", [False, True])
 def test_native_force_jvp_and_transpose(asym):
     resolution, trig, kernels = _case(lasym=asym)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -380,6 +380,24 @@ def test_least_squares_implicit_smoke(solovev_eq):
     assert abs(aspect1 - 4.0) < abs(aspect0 - 4.0)
 
 
+def test_minimize_scalarized_implicit_smoke(solovev_eq):
+    """L-BFGS-B lowers the same cost with a finite reverse gradient."""
+    jax.config.update("jax_disable_jit", False)
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    x0 = opt.pack_boundary(inp, 1)
+    cost0 = 0.5 * (float(opt.aspect_ratio(
+        solovev_eq.state, solovev_eq.runtime)) - 4.0) ** 2
+    bounds = list(zip(x0 - 0.5, x0 + 0.5))
+    res = opt.minimize(
+        [(opt.aspect_ratio, 4.0, 1.0)], inp, max_mode=1,
+        bounds=bounds, options={"maxiter": 1})
+    assert res.cost < cost0
+    assert np.isfinite(res.optimality)
+    assert np.all(np.isfinite(res.jac))
+    assert np.all(res.x >= x0 - 0.5) and np.all(res.x <= x0 + 0.5)
+    assert isinstance(res.input, VmecInput)
+
+
 def test_least_squares_implicit_jac_chunking(solovev_eq):
     """The R17.1 chunked implicit Jacobian matches the unchunked one.
 

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -408,10 +408,16 @@ def test_least_squares_implicit_jac_chunking(solovev_eq):
                                    err_msg=f"chunk={chunk!r}")
 
 
+def test_auto_jac_chunk_stays_bounded_with_large_device(monkeypatch):
+    """A reported accelerator budget must not turn ``auto`` into one vmap."""
+    monkeypatch.setattr(opt, "auto_chunk_size", lambda dim: dim)
+    assert opt._auto_jac_chunk(120) == 11
+
+
 def test_least_squares_implicit_jac_solver_block(solovev_eq):
     """The R25.2 block-tridiagonal Jacobian matches the per-dof GMRES one.
 
-    ``jac_solver="block"`` (default) assembles the raw force Jacobian's
+    ``jac_solver="block"`` assembles the raw force Jacobian's
     radial blocks by colored jvp probes, factors once
     (:func:`solvax.block_thomas_factor`) and backsolves every dof column,
     then certifies each column with a short warm-started GMRES pass against
@@ -425,8 +431,11 @@ def test_least_squares_implicit_jac_solver_block(solovev_eq):
                             jac_solver="gmres", max_nfev=1)
     got = opt.least_squares(obj, inp, max_mode=1, jac="implicit",
                             jac_solver="block", max_nfev=1)
+    reverse = opt.least_squares(obj, inp, max_mode=1, jac="implicit",
+                                jac_solver="reverse", max_nfev=1)
     assert got.jac.shape == ref.jac.shape
     np.testing.assert_allclose(got.jac, ref.jac, rtol=1e-6, atol=1e-8)
+    np.testing.assert_allclose(reverse.jac, ref.jac, rtol=1e-6, atol=1e-8)
     with pytest.raises(ValueError, match="jac_solver"):
         opt.least_squares(obj, inp, max_mode=1, jac="implicit",
                           jac_solver="svd", max_nfev=1)

--- a/tests/test_optimize_penalty.py
+++ b/tests/test_optimize_penalty.py
@@ -107,6 +107,31 @@ def test_implicit_lane_fun_penalty_path(monkeypatch, capsys):
     np.testing.assert_allclose(res.x, opt.pack_boundary(inp, 1))  # stayed at x0
 
 
+def test_minimize_penalty_path(monkeypatch, capsys):
+    """A failed scalarized trial reuses the last finite reverse gradient."""
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    real = im._host_solve
+    calls = {"new": 0, "poisoned": 0}
+
+    def flaky(cfg, params):
+        hit = im._LAST_SOLVE.get(cfg)
+        if hit is None or hit[0] != im._params_key(params):
+            calls["new"] += 1
+            if calls["new"] >= 2:
+                calls["poisoned"] += 1
+                raise _boom()
+        return real(cfg, params)
+
+    monkeypatch.setattr(im, "_host_solve", flaky)
+    res = opt.minimize(
+        OBJECTIVE, inp, max_mode=1, verbose=1,
+        options={"maxiter": 2, "maxls": 3})
+    out = capsys.readouterr().out
+    assert calls["poisoned"] >= 1
+    assert "trial solve/gradient failed" in out
+    assert np.isfinite(res.cost)
+
+
 def test_implicit_lane_jac_fallback_and_diagnostic_resolve(monkeypatch, capsys):
     """jac='implicit': failed Jacobian reuses the last valid one; final
     diagnostic re-solve falls back to a cold solve when the hot seed fails.

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -233,12 +233,13 @@ def test_glasser_stability_residual_is_smooth_upper_bound(shaped_eq):
 
 
 def test_least_squares_accepts_implicit_stability_terms():
-    """One optimizer evaluation builds DMerc/D_R/<J.B> rows and Jacobian."""
+    """Profile scalarization matches the Gauss--Newton cost and gradient."""
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    terms = [(opt.mercier_stability_residual, 0.0, 1.0),
+             (opt.glasser_stability_residual, 0.0, 1.0),
+             (opt.jdotb_residual, 0.0, 1.0e-6)]
     result = opt.least_squares(
-        [(opt.mercier_stability_residual, 0.0, 1.0),
-         (opt.glasser_stability_residual, 0.0, 1.0),
-         (opt.jdotb_residual, 0.0, 1.0e-6)],
+        terms,
         inp,
         max_mode=1,
         jac="implicit",
@@ -247,6 +248,12 @@ def test_least_squares_accepts_implicit_stability_terms():
     assert result.nfev == 1
     assert np.isfinite(result.cost)
     assert np.all(np.isfinite(result.jac))
+    x0 = opt.pack_boundary(inp, 1)
+    scalar = opt.minimize(
+        terms, inp, max_mode=1, bounds=list(zip(x0, x0)))
+    np.testing.assert_allclose(scalar.cost, result.cost, rtol=1e-12)
+    np.testing.assert_allclose(
+        scalar.jac, result.jac.T @ result.fun, rtol=2e-5, atol=1e-8)
 
 
 @pytest.mark.full

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -579,6 +579,7 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
             verbose=verbose,
             emit=emit,
             device=None if args.device == "none" else args.device,
+            release_stage_cache=True,
         )
     solve_s = time.perf_counter() - t1
 

--- a/vmex/core/fields.py
+++ b/vmex/core/fields.py
@@ -297,6 +297,7 @@ def magnetic_fields(
     gamma: float = 0.0,
     pressure: Array | None = None,
     mass: Array | None = None,
+    lamscale: Array | None = None,
     ncurr: int = 0,
     enclosed_current: Array | None = None,
 ) -> MagneticFields:
@@ -332,6 +333,9 @@ def magnetic_fields(
     pressure, mass:
         Half-mesh profiles ``(ns,)`` in VMEC internal units (mu0*Pa).  Exactly
         one should be provided; ``mass`` takes precedence.
+    lamscale:
+        Optional precomputed global lambda normalization. This avoids
+        recomputing a resolution-wide scalar from a local radial segment.
     ncurr, enclosed_current:
         ``ncurr = 1`` activates the current-constrained mode with the
         prescribed ``icurv`` profile (``enclosed_current``, defaults to zero).
@@ -341,7 +345,10 @@ def magnetic_fields(
     sqrt_g = jacobian.sqrt_g
     dtype = sqrt_g.dtype
 
-    lamscale = lambda_scale(jnp.asarray(phips, dtype=dtype), s)
+    lamscale = (
+        lambda_scale(jnp.asarray(phips, dtype=dtype), s)
+        if lamscale is None else jnp.asarray(lamscale, dtype=dtype)
+    )
     phipf = jnp.asarray(phipf, dtype=dtype)
     chips = jnp.asarray(chips, dtype=dtype)
 
@@ -751,6 +758,7 @@ def constraint_scaling(
     total_pressure: Array,
     trig: TrigTables,
     s: Array,
+    ns_total: int | None = None,
 ) -> Array:
     """Spectral-condensation constraint strength ``tcon(js)``.
 
@@ -776,6 +784,8 @@ def constraint_scaling(
     tcon0`` before overwriting the interior; the value is never used by the
     constraint operator).  The ``ns4 = 25``-iteration refresh cadence of
     VMEC2000 lives in the solver, not here — this is the pure recompute.
+    ``ns_total`` preserves the global resolution ramp when evaluating a local
+    radial segment.
     """
     s = jnp.asarray(s)
     ns = int(s.shape[0])
@@ -810,7 +820,7 @@ def constraint_scaling(
     aznorm = jnp.where(aznorm != 0, aznorm, jnp.ones_like(aznorm))
 
     tcon0_clamped = jnp.minimum(jnp.abs(jnp.asarray(tcon0, dtype=dtype)), 1.0)
-    ns_f = float(ns)
+    ns_f = float(ns if ns_total is None else ns_total)
     tcon_multiplier = tcon0_clamped * (1.0 + ns_f * (1.0 / 60.0 + ns_f / (200.0 * 120.0)))
     tcon_multiplier = tcon_multiplier / ((4.0 * r0scale**2) ** 2)
 

--- a/vmex/core/forces.py
+++ b/vmex/core/forces.py
@@ -59,6 +59,7 @@ from .fourier import ModeTable, TrigTables
 from .geometry import HalfMeshJacobian, RealSpaceGeometry, sqrt_s_half_mesh
 from .transforms import (
     SpectralForce,
+    _fourier_to_real_fft,
     fourier_to_real,
     register_pytree_dataclass as _register,
     symforce_split,
@@ -628,6 +629,7 @@ def constraint_force(
     signgs: int,
     rcon0: Array | None = None,
     zcon0: Array | None = None,
+    use_fft: bool = False,
 ) -> tuple[Array, Array, Array, Array, Array]:
     """Spectral-condensation constraint force pipeline (funct3d.f + alias.f).
 
@@ -681,7 +683,8 @@ def constraint_force(
         ],
         axis=0,
     )
-    (value,) = fourier_to_real(
+    synthesize = _fourier_to_real_fft if use_fft else fourier_to_real
+    (value,) = synthesize(
         coeff_cos,
         coeff_sin,
         modes=modes,
@@ -745,6 +748,7 @@ def mhd_forces(
     signgs: int,
     rcon0: Array | None = None,
     zcon0: Array | None = None,
+    use_fft: bool = False,
 ) -> RealSpaceForces:
     """Assemble all real-space force kernels (funct3d.f force stage).
 
@@ -784,6 +788,7 @@ def mhd_forces(
         signgs=signgs,
         rcon0=rcon0,
         zcon0=zcon0,
+        use_fft=use_fft,
     )
 
     s = jnp.asarray(s)

--- a/vmex/core/forces.py
+++ b/vmex/core/forces.py
@@ -878,6 +878,8 @@ def spectral_mhd_forces(
     ntor: int,
     trig: TrigTables,
     include_edge: bool = False,
+    backend: str = "jax",
+    threads: int = 1,
 ) -> SpectralForce:
     """Project the real-space force kernels onto the Fourier basis.
 
@@ -896,18 +898,33 @@ def spectral_mhd_forces(
             for parity in ("even", "odd")
         }
 
+    project = None
+    if backend != "jax":
+        from .native_force import project_force
+        project = lambda values, asym=False: project_force(  # noqa: E731
+            values, mpol=mpol, ntor=ntor, trig=trig,
+            include_edge=include_edge, asym=asym,
+            backend=backend, threads=threads,
+        )
+
     if not bool(trig.lasym):
+        if project is not None:
+            return project(kernel_kwargs(forces))
         return tomnsps(
             **kernel_kwargs(forces), mpol=mpol, ntor=ntor, trig=trig, include_edge=include_edge
         )
 
     forces_sym, forces_asym = symmetrize_forces(forces, trig=trig)
-    out_sym = tomnsps(
-        **kernel_kwargs(forces_sym), mpol=mpol, ntor=ntor, trig=trig, include_edge=include_edge
-    )
-    out_asym = tomnspa(
-        **kernel_kwargs(forces_asym), mpol=mpol, ntor=ntor, trig=trig, include_edge=include_edge
-    )
+    if project is None:
+        out_sym = tomnsps(
+            **kernel_kwargs(forces_sym), mpol=mpol, ntor=ntor, trig=trig, include_edge=include_edge
+        )
+        out_asym = tomnspa(
+            **kernel_kwargs(forces_asym), mpol=mpol, ntor=ntor, trig=trig, include_edge=include_edge
+        )
+    else:
+        out_sym = project(kernel_kwargs(forces_sym))
+        out_asym = project(kernel_kwargs(forces_asym), asym=True)
     return replace(
         out_sym,
         force_R_sc=out_asym.force_R_sc,

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -1076,6 +1076,8 @@ def _solve_free_boundary_stage(
     precon_type: str | None = None,
     prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
+    force_backend: str = "jax",
+    threads: int = 1,
     jacobian_retries: int = 2,
     constraint_continuation: tuple[Array, Array] | None = None,
     reuse_vacuum_cache: bool = False,
@@ -1110,6 +1112,7 @@ def _solve_free_boundary_stage(
         time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
         lconm1=lconm1, precon_type=precon_type,
         prec2d_threshold=prec2d_threshold, prec2d=prec2d,
+        force_backend=force_backend, threads=threads,
     )
     ns = int(resolution.ns)
     dtype = rt.setup.s_full.dtype
@@ -1552,6 +1555,8 @@ def solve_free_boundary(
     precon_type: str | None = None,
     prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
+    force_backend: str = "jax",
+    threads: int = 1,
     jacobian_retries: int = 2,
 ) -> SolveResult:
     """Single-grid free-boundary solve (``eqsolve.f`` + ``funct3d.f`` IVAC0).
@@ -1568,10 +1573,14 @@ def solve_free_boundary(
     optional 2D-preconditioner overrides, and bounded ``jacobian_retries``
     recovery mirror :func:`vmex.core.solver.solve`. The returned
     ``result.vacuum`` contains the final NESTOR potential modes and surface
-    fields, without internal matrix caches.
+    fields, without internal matrix caches. ``force_backend="native"`` and
+    ``threads`` affect only the plasma force projection; NESTOR remains JAX.
     """
     if resolution is None:
         resolution = resolution_from_input(inp)
+    if force_backend == "native":
+        from .native_force import require_native_cpu
+        require_native_cpu(device, resolution)
     target = _placement_device(device, resolution)
     external_field = _put_numeric_leaves(external_field, target)
     initial_state = _put_numeric_leaves(initial_state, target)
@@ -1586,6 +1595,7 @@ def solve_free_boundary(
             lconm1=lconm1,
             precon_type=precon_type, prec2d_threshold=prec2d_threshold,
             prec2d=prec2d,
+            force_backend=force_backend, threads=threads,
             jacobian_retries=jacobian_retries,
             constraint_continuation=None, reuse_vacuum_cache=False,
         )

--- a/vmex/core/freeboundary_linear.py
+++ b/vmex/core/freeboundary_linear.py
@@ -1,0 +1,71 @@
+"""Matrix-free bordered linear algebra for a coupled plasma/NESTOR root."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import jax
+import jax.numpy as jnp
+
+Array = Any
+MatVec = Callable[[Array], Array]
+
+__all__ = ["NestorBorderedOperator"]
+
+
+@dataclass(frozen=True)
+class NestorBorderedOperator:
+    """The coupled linearization ``[[A, B], [C, D]]``.
+
+    ``A`` is the plasma-force linearization, ``D`` the NESTOR potential
+    equation, and ``B``/``C`` their edge coupling. All four blocks are
+    matrix-free callables; only their static input sizes are stored.
+    """
+
+    plasma: MatVec
+    vacuum_to_plasma: MatVec
+    plasma_to_vacuum: MatVec
+    vacuum: MatVec
+    plasma_size: int
+    vacuum_size: int
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        size = self.plasma_size + self.vacuum_size
+        return size, size
+
+    def __call__(self, value: Array) -> Array:
+        x = value[:self.plasma_size]
+        q = value[self.plasma_size:]
+        return jnp.concatenate((
+            self.plasma(x) + self.vacuum_to_plasma(q),
+            self.plasma_to_vacuum(x) + self.vacuum(q),
+        ))
+
+    def transpose(self, value: Array) -> Array:
+        """Apply the exact transpose, generated from the four linear blocks."""
+        template = jnp.zeros(
+            (self.plasma_size + self.vacuum_size,), dtype=jnp.asarray(value).dtype
+        )
+        return jax.linear_transpose(self, template)(value)[0]
+
+    def schur(self, plasma_solve: MatVec) -> MatVec:
+        """Return ``q -> (D - C A^-1 B) q`` without materializing blocks."""
+        return lambda q: self.vacuum(q) - self.plasma_to_vacuum(
+            plasma_solve(self.vacuum_to_plasma(q))
+        )
+
+    def preconditioner(
+        self, plasma_solve: MatVec, schur_solve: MatVec
+    ) -> MatVec:
+        """Exact block inverse when both supplied solves are exact."""
+        def apply(rhs):
+            rx = rhs[:self.plasma_size]
+            rq = rhs[self.plasma_size:]
+            ax = plasma_solve(rx)
+            q = schur_solve(rq - self.plasma_to_vacuum(ax))
+            x = plasma_solve(rx - self.vacuum_to_plasma(q))
+            return jnp.concatenate((x, q))
+
+        return apply

--- a/vmex/core/freeboundary_linear.py
+++ b/vmex/core/freeboundary_linear.py
@@ -11,7 +11,7 @@ import jax.numpy as jnp
 Array = Any
 MatVec = Callable[[Array], Array]
 
-__all__ = ["NestorBorderedOperator"]
+__all__ = ["NestorBorderedOperator", "linearize_nestor_coupling"]
 
 
 @dataclass(frozen=True)
@@ -69,3 +69,35 @@ class NestorBorderedOperator:
             return jnp.concatenate((x, q))
 
         return apply
+
+
+def linearize_nestor_coupling(
+    plasma_residual: Callable[[Array, Array], Array],
+    vacuum_system: Callable[[Array], tuple[Array, Array]],
+    plasma: Array,
+    potential: Array,
+) -> NestorBorderedOperator:
+    """Linearize a live plasma residual and NESTOR ``A(x)q-b(x)`` equation.
+
+    ``vacuum_system(x)`` returns the NESTOR mode matrix and right-hand side
+    assembled at plasma variables ``x``; no nested vacuum solve is performed.
+    The returned four matrix-free blocks are exact JVPs of the two nonlinear
+    residuals at ``(plasma, potential)``.
+    """
+    plasma = jnp.asarray(plasma)
+    potential = jnp.asarray(potential)
+
+    def vacuum_residual(x, q):
+        matrix, rhs = vacuum_system(x)
+        return matrix @ q - rhs
+
+    def block(fun, primal):
+        return jax.linearize(fun, primal)[1]
+
+    return NestorBorderedOperator(
+        block(lambda x: plasma_residual(x, potential), plasma),
+        block(lambda q: plasma_residual(plasma, q), potential),
+        block(lambda x: vacuum_residual(x, potential), plasma),
+        block(lambda q: vacuum_residual(plasma, q), potential),
+        int(plasma.size), int(potential.size),
+    )

--- a/vmex/core/geometry.py
+++ b/vmex/core/geometry.py
@@ -38,7 +38,11 @@ import numpy as np
 import jax.numpy as jnp
 
 from .fourier import ModeTable, TrigTables
-from .transforms import fourier_to_real, register_pytree_dataclass as _register
+from .transforms import (
+    _fourier_to_real_fft,
+    fourier_to_real,
+    register_pytree_dataclass as _register,
+)
 
 __all__ = [
     "RealSpaceGeometry",
@@ -204,6 +208,7 @@ def real_space_geometry(
     modes: ModeTable,
     trig: TrigTables,
     s: Array,
+    use_fft: bool = False,
 ) -> RealSpaceGeometry:
     """Synthesize the VMEC even-m/odd-m geometry channels from coefficients.
 
@@ -223,6 +228,9 @@ def real_space_geometry(
         (:func:`apply_lambda_axis_closure`).
     s:
         Full-mesh radial grid, shape ``(ns,)`` (uniform, ``s in [0, 1]``).
+    use_fft:
+        Use separable toroidal FFT synthesis; False retains the real dense
+        contraction used by the high-column implicit Jacobian.
 
     Returns
     -------
@@ -249,7 +257,8 @@ def real_space_geometry(
     # single odd_m_sqrt_s=True synthesis serves all three parity subsets.
     batched_cos = coeff_cos[None, ...] * mask_stack[:, None, None, :]
     batched_sin = coeff_sin[None, ...] * mask_stack[:, None, None, :]
-    value, dtheta, dzeta = fourier_to_real(
+    synthesize = _fourier_to_real_fft if use_fft else fourier_to_real
+    value, dtheta, dzeta = synthesize(
         batched_cos,
         batched_sin,
         modes=modes,

--- a/vmex/core/geometry.py
+++ b/vmex/core/geometry.py
@@ -209,6 +209,8 @@ def real_space_geometry(
     trig: TrigTables,
     s: Array,
     use_fft: bool = False,
+    axis_closure: bool = True,
+    odd_m_scaling: Array | None = None,
 ) -> RealSpaceGeometry:
     """Synthesize the VMEC even-m/odd-m geometry channels from coefficients.
 
@@ -231,6 +233,11 @@ def real_space_geometry(
     use_fft:
         Use separable toroidal FFT synthesis; False retains the real dense
         contraction used by the high-column implicit Jacobian.
+    axis_closure:
+        Apply VMEC's first-interior-row closure to the axis. Disable for a
+        radial segment that does not begin on the magnetic axis.
+    odd_m_scaling:
+        Optional slice of the global ``scalxc`` table for local evaluation.
 
     Returns
     -------
@@ -266,6 +273,7 @@ def real_space_geometry(
         derivatives=("value", "dtheta", "dzeta"),
         internal_coeffs=True,
         odd_m_sqrt_s=True,
+        odd_m_scaling=odd_m_scaling,
         s=s,
     )
 
@@ -278,7 +286,7 @@ def real_space_geometry(
         """
         m1 = plane[1, field]
         combined = m1 + plane[2, field]
-        if combined.shape[0] < 2:
+        if combined.shape[0] < 2 or not axis_closure:
             return combined
         return jnp.concatenate([m1[1][None, ...], combined[1:]], axis=0)
 

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -312,6 +312,7 @@ def _template_runtime(cfg: ImplicitConfig) -> SolverRuntime:
     return prepare_runtime(
         cfg.inp, cfg.resolution, ftol=cfg.ftol,
         max_iterations=cfg.max_iterations, lconm1=cfg.lconm1,
+        use_fft=False,
     )
 
 
@@ -750,6 +751,7 @@ def residual_fn(cfg: ImplicitConfig, frozen: SpectralState,
             fields=fields, R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
             modes=rt_p.modes, trig=rt_p.trig, s=s, phipf=setup.phipf,
             tcon=tcon, signgs=setup.signgs, rcon0=rt_p.rcon0, zcon0=rt_p.zcon0,
+            use_fft=False,
         )
         spectral = spectral_mhd_forces(
             forces, mpol=cfg.resolution.mpol, ntor=cfg.resolution.ntor,
@@ -896,12 +898,12 @@ def _host_solve(cfg: ImplicitConfig, params: ImplicitParams) -> SolveResult:
         run = lambda init: solve_multigrid(  # noqa: E731
             inp2, ns_array=ns_arr, ftol_array=ftol_arr, mode=cfg.mode,
             lconm1=cfg.lconm1, raise_on_max_iterations=False,
-            initial_state=init)
+            initial_state=init, use_fft=False)
     else:
         run = lambda init: solve(  # noqa: E731
             inp2, cfg.resolution, ftol=cfg.ftol,
             max_iterations=cfg.max_iterations, mode=cfg.mode,
-            lconm1=cfg.lconm1, initial_state=init)
+            lconm1=cfg.lconm1, initial_state=init, use_fft=False)
     # Seed ladder: perturbation prediction -> plain hot restart -> cold.
     # A bad warm seed must not fail the trial (only the initial guess is at
     # stake — every rung converges to the same fixed point).

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -257,6 +257,8 @@ class ImplicitConfig:
     #: ~30% less wall — a strictly faster path to the identical converged adjoint.
     adjoint_gcrot_m: int = 100
     adjoint_gcrot_k: int = 20
+    force_backend: str = "jax"
+    force_threads: int = 1
     #: seed repeated host solves from the last converged state of this config
     #: (optimization trials; the fixed point — hence the gradient — is
     #: unchanged, only the iteration count drops).  Makes the callback
@@ -278,6 +280,8 @@ def make_config(
     adjoint_maxiter: int = 300,
     adjoint_gcrot_m: int = 100,
     adjoint_gcrot_k: int = 20,
+    force_backend: str = "jax",
+    threads: int = 1,
     hot_restart: bool = False,
 ) -> ImplicitConfig:
     """Build the static config; ``resolution`` is the (final-stage) grid."""
@@ -295,6 +299,7 @@ def make_config(
         adjoint_tol=float(adjoint_tol), adjoint_restart=int(adjoint_restart),
         adjoint_maxiter=int(adjoint_maxiter),
         adjoint_gcrot_m=int(adjoint_gcrot_m), adjoint_gcrot_k=int(adjoint_gcrot_k),
+        force_backend=force_backend, force_threads=int(threads),
         hot_restart=bool(hot_restart),
     )
 
@@ -312,7 +317,8 @@ def _template_runtime(cfg: ImplicitConfig) -> SolverRuntime:
     return prepare_runtime(
         cfg.inp, cfg.resolution, ftol=cfg.ftol,
         max_iterations=cfg.max_iterations, lconm1=cfg.lconm1,
-        use_fft=False,
+        use_fft=False, force_backend=cfg.force_backend,
+        threads=cfg.force_threads,
     )
 
 
@@ -888,6 +894,7 @@ def _host_solve(cfg: ImplicitConfig, params: ImplicitParams) -> SolveResult:
     inp2 = input_with_params(cfg.inp, params)
     hot = _HOT_CACHE.get(cfg) if cfg.hot_restart else None
     perturb = _PERTURB_SEED.pop(cfg, None) if cfg.hot_restart else None
+    solver_device = "cpu" if cfg.force_backend == "native" else AUTO
     if cfg.multigrid:
         ns_arr = np.asarray(inp2.ns_array)
         ftol_arr = np.asarray(inp2.ftol_array, dtype=float).copy()
@@ -898,12 +905,16 @@ def _host_solve(cfg: ImplicitConfig, params: ImplicitParams) -> SolveResult:
         run = lambda init: solve_multigrid(  # noqa: E731
             inp2, ns_array=ns_arr, ftol_array=ftol_arr, mode=cfg.mode,
             lconm1=cfg.lconm1, raise_on_max_iterations=False,
-            initial_state=init, use_fft=False)
+            initial_state=init, use_fft=False,
+            force_backend=cfg.force_backend, threads=cfg.force_threads,
+            device=solver_device)
     else:
         run = lambda init: solve(  # noqa: E731
             inp2, cfg.resolution, ftol=cfg.ftol,
             max_iterations=cfg.max_iterations, mode=cfg.mode,
-            lconm1=cfg.lconm1, initial_state=init, use_fft=False)
+            lconm1=cfg.lconm1, initial_state=init, use_fft=False,
+            force_backend=cfg.force_backend, threads=cfg.force_threads,
+            device=solver_device)
     # Seed ladder: perturbation prediction -> plain hot restart -> cold.
     # A bad warm seed must not fail the trial (only the initial guess is at
     # stake — every rung converges to the same fixed point).
@@ -1388,6 +1399,8 @@ def run(
     adjoint_maxiter: int = 300,
     adjoint_gcrot_m: int = 100,
     adjoint_gcrot_k: int = 20,
+    force_backend: str = "jax",
+    threads: int = 1,
     device: Any = AUTO,
 ) -> ImplicitSolution:
     """Differentiable fixed-boundary equilibrium: input -> outputs pytree.
@@ -1410,6 +1423,9 @@ def run(
     leaves placement to JAX.  When ``params`` is supplied, an explicit
     hardware device moves the complete parameter pytree consistently;
     otherwise its existing placement is preserved.
+    ``force_backend="native"`` opts into the CPU FFI primal with ``threads``
+    workers; its JVP/VJP is the exact pure-JAX projection. The default remains
+    ``"jax"`` and must be used for GPU placement.
 
     The returned solution also carries the internally built
     :class:`~vmex.core.solver.SolverRuntime` as ``sol.runtime`` (a
@@ -1419,11 +1435,15 @@ def run(
     ``runtime_from_params(params, make_config(...))`` per evaluation.
     """
     inp = VmecInput.from_file(source) if isinstance(source, str) else source
+    if force_backend == "native":
+        from .native_force import require_native_cpu
+        require_native_cpu(device, resolution_from_input(inp, ns=ns))
     cfg = make_config(
         inp, ns=ns, ftol=ftol, max_iterations=max_iterations, mode=mode,
         multigrid=multigrid, lconm1=lconm1, adjoint_tol=adjoint_tol,
         adjoint_restart=adjoint_restart, adjoint_maxiter=adjoint_maxiter,
         adjoint_gcrot_m=adjoint_gcrot_m, adjoint_gcrot_k=adjoint_gcrot_k,
+        force_backend=force_backend, threads=threads,
     )
     if params is None:
         params = params_from_input(inp, device=device)

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -121,7 +121,9 @@ from .device import AUTO, resolve_implicit_device
 from .errors import VmecError
 from .fields import magnetic_fields, metric_elements
 from .fourier import Resolution
-from .geometry import half_mesh_jacobian
+from .geometry import (
+    apply_lambda_axis_closure, half_mesh_jacobian, real_space_geometry,
+)
 from .input import VmecInput
 from .multigrid import solve_multigrid
 from .residuals import (
@@ -131,7 +133,7 @@ from .residuals import (
 from .setup import RadialGrids, flux_profiles, interior_guess
 from .solver import (
     SolveResult, SolverRuntime, SpectralState, _constraint_baselines,
-    _force_to_state, _geometry, _initial_state, _physical_coefficients,
+    _force_to_state, _initial_state, _physical_coefficients,
     _static_tables, evaluate_forces, prepare_runtime, resolution_from_input,
     solve,
 )
@@ -696,6 +698,107 @@ def _assemble(z: SpectralState, rt_p: SolverRuntime, frozen: SpectralState,
     return SpectralState(**out)
 
 
+def _raw_force_state(
+    x: SpectralState,
+    rt: SolverRuntime,
+    *,
+    s: Array | None = None,
+    phips: Array | None = None,
+    phipf: Array | None = None,
+    chips: Array | None = None,
+    mass: Array | None = None,
+    icurv: Array | None = None,
+    rcon0: Array | None = None,
+    zcon0: Array | None = None,
+    lamscale: Array | None = None,
+    scalxc: Array | None = None,
+    ns_total: int | None = None,
+    axis_closure: bool = True,
+) -> SpectralState:
+    """Raw fixed-boundary force for a full grid or a radial segment."""
+    setup = rt.setup
+    s = setup.s_full if s is None else s
+    phips = setup.phips if phips is None else phips
+    phipf = setup.phipf if phipf is None else phipf
+    chips = setup.chips if chips is None else chips
+    mass = setup.mass if mass is None else mass
+    icurv = setup.icurv if icurv is None else icurv
+    rcon0 = rt.rcon0 if rcon0 is None else rcon0
+    zcon0 = rt.zcon0 if zcon0 is None else zcon0
+    R_cos, R_sin, Z_cos, Z_sin = _physical_coefficients(
+        x, modes=rt.modes, lthreed=setup.lthreed, lasym=setup.lasym,
+        lconm1=setup.lconm1,
+    )
+    lambda_sin = (
+        apply_lambda_axis_closure(
+            x.L_sin, modes=rt.modes, ntor=rt.resolution.ntor
+        )
+        if axis_closure else x.L_sin
+    )
+    geometry = real_space_geometry(
+        R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
+        lambda_cos=x.L_cos, lambda_sin=lambda_sin, modes=rt.modes,
+        trig=rt.trig, s=s, axis_closure=axis_closure,
+        odd_m_scaling=scalxc,
+    )
+    jacobian = half_mesh_jacobian(geometry, s=s)
+    metrics = metric_elements(geometry, s=s)
+    fields = magnetic_fields(
+        geometry=geometry, jacobian=jacobian, metrics=metrics, trig=rt.trig,
+        s=s, phips=phips, phipf=phipf, chips=chips, signgs=setup.signgs,
+        gamma=rt.gamma, mass=mass, lamscale=lamscale, ncurr=setup.ncurr,
+        enclosed_current=icurv,
+    )
+    tcon = constraint_scaling(
+        tcon0=rt.tcon0, geometry=geometry, jacobian=jacobian,
+        total_pressure=fields.total_pressure, trig=rt.trig, s=s,
+        ns_total=ns_total,
+    )
+    forces = mhd_forces(
+        geometry=geometry, jacobian=jacobian, metrics=metrics, fields=fields,
+        R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
+        modes=rt.modes, trig=rt.trig, s=s, phipf=phipf, tcon=tcon,
+        signgs=setup.signgs, rcon0=rcon0, zcon0=zcon0,
+    )
+    spectral = spectral_mhd_forces(
+        forces, mpol=rt.resolution.mpol, ntor=rt.resolution.ntor,
+        trig=rt.trig, include_edge=False,
+    )
+    released = zero_m1_z_force(
+        m1_residue_rotation(spectral, lconm1=setup.lconm1),
+        jnp.asarray(True),
+    )
+    return _force_to_state(
+        scalxc_scale_force(released, s=s, scaling=scalxc), rt
+    )
+
+
+def _raw_residual_segment(
+    x: SpectralState,
+    rt: SolverRuntime,
+    start: Array,
+    *,
+    axis_closure: bool = False,
+) -> SpectralState:
+    """Evaluate the nonlinear raw-force chain on exactly three surfaces.
+
+    ``x`` contains constrained coefficients for global rows
+    ``start:start+3``. Only the small radial profiles and constraint
+    baselines are sliced from ``rt``; every angular nonlinear temporary has
+    leading dimension three. Set ``axis_closure`` only for ``start == 0``.
+    """
+    take = lambda a: jax.lax.dynamic_slice_in_dim(a, start, 3, axis=0)  # noqa: E731
+    setup = rt.setup
+    return _raw_force_state(
+        x, rt, s=take(setup.s_full), phips=take(setup.phips),
+        phipf=take(setup.phipf), chips=take(setup.chips),
+        mass=take(setup.mass), icurv=take(setup.icurv),
+        rcon0=take(rt.rcon0), zcon0=take(rt.zcon0),
+        lamscale=setup.lamscale, scalxc=take(setup.scalxc),
+        ns_total=rt.resolution.ns, axis_closure=axis_closure,
+    )
+
+
 def residual_fn(cfg: ImplicitConfig, frozen: SpectralState,
                 dof_mask: SpectralState,
                 formulation: str = "preconditioned") -> Callable:
@@ -737,37 +840,7 @@ def residual_fn(cfg: ImplicitConfig, frozen: SpectralState,
     def F_raw(z: SpectralState, params: ImplicitParams) -> SpectralState:
         rt_p = runtime_from_params(params, cfg)
         x = _assemble(z, rt_p, frozen, P, edge_mask)
-        setup = rt_p.setup
-        s = setup.s_full
-        (R_cos, R_sin, Z_cos, Z_sin), geometry = _geometry(x, rt_p)
-        jacobian = half_mesh_jacobian(geometry, s=s)
-        metrics = metric_elements(geometry, s=s)
-        fields = magnetic_fields(
-            geometry=geometry, jacobian=jacobian, metrics=metrics,
-            trig=rt_p.trig, s=s, phips=setup.phips, phipf=setup.phipf,
-            chips=setup.chips, signgs=setup.signgs, gamma=rt_p.gamma,
-            mass=setup.mass, ncurr=setup.ncurr, enclosed_current=setup.icurv,
-        )
-        tcon = constraint_scaling(
-            tcon0=rt_p.tcon0, geometry=geometry, jacobian=jacobian,
-            total_pressure=fields.total_pressure, trig=rt_p.trig, s=s,
-        )
-        forces = mhd_forces(
-            geometry=geometry, jacobian=jacobian, metrics=metrics,
-            fields=fields, R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
-            modes=rt_p.modes, trig=rt_p.trig, s=s, phipf=setup.phipf,
-            tcon=tcon, signgs=setup.signgs, rcon0=rt_p.rcon0, zcon0=rt_p.zcon0,
-            use_fft=False,
-        )
-        spectral = spectral_mhd_forces(
-            forces, mpol=cfg.resolution.mpol, ntor=cfg.resolution.ntor,
-            trig=rt_p.trig, include_edge=False,
-        )
-        rotated = m1_residue_rotation(spectral, lconm1=setup.lconm1)
-        # converged branch: fsqz < threshold zeroes the constrained m=1 Z force
-        released = zero_m1_z_force(rotated, jnp.asarray(True))
-        scaled = scalxc_scale_force(released, s=s)
-        return P(_force_to_state(scaled, rt_p))
+        return P(_raw_force_state(x, rt_p))
 
     return F_raw
 

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -34,11 +34,13 @@ host round-trips of traced values.
 
 from __future__ import annotations
 
+import gc
 from dataclasses import replace
 from typing import Any
 
 import numpy as np
 
+import jax
 import jax.numpy as jnp
 
 from .device import AUTO, _placement_device, _put_numeric_leaves, device_context
@@ -48,7 +50,7 @@ from .input import VmecInput
 from .preconditioner_2d import Prec2DConfig
 from .solver import (
     SolveResult, SpectralState, _finalize, _result_from_carry, _solve_stage,
-    hot_restart_state, prepare_runtime, resolution_from_input,
+    _resolve_use_fft, hot_restart_state, prepare_runtime, resolution_from_input,
     runtime_with_baselines,
 )
 from .transforms import odd_m_sqrt_s_scaling
@@ -198,6 +200,8 @@ def solve_multigrid(
     prec2d: Prec2DConfig | None = None,
     device: Any = AUTO,
     raise_on_max_iterations: bool = True,
+    use_fft: bool | None = None,
+    release_stage_cache: bool = False,
 ) -> SolveResult:
     """Fixed-boundary multigrid solve over the ``NS_ARRAY`` ladder.
 
@@ -245,6 +249,15 @@ def solve_multigrid(
     follows JAX placement.  Auto never overrides an active JAX device or
     platform selection.
 
+    ``use_fft`` has the same measured-hardware default and implicit-AD role as in
+    :func:`vmex.core.solver.solve`.
+
+    ``release_stage_cache=True`` clears JAX's in-memory compilation/staging
+    caches between distinct radial grids. This lowers peak RSS for a one-shot
+    high-resolution ladder while leaving the persistent on-disk cache intact.
+    It is false by default so repeated library solves retain warm executables;
+    the standalone CLI enables it.
+
     Returns the final stage's :class:`~vmex.core.solver.SolveResult`.
     """
     ns_arr = np.atleast_1d(np.asarray(
@@ -276,12 +289,13 @@ def solve_multigrid(
             continue
         ns_min = nsval
         resolution = resolution_from_input(inp, ns=nsval)
+        stage_use_fft = _resolve_use_fft(use_fft, device, resolution)
         rt = prepare_runtime(
             inp, resolution, ftol=float(ftol_arr[igrid]),
             max_iterations=int(niter_arr[igrid]), lconm1=lconm1,
             time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
             precon_type=precon_type, prec2d_threshold=prec2d_threshold,
-            prec2d=prec2d,
+            prec2d=prec2d, use_fft=stage_use_fft,
         )
         if state is not None and int(state.R_cos.shape[0]) != nsval:
             state = interpolate_state(state, ns_fine=nsval, modes=rt.modes)
@@ -291,12 +305,13 @@ def solve_multigrid(
                 state = hot_restart_state(rt, state)
             # funct3d.f: rcon0/zcon0 are set from the state at iter2 == iter1,
             # i.e. from THIS stage's starting state, not the interior guess.
-            rt = runtime_with_baselines(rt, state)
+            rt = runtime_with_baselines(rt, state, use_fft=stage_use_fft)
         with device_context(device, resolution):
             carry = _solve_stage(
                 rt, state, mode=mode, verbose=verbose, emit=emit,
                 # the eqsolve.f axis re-guess applies to the fresh interior guess
                 try_axis_reguess=first_executed and state is None,
+                use_fft=stage_use_fft,
             )
         first_executed = False
         ier = int(carry.ier)
@@ -306,6 +321,16 @@ def solve_multigrid(
                 and not (ier == MORE_ITER_FLAG and not raise_on_max_iterations)):
             _finalize(carry, rt)  # raises the typed error for this stage
         state = carry.state
+        future = ns_arr[igrid + 1:]
+        executable = future[future >= nsval]
+        if (
+            release_stage_cache
+            and executable.size
+            and int(executable[0]) != nsval
+        ):
+            jax.block_until_ready(carry)
+            jax.clear_caches()
+            gc.collect()
 
     if int(carry.ier) == MORE_ITER_FLAG and not raise_on_max_iterations:
         return _result_from_carry(carry, rt)

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -202,6 +202,8 @@ def solve_multigrid(
     device: Any = AUTO,
     raise_on_max_iterations: bool = True,
     use_fft: bool | None = None,
+    force_backend: str = "jax",
+    threads: int = 1,
     release_stage_cache: bool = False,
 ) -> SolveResult:
     """Fixed-boundary multigrid solve over the ``NS_ARRAY`` ladder.
@@ -259,6 +261,8 @@ def solve_multigrid(
 
     ``use_fft`` has the same measured-hardware default and implicit-AD role as in
     :func:`vmex.core.solver.solve`.
+    ``force_backend="native"`` and ``threads`` explicitly select the optional
+    CPU JAX-FFI force projection at every stage; the JAX backend stays default.
 
     ``release_stage_cache=True`` clears JAX's in-memory compilation/staging
     caches between distinct radial grids. This lowers peak RSS for a one-shot
@@ -297,6 +301,9 @@ def solve_multigrid(
             continue
         ns_min = nsval
         resolution = resolution_from_input(inp, ns=nsval)
+        if force_backend == "native":
+            from .native_force import require_native_cpu
+            require_native_cpu(device, resolution)
         stage_use_fft = _resolve_use_fft(use_fft, device, resolution)
         rt = prepare_runtime(
             inp, resolution, ftol=float(ftol_arr[igrid]),
@@ -304,6 +311,7 @@ def solve_multigrid(
             time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
             precon_type=precon_type, prec2d_threshold=prec2d_threshold,
             prec2d=prec2d, use_fft=stage_use_fft,
+            force_backend=force_backend, threads=threads,
         )
         if state is not None and int(state.R_cos.shape[0]) != nsval:
             state = interpolate_state(state, ns_fine=nsval, modes=rt.modes)
@@ -371,6 +379,8 @@ def solve_free_boundary_multigrid(
     precon_type: str | None = None,
     prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
+    force_backend: str = "jax",
+    threads: int = 1,
     jacobian_retries: int = 2,
 ) -> SolveResult:
     """Free-boundary solve over the VMEC2000 ``NS_ARRAY`` ladder.
@@ -401,6 +411,8 @@ def solve_free_boundary_multigrid(
     ``device="auto"`` (default) applies the measured policy independently at
     each grid and relocates carried plasma/vacuum arrays when the policy changes;
     ``None`` leaves placement to JAX.
+    The optional ``force_backend`` and ``threads`` controls are forwarded to
+    every plasma stage; native projection is CPU-only and never automatic.
     The final stage's publishable potential and surface fields are retained in
     ``result.vacuum``; internal NESTOR matrix caches are not exposed.
     """
@@ -451,6 +463,9 @@ def solve_free_boundary_multigrid(
             continue
         ns_min = nsval
         resolution = resolution_from_input(inp, ns=nsval)
+        if force_backend == "native":
+            from .native_force import require_native_cpu
+            require_native_cpu(device, resolution)
         same_grid = previous_ns == nsval
         if state is not None and previous_ns != nsval:
             # initialize_radial.f interpolates pxstore only when ns increases;
@@ -496,6 +511,7 @@ def solve_free_boundary_multigrid(
                 lconm1=lconm1,
                 precon_type=precon_type,
                 prec2d_threshold=prec2d_threshold, prec2d=prec2d,
+                force_backend=force_backend, threads=threads,
                 jacobian_retries=jacobian_retries,
                 constraint_continuation=(
                     constraint_continuation if same_grid else None),

--- a/vmex/core/native_force.py
+++ b/vmex/core/native_force.py
@@ -172,8 +172,9 @@ def project_force(
             *args, mpol=mpol, ntor=ntor, include_edge=include_edge, asym=asym
         )
     elif backend == "native":
+        native_args = tuple(jnp.asarray(arg, dtype=reference.dtype) for arg in args)
         out = _native_projection(
-            *args, mpol, ntor, include_edge, asym, int(threads)
+            *native_args, mpol, ntor, include_edge, asym, int(threads)
         )
     else:
         raise ValueError("backend must be 'jax' or 'native'")

--- a/vmex/core/native_force.py
+++ b/vmex/core/native_force.py
@@ -1,0 +1,193 @@
+"""Opt-in native force projection with an exact portable derivative rule."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Any
+
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+
+try:
+    from jax import ffi
+except ImportError:  # JAX 0.4.x
+    from jax.extend import ffi  # type: ignore[no-redef]
+
+from .transforms import (
+    SpectralForce,
+    _radial_masks,
+    _tomnsp_theta_stage,
+    _tomnsp_zeta_stage,
+)
+
+try:
+    from vmex import _force_ffi
+except ImportError:  # optional extension: the pure-JAX package remains valid
+    _force_ffi = None
+else:
+    try:
+        for _name, _target in _force_ffi.registrations().items():
+            ffi.register_ffi_target(_name, _target, platform="cpu")
+    except Exception:  # incompatible optional binary/JAX FFI API
+        _force_ffi = None
+
+
+_NAMES = (
+    "force_R", "force_R_du", "force_R_dv", "force_Z", "force_Z_du",
+    "force_Z_dv", "force_lambda_du", "force_lambda_dv",
+    "constraint_R", "constraint_Z",
+)
+
+
+def native_force_available() -> bool:
+    """Whether the optional CPU FFI extension was built."""
+    return _force_ffi is not None
+
+
+def require_native_cpu(device, resolution) -> None:
+    """Reject an explicit/effective accelerator before tracing the CPU FFI."""
+    from .device import _placement_device
+
+    target = _placement_device(device, resolution)
+    if target is None:
+        target = jax.config.jax_default_device or jax.devices()[0]
+    if target.platform != "cpu":
+        raise ValueError(
+            "force_backend='native' is CPU-only; use device='cpu' or "
+            "force_backend='jax' on accelerators"
+        )
+
+
+def _reference(packed, cosmui, sinmui, cosmumi, sinmumi, cosnv, sinnv,
+               cosnvn, sinnvn, *, mpol, ntor, include_edge, asym):
+    class Tables:
+        pass
+
+    trig = Tables()
+    trig.ntheta2 = int(cosmui.shape[0])
+    trig.cosmui, trig.sinmui = cosmui, sinmui
+    trig.cosmumi, trig.sinmumi = cosmumi, sinmumi
+    trig.cosnv, trig.sinnv = cosnv, sinnv
+    trig.cosnvn, trig.sinnvn = cosnvn, sinnvn
+    kernels = {
+        f"{name}_{parity}": packed[2 * i + p]
+        for i, name in enumerate(_NAMES)
+        for p, parity in enumerate(("even", "odd"))
+    }
+    work = _tomnsp_theta_stage(kernels, mpol=mpol, trig=trig)
+    if asym:
+        cos_pairs = ((2, 3), (4, 5), (8, 9))
+        sin_pairs = ((0, 1), (6, 7), (10, 11))
+    else:
+        cos_pairs = ((0, 1), (6, 7), (10, 11))
+        sin_pairs = ((2, 3), (4, 5), (8, 9))
+    cos_out, sin_out = _tomnsp_zeta_stage(
+        work, ntor=ntor, trig=trig, cos_pairs=cos_pairs, sin_pairs=sin_pairs
+    )
+    if sin_out is None:
+        sin_out = tuple(jnp.zeros_like(value) for value in cos_out)
+    ns = int(packed.shape[1])
+    mask_rz, mask_l = _radial_masks(ns, mpol, include_edge, packed.dtype)
+    return jnp.stack((
+        cos_out[0] * mask_rz, sin_out[0] * mask_rz,
+        cos_out[1] * mask_rz, sin_out[1] * mask_rz,
+        cos_out[2] * mask_l, sin_out[2] * mask_l,
+    ))
+
+
+@partial(jax.custom_jvp, nondiff_argnums=(9, 10, 11, 12, 13))
+def _native_projection(packed, cosmui, sinmui, cosmumi, sinmumi, cosnv,
+                       sinnv, cosnvn, sinnvn, mpol, ntor, include_edge,
+                       asym, threads):
+    if _force_ffi is None:
+        raise RuntimeError("native VMEX force extension is not available")
+    ns, nzeta = int(packed.shape[1]), int(packed.shape[3])
+    workers = min(int(threads), ns * int(mpol))
+    result, _scratch = ffi.ffi_call(
+        "vmex_force_projection",
+        (
+            jax.ShapeDtypeStruct((6, ns, mpol, ntor + 1), packed.dtype),
+            jax.ShapeDtypeStruct((workers, 12, nzeta), packed.dtype),
+        ),
+        vmap_method="broadcast_all",
+    )(
+        packed, cosmui, sinmui, cosmumi, sinmumi, cosnv, sinnv, cosnvn, sinnvn,
+        mpol=np.int64(mpol), ntor=np.int64(ntor),
+        ntheta2=np.int64(cosmui.shape[0]), threads=np.int64(workers),
+        include_edge=include_edge, asym=asym,
+    )
+    return result
+
+
+@_native_projection.defjvp
+def _native_projection_jvp(mpol, ntor, include_edge, asym, threads,
+                           primals, tangents):
+    value = _native_projection(*primals, mpol, ntor, include_edge, asym, threads)
+    _, tangent = jax.jvp(
+        lambda *args: _reference(
+            *args, mpol=mpol, ntor=ntor,
+            include_edge=include_edge, asym=asym,
+        ),
+        primals,
+        tangents,
+    )
+    return value, tangent
+
+
+def project_force(
+    kernels: dict[str, Any],
+    *,
+    mpol: int,
+    ntor: int,
+    trig,
+    include_edge: bool = False,
+    asym: bool = False,
+    backend: str = "jax",
+    threads: int = 1,
+) -> SpectralForce:
+    """Project one symmetry family with ``jax`` or the explicit CPU FFI backend."""
+    reference = jnp.asarray(kernels["force_R_even"])
+    packed = jnp.stack([
+        jnp.zeros_like(reference) if kernels.get(f"{name}_{parity}") is None
+        else jnp.asarray(kernels[f"{name}_{parity}"])
+        for name in _NAMES for parity in ("even", "odd")
+    ])
+    args = (
+        packed,
+        jnp.asarray(trig.cosmui[:trig.ntheta2, :mpol]),
+        jnp.asarray(trig.sinmui[:trig.ntheta2, :mpol]),
+        jnp.asarray(trig.cosmumi[:trig.ntheta2, :mpol]),
+        jnp.asarray(trig.sinmumi[:trig.ntheta2, :mpol]),
+        jnp.asarray(trig.cosnv[:, :ntor + 1]),
+        jnp.asarray(trig.sinnv[:, :ntor + 1]),
+        jnp.asarray(trig.cosnvn[:, :ntor + 1]),
+        jnp.asarray(trig.sinnvn[:, :ntor + 1]),
+    )
+    if threads < 1:
+        raise ValueError("threads must be positive")
+    if backend == "jax":
+        out = _reference(
+            *args, mpol=mpol, ntor=ntor, include_edge=include_edge, asym=asym
+        )
+    elif backend == "native":
+        out = _native_projection(
+            *args, mpol, ntor, include_edge, asym, int(threads)
+        )
+    else:
+        raise ValueError("backend must be 'jax' or 'native'")
+    second = None if ntor == 0 else out[1]
+    fourth = None if ntor == 0 else out[3]
+    sixth = None if ntor == 0 else out[5]
+    if asym:
+        return SpectralForce(
+            force_R_sc=out[0], force_R_cs=second,
+            force_Z_cc=out[2], force_Z_ss=fourth,
+            force_lambda_cc=out[4], force_lambda_ss=sixth,
+        )
+    return SpectralForce(
+        force_R_cc=out[0], force_R_ss=second,
+        force_Z_sc=out[2], force_Z_cs=fourth,
+        force_lambda_sc=out[4], force_lambda_cs=sixth,
+    )

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -23,6 +23,9 @@ Simsopt-style vocabulary for the QA/QH/QP/QI examples on the pure new core:
 - :func:`least_squares` — a thin :func:`scipy.optimize.least_squares` driver
   over boundary Fourier dofs (:func:`pack_boundary`/:func:`unpack_boundary`),
   taking simsopt-style ``(callable, target, weight)`` terms.
+- :func:`minimize` — the same residual definition scalarized as
+  ``0.5 * sum(residual**2)`` and minimized with L-BFGS-B, so one reverse
+  implicit adjoint supplies the gradient without a dense residual Jacobian.
 
 Helicity conventions (match legacy/simsopt exactly)
 ---------------------------------------------------
@@ -157,6 +160,7 @@ __all__ = [
     "pack_boundary",
     "unpack_boundary",
     "least_squares",
+    "minimize",
     "RedlBootstrapMismatch",  # noqa: F822 - provided lazily by __getattr__ below
 ]
 
@@ -1406,6 +1410,64 @@ def least_squares(
     return result
 
 
+def minimize(
+    objective_terms: Sequence[tuple[Callable, float, float]],
+    inp: VmecInput,
+    *,
+    max_mode: int | Sequence[int] = 1,
+    x0: np.ndarray | None = None,
+    current_dofs: int | None = None,
+    hot_restart: bool = True,
+    device: Any = AUTO,
+    solve_kwargs: dict | None = None,
+    verbose: int = 0,
+    method: str = "L-BFGS-B",
+    **scipy_kwargs,
+):
+    """Minimize the scalarized residual norm with one adjoint per gradient.
+
+    The objective is exactly ``0.5 * sum(rows**2)``, with ``rows`` defined by
+    :func:`least_squares`.  Unlike Gauss--Newton least squares, a reverse
+    gradient of this scalar needs one matrix-free implicit adjoint and never
+    forms the vector residual Jacobian or its dense radial block factors.
+    This is the bounded-storage path for profile objectives such as ``DMerc``,
+    ``jdotb``, and Glasser ``D_R``.  It changes the optimization algorithm,
+    not the objective or its unconstrained minimizers, and is therefore
+    opt-in; :func:`least_squares` retains all existing defaults.
+
+    ``method`` and remaining keywords are passed to
+    :func:`scipy.optimize.minimize` (default ``"L-BFGS-B"``; use ``bounds=``
+    and ``options={"maxiter": ...}`` in the usual scipy form).  All objective
+    terms must support ``jac="implicit"`` as documented by
+    :func:`least_squares`.  Plain state hot restarts are used because the
+    first-order perturbation warm start requires the forward state-response
+    columns that this lower-storage path deliberately avoids.
+    """
+    modes_schedule = ([int(max_mode)] if np.isscalar(max_mode)
+                      else [int(m) for m in max_mode])
+    if len(modes_schedule) > 1:
+        if x0 is not None:
+            raise ValueError("x0 cannot be combined with a max_mode schedule")
+        stage_results = []
+        current = inp
+        for mm in modes_schedule:
+            result = minimize(
+                objective_terms, current, max_mode=mm,
+                current_dofs=current_dofs, hot_restart=hot_restart,
+                device=device, solve_kwargs=solve_kwargs, verbose=verbose,
+                method=method, **scipy_kwargs)
+            stage_results.append(result)
+            current = result.input
+        result.stage_results = stage_results
+        return result
+    return _least_squares_implicit(
+        objective_terms, inp, max_mode=modes_schedule[0], x0=x0,
+        current_dofs=current_dofs, jac_solver="reverse", recycle=False,
+        warm_start=("state" if hot_restart else None),
+        solve_kwargs=dict(solve_kwargs or {}), device=device, verbose=verbose,
+        minimize_method=method, **scipy_kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Implicit-gradient mode (vmex.core.implicit wiring)
 # ---------------------------------------------------------------------------
@@ -1457,6 +1519,7 @@ def _least_squares_implicit(
     solve_kwargs: dict,
     device: Any = AUTO,
     verbose: int = 0,
+    minimize_method: str | None = None,
     **scipy_kwargs,
 ):
     """Single-stage boundary least squares with implicit-gradient Jacobians.
@@ -1565,6 +1628,12 @@ def _least_squares_implicit(
         return term_rows(state, imp.runtime_from_params(params, cfg))
 
     rows_jit = jax.jit(residual_rows)
+
+    def scalar_loss(x: jnp.ndarray) -> jnp.ndarray:
+        rows = residual_rows(x)
+        return 0.5 * jnp.vdot(rows, rows)
+
+    value_grad_jit = jax.jit(jax.value_and_grad(scalar_loss))
 
     # The evolved-dof mask is a *structural* per-config constant; fetch it
     # once (first host solve, cached in implicit._MASK_CACHE) so the Jacobian
@@ -1981,8 +2050,37 @@ def _least_squares_implicit(
         except Exception:  # the seed itself does not converge -> fun raises clearly
             pass
 
-    result = scipy.optimize.least_squares(fun, np.asarray(x0, dtype=float),
-                                          jac=jac_fn, **scipy_kwargs)
+    if minimize_method is None:
+        result = scipy.optimize.least_squares(
+            fun, np.asarray(x0, dtype=float), jac=jac_fn, **scipy_kwargs)
+    else:
+        def value_and_grad(x: np.ndarray):
+            try:
+                value, grad = value_grad_jit(_place(x))
+                value = float(jax.device_get(value))
+                grad = np.asarray(jax.device_get(grad), dtype=float)
+            except Exception as exc:
+                if holder.get("last_grad") is None:
+                    raise
+                if verbose:
+                    print(f"[minimize] trial solve/gradient failed: {exc}")
+                return 1.0e12, holder["last_grad"]
+            if np.isfinite(value) and np.all(np.isfinite(grad)):
+                holder["last_grad"] = grad
+                if verbose:
+                    print(f"[minimize] cost = {value:.6e}")
+                return value, grad
+            if holder.get("last_grad") is None:
+                raise FloatingPointError("non-finite initial objective or gradient")
+            return 1.0e12, holder["last_grad"]
+
+        result = scipy.optimize.minimize(
+            value_and_grad, np.asarray(x0, dtype=float), jac=True,
+            method=minimize_method, **scipy_kwargs)
+        if "jac" not in result:  # scipy may skip evaluation if every dof is fixed
+            result.fun, result.jac = value_and_grad(result.x)
+        result.cost = float(result.fun)
+        result.optimality = float(np.linalg.norm(result.jac, ord=np.inf))
     result.input = unpack_boundary(inp, result.x[:nboundary], max_mode)
     if k_cur:
         result.input = _apply_current(result.input, result.x[nboundary:],

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -1595,7 +1595,12 @@ def _least_squares_implicit(
         warm_start = "state"  # the recycled variant carries (C, U) instead
     cfg = imp.make_config(inp, multigrid=True,
                           hot_restart=(warm_start is not None),
-                          adjoint_tol=1e-6, adjoint_maxiter=30)
+                          adjoint_tol=1e-6, adjoint_maxiter=30,
+                          force_backend=solve_kwargs.get("force_backend", "jax"),
+                          threads=solve_kwargs.get("threads", 1))
+    if cfg.force_backend == "native":
+        from .native_force import require_native_cpu
+        require_native_cpu(device, cfg.resolution)
     # Pin the residual/Jacobian graphs to the fastest device for this launch-
     # bound path (CPU by default; explicit device= honored) — committing the
     # input dof vector to it makes both jits compile and run there, and their

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -203,6 +203,11 @@ class Equilibrium:
         )
 
 
+def _auto_jac_chunk(dim: int) -> int:
+    """Bound device-aware batching by the conservative square-root policy."""
+    return min(int(auto_chunk_size(dim)), int(np.ceil(np.sqrt(dim))))
+
+
 def solve_equilibrium(
     inp: VmecInput,
     *,
@@ -1151,7 +1156,7 @@ def least_squares(
     current_dofs: int | None = None,
     jac: str | None = None,
     jac_chunk_size: int | str | None = "auto",
-    jac_solver: str = "block",
+    jac_solver: str = "auto",
     recycle: bool = False,
     hot_restart: bool = True,
     warm_start: str | None = "perturbation",
@@ -1228,19 +1233,18 @@ def least_squares(
     ``readin.f`` delta rotation.
     ``jac_chunk_size`` (R17.1 memory knob, ``jac="implicit"`` only) chunks the
     per-dof Jacobian columns via :func:`solvax.chunk_map`: ``"auto"`` (default)
-    lets :func:`solvax.auto_chunk_size` pick a memory-bounded width (the
-    largest block that fits the device budget on GPU, a sqrt-balanced width on
-    CPU) so peak Jacobian memory is ``m0 + m1*chunk`` instead of scaling with
-    the full dof count; an ``int`` fixes that many boundary dofs at a time; and
-    ``None`` forces one wide ``vmap`` over all dofs (the pre-R17.1 behavior,
-    fastest but peak memory O(dofs)).  The column blocks are mathematically
-    independent, so the assembled Jacobian is identical to float64 round-off
-    (~1e-15) across chunk sizes.  It is inert for ``jac=None`` (scipy computes
-    the finite-difference Jacobian itself).
+    uses SOLVAX's device-aware width capped by a conservative square-root
+    width, so an accelerator memory report cannot expand the full probe batch;
+    an ``int`` fixes that many boundary dofs at a time; and ``None`` forces one
+    wide ``vmap`` over all dofs. The column blocks are mathematically
+    independent, so the assembled Jacobian is identical to float64 round-off.
+    It is inert for ``jac=None``.
 
-    ``jac_solver`` (plan R25.2, ``jac="implicit"`` only) selects the linear
-    solver behind the per-dof implicit-Jacobian columns.  ``"block"``
-    (default) amortizes one block-tridiagonal factorization of the *raw*
+    ``jac_solver`` (``jac="implicit"`` only) selects the implicit-Jacobian
+    direction. ``"auto"`` (default) uses one matrix-free reverse solve for a
+    scalar residual and the ``"block"`` path below otherwise. ``"reverse"``
+    requests one reverse solve per residual row. ``"block"``
+    amortizes one block-tridiagonal factorization of the *raw*
     force Jacobian — whose radial coupling is exactly nearest-neighbor, so
     ns dense ``(3*mn, 3*mn)`` blocks assembled by 3-colored ``jax.jvp``
     probes capture it completely at a cost independent of the dof count —
@@ -1447,7 +1451,7 @@ def _least_squares_implicit(
     x0: np.ndarray | None,
     current_dofs: int | None = None,
     jac_chunk_size: int | str | None = "auto",
-    jac_solver: str = "block",
+    jac_solver: str = "auto",
     recycle: bool = False,
     warm_start: str | None = "perturbation",
     solve_kwargs: dict,
@@ -1464,13 +1468,11 @@ def _least_squares_implicit(
     :func:`~vmex.core.implicit.runtime_from_params` -> the stacked
     objective rows: one warm host solve per trial ``x``.  ``jac`` computes
     the exact residual Jacobian by *forward* implicit differentiation:
-    by default (``jac_solver="block"``, see ``jacobian_rows_block``) one
-    amortized block-tridiagonal factorization backsolves every boundary-dof
-    column at once; ``jac_solver="gmres"`` (see ``jacobian_rows``) runs one
-    preconditioned GMRES per boundary dof, batched.  Either way this is far
-    below one full equilibrium solve per dof (finite differences) while
-    keeping the full pointwise Gauss-Newton residual geometry.  Both are
-    jit-compiled once per stage.
+    with one reverse adjoint for a scalar residual (``jac_solver="auto"``);
+    vector residuals use one amortized block-tridiagonal factorization
+    (``jacobian_rows_block``), while ``jac_solver="gmres"`` keeps the
+    per-boundary-dof fallback. All paths retain the full pointwise
+    Gauss-Newton residual geometry and are jit-compiled once per stage.
 
     The residual and Jacobian graphs run on the device chosen by
     :func:`vmex.core.device.resolve_implicit_device` — the CPU by default,
@@ -1608,7 +1610,7 @@ def _least_squares_implicit(
     # R17.1 memory knob: chunk_size None == one wide vmap (current behavior),
     # an int / "auto" caps peak Jacobian memory at that many dofs at a time.
     if jac_chunk_size == "auto":
-        chunk = int(auto_chunk_size(ndof))
+        chunk = _auto_jac_chunk(ndof)
     elif jac_chunk_size is None or isinstance(jac_chunk_size, int):
         chunk = jac_chunk_size
     else:
@@ -1710,10 +1712,7 @@ def _least_squares_implicit(
     probe_color = jnp.asarray(np.repeat(np.arange(3), m_block))
     probe_field = jnp.asarray(np.tile(np.repeat(np.arange(n_act), mn_state), 3))
     probe_col = jnp.asarray(np.tile(np.tile(np.arange(mn_state), n_act), 3))
-    if jac_chunk_size == "auto":
-        probe_chunk = int(auto_chunk_size(3 * m_block))
-    else:
-        probe_chunk = chunk
+    probe_chunk = chunk
 
     def _pack(t) -> jnp.ndarray:
         """SpectralState -> (ns, m_block): active fields side by side."""
@@ -1854,16 +1853,18 @@ def _least_squares_implicit(
         cols = cols.reshape((nchunks * csize,) + cols.shape[2:])[:ndof]
         return jnp.transpose(cols), C, U
 
-    if jac_solver not in ("block", "gmres"):
+    if jac_solver not in ("auto", "block", "gmres", "reverse"):
         raise ValueError(
-            f"jac_solver must be 'block' or 'gmres', got {jac_solver!r}")
+            "jac_solver must be 'auto', 'block', 'gmres', or 'reverse', "
+            f"got {jac_solver!r}")
     if recycle:
         jac_impl = jacobian_rows_recycled  # opt-in R25.3 experiment wins
-    elif jac_solver == "block":
+    elif jac_solver in ("auto", "block"):
         jac_impl = jacobian_rows_block
     else:
         jac_impl = jacobian_rows
     jac_jit = jax.jit(jac_impl)
+    reverse_jit = jax.jit(jax.jacrev(residual_rows))
 
     holder: dict[str, Any] = {"nres": None, "lin": None}
     if recycle:
@@ -1937,7 +1938,19 @@ def _least_squares_implicit(
 
     def jac_fn(x: np.ndarray) -> np.ndarray:
         try:
-            if recycle:
+            reverse = (
+                not recycle
+                and (
+                    jac_solver == "reverse"
+                    or (jac_solver == "auto" and holder["nres"] == 1)
+                )
+            )
+            if reverse:
+                jac = np.asarray(
+                    jax.device_get(reverse_jit(_place(x))), dtype=float
+                )
+                holder["lin"] = None
+            elif recycle:
                 rows, C, U = jac_jit(_place(x), *holder["recycle"])
                 holder["recycle"] = (C, U)  # deflate the next jac evaluation
                 jac = np.asarray(jax.device_get(rows), dtype=float)

--- a/vmex/core/residuals.py
+++ b/vmex/core/residuals.py
@@ -406,16 +406,22 @@ def _map_blocks(force: SpectralForce, names: tuple[str, ...], fn) -> dict[str, A
     return out
 
 
-def scalxc_scale_force(force: SpectralForce, *, s: Array) -> SpectralForce:
+def scalxc_scale_force(
+    force: SpectralForce, *, s: Array, scaling: Array | None = None
+) -> SpectralForce:
     """Apply the odd-m ``1/sqrt(s)`` scaling to every force block.
 
     VMEC2000: ``funct3d.f`` — ``gc = gc * scalxc`` right after ``tomnsps``,
     making the scaling part of the definition of the reported residuals.
     Uses :func:`vmex.core.transforms.odd_m_sqrt_s_scaling` (``profil3d.f``
-    ``scalxc``).
+    ``scalxc``). ``scaling`` may supply the corresponding global-table slice
+    for a local radial segment.
     """
     mpol = int(jnp.asarray(force.force_R_cc).shape[1])
-    scalxc = odd_m_sqrt_s_scaling(jnp.asarray(s), mpol)[:, :, None]
+    scalxc = (
+        odd_m_sqrt_s_scaling(jnp.asarray(s), mpol)
+        if scaling is None else jnp.asarray(scaling)
+    )[:, :, None]
     updates = _map_blocks(
         force, _R_BLOCKS + _Z_BLOCKS + _LAMBDA_BLOCKS, lambda b: b * scalxc.astype(b.dtype)
     )

--- a/vmex/core/setup.py
+++ b/vmex/core/setup.py
@@ -917,6 +917,7 @@ def run_setup(
     *,
     lconm1: bool = True,
     infer_axis_if_missing: bool = True,
+    use_fft: bool = False,
 ) -> RunSetup:
     """Build the complete pre-iteration setup for one radial resolution.
 
@@ -973,7 +974,7 @@ def run_setup(
                 modes=modes, lthreed=bool(resolution.lthreed),
                 lasym=bool(resolution.lasym), lconm1=bool(lconm1),
             ),
-            modes=modes, trig=trig, s=grids.s_full,
+            modes=modes, trig=trig, s=grids.s_full, use_fft=use_fft,
         )
         axis = guess_axis(geom, s=grids.s_full, trig=trig, signgs=boundary.signgs)
         raxis_c, raxis_s, zaxis_c, zaxis_s = axis

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -61,6 +61,7 @@ from dataclasses import dataclass, fields as dataclass_fields, is_dataclass, rep
 from typing import Any, Callable
 
 import functools
+import platform
 
 import numpy as np
 
@@ -125,7 +126,12 @@ _harden_compilation_cache()
 import jax.numpy as jnp
 from jax import lax
 
-from .device import AUTO, device_context
+from .device import (
+    AUTO,
+    GPU_MAX_SPECTRAL_MODES,
+    _placement_device,
+    device_context,
+)
 from .errors import (
     BAD_JACOBIAN_FLAG, JAC75_FLAG, MISC_ERROR_FLAG, MORE_ITER_FLAG,
     NONFINITE_FLAG, NORM_TERM_FLAG, SUCCESSFUL_TERM_FLAG,
@@ -549,7 +555,9 @@ def _physical_coefficients(state: SpectralState, *, modes, lthreed, lasym, lconm
     return R_cos, R_sin, Z_cos, Z_sin
 
 
-def _geometry(state: SpectralState, rt: SolverRuntime):
+def _geometry(
+    state: SpectralState, rt: SolverRuntime, *, use_fft: bool = False
+):
     """Constrained state -> physical coefficients + real-space geometry."""
     setup = rt.setup
     R_cos, R_sin, Z_cos, Z_sin = _physical_coefficients(
@@ -560,7 +568,7 @@ def _geometry(state: SpectralState, rt: SolverRuntime):
     geometry = real_space_geometry(
         R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
         lambda_cos=state.L_cos, lambda_sin=lambda_sin,
-        modes=rt.modes, trig=rt.trig, s=setup.s_full,
+        modes=rt.modes, trig=rt.trig, s=setup.s_full, use_fft=use_fft,
     )
     return (R_cos, R_sin, Z_cos, Z_sin), geometry
 
@@ -603,6 +611,7 @@ def prepare_runtime(
     lconm1: bool = True, setup: RunSetup | None = None,
     precon_type: str | None = None, prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
+    use_fft: bool = False,
 ) -> SolverRuntime:
     """Build the static solver context from an input file or a RunSetup.
 
@@ -629,7 +638,9 @@ def prepare_runtime(
         if resolution is None:
             resolution = resolution_from_input(inp)
         if setup is None:
-            setup = run_setup(inp, resolution, lconm1=lconm1)
+            setup = run_setup(
+                inp, resolution, lconm1=lconm1, use_fft=use_fft
+            )
         defaults = dict(ftol=float(inp.ftol_array[0]), niter=int(inp.niter_array[0]),
                         delt=float(inp.delt), tcon0=float(inp.tcon0),
                         gamma=float(inp.gamma), nstep=int(inp.nstep))
@@ -646,7 +657,9 @@ def prepare_runtime(
         rcon0=jnp.zeros(()), zcon0=jnp.zeros(()),  # placeholder, replaced below
         prec2d=_resolve_prec2d(source, prec2d, precon_type, prec2d_threshold),
     )
-    rcon0, zcon0 = _constraint_baselines(_initial_state(setup), rt)
+    rcon0, zcon0 = _constraint_baselines(
+        _initial_state(setup), rt, use_fft=use_fft
+    )
     return replace(rt, rcon0=rcon0, zcon0=zcon0)
 
 
@@ -688,7 +701,9 @@ def hot_restart_state(rt: SolverRuntime, state: SpectralState) -> SpectralState:
     )
 
 
-def runtime_with_baselines(rt: SolverRuntime, state: SpectralState) -> SolverRuntime:
+def runtime_with_baselines(
+    rt: SolverRuntime, state: SpectralState, *, use_fft: bool = False
+) -> SolverRuntime:
     """Rebind ``rcon0/zcon0`` to a new starting state (``funct3d.f``).
 
     VMEC2000 sets the constraint baselines from the *current* state whenever
@@ -700,19 +715,24 @@ def runtime_with_baselines(rt: SolverRuntime, state: SpectralState) -> SolverRun
     and hence the converged equilibrium — is subtly wrong (observed as a
     ~1e-8 relative ``wb`` shift on the nfp4_QH ladder).
     """
-    rcon0, zcon0 = _constraint_baselines(state, rt)
+    rcon0, zcon0 = _constraint_baselines(state, rt, use_fft=use_fft)
     return replace(rt, rcon0=rcon0, zcon0=zcon0)
 
 
-def _constraint_baselines(state: SpectralState, rt: SolverRuntime):
+def _constraint_baselines(
+    state: SpectralState, rt: SolverRuntime, *, use_fft: bool = False
+):
     """One-time ``rcon0/zcon0 = s * rcon(ns)`` (funct3d.f, iter2 == iter1)."""
-    (R_cos, R_sin, Z_cos, Z_sin), geometry = _geometry(state, rt)
+    (R_cos, R_sin, Z_cos, Z_sin), geometry = _geometry(
+        state, rt, use_fft=use_fft
+    )
     ns = int(rt.setup.s_full.shape[0])
     _, _, _, rcon0, zcon0 = constraint_force(
         R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
         geometry=geometry, modes=rt.modes, trig=rt.trig, s=rt.setup.s_full,
         tcon=jnp.zeros((ns,), dtype=rt.setup.s_full.dtype),
         signgs=rt.setup.signgs,
+        use_fft=use_fft,
     )
     return rcon0, zcon0
 
@@ -772,6 +792,7 @@ def _force_pipeline(
     cache: PreconditionerCache, rt: SolverRuntime,
     iteration: Array, fsqz_previous: Array,
     collect_health: bool = False,
+    use_fft: bool = False,
 ) -> tuple[Any, Any, ForcePipelineHealth]:
     """MHD forces -> residue.f90 chain -> scalfor/faclam preconditioning.
 
@@ -795,6 +816,7 @@ def _force_pipeline(
         R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
         modes=rt.modes, trig=rt.trig, s=s, phipf=setup.phipf,
         tcon=cache.tcon, signgs=setup.signgs, rcon0=rt.rcon0, zcon0=rt.zcon0,
+        use_fft=use_fft,
     )
     if rt.lfreeb:
         # forces.f (ivac >= 1): vacuum-pressure edge force.  funct3d.f builds
@@ -950,6 +972,7 @@ def _evaluate(
     iter_last_reset: Array, fsqz_previous: Array, rt: SolverRuntime,
     fsq_rz_previous: Array | None = None,
     *, collect_health: bool = False,
+    use_fft: bool = False,
 ) -> _EvalResult:
     """One funct3d.f pass (fixed boundary), pure and jit-friendly.
 
@@ -969,7 +992,9 @@ def _evaluate(
     ns = int(s.shape[0])
     hs = setup.hs
 
-    (R_cos, R_sin, Z_cos, Z_sin), geometry = _geometry(state, rt)
+    (R_cos, R_sin, Z_cos, Z_sin), geometry = _geometry(
+        state, rt, use_fft=use_fft
+    )
     jacobian = half_mesh_jacobian(geometry, s=s)
     jac_changed = jacobian.jacobian_sign_changed
 
@@ -1040,7 +1065,7 @@ def _evaluate(
         geometry=geometry, jacobian=jacobian, metrics=metrics, fields=fields,
         R_cos=R_cos, R_sin=R_sin, Z_cos=Z_cos, Z_sin=Z_sin,
         cache=cache, rt=rt, iteration=iteration, fsqz_previous=fsqz_previous,
-        collect_health=collect_health,
+        collect_health=collect_health, use_fft=use_fft,
     )
     if rt.lfreeb:
         # residue.f90 medge rule: the edge rows join fsqr/fsqz only when
@@ -1160,7 +1185,7 @@ def _evaluation_is_finite(result: _EvalResult) -> Array:
 
 
 def reguess_initial_axis(
-    rt: SolverRuntime, state: SpectralState
+    rt: SolverRuntime, state: SpectralState, *, use_fft: bool = False
 ) -> tuple[SolverRuntime, SpectralState, tuple[Array, Array, Array, Array]]:
     """Apply the VMEC2000 first-bad-Jacobian magnetic-axis retry.
 
@@ -1169,7 +1194,7 @@ def reguess_initial_axis(
     constraint baselines to that state (``funct3d.f: iter2 == iter1``).
     """
     setup = rt.setup
-    _, geometry = _geometry(state, rt)
+    _, geometry = _geometry(state, rt, use_fft=use_fft)
     axis = guess_axis(
         geometry, s=setup.s_full, trig=rt.trig, signgs=setup.signgs
     )
@@ -1191,7 +1216,9 @@ def reguess_initial_axis(
         R_cos=arrays[0], R_sin=arrays[1], Z_cos=arrays[2], Z_sin=arrays[3],
         L_cos=arrays[4], L_sin=arrays[5],
     )
-    rt = runtime_with_baselines(replace(rt, setup=new_setup), state)
+    rt = runtime_with_baselines(
+        replace(rt, setup=new_setup), state, use_fft=use_fft
+    )
     return rt, state, axis
 
 
@@ -1202,6 +1229,7 @@ def _make_body(
     rt: SolverRuntime,
     *,
     evaluation_state: SpectralState | None = None,
+    use_fft: bool = False,
 ) -> Callable[[_LoopCarry], _LoopCarry]:
     """Build the traced single-iteration body shared by both lanes.
 
@@ -1223,7 +1251,7 @@ def _make_body(
         # ---- funct3d (evolve.f) -------------------------------------------
         state_e1 = carry.state if evaluation_state is None else evaluation_state
         e1 = _evaluate(state_e1, carry.cache, it, carry.iter1, carry.fsqz, rt,
-                       carry.fsqr + carry.fsqz)
+                       carry.fsqr + carry.fsqz, use_fft=use_fft)
         jac1 = e1.jacobian_sign_changed
         nonfinite1 = (~jac1) & (~_evaluation_is_finite(e1))
         # On irst=2 funct3d skips residue: the module residuals stay stale.
@@ -1269,7 +1297,10 @@ def _make_body(
         # Re-evaluate at the restored state (TimeStepControl calls funct3d).
         e2 = lax.cond(
             restart,
-            lambda args: _evaluate(args[0], args[1], it, it, args[2], rt, args[3]),
+            lambda args: _evaluate(
+                args[0], args[1], it, it, args[2], rt, args[3],
+                use_fft=use_fft,
+            ),
             lambda args: e1,
             (state_r, e1.cache, fsqz_c, fsqr_c + fsqz_c),
         )
@@ -1563,13 +1594,49 @@ def _block_lane(carry: _LoopCarry, rt: SolverRuntime) -> _LoopCarry:
     return lax.scan(lambda cc, _: (body(cc), None), carry, None, length=BLOCK_SIZE)[0]
 
 
+@jax.jit
+def _while_lane_fft(carry: _LoopCarry, rt: SolverRuntime) -> _LoopCarry:
+    """Whole-solve lane using separable Fourier synthesis."""
+    body = _make_body(rt, use_fft=True)
+    return lax.while_loop(lambda c: jnp.logical_not(c.done), body, carry)
+
+
+@functools.partial(jax.jit, donate_argnums=(0,))
+def _block_lane_fft(carry: _LoopCarry, rt: SolverRuntime) -> _LoopCarry:
+    """Donated CLI block using separable Fourier synthesis."""
+    body = _make_body(rt, use_fft=True)
+    return lax.scan(
+        lambda cc, _: (body(cc), None), carry, None, length=BLOCK_SIZE
+    )[0]
+
+
+def _resolve_use_fft(
+    use_fft: bool | None, device: Any, resolution: Resolution
+) -> bool:
+    """Select the measured synthesis kernel without environment routing."""
+    if use_fft is not None:
+        return bool(use_fft)
+    if int(resolution.mnmax) <= GPU_MAX_SPECTRAL_MODES:
+        return False
+    target = _placement_device(device, resolution)
+    if target is None:
+        target = jax.config.jax_default_device
+    backend = (
+        getattr(target, "platform", None)
+        if target is not None
+        else jax.default_backend()
+    )
+    return backend != "cpu" or platform.machine().lower() in ("arm64", "aarch64")
+
+
 def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
-              ijacob: int, verbose: bool, emit) -> _LoopCarry:
+              ijacob: int, verbose: bool, emit,
+              use_fft: bool = False) -> _LoopCarry:
     """Run the iteration loop in the requested lane; return the final carry."""
     carry = _initial_carry(state0, rt, ijacob=ijacob)
 
     if mode == "jit":
-        return _while_lane(carry, rt)
+        return (_while_lane_fft if use_fft else _while_lane)(carry, rt)
 
     if mode != "cli":
         raise ValueError(f"unknown mode {mode!r}; expected 'cli' or 'jit'")
@@ -1587,8 +1654,9 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
 
     printed: set[int] = set()
     max_passes = rt.max_iterations + 200
+    lane = _block_lane_fft if use_fft else _block_lane
     for _ in range(max_passes):
-        carry = _block_lane(carry, rt)
+        carry = lane(carry, rt)
         done = bool(carry.done)
         upto = int(carry.iteration) if done else int(carry.iteration) - 1
         if verbose:
@@ -1601,7 +1669,8 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
 
 def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
                  mode: str, verbose: bool, emit,
-                 try_axis_reguess: bool = True) -> _LoopCarry:
+                 try_axis_reguess: bool = True,
+                 use_fft: bool = False) -> _LoopCarry:
     """Run one solve at a fixed runtime, with the eqsolve.f axis-retry.
 
     ``state0=None`` starts from the runtime's ``profil3d.f`` interior guess.
@@ -1613,7 +1682,10 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
     setup = rt.setup
     if state0 is None:
         state0 = _initial_state(setup)
-    carry = _run_loop(state0, rt, mode=mode, ijacob=0, verbose=verbose, emit=emit)
+    carry = _run_loop(
+        state0, rt, mode=mode, ijacob=0, verbose=verbose, emit=emit,
+        use_fft=use_fft,
+    )
 
     # eqsolve.f: on a first-iteration Jacobian sign change with ijacob == 0,
     # re-guess the axis from the current geometry and restart once.
@@ -1622,9 +1694,11 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
         if verbose:
             emit(" INITIAL JACOBIAN CHANGED SIGN!")
             emit(" TRYING TO IMPROVE INITIAL MAGNETIC AXIS GUESS")
-        rt, state0, _axis = reguess_initial_axis(rt, state0)
+        rt, state0, _axis = reguess_initial_axis(
+            rt, state0, use_fft=use_fft
+        )
         carry = _run_loop(state0, rt, mode=mode, ijacob=1, verbose=verbose,
-                          emit=emit)
+                          emit=emit, use_fft=use_fft)
     return carry
 
 
@@ -1672,6 +1746,7 @@ def solve(
     device: Any = AUTO,
     precon_type: str | None = None, prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
+    use_fft: bool | None = None,
 ) -> SolveResult:
     """Single-grid fixed-boundary solve (VMEC2000 ``eqsolve.f``).
 
@@ -1708,6 +1783,12 @@ def solve(
     follow JAX placement.  The automatic policy never overrides an active
     ``jax.default_device`` context or user-pinned JAX platform.
 
+    ``use_fft=None`` (default) selects separable FFT only above 512 modes on
+    accelerators and ARM CPUs; smaller problems and x86 CPUs retain the dense
+    real contraction. Explicit ``True``/``False`` always wins. The implicit
+    API sets it False internally so its equilibrium and Jacobian share one
+    lower-memory real-contraction executable.
+
     ``precon_type`` (``"NONE"`` default) with a finite ``prec2d_threshold`` —
     or an explicit ``prec2d``
     :class:`~vmex.core.preconditioner_2d.Prec2DConfig` — switches on the
@@ -1718,11 +1799,17 @@ def solve(
     stiff cases (high beta/aspect/mode-number) in far fewer iterations.  The
     default (``NONE``) path is byte-identical to the 1D-only solver.
     """
+    if resolution is None and isinstance(source, VmecInput):
+        resolution = resolution_from_input(source)
+    if resolution is None:
+        raise ValueError("solve(RunSetup) requires a Resolution")
+    use_fft_resolved = _resolve_use_fft(use_fft, device, resolution)
     rt = prepare_runtime(
         source, resolution, ftol=ftol, max_iterations=max_iterations,
         time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
         lconm1=lconm1, precon_type=precon_type,
         prec2d_threshold=prec2d_threshold, prec2d=prec2d,
+        use_fft=use_fft_resolved,
     )
     if initial_state is not None:
         ns, mnmax = rt.resolution.ns, rt.modes.mnmax
@@ -1733,7 +1820,12 @@ def solve(
                 "vmex.core.multigrid.interpolate_state first"
             )
         initial_state = hot_restart_state(rt, initial_state)
-        rt = runtime_with_baselines(rt, initial_state)  # funct3d.f iter2==iter1
+        rt = runtime_with_baselines(
+            rt, initial_state, use_fft=use_fft_resolved
+        )  # funct3d.f iter2==iter1
     with device_context(device, rt.resolution):
-        carry = _solve_stage(rt, initial_state, mode=mode, verbose=verbose, emit=emit)
+        carry = _solve_stage(
+            rt, initial_state, mode=mode, verbose=verbose, emit=emit,
+            use_fft=use_fft_resolved,
+        )
     return _finalize(carry, rt)

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -408,6 +408,8 @@ class SolverRuntime:
     jmax: int                           # evolved radial rows (fixed: ns-1)
     lforbal: bool = False               # tomnsp_mod.f m=1,n=0 force replacement
     lmove_axis: bool = True             # funct3d.f first-force irst=4 path
+    force_backend: str = "jax"          # explicit opt-in native projection
+    force_threads: int = 1
 
     # -- free-boundary seam (core/freeboundary.py; funct3d.f/forces.f) ------
     # lfreeb=True selects the vacuum-coupled lane: the edge row is evolved
@@ -463,7 +465,8 @@ class SolverRuntime:
 
 _register(SolverRuntime, meta=(
     "resolution", "gamma", "tcon0", "ftol", "max_iterations", "time_step0",
-    "nstep", "jmax", "lforbal", "lmove_axis", "lfreeb", "prec2d",
+    "nstep", "jmax", "lforbal", "lmove_axis", "force_backend",
+    "force_threads", "lfreeb", "prec2d",
 ))
 
 
@@ -630,6 +633,8 @@ def prepare_runtime(
     precon_type: str | None = None, prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
     use_fft: bool = False,
+    force_backend: str = "jax",
+    threads: int = 1,
 ) -> SolverRuntime:
     """Build the static solver context from an input file or a RunSetup.
 
@@ -674,6 +679,10 @@ def prepare_runtime(
                         gamma=float(inp.gamma), nstep=int(inp.nstep),
                         lforbal=bool(inp.lforbal),
                         lmove_axis=bool(inp.lmove_axis))
+    if force_backend not in ("jax", "native"):
+        raise ValueError("force_backend must be 'jax' or 'native'")
+    if int(threads) < 1:
+        raise ValueError("threads must be positive")
 
     rt = SolverRuntime(
         resolution=resolution, setup=setup,
@@ -686,6 +695,7 @@ def prepare_runtime(
         jmax=int(resolution.ns) - 1,
         lforbal=bool(defaults["lforbal"] if lforbal is None else lforbal),
         lmove_axis=bool(defaults["lmove_axis"]),
+        force_backend=force_backend, force_threads=int(threads),
         rcon0=jnp.zeros(()), zcon0=jnp.zeros(()),  # placeholder, replaced below
         prec2d=_resolve_prec2d(source, prec2d, precon_type, prec2d_threshold),
     )
@@ -872,7 +882,9 @@ def _force_pipeline(
     passing = jnp.asarray(True)
     real_space_finite = _all_finite(forces) if collect_health else passing
     spectral = spectral_mhd_forces(
-        forces, mpol=res.mpol, ntor=res.ntor, trig=rt.trig, include_edge=bool(rt.lfreeb)
+        forces, mpol=res.mpol, ntor=res.ntor, trig=rt.trig,
+        include_edge=bool(rt.lfreeb), backend=rt.force_backend,
+        threads=rt.force_threads,
     )
     if rt.lforbal:
         equif = radial_force_balance_error(
@@ -1919,6 +1931,8 @@ def solve(
     precon_type: str | None = None, prec2d_threshold: float | None = None,
     prec2d: Prec2DConfig | None = None,
     use_fft: bool | None = None,
+    force_backend: str = "jax",
+    threads: int = 1,
     jacobian_retries: int = 2,
 ) -> SolveResult:
     """Single-grid fixed-boundary solve (VMEC2000 ``eqsolve.f``).
@@ -1965,6 +1979,10 @@ def solve(
     API sets it False internally so its equilibrium and Jacobian share one
     lower-memory real-contraction executable.
 
+    ``force_backend="native"`` explicitly selects the optional CPU JAX-FFI
+    force projection with ``threads`` workers. The portable ``"jax"`` backend
+    remains the default and is the GPU path.
+
     ``precon_type`` (``"NONE"`` default) with a finite ``prec2d_threshold`` —
     or an explicit ``prec2d``
     :class:`~vmex.core.preconditioner_2d.Prec2DConfig` — switches on the
@@ -1979,13 +1997,16 @@ def solve(
         resolution = resolution_from_input(source)
     if resolution is None:
         raise ValueError("solve(RunSetup) requires a Resolution")
+    if force_backend == "native":
+        from .native_force import require_native_cpu
+        require_native_cpu(device, resolution)
     use_fft_resolved = _resolve_use_fft(use_fft, device, resolution)
     rt = prepare_runtime(
         source, resolution, ftol=ftol, max_iterations=max_iterations,
         time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
         lconm1=lconm1, precon_type=precon_type,
         prec2d_threshold=prec2d_threshold, prec2d=prec2d,
-        use_fft=use_fft_resolved,
+        use_fft=use_fft_resolved, force_backend=force_backend, threads=threads,
     )
     if initial_state is not None:
         ns, mnmax = rt.resolution.ns, rt.modes.mnmax

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -498,9 +498,10 @@ def _force_gather_tables(modes: ModeTable) -> tuple[np.ndarray, ...]:
     return m.astype(np.int32), np.abs(n).astype(np.int32), cos_w, sin_w
 
 
-def _blocks_to_signed(block_a, block_b, rt: SolverRuntime, w: np.ndarray) -> Array:
+def _blocks_to_signed(
+    block_a, block_b, rt: SolverRuntime, w: np.ndarray, ns: int
+) -> Array:
     """Gather one ``(ns, mpol, ntor+1)`` block pair into signed coefficients."""
-    ns = int(rt.setup.s_full.shape[0])
     dtype = rt.setup.s_full.dtype
     if block_a is None:
         return jnp.zeros((ns, rt.modes.mnmax), dtype=dtype)
@@ -519,13 +520,14 @@ def _force_to_state(force: SpectralForce, rt: SolverRuntime) -> SpectralState:
     packing is an equivalent linear reparametrization, so the momentum step
     commutes with this conversion.
     """
+    ns = int(jnp.asarray(force.force_R_cc).shape[0])
     return SpectralState(
-        R_cos=_blocks_to_signed(force.force_R_cc, force.force_R_ss, rt, rt.cos_w),
-        R_sin=_blocks_to_signed(force.force_R_sc, force.force_R_cs, rt, rt.sin_w),
-        Z_cos=_blocks_to_signed(force.force_Z_cc, force.force_Z_ss, rt, rt.cos_w),
-        Z_sin=_blocks_to_signed(force.force_Z_sc, force.force_Z_cs, rt, rt.sin_w),
-        L_cos=_blocks_to_signed(force.force_lambda_cc, force.force_lambda_ss, rt, rt.cos_w),
-        L_sin=_blocks_to_signed(force.force_lambda_sc, force.force_lambda_cs, rt, rt.sin_w),
+        R_cos=_blocks_to_signed(force.force_R_cc, force.force_R_ss, rt, rt.cos_w, ns),
+        R_sin=_blocks_to_signed(force.force_R_sc, force.force_R_cs, rt, rt.sin_w, ns),
+        Z_cos=_blocks_to_signed(force.force_Z_cc, force.force_Z_ss, rt, rt.cos_w, ns),
+        Z_sin=_blocks_to_signed(force.force_Z_sc, force.force_Z_cs, rt, rt.sin_w, ns),
+        L_cos=_blocks_to_signed(force.force_lambda_cc, force.force_lambda_ss, rt, rt.cos_w, ns),
+        L_sin=_blocks_to_signed(force.force_lambda_sc, force.force_lambda_cs, rt, rt.sin_w, ns),
     )
 
 

--- a/vmex/core/transforms.py
+++ b/vmex/core/transforms.py
@@ -15,10 +15,12 @@ VMEC2000 counterparts
 
 Structure
 ---------
-All transforms are two-stage DFTs expressed as batched matrix products
-(theta stage then zeta stage, or mode-stacked phase tables), pure ``jax.numpy``
-with ``Precision.HIGHEST``, no host round-trips, and jit-friendly: the trig
-tables and mode tables are static (NumPy) trace-time constants.
+Production geometry synthesis can use a batched toroidal FFT followed by a
+poloidal contraction (with a dense-DFT fallback for undersampled grids).
+The solver selects it on measured winning hardware; the public dense synthesis
+is retained for x86 CPUs and high-column implicit AD. Force projection uses the
+reverse two-stage order. All paths are pure ``jax.numpy``, have no host
+round-trips, and are jit-friendly.
 
 Naming: variables use physical names with the VMEC2000 Fortran name recorded
 in docstrings/comments (e.g. ``force_R`` for ``armn``, ``force_R_cc`` for
@@ -184,6 +186,122 @@ def _phase_pair(modes: ModeTable, trig: TrigTables, derivative: str) -> tuple[np
     return cos_phase, sin_phase
 
 
+def _packed_toroidal_coefficients(
+    coefficient_cos: Array, coefficient_sin: Array, modes: ModeTable
+) -> tuple[Array, Array, Array, Array]:
+    """Repack signed helical modes into separable cos/sin theta-zeta blocks."""
+    mpol = int(np.max(np.asarray(modes.m))) + 1
+    ntor = int(np.max(np.abs(np.asarray(modes.n)))) if modes.mnmax else 0
+    split = ntor + 1
+    cos0 = coefficient_cos[..., :split][..., None, :]
+    sin0 = coefficient_sin[..., :split][..., None, :]
+    shape = (*coefficient_cos.shape[:-1], mpol - 1, 2 * ntor + 1)
+    cos_rest = coefficient_cos[..., split:].reshape(shape)
+    sin_rest = coefficient_sin[..., split:].reshape(shape)
+
+    cos_neg = cos_rest[..., :ntor][..., ::-1]
+    sin_neg = sin_rest[..., :ntor][..., ::-1]
+    cos_pos = cos_rest[..., ntor + 1 :]
+    sin_pos = sin_rest[..., ntor + 1 :]
+    cos_zero = cos_rest[..., ntor : ntor + 1]
+    sin_zero = sin_rest[..., ntor : ntor + 1]
+
+    theta_cos_cos = jnp.concatenate(
+        [cos_zero, cos_neg + cos_pos], axis=-1
+    )
+    theta_cos_sin = jnp.concatenate(
+        [jnp.zeros_like(sin_zero), sin_neg - sin_pos], axis=-1
+    )
+    theta_sin_cos = jnp.concatenate(
+        [sin_zero, sin_neg + sin_pos], axis=-1
+    )
+    theta_sin_sin = jnp.concatenate(
+        [jnp.zeros_like(cos_zero), cos_pos - cos_neg], axis=-1
+    )
+
+    zero = jnp.zeros_like(cos0)
+    sin0_zeta = jnp.concatenate(
+        [jnp.zeros_like(sin0[..., :1]), -sin0[..., 1:]], axis=-1
+    )
+    return tuple(
+        jnp.concatenate([axis, rest], axis=-2)
+        for axis, rest in (
+            (cos0, theta_cos_cos),
+            (sin0_zeta, theta_cos_sin),
+            (zero, theta_sin_cos),
+            (zero, theta_sin_sin),
+        )
+    )
+
+
+def _toroidal_synthesis(
+    coefficient_cos: Array, coefficient_sin: Array, trig: TrigTables
+) -> Array:
+    """Evaluate one real toroidal Fourier series, using an FFT when unaliased."""
+    nzeta = int(np.shape(trig.cosnv)[0])
+    n_modes = int(coefficient_cos.shape[-1])
+    ntor = n_modes - 1
+    if ntor <= (nzeta - 1) // 2:
+        factors = jnp.full((n_modes,), nzeta / 2, dtype=coefficient_cos.dtype)
+        factors = factors.at[0].set(nzeta)
+        spectrum = (
+            factors * jnp.asarray(trig.nscale[:n_modes])
+            * (coefficient_cos - 1j * coefficient_sin)
+        )
+        spectrum = jnp.pad(
+            spectrum,
+            [(0, 0)] * (spectrum.ndim - 1)
+            + [(0, nzeta // 2 + 1 - n_modes)],
+        )
+        return jnp.fft.irfft(spectrum, n=nzeta, axis=-1)
+    return (
+        _einsum("...mn,kn->...mk", coefficient_cos, trig.cosnv[:, :n_modes])
+        + _einsum("...mn,kn->...mk", coefficient_sin, trig.sinnv[:, :n_modes])
+    )
+
+
+def _fast_synthesis(
+    coefficient_cos: Array,
+    coefficient_sin: Array,
+    modes: ModeTable,
+    trig: TrigTables,
+    derivatives: tuple[str, ...],
+) -> tuple[Array, ...]:
+    """Use separable FFT synthesis without expanding mode-stacked phases."""
+    a_cos, a_sin, b_cos, b_sin = _packed_toroidal_coefficients(
+        coefficient_cos, coefficient_sin, modes
+    )
+    a = _toroidal_synthesis(a_cos, a_sin, trig)
+    b = _toroidal_synthesis(b_cos, b_sin, trig)
+    mpol = int(a.shape[-2])
+    theta = {
+        "value": (trig.cosmu[:, :mpol], trig.sinmu[:, :mpol]),
+        "dtheta": (trig.sinmum[:, :mpol], trig.cosmum[:, :mpol]),
+    }
+    fields: list[Array] = []
+    for derivative in derivatives:
+        if derivative == "dzeta":
+            frequency = (
+                jnp.arange(a_cos.shape[-1], dtype=coefficient_cos.dtype)
+                * float(trig.nfp)
+            )
+            a_d = _toroidal_synthesis(frequency * a_sin, -frequency * a_cos, trig)
+            b_d = _toroidal_synthesis(frequency * b_sin, -frequency * b_cos, trig)
+            cosmu, sinmu = trig.cosmu[:, :mpol], trig.sinmu[:, :mpol]
+        elif derivative in theta:
+            a_d, b_d = a, b
+            cosmu, sinmu = theta[derivative]
+        else:
+            raise ValueError(
+                f"Unknown derivative {derivative!r}; expected one of {_DERIVATIVES}"
+            )
+        fields.append(
+            _einsum("...mk,im->...ik", a_d, cosmu)
+            + _einsum("...mk,im->...ik", b_d, sinmu)
+        )
+    return tuple(fields)
+
+
 # ---------------------------------------------------------------------------
 # Fourier -> real space (totzsps/totzspa)
 # ---------------------------------------------------------------------------
@@ -269,6 +387,51 @@ def fourier_to_real(
         phase = jnp.asarray(np.concatenate([cos_phase, sin_phase], axis=0))
         fields.append(_einsum("...k,kij->...ij", coeff, phase))
     return tuple(fields)
+
+
+def _fourier_to_real_fft(
+    coefficient_cos: Array,
+    coefficient_sin: Array,
+    *,
+    modes: ModeTable,
+    trig: TrigTables,
+    derivatives: Sequence[str] = _DERIVATIVES,
+    internal_coeffs: bool = False,
+    odd_m_sqrt_s: bool = False,
+    s: Array | None = None,
+) -> tuple[Array, ...]:
+    """Internal separable-FFT variant of :func:`fourier_to_real`."""
+    coeff_cos = jnp.asarray(coefficient_cos)
+    coeff_sin = jnp.asarray(coefficient_sin)
+    if coeff_cos.ndim < 2 or coeff_sin.ndim < 2:
+        raise ValueError("Expected coefficient arrays with shape (..., ns, mnmax)")
+    if coeff_cos.shape != coeff_sin.shape:
+        raise ValueError("coefficient_cos and coefficient_sin must have the same shape")
+    if int(coeff_cos.shape[-1]) != modes.mnmax:
+        raise ValueError("Mode count mismatch between coefficients and mode table")
+
+    if not internal_coeffs:
+        scale = jnp.asarray(
+            physical_to_internal_scale(modes, trig), dtype=coeff_cos.dtype
+        )
+        scale = scale.reshape((1,) * (coeff_cos.ndim - 1) + (modes.mnmax,))
+        coeff_cos = coeff_cos * scale
+        coeff_sin = coeff_sin * scale
+    if odd_m_sqrt_s:
+        ns = int(coeff_cos.shape[-2])
+        if s is None:
+            s = _default_radial_grid(ns, coeff_cos.dtype)
+        mpol = int(np.max(np.asarray(modes.m))) + 1
+        scalxc = odd_m_sqrt_s_scaling(s, mpol).astype(coeff_cos.dtype)
+        scalxc_mn = scalxc[:, np.asarray(modes.m, dtype=np.int64)]
+        scalxc_mn = scalxc_mn.reshape(
+            (1,) * (coeff_cos.ndim - 2) + scalxc_mn.shape
+        )
+        coeff_cos = coeff_cos * scalxc_mn
+        coeff_sin = coeff_sin * scalxc_mn
+    return _fast_synthesis(
+        coeff_cos, coeff_sin, modes, trig, tuple(derivatives)
+    )
 
 
 def real_to_fourier(

--- a/vmex/core/transforms.py
+++ b/vmex/core/transforms.py
@@ -334,6 +334,7 @@ def fourier_to_real(
     derivatives: Sequence[str] = _DERIVATIVES,
     internal_coeffs: bool = False,
     odd_m_sqrt_s: bool = False,
+    odd_m_scaling: Array | None = None,
     s: Array | None = None,
 ) -> tuple[Array, ...]:
     """Synthesize real-space fields on the VMEC internal angular grid.
@@ -365,6 +366,9 @@ def fourier_to_real(
         If True apply the odd-m ``1/sqrt(s)`` factors (``profil3d.f`` scalxc)
         to the coefficients before synthesis — VMEC's ``totzsps`` consumes
         internal coefficients that carry this scaling.
+    odd_m_scaling:
+        Optional precomputed ``(ns, mpol)`` scaling table. This preserves
+        global radial scaling when synthesizing a local segment.
     s:
         Radial grid for ``odd_m_sqrt_s`` (defaults to a uniform [0, 1] grid).
 
@@ -392,7 +396,10 @@ def fourier_to_real(
         if s is None:
             s = _default_radial_grid(ns, coeff_cos.dtype)
         mpol = int(np.max(np.asarray(modes.m))) + 1
-        scalxc = odd_m_sqrt_s_scaling(s, mpol).astype(coeff_cos.dtype)
+        scalxc = (
+            odd_m_sqrt_s_scaling(s, mpol)
+            if odd_m_scaling is None else jnp.asarray(odd_m_scaling)
+        ).astype(coeff_cos.dtype)
         scalxc_mn = scalxc[:, np.asarray(modes.m, dtype=np.int64)]
         scalxc_mn = scalxc_mn.reshape((1,) * (coeff_cos.ndim - 2) + scalxc_mn.shape)
         coeff_cos = coeff_cos * scalxc_mn
@@ -416,6 +423,7 @@ def _fourier_to_real_fft(
     derivatives: Sequence[str] = _DERIVATIVES,
     internal_coeffs: bool = False,
     odd_m_sqrt_s: bool = False,
+    odd_m_scaling: Array | None = None,
     s: Array | None = None,
 ) -> tuple[Array, ...]:
     """Internal separable-FFT variant of :func:`fourier_to_real`."""
@@ -440,7 +448,10 @@ def _fourier_to_real_fft(
         if s is None:
             s = _default_radial_grid(ns, coeff_cos.dtype)
         mpol = int(np.max(np.asarray(modes.m))) + 1
-        scalxc = odd_m_sqrt_s_scaling(s, mpol).astype(coeff_cos.dtype)
+        scalxc = (
+            odd_m_sqrt_s_scaling(s, mpol)
+            if odd_m_scaling is None else jnp.asarray(odd_m_scaling)
+        ).astype(coeff_cos.dtype)
         scalxc_mn = scalxc[:, np.asarray(modes.m, dtype=np.int64)]
         scalxc_mn = scalxc_mn.reshape(
             (1,) * (coeff_cos.ndim - 2) + scalxc_mn.shape

--- a/vmex/core/vacuum.py
+++ b/vmex/core/vacuum.py
@@ -781,6 +781,7 @@ def _mode_matrix_from_grpmn(grpmn: Array, basis: VacuumBasis) -> Array:
 class VacuumSolver:
     """Jitted NESTOR update closures over one :class:`VacuumBasis`.
 
+    ``assemble`` returns the unsolved ``(mode_matrix, rhs, ...)`` equation.
     ``full``: complete update — returns ``(potvac, mode_matrix,
     bvec_nonsing, rhs, gsource, grpmn)``.  ``skip``: incremental update with
     the cached ``(bvec_nonsing, mode_matrix)`` — returns ``(potvac, rhs)``.
@@ -790,12 +791,13 @@ class VacuumSolver:
     signgs: int
     full: Any
     skip: Any
+    assemble: Any = None
 
 
 def make_vacuum_solver(basis: VacuumBasis, *, signgs: int = -1) -> VacuumSolver:
     """Build the jit-compiled full/skip NESTOR updates for one basis."""
 
-    def _full(boundary: VacuumBoundary, bexni: Array):
+    def _assemble(boundary: VacuumBoundary, bexni: Array):
         full_grid = _full_grid_from_active(boundary, basis)
         gsource, grpmn_nonsing = _nonsingular_terms(full_grid, bexni, basis, signgs)
         bvec_nonsing = _mode_rhs_from_gsource(gsource, basis)
@@ -805,6 +807,12 @@ def make_vacuum_solver(basis: VacuumBasis, *, signgs: int = -1) -> VacuumSolver:
         rhs = bvec_nonsing + bvec_analytic
         grpmn = grpmn_nonsing + grpmn_analytic
         mode_matrix = _mode_matrix_from_grpmn(grpmn, basis)
+        return mode_matrix, rhs, bvec_nonsing, gsource, grpmn
+
+    def _full(boundary: VacuumBoundary, bexni: Array):
+        mode_matrix, rhs, bvec_nonsing, gsource, grpmn = _assemble(
+            boundary, bexni
+        )
         potvac = jnp.linalg.solve(mode_matrix, rhs)
         return potvac, mode_matrix, bvec_nonsing, rhs, gsource, grpmn
 
@@ -817,7 +825,8 @@ def make_vacuum_solver(basis: VacuumBasis, *, signgs: int = -1) -> VacuumSolver:
         return potvac, rhs
 
     return VacuumSolver(
-        basis=basis, signgs=int(signgs), full=jax.jit(_full), skip=jax.jit(_skip)
+        basis=basis, signgs=int(signgs), full=jax.jit(_full),
+        skip=jax.jit(_skip), assemble=jax.jit(_assemble),
     )
 
 

--- a/vmex/native/__init__.py
+++ b/vmex/native/__init__.py
@@ -1,0 +1,1 @@
+"""Optional native kernels used by explicit VMEX performance policies."""

--- a/vmex/native/force_ffi.cc
+++ b/vmex/native/force_ffi.cc
@@ -1,0 +1,210 @@
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+#include "pybind11/pybind11.h"
+#include "xla/ffi/api/c_api.h"
+#include "xla/ffi/api/ffi.h"
+
+namespace ffi = xla::ffi;
+namespace py = pybind11;
+
+template <typename T>
+ffi::Error Project(int64_t mpol, int64_t ntor, int64_t ntheta2,
+                   int64_t thread_count, bool include_edge, bool asym,
+                   ffi::AnyBuffer kernels, ffi::AnyBuffer cosmui,
+                   ffi::AnyBuffer sinmui, ffi::AnyBuffer cosmumi,
+                   ffi::AnyBuffer sinmumi, ffi::AnyBuffer cosnv,
+                   ffi::AnyBuffer sinnv, ffi::AnyBuffer cosnvn,
+                   ffi::AnyBuffer sinnvn, ffi::Result<ffi::AnyBuffer> result,
+                   ffi::Result<ffi::AnyBuffer> scratch) {
+  auto kd = kernels.dimensions();
+  if (kd.size() != 4 || kd[0] != 20 || kd[2] < ntheta2) {
+    return ffi::Error::InvalidArgument(
+        "kernels must have shape (20, ns, ntheta3, nzeta)");
+  }
+  const int64_t ns = kd[1];
+  const int64_t ntheta3 = kd[2];
+  const int64_t nzeta = kd[3];
+  const int64_t ncols = ntor + 1;
+  const int64_t tasks = ns * mpol;
+  const int64_t workers = std::max<int64_t>(
+      1, std::min<int64_t>({thread_count, tasks, scratch->dimensions()[0]}));
+
+  const T* k = kernels.typed_data<T>();
+  const T* cm = cosmui.typed_data<T>();
+  const T* sm = sinmui.typed_data<T>();
+  const T* cmm = cosmumi.typed_data<T>();
+  const T* smm = sinmumi.typed_data<T>();
+  const T* cn = cosnv.typed_data<T>();
+  const T* sn = sinnv.typed_data<T>();
+  const T* cnn = cosnvn.typed_data<T>();
+  const T* snn = sinnvn.typed_data<T>();
+  T* out = result->typed_data<T>();
+  T* tmp = scratch->typed_data<T>();
+
+  auto kernel = [&](int64_t channel, int64_t parity, int64_t s, int64_t i,
+                    int64_t z) -> T {
+    const int64_t plane = 2 * channel + parity;
+    return k[((plane * ns + s) * ntheta3 + i) * nzeta + z];
+  };
+  auto table = [mpol](const T* a, int64_t i, int64_t m) -> T {
+    return a[i * mpol + m];
+  };
+  auto ztable = [ncols](const T* a, int64_t z, int64_t n) -> T {
+    return a[z * ncols + n];
+  };
+  auto output = [=](int64_t channel, int64_t s, int64_t m,
+                    int64_t n) -> int64_t {
+    return ((channel * ns + s) * mpol + m) * ncols + n;
+  };
+
+  auto run = [&](int64_t worker) {
+    T* w = tmp + worker * 12 * nzeta;
+    for (int64_t task = worker; task < tasks; task += workers) {
+      const int64_t s = task / mpol;
+      const int64_t m = task % mpol;
+      const int64_t p = m & 1;
+      const T xmpq = static_cast<T>(m * (m - 1));
+      std::fill(w, w + 12 * nzeta, static_cast<T>(0));
+      for (int64_t i = 0; i < ntheta2; ++i) {
+        const T c = table(cm, i, m);
+        const T q = table(sm, i, m);
+        const T dc = table(cmm, i, m);
+        const T dq = table(smm, i, m);
+        for (int64_t z = 0; z < nzeta; ++z) {
+          const T r = kernel(0, p, s, i, z);
+          const T ru = kernel(1, p, s, i, z);
+          const T rv = kernel(2, p, s, i, z);
+          const T zz = kernel(3, p, s, i, z);
+          const T zu = kernel(4, p, s, i, z);
+          const T zv = kernel(5, p, s, i, z);
+          const T lu = kernel(6, p, s, i, z);
+          const T lv = kernel(7, p, s, i, z);
+          const T rc = kernel(8, p, s, i, z);
+          const T zc = kernel(9, p, s, i, z);
+          w[0 * nzeta + z] += r * c + ru * dq + xmpq * rc * c;
+          w[1 * nzeta + z] -= rv * c;
+          w[2 * nzeta + z] += r * q + ru * dc + xmpq * rc * q;
+          w[3 * nzeta + z] -= rv * q;
+          w[4 * nzeta + z] += zz * c + zu * dq + xmpq * zc * c;
+          w[5 * nzeta + z] -= zv * c;
+          w[6 * nzeta + z] += zz * q + zu * dc + xmpq * zc * q;
+          w[7 * nzeta + z] -= zv * q;
+          w[8 * nzeta + z] += lu * dq;
+          w[9 * nzeta + z] -= lv * c;
+          w[10 * nzeta + z] += lu * dc;
+          w[11 * nzeta + z] -= lv * q;
+        }
+      }
+
+      const std::array<int, 3> ca =
+          asym ? std::array<int, 3>{2, 4, 8}
+               : std::array<int, 3>{0, 6, 10};
+      const std::array<int, 3> cb =
+          asym ? std::array<int, 3>{3, 5, 9}
+               : std::array<int, 3>{1, 7, 11};
+      const std::array<int, 3> sa =
+          asym ? std::array<int, 3>{0, 6, 10}
+               : std::array<int, 3>{2, 4, 8};
+      const std::array<int, 3> sb =
+          asym ? std::array<int, 3>{1, 7, 11}
+               : std::array<int, 3>{3, 5, 9};
+      for (int64_t n = 0; n < ncols; ++n) {
+        for (int family = 0; family < 3; ++family) {
+          T co = 0;
+          T si = 0;
+          for (int64_t z = 0; z < nzeta; ++z) {
+            co += w[ca[family] * nzeta + z] * ztable(cn, z, n);
+            if (ntor > 0) {
+              co += w[cb[family] * nzeta + z] * ztable(snn, z, n);
+              si += w[sa[family] * nzeta + z] * ztable(sn, z, n) +
+                    w[sb[family] * nzeta + z] * ztable(cnn, z, n);
+            }
+          }
+          const bool rz = family < 2;
+          const int64_t first = rz ? (m == 0 ? 0 : 1) : 1;
+          const int64_t last = rz ? (include_edge ? ns - 1 : ns - 2) : ns - 1;
+          const bool active = s >= first && s <= last;
+          out[output(2 * family, s, m, n)] =
+              active ? co : static_cast<T>(0);
+          out[output(2 * family + 1, s, m, n)] =
+              active ? si : static_cast<T>(0);
+        }
+      }
+    }
+  };
+
+  std::vector<std::thread> threads;
+  threads.reserve(std::max<int64_t>(0, workers - 1));
+  for (int64_t worker = 1; worker < workers; ++worker) {
+    threads.emplace_back(run, worker);
+  }
+  run(0);
+  for (auto& thread : threads) thread.join();
+  return ffi::Error::Success();
+}
+
+ffi::Error Dispatch(int64_t mpol, int64_t ntor, int64_t ntheta2,
+                    int64_t threads, bool include_edge, bool asym,
+                    ffi::AnyBuffer kernels, ffi::AnyBuffer cosmui,
+                    ffi::AnyBuffer sinmui, ffi::AnyBuffer cosmumi,
+                    ffi::AnyBuffer sinmumi, ffi::AnyBuffer cosnv,
+                    ffi::AnyBuffer sinnv, ffi::AnyBuffer cosnvn,
+                    ffi::AnyBuffer sinnvn,
+                    ffi::Result<ffi::AnyBuffer> result,
+                    ffi::Result<ffi::AnyBuffer> scratch) {
+  if (threads < 1) {
+    return ffi::Error::InvalidArgument("threads must be positive");
+  }
+  switch (kernels.element_type()) {
+    case ffi::F32:
+      return Project<float>(mpol, ntor, ntheta2, threads, include_edge, asym,
+                            kernels, cosmui, sinmui, cosmumi, sinmumi, cosnv,
+                            sinnv, cosnvn, sinnvn, result, scratch);
+    case ffi::F64:
+      return Project<double>(mpol, ntor, ntheta2, threads, include_edge, asym,
+                             kernels, cosmui, sinmui, cosmumi, sinmumi, cosnv,
+                             sinnv, cosnvn, sinnvn, result, scratch);
+    default:
+      return ffi::Error::InvalidArgument("only float32 and float64 are supported");
+  }
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    VmexForceProjection, Dispatch,
+    ffi::Ffi::Bind()
+        .Attr<int64_t>("mpol")
+        .Attr<int64_t>("ntor")
+        .Attr<int64_t>("ntheta2")
+        .Attr<int64_t>("threads")
+        .Attr<bool>("include_edge")
+        .Attr<bool>("asym")
+        .Arg<ffi::AnyBuffer>()
+        .Arg<ffi::AnyBuffer>()
+        .Arg<ffi::AnyBuffer>()
+        .Arg<ffi::AnyBuffer>()
+        .Arg<ffi::AnyBuffer>()
+        .Arg<ffi::AnyBuffer>()
+        .Arg<ffi::AnyBuffer>()
+        .Arg<ffi::AnyBuffer>()
+        .Arg<ffi::AnyBuffer>()
+        .Ret<ffi::AnyBuffer>()
+        .Ret<ffi::AnyBuffer>());
+
+template <typename T>
+py::capsule Encapsulate(T* fn) {
+  static_assert(std::is_invocable_r_v<XLA_FFI_Error*, T, XLA_FFI_CallFrame*>);
+  return py::capsule(reinterpret_cast<void*>(fn));
+}
+
+PYBIND11_MODULE(_force_ffi, module) {
+  module.def("registrations", []() {
+    py::dict registrations;
+    registrations["vmex_force_projection"] = Encapsulate(VmexForceProjection);
+    return registrations;
+  });
+}


### PR DESCRIPTION
## Goals

This PR is the measured implementation/evaluation pass for the structured-solver plan:

1. add an opt-in value-only native CPU theta/zeta force projection with reusable XLA scratch and explicit `threads=` control, while keeping pure JAX as the unchanged default and accelerator path;
2. preserve exact JVP and transpose/VJP behavior and cover symmetric/LASYM, axis, fixed/free edge, CPU, and GPU contracts;
3. establish the exact radial locality needed for generated fixed-width residual rows and evaluate checkpointed SOLVAX vector AD;
4. provide the bordered plasma/NESTOR operator and Schur-complement algebra needed for a future free-boundary adjoint;
5. evaluate low-mode coarse correction plus radial smoothing for high-resolution forward/adjoint solves.

## Achieved

- Added an optional C++17 JAX-FFI CPU force-projection handler. It fuses weighted theta/zeta projection, parallelizes surface/mode work, uses an XLA-owned scratch result, and is selected only by `force_backend="native", threads=N`.
- Kept every default at `force_backend="jax"`. There are no new environment-variable controls. Native-on-accelerator requests fail before tracing; CPU/GPU/TPU continue to use the portable pure-JAX implementation.
- Added exact custom-JVP behavior from the pure-JAX reference; transposition supplies reverse mode. Tests differentiate all kernel and transform-table operands, not only values.
- Plumbed the opt-in backend through fixed boundary, free boundary, multigrid, implicit AD, and optimizer solve arguments. Native implicit forward callbacks are pinned to CPU so explicit CPU placement cannot be overridden by the independent AUTO forward policy.
- Built the optional handler against the JAX 0.4.38 baseline FFI ABI, verified under JAX 0.4.38 and current JAX 0.11.0, and made incompatible optional binaries fall back without breaking VMEX import.
- Normalized native FFI inputs to the force-buffer dtype; a float32-kernel/float64-table regression test prevents typed-buffer reinterpretation while leaving the JAX path unchanged.
- Verified exact raw-residual nearest-neighbor radial structure: axis, interior, and near-edge tangents have a nonzero local response and bit-exact zero entries outside `|i-j| <= 1`.
- Added `NestorBorderedOperator` with matrix-free `[[A,B],[C,D]]` action, exact generated transpose, `D-C A^-1 B` Schur action, and block inverse, with JIT/JVP/VJP/dense-reference tests.
- Extended the manual GPU lane to cover this backend contract. Its existing parity audit covers energy, magnetic well, DMerc, j·B, Glasser D_R, quasisymmetry, and quasi-isodynamicity.
- Updated README, algorithms/API/performance docs, changelog, and the high-resolution profiler. No unmeasured performance claim is made.

## Measured results

- Full supplied HSX deck, native-8: **215.37 s / 1.63 GiB**, unchanged 2737 final-stage iterations. Recent JAX controls were 218.94–224.64 s / 1.57–1.71 GiB. This is only a 2–4% end-to-end gain and unchanged RSS, not closure of the VMEC++ gap.
- HSX native WOUT vs VMEC2000 relative L2: `rmnc 1.62e-11`, `zmns 1.00e-10`, `bmnc 2.61e-11`, `iotaf 5.64e-10`; energy `2.03e-14` relative.
- Clean Python 3.12 / JAX 0.4.38 native source build: 14 passed, 1 platform skip with the full implicit-gradient case enabled.
- Linux CUDA JAX 0.10.2, two RTX A4000s, no platform-selection environment variables: 55 focused tests passed, 1 expected skip; final native full module 15/15.
- Seven-metric CPU/GPU audit passed; relative gradient differences: energy `7.57e-16`, well `1.50e-13`, DMerc `1.03e-11`, j·B `1.97e-12`, D_R `1.86e-11`, QS `4.55e-15`, QI `1.73e-16`. Forward states were bit-identical.
- Ruff, mypy, compileall, strict Sphinx, benchmark entry-point checks, wheel, and sdist pass.

- Exact final head `fbb43036`: all 18 required hosted CI jobs passed, including build/docs, examples, all parity and implicit-gradient shards, and the unchanged >=95% coverage gate ([run 30122192959](https://github.com/uwplasma/vmex/actions/runs/30122192959)).

## Evaluated but deliberately not retained

### Generated checkpointed SOLVAX rows

The prototype produced the identical Solovev Jacobian SHA-256 as the global block path, but failed the promotion gates:

- Solovev global block: 9.76 s / 2.48 GiB;
- generated checkpoint: 16.01 s / 2.79 GiB;
- HSX-width global block at `ns=8`: 131.71 s / 6.55 GiB;
- generated checkpoint captured 5.75 GiB of constants and was stopped after 344.73 s at 9.48 GiB RSS.

The implementation was removed. SOLVAX PR 39 is merged and correct; VMEX first needs a genuinely local nonlinear force segment instead of repeated traces of the global residual.

### Low-mode coarse correction

On the aspect-100 `ns=51` gate, the established 2D path used 18 iterations / 1.20 s. Low-mode coarse variants also used 18 iterations, took 4.80–4.93 s, and shifted the loose-tolerance result. The prototype was removed.

## Left to achieve the larger goals

- A native CUDA/ROCm handler would be a separate device kernel; this PR deliberately uses pure JAX on GPUs. The measured CPU projection wrapper alone does not close the VMEC++ gap.
- Generated SOLVAX block solves should be revisited only after extracting a truly local nonlinear three-surface force segment with bounded lowering constants.
- The live host-driven NESTOR equation and vacuum-pressure edge map still need to be exposed as the four bordered blocks and validated against finite differences before claiming a free-boundary equilibrium adjoint.
- A future coarse solve needs a physics-derived basis, correct evolved-DOF restriction, and exact inner-residual reporting.

## Stack / review order

This is stacked on PRs #76 and #78 and targets `feat/research-grade-parity` until they merge. Review/merge #76, then #78, then rebase this PR so its diff contains only its five native/structured-AD commits. All validation gates are complete. The PR stays draft only until #76 and #78 merge and this branch is rebased, so reviewers see only its five native/structured-AD commits.





