### PR TITLE
Consolidate and validate implicit block linear responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         include:
           - lane: core
             selector: pr-physics-core
+          - lane: implicit-response
+            selector: pr-implicit-response
           - lane: mirror-equilibrium
             selector: pr-mirror-equilibrium
           - lane: mirror-field

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -567,9 +567,15 @@ block-tridiagonal — ``ns`` dense :math:`(3\,mn \times 3\,mn)` blocks.
 because the 1D preconditioner's inverse is.) The blocks are assembled with
 3-colored ``jax.jvp`` probes — a cost independent of the dof count —
 factored once with SOLVAX's block-Thomas elimination (the BCYCLIC
-analogue), and back-substituted for every dof right-hand side; a short
-warm-started GMRES pass against the preconditioned system certifies each
-column to the same tolerance as the per-column path. Measured: 33x on the
+analogue), and back-substituted for every dof right-hand side; a
+warm-started GMRES pass against the preconditioned system uses the configured
+iteration budget and certifies each column to the same tolerance as the
+per-column path. The stored SOLVAX factors also serve the exact transposed
+raw system; :func:`~vmex.core.implicit.implicit_state_tangent_multi_rhs` and
+the opt-in ``solver="block"`` form of
+:func:`~vmex.core.implicit.implicit_state_pullback_multi_rhs` expose the paired
+forward and reverse responses with per-right-hand-side residual reports.
+Measured: 33x on the
 Jacobian phase of the benchmark optimization step (see
 :doc:`optimization`). The same per-dof responses :math:`dz_j` double as a
 first-order perturbation warm start for the optimizer's next trial solves —

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -254,8 +254,9 @@ default:
   1e-14), so ``ns`` dense ``(3mn, 3mn)`` blocks are assembled with
   3-colored ``jax.jvp`` probes — a cost independent of the dof count —
   factored once (``solvax.block_thomas``), and back-substituted for every
-  dof right-hand side.  A short warm-started GMRES corrector certifies each
-  column to the same ``adjoint_tol`` as the old path.  Measured: the warm
+  dof right-hand side.  A warm-started GMRES corrector uses the configured
+  budget and certifies each column to the same ``adjoint_tol`` as the old
+  path.  Measured: the warm
   Jacobian phase drops 20.35 s to 0.61 s (**33x**); ``jac_solver="gmres"``
   (one preconditioned GMRES per dof) remains as a fallback.
   A true width-three nonlinear row kernel is parity-tested, but its direct

--- a/docs/parallelization.rst
+++ b/docs/parallelization.rst
@@ -22,7 +22,12 @@ already uses several cores. This is automatic and needs no user action.
 :func:`vmex.core.implicit.implicit_state_pullback_multi_rhs` uses
 ``jax.vmap`` over the adjoint right-hand sides, so several state cotangents for
 the same fixed point share one implicit linearization and one set of GMRES
-operators. This is the batching behind the multi-RHS Jacobian assembly.
+operators. For vector forward responses,
+:func:`vmex.core.implicit.implicit_state_tangent_multi_rhs` assembles and
+factors the nearest-neighbor raw radial operator once, solves all right-hand
+sides, and reports each corrected residual. The same factorization supports
+the opt-in block-preconditioned transpose pullback; ordinary reverse AD keeps
+the established GCROT default.
 
 **Across independent solves (this module).**
 An ensemble of independent equilibria — a parameter scan, an ensemble

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -95,6 +95,8 @@
       "tests/test_solver_end_to_end.py::test_converges_with_golden_iteration_count[solovev]",
       "tests/test_implicit_grad.py::test_solovev_gradients_vs_fd",
       "tests/test_implicit_grad.py::test_jdotb_and_glasser_gradients_vs_frozen_path_fd[solovev]",
+      "tests/test_implicit_multi_rhs.py::test_block_response_forward_transpose_and_fd",
+      "tests/test_optimize.py::test_least_squares_implicit_jac_solver_block",
       "tests/test_freeboundary.py::test_nestor_skip_branch_matches_full_solve",
       "tests/test_freeboundary.py::test_jac75_retry_rebuilds_vacuum_and_converges",
       "tests/test_freeboundary.py::test_vacuum_step_skip_reuses_cached_matrix",

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -95,8 +95,6 @@
       "tests/test_solver_end_to_end.py::test_converges_with_golden_iteration_count[solovev]",
       "tests/test_implicit_grad.py::test_solovev_gradients_vs_fd",
       "tests/test_implicit_grad.py::test_jdotb_and_glasser_gradients_vs_frozen_path_fd[solovev]",
-      "tests/test_implicit_multi_rhs.py::test_block_response_forward_transpose_and_fd",
-      "tests/test_optimize.py::test_least_squares_implicit_jac_solver_block",
       "tests/test_freeboundary.py::test_nestor_skip_branch_matches_full_solve",
       "tests/test_freeboundary.py::test_jac75_retry_rebuilds_vacuum_and_converges",
       "tests/test_freeboundary.py::test_vacuum_step_skip_reuses_cached_matrix",
@@ -106,6 +104,10 @@
       "tests/test_freeboundary_diff.py::test_synthetic_surface_gradient_fd_validates",
       "tests/test_printing.py::test_compile_notice_variants",
       "tests/test_printing.py::test_emit_flushed_writes_and_flushes"
+    ],
+    "pr-implicit-response": [
+      "tests/test_implicit_multi_rhs.py::test_block_response_forward_transpose_and_fd",
+      "tests/test_optimize.py::test_least_squares_implicit_jac_solver_block"
     ],
     "pr-physics-mirror-spline": [
       "tests/mirror/test_analytic.py",

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -745,6 +745,34 @@ def test_block_response_cpu_gpu_parity():
         )
 
 
+@_requires_gpu
+def test_implicit_optimizer_nondefault_gpu_parity():
+    """Optimizer constants must be created directly on the selected GPU."""
+    devices = jax.devices("gpu")
+    if len(devices) < 2:
+        pytest.skip("needs two GPUs")
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    results = [
+        optimize.least_squares(
+            [(optimize.aspect_ratio, 4.0, 1.0)],
+            inp,
+            max_mode=1,
+            jac="implicit",
+            jac_solver="block",
+            max_nfev=1,
+            device=device,
+        )
+        for device in devices[:2]
+    ]
+    assert all(np.all(np.isfinite(result.jac)) for result in results)
+    np.testing.assert_allclose(
+        results[1].fun, results[0].fun, rtol=2e-9, atol=1e-12
+    )
+    np.testing.assert_allclose(
+        results[1].jac, results[0].jac, rtol=2e-8, atol=1e-11
+    )
+
+
 # (device, ftol, max_iterations) -> reference audit.  Memoized so the three
 # lanes per rig do not repeat the 7-metric reference sweep; computed lazily so
 # the cold-start lane can run its target-device audit FIRST.

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -685,6 +685,66 @@ def _assert_audit_matches(inp, reference, audit, *, value_rtol, grad_rtol,
             err_msg=f"{name} gradient diverged on {label}")
 
 
