### PR TITLE
ci: split review, nightly, weekly, and GPU gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
   physics:
     name: Representative ${{ matrix.lane }} physics
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -99,7 +99,7 @@ jobs:
           JAX_ENABLE_X64: "1"
         run: |
           FILES="$(python tools/test_manifest.py select pr-physics-${{ matrix.lane }})"
-          pytest -q -n 2 --dist loadscope -m "not full and not weekly" \
+          pytest -q -m "not full and not weekly" \
             $FILES --durations=20 --cov=vmex --cov-report=term
       - name: Stash coverage
         run: mv .coverage coverage.physics-${{ matrix.lane }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,22 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
-  workflow_dispatch:
-    inputs:
-      run_gpu:
-        description: "Also run the trusted self-hosted GPU job"
-        type: boolean
-        default: false
-      run_full:
-        description: "Run the full-physics matrix (disable for a GPU-only dispatch)"
-        type: boolean
-        default: true
-  schedule:
-    # nightly full-physics run (RUN_FULL=1 tests)
-    - cron: "17 4 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: CI-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -29,743 +16,166 @@ env:
 permissions:
   contents: read
 
-# Sharded CI (plan.md Phase-2 review item 1): bounded parallel test jobs, plus
-# a fast lint gate (ruff + mypy) and a coverage gate that combines the parity
-# and gradient shards and enforces >= 95% on vmex.  The explicit job limits
-# include dependency setup, coverage handling, and hosted-runner variance.
 jobs:
-  lint:
-    # Fast fail-first gate (plan Item I.3): ruff + mypy over the whole tree,
-    # separate from the test matrix so a lint regression fails in ~1 min
-    # without blocking (or being masked by) the solver shards.  mypy runs on
-    # py3.12 with the full [dev] install so its view of the numpy/jax stubs
-    # matches a local `mypy vmex` (pyproject [tool.mypy] is the config).
-    name: Lint (ruff + mypy)
+  quality:
+    name: Quality, package, and docs
     runs-on: ubuntu-latest
-    timeout-minutes: 9
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.12"
           cache: pip
-
       - name: Install
         run: |
           python -m pip install -U pip
           python -m pip install ".[dev]"
-
-      - name: ruff
-        run: ruff check vmex tests examples benchmarks tools
-
-      - name: mypy
-        run: mypy vmex
+      - name: Check source, package, and docs
+        run: |
+          ruff check vmex tests examples benchmarks tools
+          mypy vmex
+          python -m build
+          python -m sphinx -W -j auto -b html docs docs/_build/html
 
   fast:
-    name: Fast unit tests (py${{ matrix.python-version }})
+    name: Fast API tests (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    timeout-minutes: 9
+    timeout-minutes: 8
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.12"]
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-
       - name: Install
         run: |
           python -m pip install -U pip
-          python -m pip install .
-          python -m pip install pytest pytest-xdist
-
-      - name: Repository size check
+          python -m pip install . pytest pytest-xdist
+      - name: Check repository size
         run: |
           size_kb=$(du -sk --exclude=.git . | cut -f1)
           echo "working tree: ${size_kb} KiB"
-          test "$size_kb" -lt 40960 || { echo "working tree exceeds 40 MiB"; exit 1; }
-
-      - name: Run fast unit tests (no golden fixtures)
+          test "$size_kb" -lt 40960
+      - name: Run fast tests
         env:
           JAX_ENABLE_X64: "1"
         run: |
           FILES="$(python tools/test_manifest.py select pr-fast)"
-          pytest -q -n 4 -m "not full" $FILES --durations=25
+          pytest -q -n 4 -m "not full and not weekly" $FILES --durations=20
 
-  mirror:
-    name: Mirror ${{ matrix.shard }} tests
+  physics:
+    name: Representative ${{ matrix.lane }} physics
     runs-on: ubuntu-latest
-    timeout-minutes: 9
+    timeout-minutes: 12
     strategy:
       fail-fast: false
       matrix:
-        shard: [field, equilibrium, spline]
+        lane: [core, mirror]
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.12"
           cache: pip
       - name: Install
         run: |
           python -m pip install -U pip
-          python -m pip install .
-          python -m pip install pytest pytest-xdist
-      - name: Run mirror tests
-        env:
-          JAX_ENABLE_X64: "1"
-        run: |
-          FILES="$(python tools/test_manifest.py select pr-mirror-${{ matrix.shard }})"
-          pytest -q -n 2 -m "not full" $FILES --durations=20 \
-            --vmex-report="test-report-mirror-${{ matrix.shard }}.json"
-      - name: Upload test report
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-report-mirror-${{ matrix.shard }}
-          path: test-report-mirror-${{ matrix.shard }}.json
-          retention-days: 3
-
-  device-rig:
-    # Two-device placement/gradient coverage on every ordinary run: the
-    # host-rig lanes previously skipped in ALL hosted jobs (single visible
-    # device), so the placement logic was only exercised on developer
-    # machines and real GPU hardware.  A forced two-CPU-device rig runs the
-    # same audit helpers as the CUDA lanes: gradient-pytree device identity
-    # AND gradient values, cold device-1-first, cache-poisoned, and
-    # outer-context orders.
-    name: Two-host-device placement and gradients
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: "3.12"
-          cache: pip
-      - name: Install
-        run: |
-          python -m pip install -U pip
-          python -m pip install .
-          python -m pip install pytest pytest-cov
-      - name: Add swap for XLA compile-arena headroom
+          python -m pip install ".[coils,turbulence,freeb]" pytest pytest-cov pytest-xdist
+      - name: Add XLA compile headroom
         run: |
           sudo fallocate -l 12G /mnt/vmex-swap
           sudo chmod 600 /mnt/vmex-swap
           sudo mkswap /mnt/vmex-swap
           sudo swapon /mnt/vmex-swap
+      - name: Run representative physics
+        env:
+          JAX_ENABLE_X64: "1"
+        run: |
+          FILES="$(python tools/test_manifest.py select pr-physics-${{ matrix.lane }})"
+          pytest -q -n 2 --dist loadscope -m "not full and not weekly" \
+            $FILES --durations=20 --cov=vmex --cov-report=term
+      - name: Stash coverage
+        run: mv .coverage coverage.physics-${{ matrix.lane }}
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: coverage-physics-${{ matrix.lane }}
+          path: coverage.physics-${{ matrix.lane }}
+          retention-days: 3
 
-      - name: Run the two-host-device lanes
+  device:
+    name: Two-device placement and AD
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          python -m pip install . pytest pytest-cov
+      - name: Run the forced two-device representatives
         env:
           JAX_ENABLE_X64: "1"
           XLA_FLAGS: "--xla_force_host_platform_device_count=2"
         run: |
-          # This job is the only ordinary-CI executor of the adjoint
-          # device-binding, instrumentation and device_scope code paths, so
-          # its coverage feeds the gate (the parity shards skip these lanes
-          # on their single visible device).
-          FILES="$(python tools/test_manifest.py select device-rig)"
-          pytest -q $FILES -k second_host_device --durations=10 \
-            --vmex-report=test-report-device-rig.json \
-            --cov=vmex --cov-report=term
-      - name: Stash coverage data
-        run: mv .coverage coverage.device-rig
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+          FILES="$(python tools/test_manifest.py select pr-device)"
+          pytest -q $FILES --durations=10 --cov=vmex --cov-report=term
+      - name: Stash coverage
+        run: mv .coverage coverage.device
+      - uses: actions/upload-artifact@v7.0.1
         with:
-          name: coverage-device-rig
-          path: |
-            coverage.device-rig
-            test-report-device-rig.json
+          name: coverage-device
+          path: coverage.device
           retention-days: 3
 
-  optional-integrations:
-    # The ESSOS / GKX / virtual-casing test lanes silently skipped in every
-    # hosted job because the optional packages were never installed.  This
-    # lane pins exact revisions and asserts the imports BEFORE pytest, so
-    # the gated tests cannot skip: a broken integration fails instead of
-    # vanishing.  All three now install from released packages
-    # (virtual-casing-jax >= 0.0.3 via the freeb extra).
-    name: Optional integrations (released ESSOS/GKX/virtual-casing)
-    runs-on: ubuntu-latest
-    # 45: un-skipping the wout/mgrid-gated lanes added ~17 min serial local
-    # (absorbed by -n 2, but slow hosted runners need the headroom).
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: "3.12"
-          cache: pip
-      - name: Install with released/pinned optional integrations
-        run: |
-          python -m pip install -U pip
-          python -m pip install ".[coils,turbulence,freeb]"
-          python -m pip install pytest pytest-xdist pytest-cov
-      - name: Add swap for XLA compile-arena headroom
-        run: |
-          sudo fallocate -l 12G /mnt/vmex-swap
-          sudo chmod 600 /mnt/vmex-swap
-          sudo mkswap /mnt/vmex-swap
-          sudo swapon /mnt/vmex-swap
-
-      - name: Assert the integrations import (no silent skips possible)
-        run: python -c "import essos, gkx, virtual_casing_jax"
-      - name: Fetch reference assets (wout/mgrid fixtures for the gated lanes)
-        run: python tools/fetch_assets.py --bundle reference-nc
-      - name: Run the gated lanes
-        env:
-          JAX_ENABLE_X64: "1"
-        run: |
-          FILES="$(python tools/test_manifest.py select optional)"
-          pytest -q -n 2 -m "not full" $FILES \
-            --durations=15 --vmex-report=test-report-optional.json \
-            --cov=vmex --cov-report=term
-      - name: Run the ESSOS direct-coil example (full-marked, targeted)
-        env:
-          JAX_ENABLE_X64: "1"
-          RUN_FULL: "1"
-        run: |
-          pytest -q tests/test_examples.py::test_free_boundary_essos_coils \
-            --durations=5 --vmex-report=test-report-optional-example.json \
-            --cov=vmex --cov-append --cov-report=term
-      - name: Stash coverage data
-        run: mv .coverage coverage.optional
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-optional
-          path: |
-            coverage.optional
-            test-report-optional*.json
-          retention-days: 3
-
-  parity:
-    name: Parity suite ${{ matrix.shard }} (goldens, coverage)
-    runs-on: ubuntu-latest
-    # Headroom for slow shared runners: the golden solves run ~15-20 min on a
-    # healthy runner but tip over a tighter limit on a slow one (the suite
-    # content is unchanged), and c1's device-audit subprocess alone measured
-    # >10 min on a busy runner (its own cap is 30 min). 50 absorbs both
-    # without masking a hang.
-    timeout-minutes: 50
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [a1, a2, b, c1, c2, c3, d]
-    steps:
-      - uses: actions/checkout@v6.0.2
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install
-        run: |
-          python -m pip install -U pip
-          python -m pip install .
-          python -m pip install pytest pytest-xdist pytest-cov
-
-      - name: Add swap for XLA compile-arena headroom
-        run: |
-          sudo fallocate -l 12G /mnt/vmex-swap
-          sudo chmod 600 /mnt/vmex-swap
-          sudo mkswap /mnt/vmex-swap
-          sudo swapon /mnt/vmex-swap
-
-      - name: Cache golden fixtures and compiled kernels
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/vmex
-          # Rolling PER-SHARD key.  Two prior defects: a fixed key freezes
-          # the cache at its FIRST save (kernels compiled later were never
-          # persisted), and a per-run key SHARED across the matrix lets the
-          # first finishing shard win the save while the expensive shards'
-          # kernels are dropped (GitHub caches are immutable per key).  Each
-          # shard therefore rolls its own key, scoped by OS and dependency
-          # signature so toolchain changes start a fresh lineage.
-          key: vmex-v3-${{ runner.os }}-parity-${{ matrix.shard }}-${{ hashFiles('pyproject.toml') }}-${{ github.run_id }}
-          restore-keys: |
-            vmex-v3-${{ runner.os }}-parity-${{ matrix.shard }}-${{ hashFiles('pyproject.toml') }}-
-            golden-v1
-
-      - name: Prefetch golden fixtures (once, before xdist workers fork)
-        run: |
-          python - <<'EOF'
-          import importlib.util
-          spec = importlib.util.spec_from_file_location(
-              "tests_conftest", "tests/conftest.py")
-          mod = importlib.util.module_from_spec(spec)
-          spec.loader.exec_module(mod)
-          print("golden dir:", mod.resolve_golden_dir())
-          EOF
-
-      # Seven bounded shards.  The xdist dist MODE is chosen PER SHARD by
-      # whether its modules share an expensive fixture:
-      #   * loadscope groups a whole module onto ONE worker, so module-scoped
-      #     equilibrium fixtures (omnigenity qi_eq/tok_eq, bootstrap eq,
-      #     stability vacuum/highbeta/shaped) are solved ONCE, not once-per-
-      #     worker (measured: omnigenity 29 s -> 14 s).  But it SERIALISES a
-      #     module's independent heavy tests onto that single worker.
-      #   * load spreads individual tests across all 4 workers -- right for a
-      #     module with many independent heavy tests and NO shared fixture (or
-      #     a cheap /tmp-cached one), which otherwise bottlenecks its shard.
-      # The two independent-heavy modules therefore run under `load`:
-      #   b = golden_digests  (2 full VMEC2000-parity solves; no fixture;
-      #                         loadscope serialised these to 484 s on 1 worker)
-      #   d = optimize        (many least-squares runs; solovev_eq fixture is
-      #                         cheap + /tmp-cached, so per-worker re-solve is
-      #                         negligible; loadscope serialised 383 s)
-      # The fixture-sharing modules stay on loadscope:
-      #   a1 = ALL free-boundary modules, so their JAX caches leave with one
-      #        bounded shard; split from the former combined "a" after hosted
-      #        runners were shut down mid-run twice on the accumulated
-      #        free-boundary + solver-golden shard (same syndrome that split c)
-      #        -- locally the combined content runs in under a minute, so the
-      #        overruns were runner-resource pressure, not test cost;
-      #   a2 = the solver-golden parity/ladder modules formerly in "a";
-      #   c1/c2 = the former catch-all, split explicitly after two hosted
-      #           runners were externally shut down above 84% despite no test
-      #           failure.  Manifest ownership keeps coverage disjoint.
-      # Together they cover the whole non-gradient, non-example core suite once;
-      # the separate mirror matrix owns tests/mirror. Therefore
-      # every test file appears in exactly one shard (coverage gate combines
-      # a+b+c+d), so coverage is invariant under this reshuffle.
-      - name: Run parity shard ${{ matrix.shard }} with coverage
-        env:
-          JAX_ENABLE_X64: "1"
-        run: |
-          FILES="$(python tools/test_manifest.py select pr-parity-${{ matrix.shard }})"
-          if [[ "${{ matrix.shard }}" =~ ^(b|d)$ ]]; then
-            DIST=load
-          else
-            DIST=loadscope
-          fi
-          WORKERS=4
-          if [ "${{ matrix.shard }}" = "c3" ]; then WORKERS=2; fi
-          pytest -q -n "$WORKERS" --dist "$DIST" $FILES --durations=15 \
-            --vmex-report="test-report-parity-${{ matrix.shard }}.json" \
-            --cov=vmex --cov-report=term
-
-      - name: Stash coverage data
-        run: mv .coverage coverage.parity-${{ matrix.shard }}
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-parity-${{ matrix.shard }}
-          path: |
-            coverage.parity-${{ matrix.shard }}
-            test-report-parity-${{ matrix.shard }}.json
-          retention-days: 3
-
-  gradient:
-    name: Implicit-gradient suite ${{ matrix.shard }} (JIT on, coverage)
-    runs-on: ubuntu-latest
-    # Sharded so a COLD finite-difference cache remains bounded (first run
-    # after the test file changes recomputes every FD reference).  The two
-    # dominant FD tests (lasym-adjoint, lasym-3d) each get their own shard;
-    # shard "c" owns the remaining tests.  A slow hosted runner measured
-    # 14m19s for those tests alone, so include installation, coverage upload,
-    # and runner variance rather than canceling a fully passing test process
-    # during post-processing.  Warm-cache runs remain much faster.
-    timeout-minutes: 25
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [a, b, c]
-    steps:
-      - uses: actions/checkout@v6.0.2
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install
-        run: |
-          python -m pip install -U pip
-          python -m pip install .
-          python -m pip install pytest pytest-cov
-
-      - name: Cache finite-difference reference solves
-        uses: actions/cache@v4
-        with:
-          path: /tmp/vmex_implicit_fd_cache.pkl
-          # entries are keyed by (case, dof, step, ftol, ns) inside the pickle,
-          # so hash the test file: changed FD parameters invalidate the cache.
-          # keyed per shard so the two jobs never overwrite each other's cache.
-          key: implicit-fd-v2-${{ matrix.shard }}-${{ hashFiles('tests/test_implicit_grad.py') }}
-
-      - name: Add swap for XLA compile-arena headroom
-        run: |
-          sudo fallocate -l 12G /mnt/vmex-swap
-          sudo chmod 600 /mnt/vmex-swap
-          sudo mkswap /mnt/vmex-swap
-          sudo swapon /mnt/vmex-swap
-
-      - name: Run implicit-gradient tests with coverage
-        env:
-          JAX_ENABLE_X64: "1"
-        run: |
-          # -k with unique test names partitions the suite exactly into the two
-          # dominant FD tests (a, b) and their complement (c).
-          A="test_lasym_adjoint_vs_frozen_path_fd"
-          B="test_lasym_3d_gradient_vs_frozen_path_fd"
-          case "${{ matrix.shard }}" in
-            a) SELECT="$A" ;;
-            b) SELECT="$B" ;;
-            *) SELECT="not $A and not $B" ;;
-          esac
-          FILES="$(python tools/test_manifest.py select pr-gradient)"
-          pytest -q $FILES -k "$SELECT" \
-            --durations=0 \
-            --vmex-report="test-report-gradient-${{ matrix.shard }}.json" \
-            --cov=vmex --cov-report=term
-
-      - name: Stash coverage data
-        run: mv .coverage coverage.gradient-${{ matrix.shard }}
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-gradient-${{ matrix.shard }}
-          path: |
-            coverage.gradient-${{ matrix.shard }}
-            test-report-gradient-${{ matrix.shard }}.json
-          retention-days: 3
-
-  examples:
-    name: Example scripts smoke (coverage)
-    runs-on: ubuntu-latest
-    timeout-minutes: 9
-    steps:
-      - uses: actions/checkout@v6.0.2
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install
-        run: |
-          python -m pip install -U pip
-          python -m pip install .
-          python -m pip install pytest pytest-cov
-
-      - name: Add swap for XLA compile-arena headroom
-        run: |
-          sudo fallocate -l 12G /mnt/vmex-swap
-          sudo chmod 600 /mnt/vmex-swap
-          sudo mkswap /mnt/vmex-swap
-          sudo swapon /mnt/vmex-swap
-
-      - name: Run example smokes (QH/QP/QI gated to nightly RUN_FULL)
-        env:
-          JAX_ENABLE_X64: "1"
-        run: |
-          FILES="$(python tools/test_manifest.py select pr-examples)"
-          pytest -q $FILES \
-            --durations=10 \
-            --vmex-report=test-report-examples.json \
-            --cov=vmex --cov-report=term
-
-      - name: Stash coverage data
-        run: mv .coverage coverage.examples
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-examples
-          path: |
-            coverage.examples
-            test-report-examples.json
-          retention-days: 3
-
-  coverage-gate:
-    name: Coverage gate (>= 95%)
+  changed-coverage:
+    name: Changed executable lines (>= 95%)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [parity, gradient, examples, device-rig, optional-integrations]
+    needs: [physics, device]
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.12"
           cache: pip
