### PR TITLE
chore: verify and document release assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
           sudo chmod 600 /mnt/vmex-swap
           sudo mkswap /mnt/vmex-swap
           sudo swapon /mnt/vmex-swap
+      - name: Fetch the core parity fixture
+        if: matrix.selector == 'pr-physics-core'
+        run: python tools/fetch_assets.py --bundle golden-v1
       - name: Run representative physics
         env:
           JAX_ENABLE_X64: "1"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -189,15 +189,7 @@ jobs:
             golden-v1
 
       - name: Prefetch golden fixtures (once, before xdist workers fork)
-        run: |
-          python - <<'EOF'
-          import importlib.util
-          spec = importlib.util.spec_from_file_location(
-              "tests_conftest", "tests/conftest.py")
-          mod = importlib.util.module_from_spec(spec)
-          spec.loader.exec_module(mod)
-          print("golden dir:", mod.resolve_golden_dir())
-          EOF
+        run: python tools/fetch_assets.py --bundle golden-v1
 
       # Seven bounded shards.  The xdist dist MODE is chosen PER SHARD by
       # whether its modules share an expensive fixture:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 recursive-include tests *.py
+include assets/manifest.json
+include tools/fetch_assets.py

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,0 +1,55 @@
+{
+  "schema": "vmex.release-assets/1",
+  "bundles": [
+    {
+      "name": "reference-nc",
+      "url": "https://github.com/uwplasma/vmex/releases/download/assets-20260316-nc/vmec_jax_assets_20260316_nc_only.tar.gz",
+      "sha256": "3344fc2401fffed240ee57ae741ec521594c592627c76dae203503f485e4c0d8",
+      "size_bytes": 81559426,
+      "source": "VMEX reference NetCDF and mgrid release assets",
+      "license": "MIT; see repository LICENSE",
+      "generator_revision": "4ead9b814f8333d4dfbc3034d127085667743fd8",
+      "destination": "repository",
+      "default": true,
+      "common_paths": [
+        "examples/data/mgrid_cth_like.nc",
+        "examples/data/mgrid_d3d_ef.nc",
+        "examples/data/wout_*_reference.nc",
+        "examples/data/single_grid/mgrid_cth_like.nc",
+        "examples/data/single_grid/mgrid_d3d_ef.nc",
+        "examples/data/single_grid/wout_*_reference.nc"
+      ]
+    },
+    {
+      "name": "wout-fixtures",
+      "url": "https://github.com/uwplasma/vmex/releases/download/assets-20260526-wout-fixtures/vmec_jax_wout_fixtures_20260526.tar.gz",
+      "sha256": "e9fd844a4ebed043576eec8ac2b17f7ff3e2a0e0a1b5adfc89742139101e00f9",
+      "size_bytes": 9801091,
+      "source": "VMEX generated and reference WOUT fixtures",
+      "license": "MIT; see repository LICENSE",
+      "generator_revision": "3d839e4fd8cfa66d19752bbaa4a6d526b51995b6",
+      "destination": "repository",
+      "default": true,
+      "common_paths": [
+        "examples/data/wout_*.nc",
+        "examples/data/single_grid/wout_*.nc",
+        "docs/_static/readme_best_cases/*/wout_*.nc",
+        "docs/_static/qi_readme_cases/*/wout_*.nc"
+      ]
+    },
+    {
+      "name": "golden-v1",
+      "url": "https://github.com/uwplasma/vmex/releases/download/golden-v1/vmec-jax-golden-v1.tar.gz",
+      "sha256": "85b1de372066d1dd0c57b1a9ffb569ccc1276bb67dec81e7bf15a5a943ca05d7",
+      "size_bytes": 2167603,
+      "source": "VMEC2000 STELLOPT 9.0 outputs for nine public VMEX decks",
+      "license": "See repository LICENSE and release notes",
+      "generator_revision": "9c1ba849487aaba6163d201c80c3b8b6bcab05a3",
+      "destination": "cache",
+      "default": false,
+      "common_paths": [
+        "~/.cache/vmex/golden-v1/golden"
+      ]
+    }
+  ]
+}

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -53,6 +53,17 @@ The workflows obtain their selectors from the manifest:
 Use ``pytest --vmex-report=report.json`` to record the 50 slowest tests and all
 skip reasons with the same metadata.
 