+def _block_response_audit(inp, device):
+    with device_policy.device_scope(device):
+        cfg = im.make_config(inp, ftol=1e-13, max_iterations=2000)
+        params = im.params_from_input(inp)
+        state, mask = im.solve_implicit_with_aux(params, cfg)
+        zero = jax.tree.map(jax.numpy.zeros_like, params)
+        tangent = dataclasses.replace(
+            zero, rbc=zero.rbc.at[inp.ntor, 1].set(1.0)
+        )
+        tangent_batch = jax.tree.map(lambda value: value[None], tangent)
+        state_tangent, report = im.implicit_state_tangent_multi_rhs(
+            params, cfg, state, mask, tangent_batch,
+            probe_chunk_size=4, response_chunk_size=1,
+        )
+        cotangent = jax.tree.map(
+            lambda value: jax.numpy.ones((1,) + value.shape, value.dtype),
+            state,
+        )
+        pullback = im.implicit_state_pullback_multi_rhs(
+            params, cfg, state, mask, cotangent, solver="block",
+            probe_chunk_size=4, response_chunk_size=1,
+        )
+        direction = jax.jvp(
+            lambda x, p: im.aspect_ratio(
+                x, im.runtime_from_params(p, cfg)
+            ),
+            (state, params),
+            (jax.tree.map(lambda value: value[0], state_tangent), tangent),
+        )[1]
+        result = (
+            state_tangent, report, direction, pullback.rbc[0, inp.ntor, 1]
+        )
+        return jax.tree.map(
+            lambda value: value.block_until_ready(), result
+        )
+
+
+@_requires_gpu
+def test_block_response_cpu_gpu_parity():
+    """Factor-once tangents and transpose responses obey the device contract."""
+    _assert_no_platform_pins()
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    devices = (jax.devices("cpu")[0], *jax.devices("gpu"))
+    audits = [_block_response_audit(inp, device) for device in devices]
+    reference = audits[0]
+    for device, (tangent, report, direction, pullback) in zip(
+        devices, audits, strict=True
+    ):
+        assert all(
+            value.devices() == {device} for value in jax.tree.leaves(tangent)
+        )
+        assert np.all(np.asarray(report.converged))
+        np.testing.assert_allclose(
+            direction, reference[2], rtol=2e-9, atol=1e-12
+        )
+        np.testing.assert_allclose(
+            pullback, reference[3], rtol=2e-9, atol=1e-12
+        )
+
+
 # (device, ftol, max_iterations) -> reference audit.  Memoized so the three
 # lanes per rig do not repeat the 7-metric reference sweep; computed lazily so
 # the cold-start lane can run its target-device audit FIRST.

--- a/tests/test_implicit_multi_rhs.py
+++ b/tests/test_implicit_multi_rhs.py
@@ -78,7 +78,6 @@ def test_multi_rhs_pullback_matches_scalar_vjp():
             assert np.max(np.abs(a - b)) <= 1e-8 * scale, "multi-rhs != scalar VJP"
 
 
-@pytest.mark.full
 def test_block_response_forward_transpose_and_fd():
     """One factorization serves tangent and transpose responses accurately."""
     inp, cfg, p0 = _solovev_setup()

--- a/tests/test_implicit_multi_rhs.py
+++ b/tests/test_implicit_multi_rhs.py
@@ -9,6 +9,7 @@ exactly, so the batched path is a pure efficiency win with identical gradients.
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 
 import jax
@@ -17,6 +18,7 @@ import numpy as np
 import pytest
 
 from vmex.core import implicit as im
+from vmex.core.errors import AdjointSolveError
 from vmex.core.input import VmecInput
 
 DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
@@ -29,6 +31,13 @@ def _solovev_setup():
     return inp, cfg, p0
 
 
+def _tree_dot(left, right):
+    return sum(
+        jnp.vdot(a, b).real
+        for a, b in zip(jax.tree.leaves(left), jax.tree.leaves(right))
+    )
+
+
 def test_solve_implicit_with_aux_matches_solve_implicit():
     """The aux helper returns the same converged state as solve_implicit."""
     _, cfg, p0 = _solovev_setup()
@@ -38,6 +47,10 @@ def test_solve_implicit_with_aux_matches_solve_implicit():
         assert np.allclose(np.asarray(a), np.asarray(b), rtol=0, atol=1e-12)
     # the mask is a 0/1 SpectralState of the same structure as the state
     assert jax.tree.structure(mask) == jax.tree.structure(state_ref)
+    with pytest.raises(ValueError, match="solver"):
+        im.implicit_state_pullback_multi_rhs(
+            p0, cfg, state_aux, mask, state_aux, solver="dense"
+        )
 
 
 @pytest.mark.full
@@ -63,3 +76,129 @@ def test_multi_rhs_pullback_matches_scalar_vjp():
             a = np.asarray(a); b = np.asarray(b)
             scale = np.max(np.abs(a)) + 1e-30
             assert np.max(np.abs(a - b)) <= 1e-8 * scale, "multi-rhs != scalar VJP"