-
-      - name: Install coverage
-        run: python -m pip install coverage
-
-      - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+      - run: python -m pip install coverage diff-cover
+      - uses: actions/download-artifact@v8.0.1
         with:
           pattern: coverage-*
           merge-multiple: true
-
-      - name: Combine shards and enforce the gate
+      - name: Combine coverage and enforce the mirror floor
         run: |
-          coverage combine coverage.parity-a1 coverage.parity-a2 coverage.parity-b coverage.parity-c1 coverage.parity-c2 coverage.parity-c3 coverage.parity-d coverage.gradient-a coverage.gradient-b coverage.gradient-c coverage.examples coverage.device-rig coverage.optional
-          # The mirror release audit reaches 95% only after appending nightly
-          # fixed/free adjoint tests. The fast core artifacts intentionally
-          # exclude those tests, so do not mix a partial mirror number into
-          # the ordinary core gate.
-          coverage report --omit='vmex/mirror/*' --fail-under=95
+          coverage combine coverage.device coverage.physics-core coverage.physics-mirror
+          coverage report --include='*/vmex/mirror/*' --fail-under=90
+          coverage xml
+      - name: Enforce changed-line coverage
+        if: github.event_name == 'pull_request'
+        run: diff-cover coverage.xml --compare-branch="origin/${GITHUB_BASE_REF}" --fail-under=95
 