+Reference assets
+----------------
+
+Keep input decks and analytic fixtures in git. Put generated WOUT, mgrid, and
+benchmark archives in a GitHub Release and add their URL, byte size, SHA-256,
+source, license, generator revision, and installed paths to
+``assets/manifest.json``. Fetch repository fixtures with
+``python tools/fetch_assets.py`` and VMEC2000 goldens with
+``python tools/fetch_assets.py --bundle golden-v1``. CI rejects any tracked
+file larger than 1 MiB.
+
 Documentation builds must pass strict mode::
 
   python -m sphinx -W -j auto -b html docs docs/_build/html

--- a/examples/data/README.md
+++ b/examples/data/README.md
@@ -8,7 +8,8 @@ examples, tests, and documentation.
   docs, and optional cross-implementation comparisons. README runtime inputs are
   normalized to `NS_ARRAY=151`, `FTOL_ARRAY=1e-14`, and `NITER_ARRAY=5000`.
 - Large reference WOUT, mgrid, Boozer, and JXB files are ignored by git and are
-  fetched on demand with `python tools/fetch_assets.py`.
+  fetched on demand with `python tools/fetch_assets.py`. The command verifies
+  the release size and SHA-256 recorded in `assets/manifest.json`.
 
 Keep new example inputs small.  Put generated output files in ignored output
 directories, not in this data folder.

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,9 +10,10 @@ The suite tests the `vmex.core` and `vmex.mirror` packages:
   metadata.
 - `tests/mirror/`: analytic, geometry/field, fixed/free-boundary, spline,
   implicit-derivative, hybrid, output, and exterior-vacuum coverage.
-- `tests/conftest.py` resolves the VMEC2000 golden parity fixtures
-  (`VMEX_GOLDEN_DIR` env var, `~/vmex_notes/golden`, or a one-time
-  sha256-verified download of the `golden-v1` GitHub release).
+- `tests/conftest.py` resolves the VMEC2000 golden parity fixtures from an
+  explicit local override, `~/vmex_notes/golden`, or the verified user cache.
+  Populate the cache with
+  `python tools/fetch_assets.py --bundle golden-v1`.
 - `tests/manifest.json` assigns every collected test module one owner,
   primary class, duration class, device, asset bundle, oracle, and CI lanes.
   Run `python tools/test_manifest.py check` after adding or moving a test.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,15 +63,8 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if item.get_closest_marker("full") is not None and not run_full:
             item.add_marker(pytest.mark.skip(reason="Full tests disabled. Set RUN_FULL=1."))
-        if (
-            item.get_closest_marker("vmec2000_live") is not None
-            and not run_vmec2000
-        ):
-            item.add_marker(
-                pytest.mark.skip(
-                    reason="Live VMEC2000 integration disabled; use --run-vmec2000"
-                )
-            )
+        if item.get_closest_marker("vmec2000_live") is not None and not run_vmec2000:
+            item.add_marker(pytest.mark.skip(reason="Live VMEC2000 integration disabled; use --run-vmec2000"))
 
 
 def _manifest_metadata(nodeid: str) -> dict[str, str]:
@@ -80,10 +73,7 @@ def _manifest_metadata(nodeid: str) -> dict[str, str]:
     path = nodeid.split("::", 1)[0]
     row = next(row for row in data["records"] if row[0] == path)
     record = dict(zip(data["fields"], row, strict=True))
