### PR TITLE
CI: include full physics in nightly coverage

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -380,7 +380,7 @@ jobs:
     name: Coverage gate (>= 95%)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [parity, gradient, examples, device-rig, optional-integrations]
+    needs: [parity, gradient, examples, device-rig, optional-integrations, full]
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -401,7 +401,9 @@ jobs:
 
       - name: Combine shards and enforce the gate
         run: |
-          coverage combine coverage.parity-a1 coverage.parity-a2 coverage.parity-b coverage.parity-c1 coverage.parity-c2 coverage.parity-c3 coverage.parity-d coverage.gradient-a coverage.gradient-b coverage.gradient-c coverage.examples coverage.device-rig coverage.optional
+          files=(coverage.*)
+          test "${#files[@]}" -eq 37
+          coverage combine "${files[@]}"
           # The mirror release audit reaches 95% only after appending nightly
           # fixed/free adjoint tests. The fast core artifacts intentionally
           # exclude those tests, so do not mix a partial mirror number into
@@ -444,7 +446,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install ".[coils,turbulence,freeb]"
-          python -m pip install pytest
+          python -m pip install pytest pytest-cov
 
       - name: Cache golden fixtures and compiled kernels
         uses: actions/cache@v6.1.0
@@ -496,7 +498,8 @@ jobs:
           # Some optimization tests are silent for more than 15 minutes.
           # Keep the hosted runner live without changing pytest semantics.
           pytest -q -m "not weekly" $FILES --durations=25 \
-            --vmex-report="test-report-full-${{ matrix.shard }}.json" &
+            --vmex-report="test-report-full-${{ matrix.shard }}.json" \
+            --cov=vmex --cov-report= &
           pytest_pid=$!
           while kill -0 "$pytest_pid" 2>/dev/null; do
             sleep 60
@@ -506,11 +509,17 @@ jobs:
           done
           wait "$pytest_pid"
 
-      - name: Upload test report
+      - name: Stash coverage data
+        if: always()
+        run: test ! -f .coverage || mv .coverage "coverage.full-${{ matrix.shard }}"
+
+      - name: Upload test report and coverage
         if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: test-report-full-${{ matrix.shard }}
-          path: test-report-full-${{ matrix.shard }}.json
+          name: coverage-full-${{ matrix.shard }}
+          path: |
+            coverage.full-${{ matrix.shard }}
+            test-report-full-${{ matrix.shard }}.json
           if-no-files-found: warn
           retention-days: 7

--- a/tests/test_test_manifest.py
+++ b/tests/test_test_manifest.py
@@ -88,6 +88,10 @@ def test_workflow_selects_manifest_lanes() -> None:
     for name in ("ci.yml", "gpu.yml", "nightly.yml", "weekly.yml"):
         assert "tools/test_manifest.py select" in workflows[name]
     assert "name: PR gate" in workflows["ci.yml"]
-    assert workflows["nightly.yml"].count("max-parallel:") == 3
+    nightly = workflows["nightly.yml"]
+    assert nightly.count("max-parallel:") == 3
+    assert 'test "${#files[@]}" -eq 37' in nightly
+    assert 'coverage.full-${{ matrix.shard }}' in nightly
+    assert "--cov=vmex --cov-report=" in nightly
     for stale in ("A1_FILES=", "C2_FILES=", "core-a-c)"):
         assert stale not in "".join(workflows.values())


### PR DESCRIPTION
## Goal

Make the nightly `>=95%` aggregate coverage gate measure the complete nightly suite. The bounded post-merge run exposed that all 24 full-physics shards were tested without recording coverage, leaving the 13 fast artifacts at 94% even though the full tests exercise the omitted paths.

## Changes

- collect `vmex` coverage in every existing full-physics shard without changing its tests, selectors, or concurrency limits;
- upload each test report and coverage database together;
- make the coverage gate wait for the full matrix;
- require exactly 37 coverage databases (7 parity + 3 gradient + 3 singleton + 24 full) before combining;
- preserve the 95% threshold and add a workflow-contract regression assertion.

## Validation

- workflow parses as YAML;
- `tests/test_test_manifest.py`: 5 passed;
- Ruff and `git diff --check` pass;
- a representative pytest-cov invocation produced a non-empty coverage database.

## Remaining before merge

- protected PR checks must pass;
- after merge, rerun the bounded nightly and require all physics shards and the aggregate 95% gate to pass.

This changes CI evidence only. It does not modify solver code, physics, public APIs, test ownership, or the set of tests executed.