-  cli-smoke:
-    name: Console Script Smoke
+  pr-gate:
+    name: PR gate
+    if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 9
+    timeout-minutes: 2
+    needs: [quality, fast, physics, device, changed-coverage]
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: "3.11"
-          cache: pip
-
-      - name: Install
-        run: |
-          python -m pip install -U pip
-          python -m pip install .
-
-      - name: Console script smoke test
+      - name: Require every review gate
         env:
-          JAX_ENABLE_X64: "1"
+          RESULTS: ${{ toJSON(needs) }}
         run: |
-          vmec --help
-          vmec --version
-          rm -rf /tmp/vmex_cli_smoke
-          mkdir -p /tmp/vmex_cli_smoke
-          cd /tmp
-          vmec "$GITHUB_WORKSPACE/examples/data/input.solovev" \
-            --quiet \
-            --outdir /tmp/vmex_cli_smoke
-          test -f /tmp/vmex_cli_smoke/wout_solovev.nc
-
-  build:
-    name: Build (wheel/sdist + docs)
-    runs-on: ubuntu-latest
-    timeout-minutes: 9
-    steps:
-      - uses: actions/checkout@v6.0.2
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: "3.11"
-          cache: pip
-
-      - name: Install build + docs deps
-        run: |
-          python -m pip install -U pip
-          python -m pip install .
-          python -m pip install build sphinx furo
-
-      - name: Build wheel and sdist
-        run: |
-          python -m build
-
-      - name: Build docs (warnings as errors)
-        run: |
-          python -m sphinx -W -j auto -b html docs docs/_build/html
-
-  full:
-    name: Full-physics ${{ matrix.shard }} (nightly / manual only)
-    # run_full lets a GPU-only dispatch skip the long matrix instead of
-    # relaunching (and, via the concurrency group, cancelling) it.
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_full)
-    runs-on: ubuntu-latest
-    # A sequential whole-suite job reached only 39% before the previous
-    # 150-minute limit, and the core job later lost hosted runners three times
-    # after 37/79/81 minutes. Keep exact RUN_FULL coverage, split core
-    # alphabetically, isolate each stateful optimization campaign, and isolate
-    # examples/mirror so every shard stays bounded on a fresh worker.
-    # 300: the 238-mode free-boundary lanes are compile-dominated on
-    # hosted cores (one lane measured ~2 h cold); the rolling kernel
-    # cache above makes warm dispatches far cheaper, but the cold path
-    # must still fit.
-    timeout-minutes: 300
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [core-a-c, core-d-f, core-g-h, core-i, core-i-grad, core-j-m,
-                core-n-s, core-t-z, hmfb-ladders, hmfb-combined, hmfb-fft537,
-                qi-gate-free, qi-gate-ladder, qi-gate-ladder-fft,
-                qi-gate-ladder-055, qi-gate-fixed, opt-qa, opt-qh,
-                opt-qp, examples, mirror-field, mirror-equilibrium, mirror-spline]
-    steps:
-      - uses: actions/checkout@v6.0.2
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install
-        run: |
-          python -m pip install -U pip
-          python -m pip install ".[coils,turbulence,freeb]"
-          python -m pip install pytest
-
-      - name: Cache golden fixtures and compiled kernels
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/vmex
-          # Rolling PER-SHARD key.  Two prior defects: a fixed key freezes
-          # the cache at its FIRST save (kernels compiled later were never
-          # persisted), and a per-run key SHARED across the matrix lets the
-          # first finishing shard win the save while the expensive shards'
-          # kernels are dropped (GitHub caches are immutable per key).  Each
-          # shard therefore rolls its own key, scoped by OS and dependency
-          # signature so toolchain changes start a fresh lineage.
-          key: vmex-v3-${{ runner.os }}-full-${{ matrix.shard }}-${{ hashFiles('pyproject.toml') }}-${{ github.run_id }}
-          restore-keys: |
-            vmex-v3-${{ runner.os }}-full-${{ matrix.shard }}-${{ hashFiles('pyproject.toml') }}-
-            golden-v1
-
-      # The free-boundary example smokes run the examples as subprocesses,
-      # which read examples/data/mgrid_*.nc directly — fetched assets, not
-      # git-tracked (repo size budget). Without this step they raise
-      # MgridNotFoundError (nightly failure 2026-07-12).
-      - name: Fetch reference assets (mgrid files for free-boundary examples)
-        run: python tools/fetch_assets.py --bundle reference-nc
-
-      # XLA's compile arena for the enlarged free-boundary lane programs
-      # (funct3d.f Jacobian gate + stability-selected T_l recurrence)
-      # transiently exceeds the 16 GB hosted-runner RAM on x86 (the three
-      # QI-ladder shards and core-d-f were memory-evicted ~12 min into
-      # pytest on two consecutive attempts, during the first-rung compile;
-      # macOS peaks lower, ~12 GB).  Disk-backed swap lets the compile
-      # spill instead of killing the runner; the 300-minute budget absorbs
-      # the slowdown.  Program-size reduction (reusing the iteration
-      # body's Jacobian sign instead of a second synthesis) is tracked as
-      # a follow-up optimization.
-      - name: Add swap for XLA compile-arena headroom
-        run: |
-          sudo fallocate -l 12G /mnt/vmex-swap
-          sudo chmod 600 /mnt/vmex-swap
-          sudo mkswap /mnt/vmex-swap
-          sudo swapon /mnt/vmex-swap
-          free -h
-
-      - name: Run the whole suite including full-marked tests
-        env:
-          JAX_ENABLE_X64: "1"
-          RUN_FULL: "1"
-        run: |
-          FILES="$(python tools/test_manifest.py select full-${{ matrix.shard }})"
-          # Some optimization tests are silent for more than 15 minutes.
-          # Keep the hosted runner live without changing pytest semantics.
-          pytest -q $FILES --durations=25 \
-            --vmex-report="test-report-full-${{ matrix.shard }}.json" &
-          pytest_pid=$!
-          while kill -0 "$pytest_pid" 2>/dev/null; do
-            sleep 60
-            if kill -0 "$pytest_pid" 2>/dev/null; then
-              echo "pytest shard ${{ matrix.shard }} still running (${SECONDS}s)"
-            fi
-          done
-          wait "$pytest_pid"
-
-      - name: Upload test report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-report-full-${{ matrix.shard }}
-          path: test-report-full-${{ matrix.shard }}.json
-          if-no-files-found: warn
-          retention-days: 7
-
-  # Trusted self-hosted GPU job.  It lives in THIS workflow (not a separate
-  # file) because GitHub can only manually dispatch workflows that already
-  # exist on the default branch -- a gpu-ci.yml present only on a PR branch
-  # cannot be invoked at all.  Gated on an explicit dispatch input so a
-  # public pull request can never route untrusted code onto persistent
-  # hardware.
-  gpu:
-    name: CUDA placement and parity (manual, self-hosted)
-    if: github.event_name == 'workflow_dispatch' && inputs.run_gpu
-    runs-on: [self-hosted, linux, x64, gpu]
-    timeout-minutes: 120
-    steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install VMEX and official CUDA JAX
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U "jax[cuda13]"
-          python -m pip install . pytest
-
-      - name: Assert unpinned GPU runtime
-        shell: bash
-        run: |
-          if [[ -n "${JAX_PLATFORMS+x}" || -n "${JAX_PLATFORM_NAME+x}" ]]; then
-            echo "GPU CI must discover hardware without JAX platform environment pins"
-            exit 1
-          fi
-          nvidia-smi
-          python - <<'PY'
-          import jax
-
-          print("backend:", jax.default_backend())
-          print("devices:", jax.devices())
-          assert jax.default_backend() == "gpu"
-          assert any(device.platform == "gpu" for device in jax.devices())
-          PY
-
-      - name: Run focused placement, solve, and gradient checks
-        run: |
-          FILES="$(python tools/test_manifest.py select gpu-smoke)"
-          pytest -q $FILES --durations=0
-
-      - name: Audit all physics gradients on CPU and both GPUs
-        shell: bash
-        run: |
-          metrics=(
-            mhd_energy magnetic_well dmerc_interior_mean
-            jdotb_interior_mean glasser_d_r_interior_mean
-            quasisymmetry quasi_isodynamic
-          )
-          for metric in "${metrics[@]}"; do
-            # One process per metric bounds XLA executable/allocator peaks.
-            python benchmarks/device_parity.py \
-              --quick --devices cpu,gpu --metrics "$metric" \
-              --output "device-parity-gpu0-${metric}.json"
-          done
-          if [[ $(python -c 'import jax; print(len(jax.devices("gpu")))') -gt 1 ]]; then
-            for metric in "${metrics[@]}"; do
-              python benchmarks/device_parity.py \
-                --quick --devices cpu,gpu --gpu-id 1 --metrics "$metric" \
-                --output "device-parity-gpu1-${metric}.json"
-            done
-          else
-            echo "single GPU: skipping gpu-id 1 audit"
-          fi
-
-      - name: Upload parity measurements
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: device-parity-${{ github.run_id }}
-          path: device-parity-*.json
-          if-no-files-found: ignore
+          echo "$RESULTS" | jq -e 'all(.[]; .result == "success")'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lane: [core, mirror]
+        include:
+          - lane: core
+            selector: pr-physics-core
+          - lane: mirror-equilibrium
+            selector: pr-mirror-equilibrium
+          - lane: mirror-field
+            selector: pr-mirror-field
+          - lane: mirror-spline
+            selector: pr-mirror-spline
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -98,7 +106,7 @@ jobs:
         env:
           JAX_ENABLE_X64: "1"
         run: |