+
+
+@pytest.mark.full
+def test_block_response_forward_transpose_and_fd():
+    """One factorization serves tangent and transpose responses accurately."""
+    inp, cfg, p0 = _solovev_setup()
+    state, mask = im.solve_implicit_with_aux(p0, cfg)
+    zero = jax.tree.map(jnp.zeros_like, p0)
+    tangents = (
+        dataclasses.replace(
+            zero, rbc=zero.rbc.at[inp.ntor, 1].set(1.0)
+        ),
+        dataclasses.replace(zero, pres_scale=jnp.ones_like(zero.pres_scale)),
+    )
+    tangent_batch = jax.tree.map(lambda *x: jnp.stack(x), *tangents)
+    state_tangent, report = im.implicit_state_tangent_multi_rhs(
+        p0, cfg, state, mask, tangent_batch,
+        probe_chunk_size=4, response_chunk_size=2,
+    )
+    assert np.all(np.asarray(report.converged))
+    assert np.all(
+        np.asarray(report.residual_norm) <= np.asarray(report.tolerance)
+    )
+
+    keys = jax.random.split(jax.random.PRNGKey(4), 2)
+    cotangents = jax.tree.map(
+        lambda value: jnp.stack([
+            jax.random.normal(key, value.shape, value.dtype) for key in keys
+        ]),
+        state,
+    )
+    pullback = im.implicit_state_pullback_multi_rhs(
+        p0, cfg, state, mask, cotangents,
+        solver="block", probe_chunk_size=4, response_chunk_size=2,
+    )
+    lhs = _tree_dot(state_tangent, cotangents)
+    rhs = _tree_dot(tangent_batch, pullback)
+    np.testing.assert_allclose(lhs, rhs, rtol=2e-8, atol=2e-10)
+
+    reference = im.implicit_state_pullback_multi_rhs(
+        p0, cfg, state, mask, cotangents
+    )
+    for got, expected in zip(
+        jax.tree.leaves(pullback), jax.tree.leaves(reference)
+    ):
+        np.testing.assert_allclose(got, expected, rtol=2e-8, atol=2e-10)
+
+    for i, (tangent, step) in enumerate(zip(tangents, (3e-5, 1e-4))):
+        directional = jax.jvp(
+            lambda x, p: im.aspect_ratio(x, im.runtime_from_params(p, cfg)),
+            (state, p0),
+            (jax.tree.map(lambda value: value[i], state_tangent), tangent),
+        )[1]
+        finite_difference, info = im.frozen_path_directional_fd(
+            p0, cfg, im.aspect_ratio, tangent, h=step
+        )
+        assert max(info["newton_res"]) < 1e-8
+        np.testing.assert_allclose(
+            directional, finite_difference, rtol=2e-5, atol=2e-8
+        )
+
+
+@pytest.mark.full
+def test_block_pullback_rejects_unconverged_response():
+    """The opt-in transpose path cannot return an uncertified gradient."""
+    _, cfg, p0 = _solovev_setup()
+    state, mask = im.solve_implicit_with_aux(p0, cfg)
+    impossible = dataclasses.replace(
+        cfg, adjoint_tol=1e-30, adjoint_maxiter=1, adjoint_restart=2
+    )
+    cotangent = jax.tree.map(lambda value: value[None], state)
+    with pytest.raises(AdjointSolveError, match="block-preconditioned GCROT"):
+        im.implicit_state_pullback_multi_rhs(
+            p0, impossible, state, mask, cotangent,
+            solver="block", probe_chunk_size=4,
+        )
+
+
+@pytest.mark.full
+def test_block_response_lasym_parity():
+    """All six LASYM state families share the same forward/transpose engine."""
+    inp0 = VmecInput.from_file(DATA / "input.basic_non_stellsym_simsopt")
+    inp = dataclasses.replace(
+        inp0,
+        ns_array=np.asarray([11]),
+        ftol_array=np.asarray([1e-12]),
+        niter_array=np.asarray([4000]),
+    )
+    cfg = im.make_config(inp, ftol=1e-12, max_iterations=4000)
+    params = im.params_from_input(inp)
+    state, mask = im.solve_implicit_with_aux(params, cfg)
+    assert im._active_state_fields(cfg) == im._STATE_FIELDS
+
+    zero = jax.tree.map(jnp.zeros_like, params)
+    tangent = dataclasses.replace(
+        zero, rbs=zero.rbs.at[inp.ntor + 1, 1].set(1.0)
+    )
+    tangent_batch = jax.tree.map(lambda value: value[None], tangent)
+    state_tangent, report = im.implicit_state_tangent_multi_rhs(
+        params, cfg, state, mask, tangent_batch,
+        probe_chunk_size=4, response_chunk_size=1,
+    )
+    assert bool(np.asarray(report.converged[0]))
+
+    cotangent = jax.tree.map(
+        lambda value: jnp.linspace(
+            -0.2, 0.3, value.size, dtype=value.dtype
+        ).reshape((1,) + value.shape),
+        state,
+    )
+    block = im.implicit_state_pullback_multi_rhs(
+        params, cfg, state, mask, cotangent, solver="block",
+        probe_chunk_size=4, response_chunk_size=1,
+    )
+    reference = im.implicit_state_pullback_multi_rhs(
+        params, cfg, state, mask, cotangent
+    )
+    np.testing.assert_allclose(
+        _tree_dot(state_tangent, cotangent),
+        _tree_dot(tangent_batch, block),
+        rtol=2e-6, atol=2e-9,
+    )
+    for got, expected in zip(
+        jax.tree.leaves(block), jax.tree.leaves(reference)
+    ):
+        np.testing.assert_allclose(got, expected, rtol=2e-6, atol=2e-9)

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -104,7 +104,7 @@ import sys
 import types
 import weakref
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, NamedTuple
 
 import numpy as np
 
@@ -112,8 +112,13 @@ import jax
 import jax.numpy as jnp
 from jax.flatten_util import ravel_pytree
 
-from solvax import gcrot as _solvax_gcrot
-from solvax import gmres as _solvax_gmres
+from solvax import (
+    block_thomas_factor,
+    block_thomas_solve,
+    chunk_map,
+    gcrot as _solvax_gcrot,
+    gmres as _solvax_gmres,
+)
 
 from .device import AUTO, _put_numeric_leaves, resolve_implicit_device
 from .errors import AdjointSolveError, VmecError
