### PR TITLE
ci: reserve hosted capacity for review gates

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -147,6 +147,7 @@ jobs:
     timeout-minutes: 50
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         shard: [a1, a2, b, c1, c2, c3, d]
     steps:
@@ -270,6 +271,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         shard: [a, b, c]
     steps:
@@ -429,6 +431,7 @@ jobs:
     timeout-minutes: 150
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         shard: [core-a-c, core-d-f0, core-fb-a, core-fb-b, core-g-h,
                 core-i, core-i-grad, core-j-m, core-n-s, core-t-z,

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -44,7 +44,8 @@ The workflows obtain their selectors from the manifest:
   representative fixed-boundary, free-boundary/NESTOR, mirror, device, and AD
   paths. Changed executable lines must be at least 95% covered.
 - ``Nightly`` owns the complete integration/oracle matrix and aggregate
-  package coverage.
+  package coverage. Its matrices leave hosted capacity for pull-request
+  checks.
 - ``Weekly high resolution`` owns campaigns that exceed the 150-minute cold
   nightly budget.
 - ``Trusted GPU physics`` is an explicit self-hosted dispatch.

--- a/tests/test_test_manifest.py
+++ b/tests/test_test_manifest.py
@@ -88,5 +88,6 @@ def test_workflow_selects_manifest_lanes() -> None:
     for name in ("ci.yml", "gpu.yml", "nightly.yml", "weekly.yml"):
         assert "tools/test_manifest.py select" in workflows[name]
     assert "name: PR gate" in workflows["ci.yml"]
+    assert workflows["nightly.yml"].count("max-parallel:") == 3
     for stale in ("A1_FILES=", "C2_FILES=", "core-a-c)"):
         assert stale not in "".join(workflows.values())


### PR DESCRIPTION
## Goal

Ensure a manually dispatched nightly campaign cannot starve `main` or pull-request review gates.

## Observed failure

The first post-#85 nightly dispatch started enough independent hosted jobs that the green `main` coverage aggregator and every PR #86 job remained queued. Eighteen nightly jobs completed successfully before the campaign was stopped; no physics test failed.

## Change

- Bound parity to two concurrent shards.
- Bound gradient coverage to two concurrent shards.
- Bound the exhaustive full matrix to three concurrent shards.
- Leave the three singleton nightly jobs unchanged.

The nightly maximum is therefore ten concurrent hosted jobs (2 + 2 + 3 matrix slots and three singleton jobs), leaving capacity for the nine review jobs. Test ownership, selectors, tolerances, timeouts, coverage, and physics content are unchanged.

## Validation

- Workflow YAML parses.
- Manifest/workflow guard: 5 passed.
- Ruff and strict Sphinx pass.
- Diff check passes.

## Remaining

After merge, redispatch nightly from `main` and confirm PR #86 starts concurrently and the complete campaign stays inside its 150-minute cold budget.