-          FILES="$(python tools/test_manifest.py select pr-physics-${{ matrix.lane }})"
+          FILES="$(python tools/test_manifest.py select ${{ matrix.selector }})"
           pytest -q -m "not full and not weekly" \
             $FILES --durations=20 --cov=vmex --cov-report=term
       - name: Stash coverage
@@ -160,7 +168,7 @@ jobs:
           merge-multiple: true
       - name: Combine coverage and enforce the mirror floor
         run: |
-          coverage combine coverage.device coverage.physics-core coverage.physics-mirror
+          coverage combine coverage.device coverage.physics-*
           coverage report --include='*/vmex/mirror/*' --fail-under=90
           coverage xml
       - name: Enforce changed-line coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,9 @@ jobs:
           - lane: mirror-field
             selector: pr-mirror-field
           - lane: mirror-spline
-            selector: pr-mirror-spline
+            selector: pr-physics-mirror-spline
+          - lane: mirror-output
+            selector: pr-physics-mirror-output
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -1,0 +1,82 @@
+name: Trusted GPU physics
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: GPU-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  gpu:
+    name: CUDA placement and physics gradients
+    runs-on: [self-hosted, linux, x64, gpu]
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install VMEX and official CUDA JAX
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U "jax[cuda13]"
+          python -m pip install ".[coils,turbulence,freeb]" pytest
+
+      - name: Assert unpinned GPU runtime
+        shell: bash
+        run: |
+          if [[ -n "${JAX_PLATFORMS+x}" || -n "${JAX_PLATFORM_NAME+x}" ]]; then
+            echo "GPU CI must discover hardware without JAX platform environment pins"
+            exit 1
+          fi
+          nvidia-smi
+          python - <<'PY'
+          import jax
+
+          print("backend:", jax.default_backend())
+          print("devices:", jax.devices())
+          assert jax.default_backend() == "gpu"
+          assert any(device.platform == "gpu" for device in jax.devices())
+          PY
+
+      - name: Run placement, solve, and gradient checks
+        run: |
+          FILES="$(python tools/test_manifest.py select gpu-smoke)"
+          pytest -q $FILES --durations=0
+
+      - name: Audit physics gradients on CPU and both GPUs
+        shell: bash
+        run: |
+          metrics=(
+            mhd_energy magnetic_well dmerc_interior_mean
+            jdotb_interior_mean glasser_d_r_interior_mean
+            quasisymmetry quasi_isodynamic
+          )
+          for metric in "${metrics[@]}"; do
+            python benchmarks/device_parity.py \
+              --quick --devices cpu,gpu --metrics "$metric" \
+              --output "device-parity-gpu0-${metric}.json"
+          done
+          if [[ $(python -c 'import jax; print(len(jax.devices("gpu")))') -gt 1 ]]; then
+            for metric in "${metrics[@]}"; do
+              python benchmarks/device_parity.py \
+                --quick --devices cpu,gpu --gpu-id 1 --metrics "$metric" \
+                --output "device-parity-gpu1-${metric}.json"
+            done
+          else
+            echo "single GPU: skipping gpu-id 1 audit"
+          fi
+
+      - name: Upload parity measurements
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: device-parity-${{ github.run_id }}
+          path: device-parity-*.json
+          if-no-files-found: ignore

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,521 @@
+name: Nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    # nightly full-physics run (RUN_FULL=1 tests)
+    - cron: "17 4 * * *"
+
+concurrency:
+  group: Nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  LC_ALL: C.UTF-8
+  LANG: C.UTF-8
+
+permissions:
+  contents: read
+
+# Sharded CI (plan.md Phase-2 review item 1): bounded parallel test jobs, plus
+# a fast lint gate (ruff + mypy) and a coverage gate that combines the parity
+# and gradient shards and enforces >= 95% on vmex.  The explicit job limits
+# include dependency setup, coverage handling, and hosted-runner variance.
+jobs:
+  device-rig:
+    # Two-device placement/gradient coverage on every ordinary run: the
+    # host-rig lanes previously skipped in ALL hosted jobs (single visible
+    # device), so the placement logic was only exercised on developer
+    # machines and real GPU hardware.  A forced two-CPU-device rig runs the
+    # same audit helpers as the CUDA lanes: gradient-pytree device identity
+    # AND gradient values, cold device-1-first, cache-poisoned, and
+    # outer-context orders.
+    name: Two-host-device placement and gradients
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          python -m pip install .
+          python -m pip install pytest pytest-cov
+      - name: Add swap for XLA compile-arena headroom
+        run: |
+          sudo fallocate -l 12G /mnt/vmex-swap
+          sudo chmod 600 /mnt/vmex-swap
+          sudo mkswap /mnt/vmex-swap
+          sudo swapon /mnt/vmex-swap
+
+      - name: Run the two-host-device lanes
+        env:
+          JAX_ENABLE_X64: "1"
+          XLA_FLAGS: "--xla_force_host_platform_device_count=2"
+        run: |
+          # This job is the only ordinary-CI executor of the adjoint
+          # device-binding, instrumentation and device_scope code paths, so
+          # its coverage feeds the gate (the parity shards skip these lanes
+          # on their single visible device).
+          FILES="$(python tools/test_manifest.py select device-rig)"
+          pytest -q $FILES -k second_host_device --durations=10 \
+            --vmex-report=test-report-device-rig.json \
+            --cov=vmex --cov-report=term
+      - name: Stash coverage data
+        run: mv .coverage coverage.device-rig
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: coverage-device-rig
+          path: |
+            coverage.device-rig
+            test-report-device-rig.json
+          retention-days: 3
+
+  optional-integrations:
+    # The ESSOS / GKX / virtual-casing test lanes silently skipped in every
+    # hosted job because the optional packages were never installed.  This
+    # lane pins exact revisions and asserts the imports BEFORE pytest, so
+    # the gated tests cannot skip: a broken integration fails instead of
+    # vanishing.  All three now install from released packages
+    # (virtual-casing-jax >= 0.0.3 via the freeb extra).
+    name: Optional integrations (released ESSOS/GKX/virtual-casing)
+    runs-on: ubuntu-latest
+    # 45: un-skipping the wout/mgrid-gated lanes added ~17 min serial local
+    # (absorbed by -n 2, but slow hosted runners need the headroom).
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install with released/pinned optional integrations
+        run: |
+          python -m pip install -U pip
+          python -m pip install ".[coils,turbulence,freeb]"
+          python -m pip install pytest pytest-xdist pytest-cov
+      - name: Add swap for XLA compile-arena headroom
+        run: |
+          sudo fallocate -l 12G /mnt/vmex-swap
+          sudo chmod 600 /mnt/vmex-swap
+          sudo mkswap /mnt/vmex-swap
+          sudo swapon /mnt/vmex-swap
+
+      - name: Assert the integrations import (no silent skips possible)
+        run: python -c "import essos, gkx, virtual_casing_jax"
+      - name: Fetch reference assets (wout/mgrid fixtures for the gated lanes)
+        run: python tools/fetch_assets.py --bundle reference-nc
+      - name: Run the gated lanes
+        env:
+          JAX_ENABLE_X64: "1"
+        run: |
+          FILES="$(python tools/test_manifest.py select optional)"
+          pytest -q -n 2 -m "not full" $FILES \
+            --durations=15 --vmex-report=test-report-optional.json \
+            --cov=vmex --cov-report=term
+      - name: Run the ESSOS direct-coil example (full-marked, targeted)
+        env:
+          JAX_ENABLE_X64: "1"
+          RUN_FULL: "1"
+        run: |
+          pytest -q tests/test_examples.py::test_free_boundary_essos_coils \
+            --durations=5 --vmex-report=test-report-optional-example.json \
+            --cov=vmex --cov-append --cov-report=term
+      - name: Stash coverage data
+        run: mv .coverage coverage.optional
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: coverage-optional
+          path: |
+            coverage.optional
+            test-report-optional*.json
+          retention-days: 3
+
+  parity:
+    name: Parity suite ${{ matrix.shard }} (goldens, coverage)
+    runs-on: ubuntu-latest
+    # Headroom for slow shared runners: the golden solves run ~15-20 min on a
+    # healthy runner but tip over a tighter limit on a slow one (the suite
+    # content is unchanged), and c1's device-audit subprocess alone measured
+    # >10 min on a busy runner (its own cap is 30 min). 50 absorbs both
+    # without masking a hang.
+    timeout-minutes: 50
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [a1, a2, b, c1, c2, c3, d]
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          python -m pip install .
+          python -m pip install pytest pytest-xdist pytest-cov
+
+      - name: Add swap for XLA compile-arena headroom
+        run: |
+          sudo fallocate -l 12G /mnt/vmex-swap
+          sudo chmod 600 /mnt/vmex-swap
+          sudo mkswap /mnt/vmex-swap
+          sudo swapon /mnt/vmex-swap
+
+      - name: Cache golden fixtures and compiled kernels
+        uses: actions/cache@v6.1.0
+        with:
+          path: ~/.cache/vmex
+          # Rolling PER-SHARD key.  Two prior defects: a fixed key freezes
+          # the cache at its FIRST save (kernels compiled later were never
+          # persisted), and a per-run key SHARED across the matrix lets the
+          # first finishing shard win the save while the expensive shards'
+          # kernels are dropped (GitHub caches are immutable per key).  Each
+          # shard therefore rolls its own key, scoped by OS and dependency
+          # signature so toolchain changes start a fresh lineage.
+          key: vmex-v3-${{ runner.os }}-parity-${{ matrix.shard }}-${{ hashFiles('pyproject.toml') }}-${{ github.run_id }}
+          restore-keys: |
+            vmex-v3-${{ runner.os }}-parity-${{ matrix.shard }}-${{ hashFiles('pyproject.toml') }}-
+            golden-v1
+
+      - name: Prefetch golden fixtures (once, before xdist workers fork)
+        run: |
+          python - <<'EOF'
+          import importlib.util
+          spec = importlib.util.spec_from_file_location(
+              "tests_conftest", "tests/conftest.py")
+          mod = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(mod)
+          print("golden dir:", mod.resolve_golden_dir())
+          EOF
+
+      # Seven bounded shards.  The xdist dist MODE is chosen PER SHARD by
+      # whether its modules share an expensive fixture:
+      #   * loadscope groups a whole module onto ONE worker, so module-scoped
+      #     equilibrium fixtures (omnigenity qi_eq/tok_eq, bootstrap eq,
+      #     stability vacuum/highbeta/shaped) are solved ONCE, not once-per-
+      #     worker (measured: omnigenity 29 s -> 14 s).  But it SERIALISES a
+      #     module's independent heavy tests onto that single worker.
+      #   * load spreads individual tests across all 4 workers -- right for a
+      #     module with many independent heavy tests and NO shared fixture (or
+      #     a cheap /tmp-cached one), which otherwise bottlenecks its shard.
+      # The two independent-heavy modules therefore run under `load`:
+      #   b = golden_digests  (2 full VMEC2000-parity solves; no fixture;
+      #                         loadscope serialised these to 484 s on 1 worker)
+      #   d = optimize        (many least-squares runs; solovev_eq fixture is
+      #                         cheap + /tmp-cached, so per-worker re-solve is
+      #                         negligible; loadscope serialised 383 s)
+      # The fixture-sharing modules stay on loadscope:
+      #   a1 = ALL free-boundary modules, so their JAX caches leave with one
+      #        bounded shard; split from the former combined "a" after hosted
+      #        runners were shut down mid-run twice on the accumulated
+      #        free-boundary + solver-golden shard (same syndrome that split c)
+      #        -- locally the combined content runs in under a minute, so the
+      #        overruns were runner-resource pressure, not test cost;
+      #   a2 = the solver-golden parity/ladder modules formerly in "a";
+      #   c1/c2 = the former catch-all, split explicitly after two hosted
+      #           runners were externally shut down above 84% despite no test
+      #           failure.  Manifest ownership keeps coverage disjoint.
+      # Together they cover the whole non-gradient, non-example core suite once;
+      # the separate mirror matrix owns tests/mirror. Therefore
+      # every test file appears in exactly one shard (coverage gate combines
+      # a+b+c+d), so coverage is invariant under this reshuffle.
+      - name: Run parity shard ${{ matrix.shard }} with coverage
+        env:
+          JAX_ENABLE_X64: "1"
+        run: |
+          FILES="$(python tools/test_manifest.py select pr-parity-${{ matrix.shard }})"
+          if [[ "${{ matrix.shard }}" =~ ^(b|d)$ ]]; then
+            DIST=load
+          else
+            DIST=loadscope
+          fi
+          WORKERS=4
+          if [ "${{ matrix.shard }}" = "c3" ]; then WORKERS=2; fi
+          pytest -q -n "$WORKERS" --dist "$DIST" $FILES --durations=15 \
+            --vmex-report="test-report-parity-${{ matrix.shard }}.json" \
+            --cov=vmex --cov-report=term
+
+      - name: Stash coverage data
+        run: mv .coverage coverage.parity-${{ matrix.shard }}
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: coverage-parity-${{ matrix.shard }}
+          path: |
+            coverage.parity-${{ matrix.shard }}
+            test-report-parity-${{ matrix.shard }}.json
+          retention-days: 3
+
+  gradient:
+    name: Implicit-gradient suite ${{ matrix.shard }} (JIT on, coverage)
+    runs-on: ubuntu-latest
+    # Sharded so a COLD finite-difference cache remains bounded (first run
+    # after the test file changes recomputes every FD reference).  The two
+    # dominant FD tests (lasym-adjoint, lasym-3d) each get their own shard;
+    # shard "c" owns the remaining tests.  A slow hosted runner measured
+    # 14m19s for those tests alone, so include installation, coverage upload,
+    # and runner variance rather than canceling a fully passing test process
+    # during post-processing.  Warm-cache runs remain much faster.
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [a, b, c]
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          python -m pip install .
+          python -m pip install pytest pytest-cov
+
+      - name: Cache finite-difference reference solves
+        uses: actions/cache@v6.1.0
+        with:
+          path: /tmp/vmex_implicit_fd_cache.pkl
+          # entries are keyed by (case, dof, step, ftol, ns) inside the pickle,
+          # so hash the test file: changed FD parameters invalidate the cache.
+          # keyed per shard so the two jobs never overwrite each other's cache.
+          key: implicit-fd-v2-${{ matrix.shard }}-${{ hashFiles('tests/test_implicit_grad.py') }}
+
+      - name: Add swap for XLA compile-arena headroom
+        run: |
+          sudo fallocate -l 12G /mnt/vmex-swap
+          sudo chmod 600 /mnt/vmex-swap
+          sudo mkswap /mnt/vmex-swap
+          sudo swapon /mnt/vmex-swap
+
+      - name: Run implicit-gradient tests with coverage
+        env:
+          JAX_ENABLE_X64: "1"
+        run: |
+          # -k with unique test names partitions the suite exactly into the two
+          # dominant FD tests (a, b) and their complement (c).
+          A="test_lasym_adjoint_vs_frozen_path_fd"
+          B="test_lasym_3d_gradient_vs_frozen_path_fd"
+          case "${{ matrix.shard }}" in
+            a) SELECT="$A" ;;
+            b) SELECT="$B" ;;
+            *) SELECT="not $A and not $B" ;;
+          esac
+          FILES="$(python tools/test_manifest.py select pr-gradient)"
+          pytest -q $FILES -k "$SELECT" \
+            --durations=0 \
+            --vmex-report="test-report-gradient-${{ matrix.shard }}.json" \
+            --cov=vmex --cov-report=term
+
+      - name: Stash coverage data
+        run: mv .coverage coverage.gradient-${{ matrix.shard }}
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: coverage-gradient-${{ matrix.shard }}
+          path: |
+            coverage.gradient-${{ matrix.shard }}
+            test-report-gradient-${{ matrix.shard }}.json
+          retention-days: 3
+
+  examples:
+    name: Example scripts smoke (coverage)
+    runs-on: ubuntu-latest
+    timeout-minutes: 9
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          python -m pip install .
+          python -m pip install pytest pytest-cov
+
+      - name: Add swap for XLA compile-arena headroom
+        run: |
+          sudo fallocate -l 12G /mnt/vmex-swap
+          sudo chmod 600 /mnt/vmex-swap
+          sudo mkswap /mnt/vmex-swap
+          sudo swapon /mnt/vmex-swap
+
+      - name: Run example smokes (QH/QP/QI gated to nightly RUN_FULL)
+        env:
+          JAX_ENABLE_X64: "1"
+        run: |
+          FILES="$(python tools/test_manifest.py select pr-examples)"
+          pytest -q $FILES \
+            --durations=10 \
+            --vmex-report=test-report-examples.json \
+            --cov=vmex --cov-report=term
+
+      - name: Stash coverage data
+        run: mv .coverage coverage.examples
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: coverage-examples
+          path: |
+            coverage.examples
+            test-report-examples.json
+          retention-days: 3
+
+  coverage-gate:
+    name: Coverage gate (>= 95%)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [parity, gradient, examples, device-rig, optional-integrations]
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install coverage
+        run: python -m pip install coverage
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+
+      - name: Combine shards and enforce the gate
+        run: |
+          coverage combine coverage.parity-a1 coverage.parity-a2 coverage.parity-b coverage.parity-c1 coverage.parity-c2 coverage.parity-c3 coverage.parity-d coverage.gradient-a coverage.gradient-b coverage.gradient-c coverage.examples coverage.device-rig coverage.optional
+          # The mirror release audit reaches 95% only after appending nightly
+          # fixed/free adjoint tests. The fast core artifacts intentionally
+          # exclude those tests, so do not mix a partial mirror number into
+          # the ordinary core gate.
+          coverage report --omit='vmex/mirror/*' --fail-under=95
+
+  full:
+    name: Full-physics ${{ matrix.shard }} (nightly / manual only)
+    runs-on: ubuntu-latest
+    # A sequential whole-suite job reached only 39% before the previous
+    # 150-minute limit, and the core job later lost hosted runners three times
+    # after 37/79/81 minutes. Keep exact RUN_FULL coverage, split core
+    # alphabetically, isolate each stateful optimization campaign, and isolate
+    # examples/mirror so every shard stays bounded on a fresh worker.
+    # High-mode ladders and the 94-minute mirror refinement live in the
+    # weekly workflow. The remaining nightly shards must fit the measured
+    # 150-minute cold budget; a timeout is a routing defect, not permission
+    # to extend this limit.
+    timeout-minutes: 150
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [core-a-c, core-d-f0, core-fb-a, core-fb-b, core-g-h,
+                core-i, core-i-grad, core-j-m, core-n-s, core-t-z,
+                hmfb-combined, hmfb-fft537,
+                qi-gate-free, qi-gate-ladder, qi-gate-ladder-fft,
+                qi-gate-ladder-055, qi-gate-fixed, opt-qa, opt-qh,
+                opt-qp, examples, mirror-field, mirror-equilibrium, mirror-spline]
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          python -m pip install ".[coils,turbulence,freeb]"
+          python -m pip install pytest
+
+      - name: Cache golden fixtures and compiled kernels
+        uses: actions/cache@v6.1.0
+        with:
+          path: ~/.cache/vmex
+          # Rolling PER-SHARD key.  Two prior defects: a fixed key freezes
+          # the cache at its FIRST save (kernels compiled later were never
+          # persisted), and a per-run key SHARED across the matrix lets the
+          # first finishing shard win the save while the expensive shards'
+          # kernels are dropped (GitHub caches are immutable per key).  Each
+          # shard therefore rolls its own key, scoped by OS and dependency
+          # signature so toolchain changes start a fresh lineage.
+          key: vmex-v3-${{ runner.os }}-full-${{ matrix.shard }}-${{ hashFiles('pyproject.toml') }}-${{ github.run_id }}
+          restore-keys: |
+            vmex-v3-${{ runner.os }}-full-${{ matrix.shard }}-${{ hashFiles('pyproject.toml') }}-
+            golden-v1
+
+      # The free-boundary example smokes run the examples as subprocesses,
+      # which read examples/data/mgrid_*.nc directly — fetched assets, not
+      # git-tracked (repo size budget). Without this step they raise
+      # MgridNotFoundError (nightly failure 2026-07-12).
+      - name: Fetch reference assets (mgrid files for free-boundary examples)
+        run: python tools/fetch_assets.py --bundle reference-nc
+
+      # XLA's compile arena for the enlarged free-boundary lane programs
+      # (funct3d.f Jacobian gate + stability-selected T_l recurrence)
+      # transiently exceeds the 16 GB hosted-runner RAM on x86 (the three
+      # QI-ladder shards and core-d-f were memory-evicted ~12 min into
+      # pytest on two consecutive attempts, during the first-rung compile;
+      # macOS peaks lower, ~12 GB).  Disk-backed swap lets the compile
+      # spill instead of killing the runner; the 150-minute budget absorbs
+      # the slowdown.  Program-size reduction (reusing the iteration
+      # body's Jacobian sign instead of a second synthesis) is tracked as
+      # a follow-up optimization.
+      - name: Add swap for XLA compile-arena headroom
+        run: |
+          sudo fallocate -l 12G /mnt/vmex-swap
+          sudo chmod 600 /mnt/vmex-swap
+          sudo mkswap /mnt/vmex-swap
+          sudo swapon /mnt/vmex-swap
+          free -h
+
+      - name: Run the whole suite including full-marked tests
+        env:
+          JAX_ENABLE_X64: "1"
+          RUN_FULL: "1"
+        run: |
+          FILES="$(python tools/test_manifest.py select full-${{ matrix.shard }})"
+          # Some optimization tests are silent for more than 15 minutes.
+          # Keep the hosted runner live without changing pytest semantics.
+          pytest -q -m "not weekly" $FILES --durations=25 \
+            --vmex-report="test-report-full-${{ matrix.shard }}.json" &
+          pytest_pid=$!
+          while kill -0 "$pytest_pid" 2>/dev/null; do
+            sleep 60
+            if kill -0 "$pytest_pid" 2>/dev/null; then
+              echo "pytest shard ${{ matrix.shard }} still running (${SECONDS}s)"
+            fi
+          done
+          wait "$pytest_pid"
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: test-report-full-${{ matrix.shard }}
+          path: test-report-full-${{ matrix.shard }}.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -52,7 +52,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-package-distributions
           path: dist/