@@ -145,9 +150,10 @@ from .transforms import (
 
 __all__ = [
     "ImplicitParams", "ImplicitConfig", "ImplicitSolution",
+    "LinearResponseReport",
     "params_from_input", "input_with_params", "runtime_from_params",
     "make_config", "solve_implicit", "solve_implicit_with_aux",
-    "implicit_state_pullback_multi_rhs", "run",
+    "implicit_state_tangent_multi_rhs", "implicit_state_pullback_multi_rhs", "run",
     "mhd_energy", "plasma_volume", "aspect_ratio", "iota_profile",
     "iota_axis", "iota_edge", "edge_iota", "residual_fn", "adjoint_matvec",
     "frozen_path_directional_fd",
@@ -156,6 +162,15 @@ __all__ = [
 Array = Any
 
 _STATE_FIELDS = ("R_cos", "R_sin", "Z_cos", "Z_sin", "L_cos", "L_sin")
+
+
+class LinearResponseReport(NamedTuple):
+    """Per-right-hand-side residual certificate for an implicit response."""
+
+    residual_norm: Array
+    tolerance: Array
+    iterations: Array
+    converged: Array
 
 
 # ---------------------------------------------------------------------------
@@ -1327,11 +1342,14 @@ def _adjoint_acceptance(cfg: ImplicitConfig, b_norm):
 
 
 def _raise_adjoint_unconverged(cfg: ImplicitConfig, *, iterations: int,
-                               residual_norm: float, tolerance: float):
+                               residual_norm: float, tolerance: float,
+                               method: str | None = None):
+    method = method or (
+        f"GCROT({cfg.adjoint_gcrot_m}, {cfg.adjoint_gcrot_k})"
+    )
     raise AdjointSolveError(
         message=(
-            f"implicit adjoint GCROT({cfg.adjoint_gcrot_m}, "
-            f"{cfg.adjoint_gcrot_k}) solve did not converge: residual "
+            f"implicit adjoint {method} solve did not converge: residual "
             f"{residual_norm:.3e} > acceptance {tolerance:.3e} "
             f"(= {_ADJOINT_RESIDUAL_SLACK:g} x adjoint_tol x ||rhs||) after "
             f"{iterations} Krylov iterations "
@@ -1342,6 +1360,26 @@ def _raise_adjoint_unconverged(cfg: ImplicitConfig, *, iterations: int,
         iterations=int(iterations),
         residual_norm=float(residual_norm),
         tolerance=float(tolerance),
+    )
+
+
+def _tree_norm(tree):
+    return jnp.sqrt(sum(
+        (jnp.vdot(v, v).real for v in jax.tree.leaves(tree)),
+        jnp.asarray(0.0),
+    ))
+
+
+def _linear_response_report(sol, rhs, cfg: ImplicitConfig):
+    b_norm = _tree_norm(rhs)
+    tolerance = _adjoint_acceptance(cfg, b_norm)
+    return LinearResponseReport(
+        residual_norm=sol.residual_norm,
+        tolerance=tolerance,
+        iterations=sol.iterations,
+        converged=jnp.logical_or(
+            sol.converged, sol.residual_norm <= tolerance
+        ),
     )
 
 
@@ -1409,7 +1447,7 @@ def _adjoint_solve(A, b, cfg: ImplicitConfig, *, x0=None, max_restarts=None):
     return unravel(sol.x), sol
 
 
-def _adjoint_solve_gcrot(A, b, cfg: ImplicitConfig):
+def _adjoint_solve_gcrot(A, b, cfg: ImplicitConfig, *, precond=None):
     """Adjoint linear solve ``(dF/dz)^T lambda = b`` via ``solvax.gcrot(m, k)``.
 
     The reverse-pass default (:func:`_solve_implicit_bwd`,
@@ -1419,9 +1457,10 @@ def _adjoint_solve_gcrot(A, b, cfg: ImplicitConfig):
     the small eigendirections a truncated GMRES restart discards, and
     reaches the identical converged ``lambda`` in fewer matvecs / more
     robustly at high poloidal mode number (where plain restarted GMRES
-    stalls short of ``adjoint_tol`` inside its budget).  Cold
-    (``recycle=None``) start; ``m``/``k`` capped at the problem size ``n``
-    so a small system degenerates to an exact single-cycle solve.
+    stalls short of ``adjoint_tol`` inside its budget). ``precond`` optionally
+    supplies a pytree right preconditioner; ``recycle=None``. ``m``/``k`` are
+    capped at the problem size ``n`` so a small system degenerates to an exact
+    single-cycle solve.
 
     Device binding: this call is the adjoint's actual execution site and
     runs HOST-EAGERLY on the caller's thread (section note above) — RHS
@@ -1442,9 +1481,14 @@ def _adjoint_solve_gcrot(A, b, cfg: ImplicitConfig):
     def matvec(v):
         return ravel_pytree(A(unravel(v)))[0]
 
+    def precond_flat(v):
+        return ravel_pytree(precond(unravel(v)))[0]
+
     with _device_context(cfg):
         sol = _solvax_gcrot(
-            matvec, b_flat, rtol=cfg.adjoint_tol, atol=0.0, m=m, k=k,
+            matvec, b_flat,
+            precond=None if precond is None else precond_flat,
+            rtol=cfg.adjoint_tol, atol=0.0, m=m, k=k,
             max_restarts=cfg.adjoint_maxiter,
         )
         x = _checked_adjoint_x(sol, b_flat, cfg)
@@ -1507,6 +1551,272 @@ def _recycled_solve(A, b, cfg: ImplicitConfig, recycle):
     # callers need to decide whether carrying the pair is still worthwhile
     # (see optimize.jacobian_rows_recycled's drift-gated carry).
     return unravel(sol.x), sol
+
+
+@dataclass(frozen=True)
+class _RawBlockSystem:
+    """One factored raw-force linearization and its exact transpose."""
+
+    factors: Any
+    pack: Callable
+    unpack: Callable
+    project: Callable
+    operator: Callable
+    operator_t: Callable
+
+
+def _active_state_fields(cfg: ImplicitConfig) -> tuple[str, ...]:
+    if cfg.resolution.lasym:
+        return _STATE_FIELDS
+    return ("R_cos", "Z_sin", "L_sin")
+
+
+def _raw_block_system(
+    params: ImplicitParams,
+    cfg: ImplicitConfig,
+    frozen: SpectralState,
+    dof_mask: SpectralState,
+    active_fields: tuple[str, ...],
+    probe_chunk_size: int,
+) -> _RawBlockSystem:
+    """Factor the exactly nearest-neighbor raw-force Jacobian once."""
+    if not active_fields:
+        raise ValueError("implicit response has no active state fields")
+    ns = int(cfg.resolution.ns)
+    mn = int(dof_mask.R_cos.shape[1])
+    n_active = len(active_fields)
+    block_size = n_active * mn
+    project = _dof_projector(cfg, dof_mask)
+    z_star = project(frozen)
+    residual = residual_fn(cfg, frozen, dof_mask, formulation="raw")
+
+    def pack(tree):
+        return jnp.concatenate(
+            [getattr(tree, name) for name in active_fields], axis=1
+        )
+
+    def unpack(matrix):
+        parts = dict(zip(
+            active_fields, jnp.split(matrix, n_active, axis=1)
+        ))
+        return SpectralState(**{
+            name: parts.get(name, jnp.zeros((ns, mn), matrix.dtype))
+            for name in _STATE_FIELDS
+        })
+
+    def operator(tangent):
+        return jax.jvp(
+            lambda z: residual(z, params), (z_star,), (tangent,)
+        )[1]
+
+    _, pullback = jax.vjp(lambda z: residual(z, params), z_star)
+    operator_t = lambda cotangent: pullback(cotangent)[0]  # noqa: E731
+
+    colors = jnp.asarray(np.repeat(np.arange(3), block_size))
+    fields = jnp.asarray(np.tile(
+        np.repeat(np.arange(n_active), mn), 3
+    ))
+    columns = jnp.asarray(np.tile(
+        np.tile(np.arange(mn), n_active), 3
+    ))
+    dtype = frozen.R_cos.dtype
+
+    def probe(spec):
+        color, field, column = spec
+        rows = jnp.arange(ns) % 3 == color
+        values = jnp.where(
+            rows[:, None],
+            jax.nn.one_hot(column, mn, dtype=dtype)[None, :],
+            0.0,
+        )
+        stack = (
+            jax.nn.one_hot(field, n_active, dtype=dtype)[:, None, None]
+            * values[None]
+        )
+        tangent = unpack(jnp.concatenate(
+            [stack[i] for i in range(n_active)], axis=1
+        ))
+        response = jax.tree.map(
+            lambda a, b, p: a + b - p,
+            operator(tangent), tangent, project(tangent),
+        )
+        return pack(response)
+
+    probes = chunk_map(
+        probe, (colors, fields, columns),
+        chunk_size=max(1, int(probe_chunk_size)),
+    ).reshape((3, block_size, ns, block_size))
+    rows = jnp.arange(ns)
+
+    def band(offset):
+        values = probes[(rows + offset) % 3, :, rows, :]
+        return jnp.swapaxes(values, 1, 2)
+
+    factors = block_thomas_factor(band(-1), band(0), band(1))
+    return _RawBlockSystem(
+        factors, pack, unpack, project, operator, operator_t
+    )
+
+
+def _raw_block_solve(
+    system: _RawBlockSystem,
+    rhs_batch: SpectralState,
+    cfg: ImplicitConfig,
+    *,
+    transpose: bool = False,
+) -> tuple[SpectralState, LinearResponseReport]:
+    """Solve all raw-force right-hand sides with one stored factorization."""
+    rhs_batch = jax.vmap(system.project)(rhs_batch)
+    packed = jax.vmap(system.pack)(rhs_batch)
+    solution = block_thomas_solve(
+        system.factors, jnp.moveaxis(packed, 0, -1), transpose=transpose
+    )
+    solution = jax.vmap(
+        lambda matrix: system.project(system.unpack(matrix))
+    )(jnp.moveaxis(solution, -1, 0))
+    operator = system.operator_t if transpose else system.operator
+    residual = jax.vmap(
+        lambda x, b: jax.tree.map(jnp.subtract, b, operator(x))
+    )(solution, rhs_batch)
+    residual_norm = jax.vmap(_tree_norm)(residual)
+    tolerance = _adjoint_acceptance(
+        cfg, jax.vmap(_tree_norm)(rhs_batch)
+    )
+    return solution, LinearResponseReport(
+        residual_norm=residual_norm,
+        tolerance=tolerance,
+        iterations=jnp.ones(residual_norm.shape, dtype=jnp.int32),
+        converged=residual_norm <= tolerance,
+    )
+
+
+def _raw_block_apply(
+    system: _RawBlockSystem,
+    rhs: SpectralState,
+    *,
+    transpose: bool = False,
+) -> SpectralState:
+    """Apply one stored raw block inverse without rebuilding its factors."""
+    packed = system.pack(system.project(rhs))[..., None]
+    solution = block_thomas_solve(
+        system.factors, packed, transpose=transpose
+    )[..., 0]
+    return system.project(system.unpack(solution))
+
+
+def _implicit_evolved_tangent_multi_rhs(
+    params: ImplicitParams,
+    cfg: ImplicitConfig,
+    x_star: SpectralState,
+    dof_mask: SpectralState,
+    tangent_batch: ImplicitParams,
+    *,
+    active_fields: tuple[str, ...],
+    probe_chunk_size: int,
+    response_chunk_size: int,
+) -> tuple[SpectralState, LinearResponseReport]:
+    frozen = jax.lax.stop_gradient(x_star)
+    system = _raw_block_system(
+        params, cfg, frozen, dof_mask, active_fields, probe_chunk_size
+    )
+    z_star = system.project(x_star)
+    raw_residual = residual_fn(
+        cfg, frozen, dof_mask, formulation="raw"
+    )
+    residual = residual_fn(cfg, frozen, dof_mask)
+
+    def raw_rhs(tangent):
+        value = jax.jvp(
+            lambda prm: raw_residual(z_star, prm), (params,), (tangent,)
+        )[1]
+        return jax.tree.map(jnp.negative, value)
+
+    initial, _ = _raw_block_solve(
+        system, jax.vmap(raw_rhs)(tangent_batch), cfg
+    )
+
+    def correct(args):
+        tangent, x0 = args
+        rhs = jax.tree.map(
+            jnp.negative,
+            jax.jvp(
+                lambda prm: residual(z_star, prm),
+                (params,), (tangent,),
+            )[1],
+        )
+        solution, krylov = _adjoint_solve(
+            lambda value: jax.jvp(
+                lambda z: residual(z, params),
+                (z_star,), (value,),
+            )[1],
+            rhs, cfg, x0=x0,
+        )
+        return solution, _linear_response_report(krylov, rhs, cfg)
+
+    solution, report = chunk_map(
+        correct, (tangent_batch, initial),
+        chunk_size=max(1, int(response_chunk_size)),
+    )
+    solution = jax.tree.map(
+        lambda value: jnp.where(
+            report.converged.reshape(
+                (report.converged.shape[0],)
+                + (1,) * (value.ndim - 1)
+            ),
+            value, jnp.full_like(value, jnp.nan),
+        ),
+        solution,
+    )
+    return solution, report
+
+
+def implicit_state_tangent_multi_rhs(
+    params: ImplicitParams,
+    cfg: ImplicitConfig,
+    x_star: SpectralState,
+    dof_mask: SpectralState,
+    tangent_batch: ImplicitParams,
+    *,
+    probe_chunk_size: int = 1,
+    response_chunk_size: int = 1,
+) -> tuple[SpectralState, LinearResponseReport]:
+    """State tangents for several parameter directions, factored once.
+
+    The pure-JAX raw-force Jacobian is exactly block tridiagonal in radius.
+    One three-color assembly and SOLVAX factorization therefore initializes
+    every right-hand side; a warm-started solve then certifies the ordinary
+    preconditioned residual against ``10 * cfg.adjoint_tol * ||rhs||``.  The
+    two chunk sizes independently bound probe assembly and response solves.
+    The ordinary implicit reverse rule remains the default for
+    :func:`solve_implicit`.
+    """
+    active_fields = _active_state_fields(cfg)
+    with _device_context(cfg):
+        params, x_star, dof_mask, tangent_batch = _device_pin(
+            cfg, (params, x_star, dof_mask, tangent_batch)
+        )
+        dz_batch, report = _implicit_evolved_tangent_multi_rhs(
+            params, cfg, x_star, dof_mask, tangent_batch,
+            active_fields=active_fields,
+            probe_chunk_size=probe_chunk_size,
+            response_chunk_size=response_chunk_size,
+        )
+        frozen = jax.lax.stop_gradient(x_star)
+        project = _dof_projector(cfg, dof_mask)
+        edge = _edge_mask(cfg)
+        z_star = project(x_star)
+
+        def assemble_tangent(dz, tangent):
+            return jax.jvp(
+                lambda z, prm: _assemble(
+                    z, runtime_from_params(prm, cfg),
+                    frozen, project, edge,
+                ),
+                (z_star, params), (project(dz), tangent),
+            )[1]
+
+        state_batch = jax.vmap(assemble_tangent)(dz_batch, tangent_batch)
+        return _device_pin(cfg, (state_batch, report))
 
 
 def _solve_implicit_bwd(cfg, res, gbar):
@@ -1575,26 +1885,43 @@ def implicit_state_pullback_multi_rhs(
     x_star: SpectralState,
     dof_mask: SpectralState,
     gbar_batch: SpectralState,
+    *,
+    solver: str = "gcrot",
+    probe_chunk_size: int = 1,
+    response_chunk_size: int = 1,
 ) -> ImplicitParams:
     """Batched state-cotangent pullback with shared implicit-linearization setup.
 
     This preserves the scalar solve_implicit VJP and only adds a helper for
     callers that already have several state cotangents for the same fixed
-    point.  It reuses the residual/projector/VJP setup once, then applies the
-    existing single-RHS GMRES per row.  Runs inside the config's device
-    context (see ``_solve_implicit_bwd``).
+    point.  ``solver="gcrot"`` (default) is the ordinary reverse rule.
+    ``solver="block"`` factors the raw nearest-neighbor radial Jacobian once,
+    reuses the same factors with ``transpose=True`` as a right preconditioner,
+    and certifies the ordinary preconditioned VJP.  Runs inside the config's
+    device context (see ``_solve_implicit_bwd``); the two chunk sizes bound
+    probe assembly and right-hand-side solves independently.
     """
+    if solver not in ("gcrot", "block"):
+        raise ValueError("solver must be 'gcrot' or 'block'")
+    active_fields = (
+        _active_state_fields(cfg) if solver == "block" else ()
+    )
     with _device_context(cfg):
         params = _device_pin(cfg, params)
         x_star = _device_pin(cfg, x_star)
         dof_mask = _device_pin(cfg, dof_mask)
         gbar_batch = _device_pin(cfg, gbar_batch)
         return _device_pin(cfg, _implicit_state_pullback_multi_rhs_impl(
-            params, cfg, x_star, dof_mask, gbar_batch))
+            params, cfg, x_star, dof_mask, gbar_batch,
+            solver=solver, active_fields=active_fields,
+            probe_chunk_size=probe_chunk_size,
+            response_chunk_size=response_chunk_size))
 
 
 def _implicit_state_pullback_multi_rhs_impl(
     params, cfg, x_star, dof_mask, gbar_batch,
+    *, solver="gcrot", active_fields=(), probe_chunk_size=1,
+    response_chunk_size=1,
 ) -> ImplicitParams:
     frozen = jax.lax.stop_gradient(x_star)
     edge_mask = _edge_mask(cfg)
@@ -1610,28 +1937,59 @@ def _implicit_state_pullback_multi_rhs_impl(
 
     rhs_batch = jax.vmap(P)(gbar_batch)
 
-    def solve_row(rhs):
-        lam, sol = _adjoint_solve_gcrot(lambda v: vjp_z(v)[0], rhs, cfg)
-        b_norm = jnp.sqrt(sum(jnp.vdot(v, v).real
-                              for v in jax.tree.leaves(rhs)))
-        return lam, sol.residual_norm, sol.iterations, sol.converged, b_norm
+    if solver == "block":
+        system = _raw_block_system(
+            params, cfg, frozen, dof_mask, active_fields, probe_chunk_size
+        )
+        def solve_row(rhs):
+            lam, sol = _adjoint_solve_gcrot(
+                lambda value: vjp_z(value)[0], rhs, cfg,
+                precond=lambda value: _raw_block_apply(
+                    system, value, transpose=True
+                ),
+            )
+            return lam, _linear_response_report(sol, rhs, cfg)
 
-    # Inside the vmap every row is traced, so _adjoint_solve_gcrot can only
-    # NaN-poison an unconverged row; the per-row solve stats are returned and
-    # re-checked concretely here (this helper runs host-eagerly) so the
-    # multi-RHS path raises the same typed AdjointSolveError as the scalar
-    # reverse pass.
-    lam_batch, res_batch, iter_batch, conv_batch, bnorm_batch = jax.vmap(
-        solve_row)(rhs_batch)
+        lam_batch, report = chunk_map(
+            solve_row, rhs_batch,
+            chunk_size=max(1, int(response_chunk_size)),
+        )
+        res_batch = report.residual_norm
+        iter_batch = report.iterations
+        conv_batch = report.converged
+        accept = report.tolerance
+    else:
+        def solve_row(rhs):
+            lam, sol = _adjoint_solve_gcrot(
+                lambda v: vjp_z(v)[0], rhs, cfg
+            )
+            return lam, _linear_response_report(sol, rhs, cfg)
+
+        lam_batch, report = jax.vmap(solve_row)(rhs_batch)
+        res_batch = report.residual_norm
+        iter_batch = report.iterations
+        conv_batch = report.converged
+        accept = report.tolerance
+
+    # A vmapped Krylov row is traced and therefore NaN-poisoned on failure;
+    # Both solver paths use the same host-eager convergence contract.
     if not isinstance(conv_batch, jax.core.Tracer):
-        accept = np.asarray(_adjoint_acceptance(cfg, bnorm_batch))
-        bad = ~(np.asarray(conv_batch) | (np.asarray(res_batch) <= accept))
+        bad = ~np.asarray(conv_batch)
         if np.any(bad):
             worst = int(np.argmax(np.where(bad, np.asarray(res_batch), -1.0)))
             _raise_adjoint_unconverged(
                 cfg, iterations=int(np.asarray(iter_batch)[worst]),
                 residual_norm=float(np.asarray(res_batch)[worst]),
-                tolerance=float(accept[worst]))
+                tolerance=float(np.asarray(accept)[worst]),
+                method=("block-preconditioned GCROT" if solver == "block" else None))
+    lam_batch = jax.tree.map(
+        lambda value: jnp.where(
+            conv_batch.reshape((conv_batch.shape[0],)
+                               + (1,) * (value.ndim - 1)),
+            value, jnp.full_like(value, jnp.nan),
+        ),
+        lam_batch,
+    )
     g1_batch = jax.vmap(lambda lam: vjp_p(jax.tree.map(jnp.negative, lam))[0])(lam_batch)
     g2_batch = jax.vmap(lambda gbar: vjp_p2(gbar)[0])(gbar_batch)
     return jax.tree.map(jnp.add, g1_batch, g2_batch)

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -70,8 +70,6 @@ import jax.numpy as jnp
 
 from solvax import (
     auto_chunk_size,
-    block_thomas_factor,
-    block_thomas_solve,
     chunk_map,
 )
 
@@ -1224,9 +1222,10 @@ def least_squares(
     by 3-colored ``jax.jvp`` probes capture it completely at a cost
     independent of the dof count — then backsolves every dof right-hand side
     (:func:`solvax.block_thomas_factor` / :func:`solvax.block_thomas_solve`)
-    and certifies each column with a short warm-started GMRES pass against
-    the preconditioned system (same ``adjoint_tol`` norm; columns already at
-    tolerance cost one matvec).  ``"gmres"`` is the per-dof-column fallback
+    and certifies each column with a warm-started GMRES pass against the
+    preconditioned system (same ``adjoint_tol`` and configured iteration
+    budget; columns already at tolerance cost one matvec).  ``"gmres"`` is
+    the per-dof-column fallback
     if the block path misbehaves on an exotic configuration; both produce
     the same Jacobian to solver tolerance.  ``recycle=True`` takes
     precedence.
@@ -1716,38 +1715,17 @@ def _least_squares_implicit(
     # share the fixed point, so dz_j = -(dF/dz)^{-1} dF/dp t_j is the same
     # through either: assemble the raw blocks with 3-colored jvp probes
     # (~3*(3*mn) linearizations, dof-count independent), factor once (solvax
-    # block Thomas), backsolve every dof RHS, then one short warm-started
-    # GMRES pass per column certifies cfg.adjoint_tol (solvax checks the
-    # initial residual first, so columns already at tolerance cost one
-    # matvec).
-    mn_state = int(np.asarray(mask_np.R_cos).shape[1])
-    ns_state = int(cfg.resolution.ns)
-    active_fields = tuple(f for f in imp._STATE_FIELDS
-                          if np.asarray(getattr(mask_np, f)).any())
-    n_act = len(active_fields)
-    m_block = n_act * mn_state
-    # Probe (color, field, column) index triples, color-major so the probe
-    # axis reshapes to (3, m_block, ...) below.
-    probe_color = jnp.asarray(np.repeat(np.arange(3), m_block))
-    probe_field = jnp.asarray(np.tile(np.repeat(np.arange(n_act), mn_state), 3))
-    probe_col = jnp.asarray(np.tile(np.tile(np.arange(mn_state), n_act), 3))
+    # block Thomas), backsolve every dof RHS, then one warm-started GMRES pass
+    # per column certifies cfg.adjoint_tol (solvax checks the initial residual
+    # first, so columns already at tolerance cost one matvec).
+    active_fields = imp._active_state_fields(cfg)
+    m_block = len(active_fields) * int(np.asarray(mask_np.R_cos).shape[1])
     if jac_chunk_size == "auto":
         probe_chunk = _auto_jac_chunk(3 * m_block)
     elif jac_chunk_size is None:
         probe_chunk = 3 * m_block
     else:
         probe_chunk = chunk
-
-    def _pack(t) -> jnp.ndarray:
-        """SpectralState -> (ns, m_block): active fields side by side."""
-        return jnp.concatenate([getattr(t, f) for f in active_fields], axis=1)
-
-    def _unpack(mat: jnp.ndarray) -> SpectralState:
-        """(ns, m_block) -> SpectralState (structurally-zero fields zero)."""
-        parts = dict(zip(active_fields, jnp.split(mat, n_act, axis=1)))
-        return SpectralState(**{
-            f: parts.get(f, jnp.zeros((ns_state, mn_state), mat.dtype))
-            for f in imp._STATE_FIELDS})
 
     def jacobian_rows_block(x: jnp.ndarray):
         """``jacobian_rows`` via one block-tridiagonal factorization (R25.2).
@@ -1759,69 +1737,24 @@ def _least_squares_implicit(
         perturbation warm-start linearization, same contract as
         ``jacobian_rows``).
         """
-        Fz, tangent_of, rhs_of, column_of, (params, frozen, P, z_star) = \
+        _, tangent_of, _, column_of, (params, frozen, _, _) = \
             _jac_parts(x)
-        F_raw = imp.residual_fn(cfg, frozen, mask_const, formulation="raw")
-
-        def Fz_raw(dz):
-            return jax.jvp(lambda z: F_raw(z, params), (z_star,), (dz,))[1]
-
-        def probe_response(spec):
-            c, fi, k = spec
-            rows = (jnp.arange(ns_state) % 3 == c)
-            mat = jnp.where(rows[:, None],
-                            jax.nn.one_hot(k, mn_state, dtype=x.dtype)[None, :],
-                            0.0)
-            stack = (jax.nn.one_hot(fi, n_act, dtype=x.dtype)[:, None, None]
-                     * mat[None])
-            dz = _unpack(jnp.concatenate(
-                [stack[i] for i in range(n_act)], axis=1))
-            # F_raw projects both sides onto the evolved-dof subspace, so
-            # its linearization is singular on the (I - P) complement; the
-            # identity fill (dz - P(dz)) makes the assembled blocks
-            # invertible without changing the solution for P-masked RHS.
-            return _pack(jax.tree.map(lambda a, b, p: a + (b - p),
-                                      Fz_raw(dz), dz, P(dz)))
-
-        probes = chunk_map(probe_response,
-                           (probe_color, probe_field, probe_col),
-                           chunk_size=probe_chunk)
-        # probes[c*m_block + q, i, :] = rows i of A(dz) for the color-c
-        # one-hot-q tangent; for row i the unique in-stencil source surface
-        # of color c is j = i + d with d = the offset satisfying
-        # (i + d) % 3 == c, so gathering at color (i + d) % 3 reads off the
-        # d-band blocks A[i, i+d] for every surface at once.
-        probes = probes.reshape((3, m_block, ns_state, m_block))
-        ii = jnp.arange(ns_state)
-
-        def band(d):
-            g = probes[(ii + d) % 3, :, ii, :]  # (ns, col q, row)
-            return jnp.swapaxes(g, 1, 2)  # (ns, row, col)
-
-        # lower[0] / upper[-1] gather out-of-stencil (zero) responses and
-        # are ignored by the factorization anyway.
-        factors = block_thomas_factor(band(-1), band(0), band(1))
-
-        def raw_rhs(tp_stack):
-            tp = tangent_of(tp_stack)
-            b = jax.jvp(lambda prm: F_raw(z_star, prm), (params,), (tp,))[1]
-            return _pack(jax.tree.map(jnp.negative, b))
-
+        tangent_batch = jax.vmap(tangent_of)(tangent_stack)
         tangent_chunk = ndof if chunk is None else chunk
-        rhs = chunk_map(raw_rhs, tangent_stack, chunk_size=tangent_chunk)
-        dz0 = block_thomas_solve(factors, jnp.moveaxis(rhs, 0, -1))
+        dz0, _ = imp._implicit_evolved_tangent_multi_rhs(
+            params, cfg, frozen, mask_const, tangent_batch,
+            active_fields=active_fields, probe_chunk_size=probe_chunk,
+            response_chunk_size=tangent_chunk,
+        )
 
         def column(args):
-            *tp_stack_j, dz0_mat = args
-            tp = tangent_of(tuple(tp_stack_j))
-            dz, _ = imp._adjoint_solve(
-                Fz, rhs_of(tp), cfg, x0=_unpack(dz0_mat),
-                max_restarts=min(3, cfg.adjoint_maxiter))
+            tp_stack, dz = args
+            tp = tangent_of(tp_stack)
             return column_of(dz, tp), dz
 
         cols, dz_cols = chunk_map(
-            column, (*tangent_stack, jnp.moveaxis(dz0, -1, 0)),
-            chunk_size=tangent_chunk)
+            column, (tangent_stack, dz0), chunk_size=tangent_chunk
+        )
         return jnp.transpose(cols), dz_cols
 
     # Recycled variant: all ndof solves share the operator Fz (which drifts

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -1543,8 +1543,9 @@ def _least_squares_implicit(
     cfg = dataclasses.replace(cfg, device=jac_device)
 
     def _place(x: np.ndarray) -> jnp.ndarray:
-        a = jnp.asarray(x, dtype=jnp.float64)
-        return a if jac_device is None else jax.device_put(a, jac_device)
+        if jac_device is None:
+            return jnp.asarray(x, dtype=jnp.float64)
+        return jax.device_put(np.asarray(x, dtype=np.float64), jac_device)
 
     params0 = imp.params_from_input(inp, device=jac_device)
     imp._template_runtime(cfg)  # host-built template: warm the per-cfg cache
@@ -1589,9 +1590,9 @@ def _least_squares_implicit(
         if k_cur:
             x0 = np.concatenate([x0, _pack_current(inp, k_cur, ac_scale)])
     params0_np = jax.tree.map(lambda a: np.asarray(a, dtype=np.float64),
-                              params_of(jnp.asarray(x0, dtype=jnp.float64)))
+                              params_of(_place(x0)))
     _, mask_np = imp._host_solve_and_mask(cfg, params0_np)
-    mask_const = jax.tree.map(jnp.asarray, mask_np)
+    mask_const = jax.tree.map(_place, mask_np)
 
     # One-hot dof tangents in ImplicitParams space, stacked over dofs
     # (leading axis ndof) so chunk_map can process them in fixed-size chunks:
@@ -1613,14 +1614,13 @@ def _least_squares_implicit(
         t_ac[nboundary + j, j] = ac_scale
     if k_cur:
         t_curtor[nboundary + k_cur] = _CURTOR_SCALE
-    zerop = jax.tree.map(jnp.zeros_like, params0)
+    zerop = jax.tree.map(lambda a: _place(np.zeros(a.shape)), params0)
     if lasym:
-        tangent_stack = (jnp.asarray(t_rbc), jnp.asarray(t_zbs),
-                         jnp.asarray(t_rbs), jnp.asarray(t_zbc),
-                         jnp.asarray(t_ac), jnp.asarray(t_curtor))
+        tangent_stack = tuple(map(
+            _place, (t_rbc, t_zbs, t_rbs, t_zbc, t_ac, t_curtor)
+        ))
     else:
-        tangent_stack = (jnp.asarray(t_rbc), jnp.asarray(t_zbs),
-                         jnp.asarray(t_ac), jnp.asarray(t_curtor))
+        tangent_stack = tuple(map(_place, (t_rbc, t_zbs, t_ac, t_curtor)))
 
     # R17.1 memory knob: chunk_size None == one full-width batch, while an int
     # / "auto" caps peak Jacobian memory at that many dofs at a time.  Route
@@ -1878,7 +1878,7 @@ def _least_squares_implicit(
         """Record ``(x_ref, converged state, dz columns)`` for trial seeding."""
         hit = imp._LAST_SOLVE.get(cfg)
         params_np = jax.tree.map(lambda a: np.asarray(a, dtype=np.float64),
-                                 params_of(jnp.asarray(x, dtype=jnp.float64)))
+                                 params_of(_place(x)))
         if hit is not None and hit[0] == imp._params_key(params_np):
             holder["lin"] = (np.array(x, dtype=float), hit[1].state, dz_cols)
         else:  # unexpected call pattern: better no seed than a wrong one


### PR DESCRIPTION
## Goal

Replace the useful part of #81 with one tested implicit linear-response
implementation.

This PR centralizes VMEX's fixed-boundary multi-right-hand-side tangent and
transpose responses, preserves the existing GCROT reverse-AD default, and
gives the optimizer and advanced callers one residual-checked block path. It
is intentionally limited to the converged fixed-boundary implicit state;
coupled plasma-NESTOR differentiation remains a later PR.

## What has been achieved

- Moved the optimizer's private raw block assembly into
  `vmex.core.implicit` so there is one implementation.
- Added `implicit_state_tangent_multi_rhs` for factor-once vector forward
  responses.
- Extended `implicit_state_pullback_multi_rhs` with opt-in
  `solver="block"`.
- Uses the stored raw three-surface transpose inverse as a **right
  preconditioner** for the true preconditioned transpose GCROT equation. It
  is not used as an approximate final VJP.
- Added `LinearResponseReport` with residual, tolerance, iteration, and
  convergence information for every right-hand side.
- Kept ordinary reverse AD and all device defaults unchanged.
- Kept generic differentiable linear algebra in SOLVAX; VMEX contains only
  its equilibrium-specific assembly and contracts.
- Documented the forward/reverse response APIs and corrected the optimizer
  description to match its configured iteration budget.

## Why this formulation

Three alternatives were measured and rejected:

1. The raw transpose alone satisfied its own algebraic identity but changed
   the converged-equilibrium derivative by up to 0.9% at finite forward
   residual.
2. A raw-transpose GMRES warm start stalled on the LASYM case.
3. A raw-transpose GCROT warm start was device-order dependent with the
   supported SOLVAX 0.9 release despite reporting convergence.

Cold GCROT with the raw transpose inverse as a right preconditioner satisfies
the exact implicit transpose equation and passed symmetric, LASYM, CPU, and
two-GPU validation.

## Validation

Local CPU:

- `RUN_FULL=1 pytest -q tests/test_implicit_multi_rhs.py`: 5 passed.
- Coverage acceptance plus optimizer block integration: 6 passed in 7m30s.
- Changed production lines: 99% (141/142);
  `vmex/core/optimize.py`: 100%.
- Existing implicit optimizer selection: 5 passed.
- Raw residual, nonlinear three-surface, Solovev gradient, preconditioner,
  and multigrid-gradient checks: 8 passed.
- Symmetric and six-family LASYM tangent/VJP identities pass.
- Boundary and pressure-profile responses agree with Newton-reconverged
  finite differences.
- Impossible tolerance raises a typed `AdjointSolveError`.

Real GPU:

- Formal synchronized CPU/`cuda:0`/`cuda:1` parity test: 1 passed in
  116.71 s on two RTX A4000s.
- Checks device placement plus boundary tangent and transpose parity.
- JAX discovered both GPUs normally; `JAX_PLATFORMS` and
  `JAX_PLATFORM_NAME` were unset.

Quality gates:

- Ruff, mypy, byte compilation, diff checks: pass.
- Test manifest: current (82 modules, 1,017 tests, 11 campaigns).
- Strict Sphinx (`-W --keep-going`): pass.

## Remote acceptance

- Exact head `eb753fc0` passed the protected hosted gate: all 12 jobs green, including the 95% changed-line threshold.
- The new `implicit-response` lane completed in 13m34s; the ordinary core lane completed in 6m36s.
- Production-equivalent GPU run `30540119532` passed the expanded selector and all 14 CPU/GPU metric reports on `cuda:0` and `cuda:1`.
- Largest gradient relative difference: DMerc `3.37e-11`; largest value relative difference: Glasser D_R `4.01e-13`.
- Exact-head GPU run `30542912673` completed successfully on `eb753fc0`: hardware discovery, the placement/solve/gradient selector, and all 14 CPU/`cuda:0`/`cuda:1` metric reports passed.
- Artifact verification found 14/14 reports with `status="passed"`, both platform-selection environment variables unset, maximum gradient relative difference `3.37e-11` (DMerc), and maximum value relative difference `4.01e-13` (Glasser D_R).

## Compatibility

- No default solver or device policy changes.
- No input or WOUT schema changes.
- `solver="block"` is opt-in.
- The optimizer's existing `jac_solver="block"` behavior now calls the
  shared implementation.
- Symmetric and LASYM active-state conventions are derived from the existing
  configuration.

## What remains before merge

- Obtain independent review of the narrow fixed-boundary API and reports.
- Once accepted, merge this PR and close #81 as superseded by the tested replacement.

## Out of scope / later roadmap

- Coupled converged plasma-NESTOR free-boundary adjoint.
- QI/maximum-J objective repair from #82.
- High-resolution storage and transform/force performance work.