-    return {
-        key: record[key]
-        for key in ("owner", "primary", "duration", "device", "asset", "oracle")
-    }
+    return {key: record[key] for key in ("owner", "primary", "duration", "device", "asset", "oracle")}
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
@@ -100,20 +90,12 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
                 durations[nodeid] = durations.get(nodeid, 0.0) + duration
     slowest = [
         {"nodeid": nodeid, "seconds": seconds, **_manifest_metadata(nodeid)}
-        for nodeid, seconds in sorted(
-            durations.items(), key=lambda item: item[1], reverse=True
-        )[:50]
+        for nodeid, seconds in sorted(durations.items(), key=lambda item: item[1], reverse=True)[:50]
     ]
     skips = []
     for report in terminalreporter.stats.get("skipped", ()):
-        reason = (
-            report.longrepr[2]
-            if isinstance(report.longrepr, tuple)
-            else str(report.longrepr)
-        )
-        skips.append(
-            {"nodeid": report.nodeid, "reason": reason, **_manifest_metadata(report.nodeid)}
-        )
+        reason = report.longrepr[2] if isinstance(report.longrepr, tuple) else str(report.longrepr)
+        skips.append({"nodeid": report.nodeid, "reason": reason, **_manifest_metadata(report.nodeid)})
     payload = {
         "schema": "vmex.test-report/1",
         "collected": len(durations),
@@ -124,9 +106,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     path = Path(target)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
-    terminalreporter.write_line(
-        f"VMEX test report: {path} ({len(slowest)} timings, {len(skips)} skips)"
-    )
+    terminalreporter.write_line(f"VMEX test report: {path} ({len(slowest)} timings, {len(skips)} skips)")
 
 
 # ---------------------------------------------------------------------------
@@ -136,12 +116,11 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 #   2. ~/vmex_notes/golden (local development snapshot),
 #   3. ~/.cache/vmex/golden-v1 (downloaded once from the golden-v1 release).
 # ---------------------------------------------------------------------------
-# Keep the owner/repo as ``vmec_jax`` (the pre-rename name): the release asset
-# lives there, and after the repo is renamed to VMEX GitHub redirects the old
-# path to the new one, so this URL resolves both before and after the rename.
-# Pointing it at ``VMEX`` directly 404s until the rename lands.
-GOLDEN_URL = "https://github.com/uwplasma/vmec_jax/releases/download/golden-v1/vmec-jax-golden-v1.tar.gz"
-GOLDEN_SHA256 = "85b1de372066d1dd0c57b1a9ffb569ccc1276bb67dec81e7bf15a5a943ca05d7"
+_ASSET_MANIFEST = json.loads((_ROOT / "assets" / "manifest.json").read_text())
+_GOLDEN_BUNDLE = next(bundle for bundle in _ASSET_MANIFEST["bundles"] if bundle["name"] == "golden-v1")
+GOLDEN_URL = _GOLDEN_BUNDLE["url"]
+GOLDEN_SHA256 = _GOLDEN_BUNDLE["sha256"]
+GOLDEN_SIZE_BYTES = _GOLDEN_BUNDLE["size_bytes"]
 
 
 def _download_golden(cache_root: Path) -> Path:
@@ -149,6 +128,9 @@ def _download_golden(cache_root: Path) -> Path:
     tarball = cache_root / "vmec-jax-golden-v1.tar.gz"
     if not tarball.exists():
         urllib.request.urlretrieve(GOLDEN_URL, tarball)  # noqa: S310 - fixed https URL
+    if tarball.stat().st_size != GOLDEN_SIZE_BYTES:
+        tarball.unlink()
+        raise RuntimeError("golden bundle size mismatch")
     digest = hashlib.sha256(tarball.read_bytes()).hexdigest()
     if digest != GOLDEN_SHA256:
         tarball.unlink()

--- a/tests/test_fetch_assets.py
+++ b/tests/test_fetch_assets.py
@@ -132,6 +132,20 @@ def test_fetch_assets_safe_extract_rejects_links(tmp_path) -> None:
             module._safe_extract(tf, tmp_path)
 
 
+def test_fetch_assets_safe_extract_rejects_special_files(tmp_path) -> None:
+    module = _load_fetch_assets()
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as tf:
+        info = tarfile.TarInfo("fifo")
+        info.type = tarfile.FIFOTYPE
+        tf.addfile(info)
+    payload.seek(0)
+
+    with tarfile.open(fileobj=payload, mode="r:gz") as tf:
+        with pytest.raises(SystemExit, match="special archive member"):
+            module._safe_extract(tf, tmp_path)
+
+
 def test_no_tracked_file_exceeds_one_mib() -> None:
     if not (ROOT / ".git").exists():
         pytest.skip("tracked-file gate requires a git checkout")

--- a/tests/test_fetch_assets.py
+++ b/tests/test_fetch_assets.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
+import subprocess
 import sys
 import tarfile
 from pathlib import Path
@@ -10,6 +12,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "tools" / "fetch_assets.py"
+MANIFEST = ROOT / "assets" / "manifest.json"
 
 
 def _load_fetch_assets():
@@ -31,6 +34,8 @@ def test_fetch_assets_dry_run_lists_bundle(capsys) -> None:
     assert "Asset bundles:" in out
     assert "reference-nc" in out
     assert "wout-fixtures" in out
+    assert "golden-v1" not in out
+    assert "Expected bytes:" in out
     assert "Expected SHA256:" in out
     assert "examples/data/mgrid_cth_like.nc" in out
     assert "examples/data/wout_*.nc" in out
@@ -48,6 +53,53 @@ def test_fetch_assets_can_select_one_default_bundle(capsys) -> None:
     assert "docs/_static/readme_best_cases/*/wout_*.nc" in out
 
 
+def test_asset_manifest_has_complete_provenance() -> None:
+    data = json.loads(MANIFEST.read_text())
+    assert data["schema"] == "vmex.release-assets/1"
+    bundles = data["bundles"]
+    assert {bundle["name"] for bundle in bundles} == {
+        "golden-v1",
+        "reference-nc",
+        "wout-fixtures",
+    }
+    for bundle in bundles:
+        assert bundle["url"].startswith("https://github.com/uwplasma/vmex/")
+        assert len(bundle["sha256"]) == 64
+        assert bundle["size_bytes"] > 0
+        assert bundle["source"] and bundle["license"]
+        assert len(bundle["generator_revision"]) == 40
+
+
+def test_golden_bundle_targets_the_user_cache(capsys) -> None:
+    module = _load_fetch_assets()
+
+    assert module.main(["--bundle", "golden-v1", "--dry-run"]) == 0
+
+    out = capsys.readouterr().out
+    assert "golden-v1" in out
+    assert "Destination:     cache" in out
+
+
+def test_asset_download_rejects_wrong_size(tmp_path, monkeypatch) -> None:
+    module = _load_fetch_assets()
+    bundle = module.AssetBundle(
+        name="small",
+        url="https://example.invalid/small.tar.gz",
+        sha256="0" * 64,
+        size_bytes=4,
+        source="test",
+        license="test",
+        generator_revision="0" * 40,
+        destination="repository",
+        default=False,
+        common_paths=(),
+    )
+    monkeypatch.setattr(module.urllib.request, "urlopen", lambda _: io.BytesIO(b"bad"))
+
+    with pytest.raises(SystemExit, match="Size mismatch"):
+        module._download_and_extract_bundle(bundle, dest=tmp_path, force=False)
+
+
 def test_fetch_assets_safe_extract_rejects_path_traversal(tmp_path) -> None:
     module = _load_fetch_assets()
     payload = io.BytesIO()
@@ -63,3 +115,32 @@ def test_fetch_assets_safe_extract_rejects_path_traversal(tmp_path) -> None:
             module._safe_extract(tf, tmp_path)
 
     assert not (tmp_path.parent / "outside.txt").exists()
+
+
+def test_fetch_assets_safe_extract_rejects_links(tmp_path) -> None:
+    module = _load_fetch_assets()
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as tf:
+        info = tarfile.TarInfo("link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "../outside.txt"
+        tf.addfile(info)
+    payload.seek(0)
+
+    with tarfile.open(fileobj=payload, mode="r:gz") as tf:
+        with pytest.raises(SystemExit, match="archive link"):
+            module._safe_extract(tf, tmp_path)
+
+
+def test_no_tracked_file_exceeds_one_mib() -> None:
+    if not (ROOT / ".git").exists():
+        pytest.skip("tracked-file gate requires a git checkout")
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    paths = [ROOT / path for path in result.stdout.decode().rstrip("\0").split("\0") if path]
+    oversized = [path.relative_to(ROOT) for path in paths if path.stat().st_size > 2**20]
+    assert not oversized

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,8 +2,15 @@
 
 This directory contains developer-facing tools, not end-user examples.
 
-- `fetch_assets.py`: downloads optional large validation/reference assets
-  (reference netCDF files and wout fixtures) from GitHub release bundles.
+- `fetch_assets.py`: downloads optional validation assets and verifies their
+  byte size and SHA-256 before extraction. `assets/manifest.json` records the
+  release URL, provenance, license, generator revision, and installed paths.
+  Repository fixtures are the default; VMEC2000 goldens use the user cache:
+
+  ```console
+  python tools/fetch_assets.py
+  python tools/fetch_assets.py --bundle golden-v1
+  ```
 
 - `profile_hotpaths.py`: cold-vs-warm wall-time + peak-RSS profile of the
   production hot paths (fixed-boundary solve and the differentiable

--- a/tools/fetch_assets.py
+++ b/tools/fetch_assets.py
@@ -4,60 +4,24 @@
 Generated optimization figures are intentionally not part of this asset bundle:
 rerun the optimization renderers when report-quality panels are needed.
 """
+
 from __future__ import annotations
 
 import argparse
 import hashlib
 import io
+import json
 import shutil
 import tarfile
 import urllib.request
-from dataclasses import dataclass
 from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "assets" / "manifest.json"
 
-REFERENCE_TAG = "assets-20260316-nc"
-# NOTE: the published release tarball keeps the pre-rename "vmec_jax_" prefix --
-# it was uploaded before the vmec_jax -> vmex repo rename, and only the repo and
-# its code were renamed, not the already-published GitHub release assets. Keep
-# this in sync with the actual asset filename, not the current package name.
-REFERENCE_ASSET_NAME = "vmec_jax_assets_20260316_nc_only.tar.gz"
-REFERENCE_URL = (
-    "https://github.com/uwplasma/vmex/releases/download/"
-    f"{REFERENCE_TAG}/{REFERENCE_ASSET_NAME}"
-)
-REFERENCE_SHA256 = "3344fc2401fffed240ee57ae741ec521594c592627c76dae203503f485e4c0d8"
-
-WOUT_FIXTURES_TAG = "assets-20260526-wout-fixtures"
-# Same pre-rename asset-filename caveat as REFERENCE_ASSET_NAME above.
-WOUT_FIXTURES_ASSET_NAME = "vmec_jax_wout_fixtures_20260526.tar.gz"
-WOUT_FIXTURES_URL = (
-    "https://github.com/uwplasma/vmex/releases/download/"
-    f"{WOUT_FIXTURES_TAG}/{WOUT_FIXTURES_ASSET_NAME}"
-)
-WOUT_FIXTURES_SHA256 = "e9fd844a4ebed043576eec8ac2b17f7ff3e2a0e0a1b5adfc89742139101e00f9"
-
-REFERENCE_ASSET_PATHS = (
-    "examples/data/mgrid_cth_like.nc",
-    "examples/data/mgrid_d3d_ef.nc",
-    "examples/data/wout_*_reference.nc",
-    "examples/data/single_grid/mgrid_cth_like.nc",
-    "examples/data/single_grid/mgrid_d3d_ef.nc",
-    "examples/data/single_grid/wout_*_reference.nc",
-)
-
-WOUT_FIXTURE_PATHS = (
-    "examples/data/wout_*.nc",
-    "examples/data/single_grid/wout_*.nc",
-    "docs/_static/readme_best_cases/*/wout_*.nc",
-    "docs/_static/qi_readme_cases/*/wout_*.nc",
-)
-
-ASSET_PATH_REWRITES = (
-    ("examples_single_grid/data", "examples/data/single_grid"),
-)
+ASSET_PATH_REWRITES = (("examples_single_grid/data", "examples/data/single_grid"),)
 
 
 @dataclass(frozen=True)
@@ -65,6 +29,12 @@ class AssetBundle:
     name: str
     url: str
     sha256: str
+    size_bytes: int
+    source: str
+    license: str
+    generator_revision: str
+    destination: str
+    default: bool
     common_paths: tuple[str, ...]
 
     @property
@@ -72,21 +42,21 @@ class AssetBundle:
         return f".assets_installed_{self.name}.txt"
 
 
-DEFAULT_BUNDLES = (
-    AssetBundle(
-        name="reference-nc",
-        url=REFERENCE_URL,
-        sha256=REFERENCE_SHA256,
-        common_paths=REFERENCE_ASSET_PATHS,
-    ),
-    AssetBundle(
-        name="wout-fixtures",
-        url=WOUT_FIXTURES_URL,
-        sha256=WOUT_FIXTURES_SHA256,
-        common_paths=WOUT_FIXTURE_PATHS,
-    ),
-)
-BUNDLES_BY_NAME = {bundle.name: bundle for bundle in DEFAULT_BUNDLES}
+def _load_bundles() -> tuple[AssetBundle, ...]:
+    data = json.loads(MANIFEST_PATH.read_text())
+    if data.get("schema") != "vmex.release-assets/1":
+        raise RuntimeError(f"unsupported asset manifest schema in {MANIFEST_PATH}")
+    bundles = tuple(
+        AssetBundle(**{**record, "common_paths": tuple(record["common_paths"])}) for record in data["bundles"]
+    )
+    if any(bundle.destination not in {"cache", "repository"} for bundle in bundles):
+        raise RuntimeError(f"invalid asset destination in {MANIFEST_PATH}")
+    return bundles
+
+
+ALL_BUNDLES = _load_bundles()
+DEFAULT_BUNDLES = tuple(bundle for bundle in ALL_BUNDLES if bundle.default)
+BUNDLES_BY_NAME = {bundle.name: bundle for bundle in ALL_BUNDLES}
 
 
 def _sha256(data: bytes) -> str:
@@ -104,10 +74,15 @@ def _safe_extract(tf: tarfile.TarFile, dest: Path, members=None) -> None:
     dest_resolved = dest.resolve()
     selected = tf.getmembers() if members is None else members
     for member in selected:
+        if member.issym() or member.islnk():
+            raise SystemExit(f"Refusing to extract archive link: {member.name}")
         target = (dest_resolved / member.name).resolve()
         if target != dest_resolved and dest_resolved not in target.parents:
             raise SystemExit(f"Refusing to extract path outside destination: {member.name}")
-    tf.extractall(dest_resolved, members=selected)
+    if hasattr(tarfile, "data_filter"):
+        tf.extractall(dest_resolved, members=selected, filter="data")
+    else:  # Python 3.10 and 3.11
+        tf.extractall(dest_resolved, members=selected)
 
 
 def _print_bundle_info(bundles: Sequence[AssetBundle]) -> None:
@@ -115,7 +90,12 @@ def _print_bundle_info(bundles: Sequence[AssetBundle]) -> None:
     for bundle in bundles:
         print(f"- {bundle.name}")
         print(f"  URL:             {bundle.url}")
+        print(f"  Expected bytes:  {bundle.size_bytes}")
         print(f"  Expected SHA256: {bundle.sha256 or '(not checked)'}")
+        print(f"  Source:          {bundle.source}")
+        print(f"  License:         {bundle.license}")
+        print(f"  Generator:       {bundle.generator_revision}")
+        print(f"  Destination:     {bundle.destination}")
         print("  Common installed paths:")
         for path in bundle.common_paths:
             print(f"    {path}")
@@ -151,16 +131,21 @@ def _selected_default_bundles(names: Sequence[str] | None) -> tuple[AssetBundle,
 
 
 def _download_and_extract_bundle(bundle: AssetBundle, *, dest: Path, force: bool) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
     marker = dest / bundle.marker_name
     if marker.exists() and not force:
-        print(f"Assets already installed for bundle {bundle.name!r} at {dest}. Use --force to re-download.")
-        _migrate_release_asset_paths(dest)
-        return
+        if marker.read_text().splitlines() == [bundle.url, bundle.sha256]:
+            print(f"Assets already installed for bundle {bundle.name!r} at {dest}. Use --force to re-download.")
+            _migrate_release_asset_paths(dest)
+            return
+        print(f"Replacing stale marker for bundle {bundle.name!r}")
 
     print(f"Downloading {bundle.name} assets from: {bundle.url}")
     with urllib.request.urlopen(bundle.url) as resp:
         data = resp.read()
 
+    if bundle.size_bytes and len(data) != bundle.size_bytes:
+        raise SystemExit(f"Size mismatch for {bundle.name}: expected {bundle.size_bytes}, got {len(data)}")
     digest = _sha256(data)
     if bundle.sha256 and digest != bundle.sha256:
         raise SystemExit(f"SHA256 mismatch for {bundle.name}: expected {bundle.sha256}, got {digest}")
@@ -174,12 +159,10 @@ def _download_and_extract_bundle(bundle: AssetBundle, *, dest: Path, force: bool
             # one poisoned the nightly free-boundary golden test
             # (edge zmns 17.8% error, 2026-07-12).  --force restores the
             # old overwrite-everything behavior.
-            members = [m for m in tf.getmembers()
-                       if not (dest / m.name).exists()]
+            members = [m for m in tf.getmembers() if not (dest / m.name).exists()]
             skipped = len(tf.getmembers()) - len(members)
             if skipped:
-                print(f"  (skipping {skipped} already-present files; "
-                      "--force overwrites)")
+                print(f"  (skipping {skipped} already-present files; --force overwrites)")
             _safe_extract(tf, dest, members=members)
         else:
             _safe_extract(tf, dest)
@@ -198,7 +181,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     p.add_argument("--url", type=str, default="", help="Custom asset tarball URL. Overrides --bundle.")
     p.add_argument("--sha256", type=str, default="", help="Expected SHA256 for --url.")
-    p.add_argument("--dest", type=str, default=str(REPO_ROOT), help="Destination repo root.")
+    p.add_argument(
+        "--dest",
+        type=str,
+        help="Override the manifest destination (repository or user cache).",
+    )
     p.add_argument("--force", action="store_true", help="Re-download even if files already exist.")
     p.add_argument("--list", action="store_true", help="Print the default bundle location and common paths.")
     p.add_argument("--dry-run", action="store_true", help="Print what would be downloaded without fetching it.")
@@ -210,6 +197,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 name="custom",
                 url=args.url,
                 sha256=args.sha256,
+                size_bytes=0,
+                source="custom URL",
+                license="user supplied",
+                generator_revision="user supplied",
+                destination="repository",
+                default=False,
                 common_paths=(),
             ),
         )
@@ -222,10 +215,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("Dry run: no files downloaded or extracted.")
         return 0
 
-    dest = Path(args.dest).expanduser().resolve()
+    dest_override = Path(args.dest).expanduser().resolve() if args.dest else None
     for bundle in bundles:
+        dest = dest_override
+        if dest is None:
+            dest = Path.home() / ".cache" / "vmex" / bundle.name if bundle.destination == "cache" else REPO_ROOT
         _download_and_extract_bundle(bundle, dest=dest, force=bool(args.force))
-    _migrate_release_asset_paths(dest)
     print("Assets installed.")
     return 0
 

--- a/tools/fetch_assets.py
+++ b/tools/fetch_assets.py
@@ -76,6 +76,8 @@ def _safe_extract(tf: tarfile.TarFile, dest: Path, members=None) -> None:
     for member in selected:
         if member.issym() or member.islnk():
             raise SystemExit(f"Refusing to extract archive link: {member.name}")
+        if not (member.isfile() or member.isdir()):
+            raise SystemExit(f"Refusing to extract special archive member: {member.name}")
         target = (dest_resolved / member.name).resolve()
         if target != dest_resolved and dest_resolved not in target.parents:
             raise SystemExit(f"Refusing to extract path outside destination: {member.name}")


### PR DESCRIPTION
## Goal

Make optional VMEX validation assets reproducible, auditable, safe to fetch, and absent from the normal git tree. Preserve existing user paths while giving CI and contributors one authoritative asset contract.

## What this PR achieves

- Adds `assets/manifest.json` with stable release URL, byte size, SHA-256, source, license, generator revision, destination, and common installed paths for the reference NetCDF/mgrid bundle, WOUT fixtures, and VMEC2000 golden outputs.
- Replaces duplicated fetcher constants with the manifest and verifies both byte size and SHA-256 before extraction.
- Rejects path traversal, links, and special archive members on every supported Python version; uses the standard data filter when available; preserves the no-clobber default; and refreshes stale installation markers.
- Adds an explicit `golden-v1` fetch that defaults to `~/.cache/vmex/golden-v1`; repository fixtures keep their existing default destination.
- Makes PR core physics and nightly parity fetch the golden bundle explicitly before tests fork, while retaining the existing local override/fallback behavior.
- Adds a gate rejecting tracked files larger than 1 MiB. The current tree has none; input decks and analytic fixtures remain in git.
- Includes the asset manifest and fetch tool in the source distribution and documents the contributor/user workflow.

## User and numerical impact

No equilibrium, diagnostic, optimizer, device, or output-schema code changes. Existing `python tools/fetch_assets.py` behavior for repository fixtures is preserved. The new `--bundle golden-v1` command provides an explicit verified user-cache path. Custom URLs and `--dest` remain supported.

## Validation

- Exact final head: `709fd730`.
- Protected CI: all 11 jobs passed, including explicit Linux golden prefetch and the aggregate `PR gate` ([run 30533951439](https://github.com/uwplasma/vmex/actions/runs/30533951439)).
- Real download/extraction: 81,559,426-byte reference bundle, 9,801,091-byte WOUT bundle, and 2,167,603-byte golden bundle; all size and SHA-256 checks passed.
- Extracted 116 release files and all nine golden case directories. A clean post-hardening golden fetch installed 37 files, and a second invocation reused its verified marker.
- Focused fetcher tests: 9 passed.
- Fast PR selector: 292 passed, 6 explicit skips in 7.38 s.
- Golden solver representative: passed.
- Manifest ownership: 1,012 collected tests, 82 modules, 11 campaigns.
- Ruff, mypy, strict Sphinx, workflow YAML parsing, wheel/sdist builds, extracted-sdist tests, tracked-size gate, changed-line coverage, and diff checks pass.

## Remaining toward the larger roadmap

No work remains in this PR. Historical large blobs are intentionally deferred to the repository-slimming phase because rewriting shared git history is a separate coordinated operation. The full bounded nightly campaign continues independently as the final PR 0.3 post-merge evidence.