@@ -69,7 +69,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,64 @@
+name: Weekly high resolution
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 1 * * 6"
+
+concurrency:
+  group: Weekly-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  campaign:
+    name: Weekly ${{ matrix.campaign }}
+    runs-on: ubuntu-latest
+    # The 238-mode free-boundary activation test measured 124 minutes and
+    # its five-test campaign 164 minutes cold. Keep bounded variance headroom.
+    timeout-minutes: 210
+    strategy:
+      fail-fast: false
+      matrix:
+        campaign: [hmfb, mirror]
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          python -m pip install ".[coils,turbulence,freeb]" pytest
+      - uses: actions/cache@v6.1.0
+        with:
+          path: ~/.cache/vmex
+          key: vmex-v4-${{ runner.os }}-weekly-${{ matrix.campaign }}-${{ hashFiles('pyproject.toml') }}-${{ github.run_id }}
+          restore-keys: |
+            vmex-v4-${{ runner.os }}-weekly-${{ matrix.campaign }}-${{ hashFiles('pyproject.toml') }}-
+            golden-v1
+      - run: python tools/fetch_assets.py --bundle reference-nc
+      - name: Add XLA compile headroom
+        run: |
+          sudo fallocate -l 12G /mnt/vmex-swap
+          sudo chmod 600 /mnt/vmex-swap
+          sudo mkswap /mnt/vmex-swap
+          sudo swapon /mnt/vmex-swap
+      - name: Run the high-resolution campaign
+        env:
+          JAX_ENABLE_X64: "1"
+          RUN_FULL: "1"
+        run: |
+          FILES="$(python tools/test_manifest.py select weekly-${{ matrix.campaign }})"
+          pytest -q $FILES --durations=25 \
+            --vmex-report="test-report-weekly-${{ matrix.campaign }}.json"
+      - uses: actions/upload-artifact@v7.0.1
+        if: always()
+        with:
+          name: test-report-weekly-${{ matrix.campaign }}
+          path: test-report-weekly-${{ matrix.campaign }}.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -585,6 +585,10 @@ equation-to-source cross-references, API reference, and
 performance/validation notes — at
 [vmex.readthedocs.io](https://vmex.readthedocs.io/en/latest/).
 
+Pull requests use short representative fixed/free-boundary, mirror, device,
+and AD checks. Exhaustive oracle, high-resolution, and trusted-GPU campaigns
+run separately; the contributor guide describes the test layers.
+
 ## Mirror equilibria
 
 Alongside the toroidal VMEC core, `vmex.mirror` solves scalar-pressure

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -38,8 +38,18 @@ Development install and checks::
   python tools/test_manifest.py check
   pytest -q
 
-The workflow obtains its file and campaign selectors from the manifest. Use
-``pytest --vmex-report=report.json`` to record the 50 slowest tests and all
+The workflows obtain their selectors from the manifest:
+
+- ``CI`` is the stable pull-request gate. It runs fast API checks and
+  representative fixed-boundary, free-boundary/NESTOR, mirror, device, and AD
+  paths. Changed executable lines must be at least 95% covered.
+- ``Nightly`` owns the complete integration/oracle matrix and aggregate
+  package coverage.
+- ``Weekly high resolution`` owns campaigns that exceed the 150-minute cold
+  nightly budget.
+- ``Trusted GPU physics`` is an explicit self-hosted dispatch.
+
+Use ``pytest --vmex-report=report.json`` to record the 50 slowest tests and all
 skip reasons with the same metadata.
 
 Documentation builds must pass strict mode::
@@ -59,7 +69,7 @@ potential and surface-field tables. Omitting ``--run-vmec2000`` skips it.
 GPU CI
 ------
 
-``GPU CI`` is a manual workflow because this is a public repository: pull
+``Trusted GPU physics`` is a manual workflow because this is a public repository: pull
 requests from forks are never run automatically on persistent self-hosted
 hardware.  Its runner must carry the labels ``self-hosted``, ``linux``,
 ``x64``, and ``gpu``, provide an NVIDIA driver 580 or newer for CUDA 13, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ vmex = ["resources/input.nfp4_QH_warm_start"]
 [tool.pytest.ini_options]
 markers = [
   "full: slower/full-physics tests; set RUN_FULL=1 to run",
+  "weekly: high-resolution campaigns excluded from nightly CI",
   "gpu: tests that require a real GPU; skipped when no GPU is available",
   "vmec2000_live: opt-in integration tests requiring a local VMEC2000 executable",
 ]

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,7 +19,12 @@ The suite tests the `vmex.core` and `vmex.mirror` packages:
   CI selects files from this manifest rather than maintaining path lists in
   workflow YAML.
 
-Markers: `full` tests are skipped unless `RUN_FULL=1` is set.
+Markers: `full` tests are skipped unless `RUN_FULL=1` is set. The `weekly`
+marker identifies high-resolution campaigns that also stay out of the nightly
+matrix. Pull requests run fast API tests plus representative fixed-boundary,
+free-boundary/NESTOR, mirror, device, and AD selectors. Nightly runs the
+complete integration/oracle matrix; weekly runs the high-mode free-boundary
+ladder and exterior-mirror resolution study.
 `vmec2000_live` tests additionally require `--run-vmec2000` and accept
 `--vmec2000-executable PATH`; they are never part of ordinary offline CI. The
 live lane includes fixed-boundary current/Mercier profiles and a converged

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -98,6 +98,12 @@
       "tests/test_freeboundary_linear.py",
       "tests/test_freeboundary_diff.py::test_synthetic_surface_gradient_fd_validates"
     ],
+    "pr-physics-mirror-spline": [
+      "tests/mirror/test_analytic.py",
+      "tests/mirror/test_qi_hybrid.py",
+      "tests/mirror/test_splines.py"
+    ],
+    "pr-physics-mirror-output": ["tests/mirror/test_output.py"],
     "pr-device": [
       "tests/test_gpu_ci.py::test_device_scope_second_host_device_gradient_equality",
       "tests/test_gpu_ci.py::test_second_host_device_unconverged_adjoint_raises_typed_error"

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -23,20 +23,20 @@
     ["tests/test_cli_summary_wout.py", "interface", "integration", "medium", "cpu", "golden", "golden", ["pr-parity-c1", "full-core-a-c"]],
     ["tests/test_compat.py", "interface", "unit", "fast", "cpu", "none", "none", ["pr-parity-c1", "full-core-a-c"]],
     ["tests/test_coverage_margin.py", "infrastructure", "unit", "fast", "cpu", "none", "none", ["pr-parity-c1", "full-core-a-c"]],
-    ["tests/test_device.py", "infrastructure", "unit", "fast", "cpu-gpu", "none", "none", ["pr-parity-c1", "pr-fast", "gpu-smoke", "full-core-d-f"]],
-    ["tests/test_device_parity_tool.py", "infrastructure", "integration", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-d-f"]],
-    ["tests/test_doctor.py", "interface", "unit", "fast", "cpu-gpu", "none", "none", ["pr-parity-c1", "full-core-d-f"]],
+    ["tests/test_device.py", "infrastructure", "unit", "fast", "cpu-gpu", "none", "none", ["pr-parity-c1", "pr-fast", "gpu-smoke", "full-core-d-f0"]],
+    ["tests/test_device_parity_tool.py", "infrastructure", "integration", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-d-f0"]],
+    ["tests/test_doctor.py", "interface", "unit", "fast", "cpu-gpu", "none", "none", ["pr-parity-c1", "full-core-d-f0"]],
     ["tests/test_examples.py", "interface", "campaign", "campaign", "cpu-gpu", "reference-nc", "external", ["pr-examples", "full-examples"]],
-    ["tests/test_fetch_assets.py", "infrastructure", "unit", "fast", "cpu", "none", "none", ["pr-parity-c1", "pr-fast", "full-core-d-f"]],
-    ["tests/test_first_divergence.py", "infrastructure", "unit", "fast", "cpu", "none", "analytic", ["pr-parity-c1", "full-core-d-f"]],
-    ["tests/test_force_oracle.py", "equilibrium", "oracle", "medium", "cpu", "golden", "vmec2000", ["pr-parity-c1", "full-core-d-f"]],
-    ["tests/test_forces_residuals.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-d-f"]],
-    ["tests/test_fourier_transforms.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "pr-fast", "full-core-d-f"]],
-    ["tests/test_freeboundary.py", "free-boundary", "integration", "slow", "cpu-gpu", "golden", "vmec2000", ["pr-parity-a1", "full-core-d-f"]],
-    ["tests/test_freeboundary_diff.py", "free-boundary", "ad", "medium", "cpu-gpu", "reference-nc", "fd", ["pr-parity-a1", "optional", "full-core-d-f"]],
-    ["tests/test_freeboundary_linear.py", "free-boundary", "ad", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-a1", "full-core-d-f"]],
-    ["tests/test_freeboundary_multigrid.py", "free-boundary", "integration", "slow", "cpu-gpu", "golden", "vmec2000", ["pr-parity-a1", "full-core-d-f"]],
-    ["tests/test_freeboundary_stress.py", "free-boundary", "integration", "medium", "cpu-gpu", "generated", "analytic", ["pr-parity-a1", "full-core-d-f"]],
+    ["tests/test_fetch_assets.py", "infrastructure", "unit", "fast", "cpu", "none", "none", ["pr-parity-c1", "pr-fast", "full-core-d-f0"]],
+    ["tests/test_first_divergence.py", "infrastructure", "unit", "fast", "cpu", "none", "analytic", ["pr-parity-c1", "full-core-d-f0"]],
+    ["tests/test_force_oracle.py", "equilibrium", "oracle", "medium", "cpu", "golden", "vmec2000", ["pr-parity-c1", "full-core-d-f0"]],
+    ["tests/test_forces_residuals.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-d-f0"]],
+    ["tests/test_fourier_transforms.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "pr-fast", "full-core-d-f0"]],
+    ["tests/test_freeboundary.py", "free-boundary", "integration", "slow", "cpu-gpu", "golden", "vmec2000", ["pr-parity-a1", "full-core-fb-a"]],
+    ["tests/test_freeboundary_diff.py", "free-boundary", "ad", "medium", "cpu-gpu", "reference-nc", "fd", ["pr-parity-a1", "optional", "full-core-fb-a"]],
+    ["tests/test_freeboundary_linear.py", "free-boundary", "ad", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-a1", "full-core-fb-a"]],
+    ["tests/test_freeboundary_multigrid.py", "free-boundary", "integration", "slow", "cpu-gpu", "golden", "vmec2000", ["pr-parity-a1", "full-core-fb-b"]],
+    ["tests/test_freeboundary_stress.py", "free-boundary", "integration", "medium", "cpu-gpu", "generated", "analytic", ["pr-parity-a1", "full-core-fb-b"]],
     ["tests/test_geometry_fields.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-g-h"]],
     ["tests/test_golden_digests.py", "equilibrium", "oracle", "slow", "cpu", "golden", "vmec2000", ["pr-parity-b", "full-core-g-h"]],
     ["tests/test_gpu_ci.py", "infrastructure", "gpu", "slow", "cpu-gpu", "generated", "fd", ["pr-parity-c1", "device-rig", "gpu-smoke", "full-core-g-h"]],
@@ -88,6 +88,31 @@
   "excluded": {
     "tests/test_lasym_free_case.py": "fixture helper; no collected tests",
     "tests/test_qi_free_boundary_case.py": "fixture helper; no collected tests"
+  },
+  "selectors": {
+    "pr-physics-core": [
+      "tests/test_solver_end_to_end.py::test_converges_with_golden_iteration_count[solovev]",
+      "tests/test_implicit_grad.py::test_solovev_gradients_vs_fd",
+      "tests/test_implicit_grad.py::test_jdotb_and_glasser_gradients_vs_frozen_path_fd[solovev]",
+      "tests/test_freeboundary.py::test_nestor_skip_branch_matches_full_solve",
+      "tests/test_freeboundary_linear.py",
+      "tests/test_freeboundary_diff.py::test_synthetic_surface_gradient_fd_validates"
+    ],
+    "pr-physics-mirror": ["tests/mirror"],
+    "pr-device": [
+      "tests/test_gpu_ci.py::test_device_scope_second_host_device_gradient_equality",
+      "tests/test_gpu_ci.py::test_second_host_device_unconverged_adjoint_raises_typed_error"
+    ],
+    "weekly-hmfb": [
+      "tests/test_high_mode_free_boundary_parity.py::test_all_reported_features_parse_together",
+      "tests/test_high_mode_free_boundary_parity.py::test_fixed_boundary_238_mode_ladder_converges",
+      "tests/test_high_mode_free_boundary_parity.py::test_free_boundary_238_mode_ladder_survives_activation",
+      "tests/test_high_mode_free_boundary_parity.py::test_vacuum_survives_a_radial_transition",
+      "tests/test_high_mode_free_boundary_parity.py::test_mgrid_nzeta_policy_matches_vmec2000"
+    ],
+    "weekly-mirror": [
+      "tests/mirror/test_free_boundary.py::test_unbounded_exterior_beta_observables_converge_with_resolution"
+    ]
   },
   "campaigns": {
     "full-hmfb-ladders": [

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -98,7 +98,6 @@
       "tests/test_freeboundary_linear.py",
       "tests/test_freeboundary_diff.py::test_synthetic_surface_gradient_fd_validates"
     ],
-    "pr-physics-mirror": ["tests/mirror"],
     "pr-device": [
       "tests/test_gpu_ci.py::test_device_scope_second_host_device_gradient_equality",
       "tests/test_gpu_ci.py::test_second_host_device_unconverged_adjoint_raises_typed_error"

--- a/tests/mirror/test_free_boundary.py
+++ b/tests/mirror/test_free_boundary.py
@@ -223,6 +223,7 @@ def test_unbounded_exterior_free_boundary_beta_scan_converges(_module_jit_enable
 
 
 @pytest.mark.full
+@pytest.mark.weekly
 def test_unbounded_exterior_beta_observables_converge_with_resolution(_module_jit_enabled) -> None:
     observables = []
     compatibility = []

--- a/tests/mirror/test_output.py
+++ b/tests/mirror/test_output.py
@@ -21,12 +21,19 @@ from vmex.mirror import (
     MirrorConfig,
     MirrorResolution,
     MirrorState,
+    build_stellarator_mirror_hybrid,
     mout_from_result,
     read_mout,
     write_mout,
 )
 from vmex.mirror.forces import mirror_energy
-from vmex.mirror.output import MoutData, _theta_samples
+from vmex.mirror.output import (
+    MoutData,
+    _theta_samples,
+    plot_axisymmetric_beta_scan_summary,
+    plot_mirror_3d_pair,
+    plot_stellarator_mirror_hybrid,
+)
 
 
 REPO = Path(__file__).resolve().parents[2]
@@ -242,3 +249,59 @@ def test_command_line_plots_mout_without_toroidal_dispatch(tmp_path) -> None:
     pixels = mpimg.imread(tmp_path / "sample_3d.png")
     cyan = (pixels[..., 0] < 0.2) & (pixels[..., 1] > 0.6) & (pixels[..., 2] > 0.7)
     assert int(np.count_nonzero(cyan)) > 200
+
+
+@pytest.mark.filterwarnings(
+    "ignore:constrained_layout not applied because axes sizes collapsed to zero.*"
+)
+def test_mirror_comparison_and_beta_scan_plots(tmp_path) -> None:
+    data = _sample_mout()
+    paths = [
+        plot_mirror_3d_pair(
+            data,
+            data,
+            tmp_path,
+            titles=("baseline", "comparison"),
+        ),
+        plot_axisymmetric_beta_scan_summary(
+            [("supported", data, True), ("validation", data, False)],
+            tmp_path,
+            display=(0, 1),
+            strong_force_gate=1.0e-3,
+        ),
+    ]
+    for path in paths:
+        pixels = mpimg.imread(path)
+        assert pixels.shape[0] > 200 and pixels.shape[1] > 300
+        assert float(np.std(pixels)) > 0.03
+
+
+def test_stellarator_mirror_hybrid_plot(tmp_path) -> None:
+    resolution = MirrorResolution(ns=3, mpol=1, nxi=3)
+    setup = build_stellarator_mirror_hybrid(
+        resolution,
+        coefficient_count=16,
+        quadrature_order=2,
+    )
+    state = setup.discretization.evaluate_state(setup.initial_state)
+    energy = mirror_energy(
+        state,
+        setup.discretization.grid,
+        axial_flux_derivative=0.02,
+        axis=setup.axis,
+    )
+    result = SimpleNamespace(
+        state=state,
+        energy=energy,
+        history=np.asarray([[0.0, 0.0, 0.0, 0.0, 1.0e-5]]),
+        iterations=0,
+        force=SimpleNamespace(normalized_rms=1.0e-5),
+        normalized_divergence_rms=1.0e-12,
+        variational=SimpleNamespace(maximum=1.0e-5),
+    )
+
+    path = plot_stellarator_mirror_hybrid(result, setup, tmp_path)
+
+    pixels = mpimg.imread(path)
+    assert pixels.shape[0] > 200 and pixels.shape[1] > 300
+    assert float(np.std(pixels)) > 0.03

--- a/tests/test_freeboundary.py
+++ b/tests/test_freeboundary.py
@@ -119,6 +119,7 @@ def test_nestor_skip_branch_matches_full_solve(ab_inputs):
     np.testing.assert_allclose(np.asarray(rhs_skip), np.asarray(rhs), rtol=1e-12, atol=1e-14)
 
 
+@pytest.mark.full
 def test_live_nestor_blocks_match_coupled_residual_jvp_and_vjp():
     """The bordered blocks come from a live, small LASYM NESTOR equation."""
     basis = V.vacuum_basis(

--- a/tests/test_freeboundary_multigrid.py
+++ b/tests/test_freeboundary_multigrid.py
@@ -132,6 +132,7 @@ def test_vmec2000_niter_exhaustion_is_not_converged() -> None:
     assert not _vmec_converged(stdout)
 
 
+@pytest.mark.full
 def test_public_two_stage_free_boundary_rebuilds_and_stays_finite() -> None:
     """The bundled non-confidential LASYM case crosses vacuum turn-on."""
     inp = VmecInput.from_file(DECK)
@@ -385,6 +386,7 @@ def test_symmetric_multigrid_exports_final_nestor_wout(tmp_path) -> None:
         assert "bsubumnc_sur" not in ds.variables
 
 
+@pytest.mark.full
 def test_prefetch_compile_parity_and_bookkeeping() -> None:
     """Free-boundary ``prefetch_compile`` is cache warming only.
 

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -827,6 +827,7 @@ def test_lasym_wb_aspect_gradient_vs_fd(lasym):
         assert rel <= tol, f"{out}/{field}{idx}: rel {rel:.3e} > {tol:.0e}"
 
 
+@pytest.mark.full
 def test_lasym_adjoint_vs_frozen_path_fd(lasym):
     """Lasym-adjoint correctness lock: the analytic directional derivative and
     the central frozen-path FD, BOTH anchored at the same Newton-refined
@@ -952,6 +953,7 @@ def lasym_3d():
     return "basic_non_stellsym_simsopt", inp, cfg, p0, result.state, rt, mask
 
 
+@pytest.mark.full
 def test_lasym_3d_gradient_vs_frozen_path_fd(lasym_3d):
     """``jax.grad`` through ``im.run`` on a 3D lasym boundary vs frozen-path
     central FD: toroidal (n = 1) rbs/zbc dofs plus the symmetric rbc family

--- a/tests/test_implicit_multi_rhs.py
+++ b/tests/test_implicit_multi_rhs.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from vmex.core import implicit as im
 from vmex.core.input import VmecInput
@@ -39,6 +40,7 @@ def test_solve_implicit_with_aux_matches_solve_implicit():
     assert jax.tree.structure(mask) == jax.tree.structure(state_ref)
 
 
+@pytest.mark.full
 def test_multi_rhs_pullback_matches_scalar_vjp():
     """Batched pullback == stacking the scalar solve_implicit VJP per cotangent."""
     _, cfg, p0 = _solovev_setup()

--- a/tests/test_single_stage_simultaneous.py
+++ b/tests/test_single_stage_simultaneous.py
@@ -52,6 +52,7 @@ def _mf(base, extcur):
                       zmax=base.zmax, nfp=base.nfp)
 
 
+@pytest.mark.full
 def test_surface_field_from_state_matches_wout(cth):
     """The traceable state->surface bridge reproduces the wout path bit-for-bit."""
     inp, res, _ = cth
@@ -85,6 +86,7 @@ def _setup(cth):
     return inp, base, p0, obj
 
 
+@pytest.mark.full
 def test_joint_gradient_is_finite(cth):
     """value_and_grad wrt BOTH boundary params and coil currents is finite.
 

--- a/tests/test_test_manifest.py
+++ b/tests/test_test_manifest.py
@@ -25,6 +25,15 @@ def test_manifest_routes_the_previously_nightly_only_mirror_module() -> None:
     assert "tests/mirror/test_qi_hybrid.py" in selected
 
 
+def test_manifest_routes_short_pr_and_weekly_selectors() -> None:
+    assert "tests/mirror" in test_manifest.select("pr-physics-mirror")
+    weekly = test_manifest.select("weekly-mirror")
+    assert weekly == [
+        "tests/mirror/test_free_boundary.py::"
+        "test_unbounded_exterior_beta_observables_converge_with_resolution"
+    ]
+
+
 def test_manifest_report_lists_timings_and_every_skip(tmp_path: Path) -> None:
     report = tmp_path / "report.json"
     env = os.environ.copy()
@@ -61,7 +70,12 @@ def test_manifest_report_lists_timings_and_every_skip(tmp_path: Path) -> None:
 
 
 def test_workflow_selects_manifest_lanes() -> None:
-    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
-    assert "tools/test_manifest.py select" in workflow
+    workflows = {
+        path.name: path.read_text()
+        for path in (ROOT / ".github" / "workflows").glob("*.yml")
+    }
+    for name in ("ci.yml", "gpu.yml", "nightly.yml", "weekly.yml"):
+        assert "tools/test_manifest.py select" in workflows[name]
+    assert "name: PR gate" in workflows["ci.yml"]
     for stale in ("A1_FILES=", "C2_FILES=", "core-a-c)"):
-        assert stale not in workflow
+        assert stale not in "".join(workflows.values())

--- a/tests/test_test_manifest.py
+++ b/tests/test_test_manifest.py
@@ -26,7 +26,15 @@ def test_manifest_routes_the_previously_nightly_only_mirror_module() -> None:
 
 
 def test_manifest_routes_short_pr_and_weekly_selectors() -> None:
-    assert "tests/mirror" in test_manifest.select("pr-physics-mirror")
+    assert "tests/mirror/test_implicit.py" in test_manifest.select(
+        "pr-mirror-equilibrium"
+    )
+    assert "tests/mirror/test_free_boundary.py" in test_manifest.select(
+        "pr-mirror-field"
+    )
+    assert "tests/mirror/test_splines.py" in test_manifest.select(
+        "pr-mirror-spline"
+    )
     weekly = test_manifest.select("weekly-mirror")
     assert weekly == [
         "tests/mirror/test_free_boundary.py::"

--- a/tests/test_test_manifest.py
+++ b/tests/test_test_manifest.py
@@ -33,8 +33,11 @@ def test_manifest_routes_short_pr_and_weekly_selectors() -> None:
         "pr-mirror-field"
     )
     assert "tests/mirror/test_splines.py" in test_manifest.select(
-        "pr-mirror-spline"
+        "pr-physics-mirror-spline"
     )
+    assert test_manifest.select("pr-physics-mirror-output") == [
+        "tests/mirror/test_output.py"
+    ]
     weekly = test_manifest.select("weekly-mirror")
     assert weekly == [
         "tests/mirror/test_free_boundary.py::"

--- a/tools/test_manifest.py
+++ b/tools/test_manifest.py
@@ -107,6 +107,21 @@ def validate(nodes: list[str]) -> list[str]:
             )
 
     node_set = set(nodes)
+    for lane, selectors in data.get("selectors", {}).items():
+        if not lane.startswith(("pr-", "weekly-")):
+            errors.append(f"selector lane must be pr-* or weekly-*: {lane}")
+        for selector in selectors:
+            if "::" in selector:
+                collected = selector in node_set
+            else:
+                prefix = selector.rstrip("/")
+                collected = any(
+                    node.startswith(f"{prefix}::") or node.startswith(f"{prefix}/")
+                    for node in nodes
+                )
+            if not collected:
+                errors.append(f"{lane}: selector does not collect: {selector}")
+
     full_members: list[str] = []
     by_file: dict[str, list[str]] = {}
     for node in nodes:
@@ -143,6 +158,7 @@ def select(lane: str) -> list[str]:
     """Return module or node selectors owned by a CI lane."""
     data, records = load()
     selected = [record["path"] for record in records if lane in record["lanes"]]
+    selected.extend(data.get("selectors", {}).get(lane, ()))
     selected.extend(data["campaigns"].get(lane, ()))
     if not selected:
         raise ValueError(f"unknown or empty manifest lane: {lane}")


### PR DESCRIPTION
## Goal

Make pull-request feedback fast and stable without weakening VMEX's research validation. Separate representative review checks from exhaustive nightly/oracle, high-resolution weekly, and trusted-GPU campaigns; expose one stable `PR gate` suitable for branch protection.

## What this PR achieves

- Replaces the mixed-trigger workflow with separate PR, nightly, weekly high-resolution, and trusted-GPU workflows.
- Keeps fixed-boundary, free-boundary/NESTOR, implicit AD, all 108 non-campaign mirror tests, and two-device representatives on every PR.
- Routes mirror equilibrium/AD, field/free-boundary, analytic/QI/splines, and output independently so JAX compilation stays inside the 15-minute review budget. No physics test was dropped or downgraded.
- Moves eight measured 4–21 minute exhaustive checks behind the existing `full` opt-in and promotes the 94-minute mirror refinement plus 164-minute high-mode ladder campaign to weekly.
- Splits the 134-test `core-d-f` full shard into bounded non-free-boundary, free-boundary/AD, and free-boundary multigrid/stress groups.
- Preserves nightly aggregate core coverage >=95%, adds 95% changed-executable-line coverage on PRs, and replaces the silent mirror omission with a visible 90% floor (measured 91%).
- Adds meaningful rendering tests for public mirror comparison, beta-scan, and stellarator-mirror-hybrid plots; `mirror/output.py` rises to 95% coverage.
- Retains the seven-metric CPU/GPU audit for MHD energy, magnetic well, DMerc, `jdotb`, Glasser `D_R`, quasisymmetry, and quasi-isodynamicity.
- Updates GitHub actions to current Node 24 releases and documents the four validation layers.

## User and numerical impact

No equilibrium equation, solver path, public Python/CLI API, device default, output schema, or production numerical result changes. Only test classification, plotting coverage tests, CI routing, and documentation change.

## Validation

- Exact final-head hosted run: 11/11 jobs passed; stable `PR gate` green; total wall 11m59s.
- Longest hosted job: analytic/QI/splines 11m33s. Other physics jobs: core 5m18s, mirror field/free-boundary 5m25s, mirror equilibrium/AD 7m14s, mirror output 4m57s, two-device AD 3m31s.
- Local mirror union: 108 passed and 10 campaign deselections in 3m18s.
- Fast API: 286 passed and 6 explicit skips in 5.18s locally; hosted Python 3.10 and 3.12 jobs pass.
- Coverage: mirror 91% (visible floor 90%); changed executable lines >=95%; nightly core floor remains >=95%.
- GPU smoke on the PR head: 49 passed and 6 host-rig-only skips in 7m00s on two RTX A4000s, without platform-selection environment variables.
- CPU/GPU parity: 14/14 reports passed across `cuda:0` and `cuda:1`; worst gradient relative difference was DMerc at 3.45e-11 against a 1e-7 gate.
- Exhaustive retained evidence: 44 hosted full jobs passed; the sole old-head failure was the nested report timeout already fixed on the accepted PR #84 head. High-mode ladder 5/5 in 164 minutes; mirror-field campaign 28/28, including the 94-minute refinement.
- Quality: Ruff, mypy, wheel/sdist, strict Sphinx, workflow YAML parsing, manifest ownership (1,007 tests, 82 modules, 11 campaigns), and diff checks pass.

## Remaining acceptance work

- Complete the active cache-warm rerun of the exact final head.
- After merge, dispatch the newly registered nightly workflow and an ephemeral one-job office GPU runner.
- Observe `PR gate` green on `main`, then require that stable context in branch protection.
