### PR TITLE
Add validated trapped-fraction WOUT profiles

### DIFF
--- a/docs/confinement.rst
+++ b/docs/confinement.rst
@@ -452,7 +452,11 @@ substitution :math:`y=\sqrt{1-\lambda B_{\max}}` in
          \frac{\lambda\,d\lambda}{\langle\sqrt{1-\lambda B}\rangle},
 
 evaluated with fixed-order Gauss–Legendre quadrature so the whole chain stays
-differentiable. Their normalized mismatch is the residual
+differentiable. :func:`~vmex.core.bootstrap.trapped_fraction_from_state`
+evaluates the radial profile directly from a converged state; every VMEX WOUT
+stores the same full-mesh result as ``vmex_trapped_fraction``. A QI axis with
+finite :math:`B_0(\varphi)` mirror ratio therefore has a finite trapped
+fraction rather than an imposed zero. Their normalized mismatch is the residual
 :class:`~vmex.core.bootstrap.RedlBootstrapMismatch` (the exact formula and
 the finite-beta profile conventions are in :doc:`equations`); driving it to
 zero, optionally with ``current_dofs`` freed, yields a current profile

--- a/docs/wout_reference.rst
+++ b/docs/wout_reference.rst
@@ -54,6 +54,28 @@ Half mesh: ``iotas``, ``mass``, ``pres``, ``beta_vol``, ``buco``, ``bvco``,
 
 Convergence history: ``fsqt(:)``, ``wdot(:)``.
 
+VMEX extension
+--------------
+
+VMEX adds two names that VMEC2000 readers may ignore:
+
+- ``vmex_diagnostics_schema = 1`` identifies this extension.
+- ``vmex_trapped_fraction`` is the effective trapped-particle fraction
+  :math:`f_t` on the full normalized-toroidal-flux mesh.
+
+The profile is computed from the converged half-mesh :math:`|B|` and
+:math:`\sqrt{g}` fields with 64-point pitch quadrature. At the axis, VMEX
+keeps the poloidal :math:`m=0` field and extrapolates it linearly in
+:math:`s`; finite-radius poloidal modes vanish there by regularity. This
+recovers zero trapped fraction for a constant on-axis field without forcing
+the result to zero, so a QI :math:`B_0(\varphi)` with finite mirror ratio
+remains finite. Linear extrapolation supplies the boundary value. Symmetric
+and LASYM equilibria use their respective full-surface angular grids.
+
+Reading an older WOUT sets ``vmex_diagnostics_schema`` to zero and
+``vmex_trapped_fraction`` to ``None``. Rewriting that object does not add the
+extension.
+
 Fourier tables (mode x radius)
 ------------------------------
 

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -103,7 +103,9 @@
       "tests/test_freeboundary_linear.py",
       "tests/test_freeboundary_diff.py::test_synthetic_surface_gradient_fd_validates",
       "tests/test_printing.py::test_compile_notice_variants",
-      "tests/test_printing.py::test_emit_flushed_writes_and_flushes"
+      "tests/test_printing.py::test_emit_flushed_writes_and_flushes",
+      "tests/test_bootstrap.py",
+      "tests/test_wout_golden.py"
     ],
     "pr-physics-mirror-spline": [
       "tests/mirror/test_analytic.py",

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 import dataclasses
 from pathlib import Path
 
+import netCDF4
 import numpy as np
 import pytest
+from scipy.integrate import quad
 
 import jax
 
@@ -184,12 +186,17 @@ def test_trapped_fraction_analytic_model():
     # Large-aspect-ratio asymptote f_t ~ 1.46 sqrt(eps) at small eps.
     ratio = np.asarray(f_t)[:2] / (1.46 * np.sqrt(eps[:2]))
     np.testing.assert_allclose(ratio, 1.0, atol=0.05)
+    np.testing.assert_allclose(
+        f_t, 1.46 * np.sqrt(eps) - 0.46 * eps, rtol=0.04)
     # f_t increases with eps and stays in (0, 1).
     ft = np.asarray(f_t)
     assert np.all(np.diff(ft) > 0) and np.all((ft > 0) & (ft < 1))
     # Fixed-order quadrature self-check: 64 vs 256 nodes.
     *_, f_t_hi = bs.compute_trapped_fraction(modB, sqrtg, n_lambda=256)
     np.testing.assert_allclose(ft, np.asarray(f_t_hi), rtol=1e-4)
+    constant, weight = _analytic_model([0.0], B0=B0)
+    assert abs(float(bs.compute_trapped_fraction(
+        constant, weight, n_lambda=8)[-1][0])) < 3e-14
 
 
 def test_trapped_fraction_grad_finite():
@@ -201,6 +208,93 @@ def test_trapped_fraction_grad_finite():
 
     grad = jax.grad(scalar)(modB)
     assert np.all(np.isfinite(np.asarray(grad)))
+
+
+def test_qi_axis_trapped_fraction_is_nonzero():
+    """pyQIC ``QI NFP1 r2`` axis field, whose mirror ratio stays finite."""
+    zeta = np.linspace(0.0, 2.0 * np.pi, 1024, endpoint=False)
+    modB = 1.0 + 0.15824229612567256 * np.cos(zeta)
+    modB = jnp.asarray(np.broadcast_to(modB[None, None, :], (1, 8, zeta.size)))
+    sqrtg = 1.2355077254369284 / modB**2
+    *_, coarse = bs.compute_trapped_fraction(modB, sqrtg, n_lambda=64)
+    *_, fine = bs.compute_trapped_fraction(modB, sqrtg, n_lambda=256)
+    assert float(fine[0]) == pytest.approx(0.5536054318, rel=2e-8)
+    np.testing.assert_allclose(coarse, fine, rtol=5e-8)
+
+
+def test_axis_limit_preserves_qi_b0_and_removes_poloidal_terms():
+    theta = np.linspace(0.0, 2.0 * np.pi, 16, endpoint=False)
+    zeta = np.linspace(0.0, 2.0 * np.pi, 65, endpoint=False)
+    theta, zeta = np.meshgrid(theta, zeta, indexing="ij")
+    s_full = np.linspace(0.0, 1.0, 4)
+    s_half = 0.5 * (s_full[:-1] + s_full[1:])
+    b0 = 1.0 + 0.15 * np.cos(zeta)
+    g0 = 1.2 / b0**2
+    modB = np.stack([
+        b0 + np.sqrt(s) * 0.2 * np.cos(theta) + s * 0.04 * np.cos(zeta)
+        for s in s_half
+    ])
+    sqrtg = np.stack([
+        g0 + np.sqrt(s) * 0.1 * np.sin(theta) + s * 0.03 * np.cos(zeta)
+        for s in s_half
+    ])
+    zeros = np.zeros((1,) + modB.shape[1:])
+    result = bs._trapped_fraction_from_fields(
+        total_pressure=0.5 * np.concatenate((zeros, modB**2)),
+        pressure=np.zeros(4),
+        sqrt_g=np.concatenate((zeros, sqrtg)),
+        s_full=s_full,
+        surfaces=np.array([0.0]),
+        lasym=True,
+        n_lambda=32,
+    )
+    expected = bs.compute_trapped_fraction(
+        b0[None], g0[None], n_lambda=32)
+    for actual, reference in zip(result, expected):
+        np.testing.assert_allclose(actual, reference, rtol=2e-13, atol=2e-13)
+
+
+def test_trapped_fraction_desc_and_adaptive_parity():
+    """DESC ``5bf45439`` two-surface oracle and independent adaptive integral."""
+    theta = np.linspace(0.0, 2.0 * np.pi, 201, endpoint=False)
+    zeta = np.linspace(0.0, 2.0 * np.pi / 3.0, 51, endpoint=False)
+    theta, zeta = np.meshgrid(theta, zeta, indexing="ij")
+    modB = np.stack((
+        13.0 + 2.6 * np.cos(theta),
+        9.0 + 3.7 * np.sin(theta - 3.0 * zeta),
+    ))
+    sqrtg = np.stack((
+        np.full_like(theta, 10.0),
+        np.full_like(theta, -25.0),
+    ))
+    result = tuple(np.asarray(x) for x in bs.compute_trapped_fraction(
+        modB, sqrtg, n_lambda=64))
+    expected = (
+        [10.400317571954302, 5.30000039095027],
+        [15.6, 12.69999960904973],
+        [0.1999853430119033, 0.4111110676721922],
+        [172.38, 87.845],
+        [0.07850928662766593, 0.12188779055693756],
+        [0.5618460489104805, 0.70107870190748],
+    )
+    for actual, reference in zip(result[:-1], expected[:-1]):
+        np.testing.assert_allclose(actual, reference, rtol=3e-14, atol=3e-14)
+    np.testing.assert_allclose(result[-1], expected[-1], rtol=5e-8)
+
+    for i in range(2):
+        weight = np.abs(sqrtg[i])
+        volume = np.mean(weight)
+        bmax = np.max(modB[i])
+
+        def integrand(pitch):
+            average = np.mean(
+                np.sqrt(np.maximum(1.0 - pitch * modB[i], 0.0)) * weight)
+            return pitch / (average / volume)
+
+        integral = quad(
+            integrand, 0.0, 1.0 / bmax, epsabs=1e-12, epsrel=1e-12)[0]
+        adaptive = 1.0 - 0.75 * result[3][i] * integral
+        assert result[-1][i] == pytest.approx(adaptive, rel=1e-9)
 
 
 # ---------------------------------------------------------------------------
@@ -391,12 +485,86 @@ def test_state_lane_matches_wout_lane(eq):
     np.testing.assert_allclose(np.asarray(j_state), np.asarray(j_wout), rtol=5e-2)
 
 
+def test_wout_lane_uses_lasym_sine_fields(eq):
+    surfaces = np.array([0.3, 0.5, 0.7])
+    symmetric = bs.redl_geometry_from_wout(eq.wout, surfaces)
+    bmns = np.zeros_like(eq.wout.bmnc)
+    mode = int(np.flatnonzero(np.asarray(eq.wout.xm_nyq) > 0)[0])
+    bmns[:, mode] = 0.03
+    asymmetric = bs.redl_geometry_from_wout(
+        dataclasses.replace(
+            eq.wout, lasym=True, bmns=bmns, gmns=np.zeros_like(eq.wout.gmnc)),
+        surfaces,
+    )
+    assert np.all(np.isfinite(np.asarray(asymmetric.f_t)))
+    assert not np.allclose(asymmetric.f_t, symmetric.f_t)
+
+
 def test_state_lane_default_surfaces_and_pytree(eq):
     geom = bs.redl_geometry_from_state(eq.state, eq.runtime)
     assert geom.surfaces.shape == (16,)
     leaves = jax.tree_util.tree_leaves(geom)
     assert leaves and all(np.all(np.isfinite(np.asarray(leaf))) for leaf in leaves)
     assert 0.0 < float(np.min(np.asarray(geom.f_t))) < float(np.max(np.asarray(geom.f_t))) < 1.0
+
+
+def test_trapped_fraction_state_profile_and_wout_roundtrip(eq, tmp_path):
+    from vmex.core.wout import read_wout, write_wout
+
+    profile = bs.trapped_fraction_from_state(eq.state, eq.runtime)
+    assert profile.shape == (eq.wout.ns,)
+    assert np.all(np.isfinite(np.asarray(profile)))
+    np.testing.assert_allclose(
+        profile, eq.wout.vmex_trapped_fraction, rtol=2e-12, atol=2e-12)
+    assert abs(float(profile[0])) < 1e-10
+    assert abs(float(bs.redl_geometry_from_wout(
+        eq.wout, [0.0]).f_t[0])) < 1e-10
+    path = write_wout(tmp_path / "wout_trapped.nc", eq.wout)
+    loaded = read_wout(path)
+    assert loaded.vmex_diagnostics_schema == 1
+    np.testing.assert_array_equal(
+        loaded.vmex_trapped_fraction, eq.wout.vmex_trapped_fraction)
+    with netCDF4.Dataset(path) as dataset:
+        variable = dataset.variables["vmex_trapped_fraction"]
+        assert variable.units == "1"
+        assert variable.mesh == "full"
+        assert variable.n_lambda == 64
+    with pytest.raises(ValueError, match="must have shape"):
+        write_wout(
+            tmp_path / "wout_bad_trapped.nc",
+            dataclasses.replace(eq.wout, vmex_trapped_fraction=np.zeros(2)),
+        )
+
+
+def test_trapped_fraction_state_jvp_matches_finite_difference(eq):
+    surfaces = [0.3, 0.6]
+    direction = jnp.zeros_like(eq.state.R_cos).at[-1, 0].set(1.0)
+
+    def objective(r_cos):
+        state = dataclasses.replace(eq.state, R_cos=r_cos)
+        return jnp.sum(bs.trapped_fraction_from_state(
+            state, eq.runtime, surfaces=surfaces, n_lambda=16))
+
+    _, tangent = jax.jvp(objective, (eq.state.R_cos,), (direction,))
+    step = 1.0e-5
+    finite_difference = (
+        objective(eq.state.R_cos + step * direction)
+        - objective(eq.state.R_cos - step * direction)
+    ) / (2.0 * step)
+    np.testing.assert_allclose(tangent, finite_difference, rtol=3e-3)
+
+
+def test_trapped_fraction_angular_convergence(eq):
+    surfaces = [0.0, 0.25, 0.5, 0.75, 1.0]
+    profiles = [
+        np.asarray(bs.redl_geometry_from_wout(
+            eq.wout, surfaces, ntheta=n, nphi=n + 1).f_t)
+        for n in (16, 32, 64)
+    ]
+    coarse = np.max(np.abs(profiles[1] - profiles[0]))
+    fine = np.max(np.abs(profiles[2] - profiles[1]))
+    assert fine < 0.1 * coarse
+    np.testing.assert_allclose(profiles[1], profiles[2], rtol=2e-6, atol=2e-8)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -11,6 +11,7 @@ import jax
 import numpy as np
 import pytest
 
+from vmex.core import bootstrap
 from vmex.core import device as device_policy
 from vmex.core import errors
 from vmex.core import implicit as im
@@ -98,6 +99,27 @@ def test_implicit_default_follows_jax_but_auto_prefers_cpu():
 
     assert {_platform(x) for x in jax.tree.leaves(following_jax)} == {"gpu"}
     assert {_platform(x) for x in jax.tree.leaves(automatic)} == {"cpu"}
+
+
+@_requires_gpu
+def test_trapped_fraction_value_and_gradient_cpu_gpu_parity():
+    def value_and_gradient(device):
+        with device_policy.device_scope(device):
+            zeta = jax.numpy.linspace(
+                0.0, 2.0 * jax.numpy.pi, 128, endpoint=False)
+            amplitude = jax.device_put(0.15, device)
+
+            def objective(a):
+                modb = 1.0 + a * jax.numpy.cos(zeta)
+                modb = jax.numpy.broadcast_to(modb, (2, 8, zeta.size))
+                return jax.numpy.sum(bootstrap.compute_trapped_fraction(
+                    modb, 1.2 / modb**2, n_lambda=32)[-1])
+
+            return jax.value_and_grad(objective)(amplitude)
+
+    cpu = value_and_gradient(jax.devices("cpu")[0])
+    gpu = value_and_gradient(_gpu())
+    np.testing.assert_allclose(gpu, cpu, rtol=2e-11, atol=2e-12)
 
 
 @_requires_gpu
@@ -397,6 +419,14 @@ def test_converged_lasym_free_boundary_cpu_gpu_parity(monkeypatch):
         )
         for platform, result in results.items()
     }
+    assert wouts["cpu"].vmex_diagnostics_schema == 1
+    assert wouts["gpu"].vmex_diagnostics_schema == 1
+    np.testing.assert_allclose(
+        wouts["gpu"].vmex_trapped_fraction,
+        wouts["cpu"].vmex_trapped_fraction,
+        rtol=2e-10,
+        atol=2e-12,
+    )
     for name in (
         "potsin",
         "potcos",

--- a/tests/test_wout_golden.py
+++ b/tests/test_wout_golden.py
@@ -256,11 +256,14 @@ def case(request, tmp_path_factory):
 def test_completeness_and_structure(case):
     """New wout covers every golden variable with identical dims/dtypes."""
     out, golden = case
+    old = read_wout(golden)
+    assert old.vmex_diagnostics_schema == 0
+    assert old.vmex_trapped_fraction is None
     with netCDF4.Dataset(golden) as gd, netCDF4.Dataset(out) as nd:
         gvars, nvars = set(gd.variables), set(nd.variables)
         missing = gvars - nvars
         assert not missing, f"variables missing from new wout: {sorted(missing)}"
-        extra = nvars - gvars
+        extra = {name for name in nvars - gvars if not name.startswith("vmex_")}
         assert not extra, f"nonstandard extra variables written: {sorted(extra)}"
 
         lasym = bool(int(_get(gd, "lasym__logical__")))

--- a/vmex/core/bootstrap.py
+++ b/vmex/core/bootstrap.py
@@ -76,6 +76,7 @@ __all__ = [
     "KineticProfiles",
     "profile_value_and_dds",
     "compute_trapped_fraction",
+    "trapped_fraction_from_state",
     "RedlGeometry",
     "redl_geometry_from_wout",
     "redl_geometry_from_state",
@@ -161,9 +162,9 @@ def compute_trapped_fraction(modB: Array, sqrtg: Array, *, n_lambda: int = 64):
         modB: ``(nsurf, ntheta, nzeta)`` array of :math:`|B|` on a uniform
             angular grid (leading surface axis — note simsopt uses trailing).
         sqrtg: same shape, the Jacobian :math:`\sqrt{g}` on the grid.
-        n_lambda: fixed Gauss-Legendre quadrature order for the lambda
-            integral on ``[0, 1/Bmax]`` (replaces simsopt's adaptive quad;
-            the nodes exclude the ``lambda = 1/Bmax`` endpoint).
+        n_lambda: fixed Gauss-Legendre order after the substitution
+            :math:`y=\sqrt{1-\lambda B_{\max}}` (replaces simsopt's
+            adaptive quadrature).
 
     Returns:
         ``(Bmin, Bmax, epsilon, fsa_B2, fsa_1overB, f_t)`` — 1D arrays of
@@ -189,7 +190,8 @@ def compute_trapped_fraction(modB: Array, sqrtg: Array, *, n_lambda: int = 64):
     x = jnp.asarray(0.5 * (nodes + 1.0), dtype=modB.dtype)      # (nl,) in (0, 1)
     wq = jnp.asarray(0.5 * weights, dtype=modB.dtype)
 
-    lam = x[None, :] / Bmax[:, None]                            # (nsurf, nl)
+    y = x[None, :]
+    lam = (1.0 - y * y) / Bmax[:, None]
     arg = 1.0 - lam[:, :, None, None] * modB[:, None, :, :]
     # Double-where guard: at the |B| = Bmax grid point arg -> 0 as
     # lambda -> 1/Bmax; d/dx sqrt(x) is infinite there, so reverse-mode AD
@@ -198,8 +200,9 @@ def compute_trapped_fraction(modB: Array, sqrtg: Array, *, n_lambda: int = 64):
     safe = jnp.where(positive, arg, 1.0)
     root = jnp.where(positive, jnp.sqrt(safe), 0.0)
     fsa_root = (jnp.mean(root * w[:, None, :, :], axis=(2, 3))
-                / Vp[:, None])                                  # <sqrt(1 - lam B)>
-    integral = jnp.sum(wq[None, :] * lam / fsa_root, axis=1) / Bmax
+                / Vp[:, None])
+    integral = jnp.sum(
+        wq[None, :] * 2.0 * y * lam / fsa_root, axis=1) / Bmax
     f_t = 1.0 - 0.75 * fsa_B2 * integral
     return Bmin, Bmax, epsilon, fsa_B2, fsa_1overB, f_t
 
@@ -266,8 +269,7 @@ def redl_geometry_from_wout(
     if isinstance(wout, (str, Path)):
         wout = read_wout(wout)
     wout = getattr(wout, "wout", wout)
-    if bool(getattr(wout, "lasym", False)):
-        raise NotImplementedError("redl_geometry_from_wout supports lasym = False only")
+    lasym = bool(getattr(wout, "lasym", False))
 
     surfaces = _as_1d(surfaces)
     nfp = int(wout.nfp)
@@ -287,6 +289,14 @@ def redl_geometry_from_wout(
     mn = int(xm.shape[0])
     bmnc = half(_mode_matrix(wout, "bmnc", ns=ns, mn=mn))
     gmnc = half(_mode_matrix(wout, "gmnc", ns=ns, mn=mn))
+    bmns = half(_mode_matrix(wout, "bmns", ns=ns, mn=mn)) if lasym else None
+    gmns = half(_mode_matrix(wout, "gmns", ns=ns, mn=mn)) if lasym else None
+    axis_modes = (surfaces == 0.0)[:, None] & (xm != 0.0)[None, :]
+    bmnc, gmnc = jnp.where(axis_modes, 0.0, bmnc), jnp.where(
+        axis_modes, 0.0, gmnc)
+    if lasym:
+        bmns, gmns = jnp.where(axis_modes, 0.0, bmns), jnp.where(
+            axis_modes, 0.0, gmns)
 
     theta1d = jnp.linspace(0.0, 2.0 * jnp.pi, int(ntheta), endpoint=False)
     phi1d = jnp.linspace(0.0, 2.0 * jnp.pi / nfp, int(nphi), endpoint=False)
@@ -295,6 +305,10 @@ def redl_geometry_from_wout(
     cosangle = jnp.cos(angle)
     modB = jnp.einsum("sm,tpm->stp", bmnc, cosangle)
     sqrtg = jnp.einsum("sm,tpm->stp", gmnc, cosangle)
+    if lasym:
+        sinangle = jnp.sin(angle)
+        modB += jnp.einsum("sm,tpm->stp", bmns, sinangle)
+        sqrtg += jnp.einsum("sm,tpm->stp", gmns, sinangle)
 
     Bmin, Bmax, epsilon, fsa_B2, fsa_1overB, f_t = compute_trapped_fraction(
         modB, sqrtg, n_lambda=n_lambda)
@@ -328,6 +342,65 @@ class _HalfMeshFields(NamedTuple):
     nfp: int
 
 
+def _full_surface_values(values: Array, *, lasym: bool) -> Array:
+    """Drop the axis slot and restore the full poloidal surface."""
+    values = jnp.asarray(values)[1:]
+    if lasym:
+        return values
+    ntheta2, nzeta = int(values.shape[1]), int(values.shape[2])
+    ntheta1 = max(2 * (ntheta2 - 1), 1)
+    i_full = np.arange(ntheta1)
+    i_src = np.where(i_full < ntheta2, i_full, ntheta1 - i_full)
+    k = np.arange(nzeta)
+    k_src = np.where(
+        i_full[:, None] < ntheta2, k[None, :],
+        (nzeta - k[None, :]) % nzeta,
+    )
+    return values[:, np.broadcast_to(i_src[:, None], k_src.shape), k_src]
+
+
+def _trapped_fraction_from_fields(
+    *,
+    total_pressure,
+    pressure,
+    sqrt_g,
+    s_full,
+    surfaces,
+    lasym: bool,
+    n_lambda: int,
+    serial_surfaces: bool = False,
+):
+    """Evaluate trapped-fraction quantities from an existing field pass."""
+    b2 = 2.0 * (
+        jnp.asarray(total_pressure) - jnp.asarray(pressure)[:, None, None])
+    tiny = jnp.asarray(jnp.finfo(b2.dtype).tiny, dtype=b2.dtype)
+    modB = _full_surface_values(jnp.sqrt(jnp.maximum(b2, tiny)), lasym=lasym)
+    sqrtg = jnp.abs(_full_surface_values(sqrt_g, lasym=lasym))
+    s_full = jnp.asarray(s_full)
+    s_half = 0.5 * (s_full[:-1] + s_full[1:])
+
+    def interpolate(values):
+        result = _interp_half_grid(values, surfaces, s_half)
+        axis_samples = jnp.mean(values, axis=1, keepdims=True)
+        axis = _interp_half_grid(
+            axis_samples, jnp.zeros((1,), dtype=surfaces.dtype), s_half)[0]
+        mask = (surfaces == 0.0).reshape(
+            (surfaces.shape[0],) + (1,) * (values.ndim - 1))
+        result = jnp.where(mask, axis, result)
+        return result
+
+    modB = interpolate(modB)
+    sqrtg = interpolate(sqrtg)
+    if serial_surfaces:
+        result = jax.lax.map(
+            lambda x: compute_trapped_fraction(
+                x[0][None], x[1][None], n_lambda=n_lambda),
+            (modB, sqrtg),
+        )
+        return tuple(x[:, 0] for x in result)
+    return compute_trapped_fraction(modB, sqrtg, n_lambda=n_lambda)
+
+
 def _half_mesh_fields(state: SpectralState, rt: SolverRuntime) -> _HalfMeshFields:
     """One ``_field_chain`` pass -> the half-mesh inputs of both bootstrap lanes.
 
@@ -340,34 +413,17 @@ def _half_mesh_fields(state: SpectralState, rt: SolverRuntime) -> _HalfMeshField
     :func:`~vmex.core.fields.surface_currents` (``bvco``/``buco``).
     """
     setup = rt.setup
-    if bool(setup.lasym):
-        raise NotImplementedError(
-            "bootstrap state-lane evaluation supports lasym = False only")
     s = jnp.asarray(setup.s_full)
     nfp = int(rt.resolution.nfp)
     _, jacobian, _, fields, _ = _field_chain(state, rt)
 
-    # Mirror the reduced [0, pi] theta grid to the full circle
-    # (stellarator-symmetry map X(2 pi - theta, -zeta) = X(theta, zeta)).
-    ntheta2 = int(np.shape(fields.total_pressure)[1])
-    nzeta = int(np.shape(fields.total_pressure)[2])
-    ntheta1 = max(2 * (ntheta2 - 1), 1)
-    i_full = np.arange(ntheta1)
-    i_src = np.where(i_full < ntheta2, i_full, ntheta1 - i_full)
-    k = np.arange(nzeta)
-    k_src = np.where(i_full[:, None] < ntheta2, k[None, :],
-                     (nzeta - k[None, :]) % nzeta)
-    i_src = np.broadcast_to(i_src[:, None], (ntheta1, nzeta))
-
-    def full(a):
-        # Drop the zeroed axis row (js = 0) before the divisions downstream.
-        return jnp.asarray(a)[1:, i_src, k_src]
-
     bsq2 = 2.0 * (jnp.asarray(fields.total_pressure)
                   - jnp.asarray(fields.pressure)[:, None, None])
     tiny = jnp.asarray(jnp.finfo(bsq2.dtype).tiny, dtype=bsq2.dtype)
-    bmag = jnp.sqrt(jnp.maximum(full(bsq2), tiny))     # half mesh js = 1..ns-1
-    w = jnp.abs(full(jacobian.sqrt_g))
+    bmag = _full_surface_values(
+        jnp.sqrt(jnp.maximum(bsq2, tiny)), lasym=bool(setup.lasym))
+    w = jnp.abs(_full_surface_values(
+        jacobian.sqrt_g, lasym=bool(setup.lasym)))
 
     iota_h = _iotas_half(state, rt)[1:]
     cur = surface_currents(bsubu=fields.bsubu, bsubv=fields.bsubv,
@@ -424,6 +480,34 @@ def redl_geometry_from_state(
     surfaces = _as_1d(surfaces)
     return _geometry_from_half(_half_mesh_fields(state, rt), surfaces,
                                n_lambda=n_lambda)
+
+
+def trapped_fraction_from_state(
+    state: SpectralState,
+    rt: SolverRuntime,
+    *,
+    surfaces=None,
+    n_lambda: int = 64,
+) -> Array:
+    """Effective trapped fraction on requested normalized-flux surfaces.
+
+    The default is VMEX's full radial mesh. The axis keeps only the regular
+    poloidal ``m=0`` limit; the boundary uses linear half-mesh extrapolation.
+    LASYM uses the full poloidal grid; symmetric runs restore it by parity.
+    """
+    if surfaces is None:
+        surfaces = jnp.asarray(rt.setup.s_full)
+    surfaces = _as_1d(surfaces)
+    _, jacobian, _, fields, _ = _field_chain(state, rt)
+    return _trapped_fraction_from_fields(
+        total_pressure=fields.total_pressure,
+        pressure=fields.pressure,
+        sqrt_g=jacobian.sqrt_g,
+        s_full=rt.setup.s_full,
+        surfaces=surfaces,
+        lasym=bool(rt.setup.lasym),
+        n_lambda=n_lambda,
+    )[-1]
 
 
 # ===========================================================================

--- a/vmex/core/wout.py
+++ b/vmex/core/wout.py
@@ -21,6 +21,9 @@ their public ``VacuumOutput`` is supplied:
 
 :class:`WoutData` stores every field in **file convention** (exactly the
 values found in the netCDF file), so ``read_wout(write_wout(x)) == x``.
+VMEX-written files also carry the versioned ``vmex_trapped_fraction`` radial
+profile; older WOUT files remain readable and are rewritten without the
+extension.
 
 :func:`wout_from_state` builds the complete dataset from a converged
 fixed-boundary core state (:class:`vmex.core.input.VmecInput` +
@@ -108,6 +111,9 @@ _ATTRS = {
     "bsubvmns_sur": ("sinmn covaiant v-component of B, surface", None),
     "bsupumns_sur": ("sinmn contravariant u-component of B, surface", None),
     "bsupvmns_sur": ("sinmn contravariant v-component of B, surface", None),
+    "vmex_diagnostics_schema": ("VMEX diagnostics schema version", None),
+    "vmex_trapped_fraction": (
+        "Effective trapped-particle fraction on full mesh", "1"),
 }
 
 _LOGICALS = ("lasym", "lrecon", "lfreeb", "lmove_axis", "lrfp")
@@ -296,6 +302,9 @@ class WoutData:
     bsubvmns_sur: np.ndarray | None = None
     bsupumns_sur: np.ndarray | None = None
     bsupvmns_sur: np.ndarray | None = None
+    # -- backward-compatible VMEX extension -------------------------------
+    vmex_diagnostics_schema: int = 0
+    vmex_trapped_fraction: np.ndarray | None = None
 
 
 # ==========================================================================
@@ -446,6 +455,17 @@ def write_wout(path: str | Path, data: WoutData, *, overwrite: bool = True) -> P
             if lfreeb:
                 for name in _SUR_ASYM:
                     _put(ds, name, (_DIM_MN_NYQ,), getattr(d, name))
+        if int(d.vmex_diagnostics_schema) > 0:
+            if (d.vmex_trapped_fraction is None
+                    or np.shape(d.vmex_trapped_fraction) != (int(d.ns),)):
+                raise ValueError(
+                    "vmex_trapped_fraction must have shape (ns,) for schema >= 1")
+            _put(ds, "vmex_diagnostics_schema", (),
+                 int(d.vmex_diagnostics_schema), "i4")
+            _put(ds, "vmex_trapped_fraction", (_DIM_RADIUS,),
+                 d.vmex_trapped_fraction)
+            ds.variables["vmex_trapped_fraction"].mesh = "full"
+            ds.variables["vmex_trapped_fraction"].n_lambda = 64
     return path
 
 
@@ -515,6 +535,9 @@ def read_wout(path: str | Path) -> WoutData:
                     row.tobytes().decode("ascii", "ignore").rstrip(" \x00")
                     for row in np.atleast_2d(raw)
                 )
+        schema = _rd(ds, "vmex_diagnostics_schema", 0)
+        kw["vmex_diagnostics_schema"] = int(np.ravel(schema)[0])
+        kw["vmex_trapped_fraction"] = _rd(ds, "vmex_trapped_fraction")
     return WoutData(**kw)
 
 
@@ -589,6 +612,7 @@ def wout_from_state(
     import jax
 
     from . import nyquist as _nyq
+    from .bootstrap import _trapped_fraction_from_fields
     from .fields import energies_and_force_norms, magnetic_fields, metric_elements
     from .fourier import Resolution, mode_table, trig_tables
     from .geometry import (
@@ -645,10 +669,20 @@ def wout_from_state(
         jacobian=jacobian, metrics=metrics, fields=fields, trig=trig,
         s=grids.s_full, signgs=signgs,
     )
+    trapped_fraction = _trapped_fraction_from_fields(
+        total_pressure=fields.total_pressure,
+        pressure=fields.pressure,
+        sqrt_g=jacobian.sqrt_g,
+        s_full=grids.s_full,
+        surfaces=grids.s_full,
+        lasym=lasym,
+        n_lambda=64,
+        serial_surfaces=True,
+    )[-1]
     (geometry, jacobian, metrics, fields, norms, R_cos_p, Z_sin_p, R_sin_p,
-     Z_cos_p) = jax.device_get(
+     Z_cos_p, trapped_fraction) = jax.device_get(
         (geometry, jacobian, metrics, fields, norms, R_cos_p, Z_sin_p,
-         R_sin_p, Z_cos_p))
+         R_sin_p, Z_cos_p, trapped_fraction))
 
     # -- 1D profiles in file conventions ------------------------------------
     vp = np.asarray(norms.vp, dtype=float).copy()
@@ -940,6 +974,8 @@ def wout_from_state(
         bsubvmns_sur=vacuum_sur.get("bsubvmns_sur"),
         bsupumns_sur=vacuum_sur.get("bsupumns_sur"),
         bsupvmns_sur=vacuum_sur.get("bsupvmns_sur"),
+        vmex_diagnostics_schema=1,
+        vmex_trapped_fraction=np.asarray(trapped_fraction, dtype=float),
     )
 
 


### PR DESCRIPTION
## Goal

Make the effective trapped-particle fraction a validated, differentiable radial diagnostic available from a converged VMEX state and every VMEX-written WOUT. Preserve standard VMEC2000 fields, old-WOUT readability, solver/device defaults, and the existing optimization API.

## Achieved

- Reuses `compute_trapped_fraction`; no second physics formula was introduced.
- Corrects the documented singularity-removing substitution `y=sqrt(1-lambda*Bmax)`, making a constant-B surface return zero at roundoff instead of about `1.01e-2` at 64 pitch points.
- Adds `trapped_fraction_from_state` on requested normalized-flux surfaces, with symmetric and LASYM geometry support.
- Uses the regular poloidal `m=0` axis limit, retaining finite QI `B0(phi)` mirror variation while removing finite-radius poloidal modes.
- Extends LASYM WOUT reconstruction with the sine `bmns` and `gmns` fields.
- Adds `vmex_diagnostics_schema = 1` and full-mesh `vmex_trapped_fraction` to VMEX WOUTs, with dimensionless units, mesh, and 64-point pitch metadata.
- Reads old WOUT files as schema 0 with no trapped-fraction profile. Standard non-VMEX variables are unchanged.
- Uses a WOUT-only sequential `lax.map` so the final diagnostic does not materialize the full surface-by-pitch scratch array. The differentiable/optimization kernel remains vectorized.
- Documents the formula, axis convention, schema, mesh, and compatibility behavior.

## Validation completed

Current head: `98bc1bc`

- Circular analytic fields and Kim-Diamond-Callen approximation pass.
- Constant-B limit: `|f_t| < 5e-14` with only 8 Gauss points.
- Exact field-average parity with DESC `5bf45439`; transformed 64-point quadrature agrees with independent adaptive SciPy quadrature to `1e-9` relative.
- Existing QA/QH Simsopt/SFINCS bootstrap references pass. The corrected quadrature changes those established profiles by at most `2.7e-6` relative.
- pyQIC `QI NFP1 r2` axis: `f_t = 0.55360543`; 64/256-point agreement is below `5e-8` relative.
- External pyQSC `cd75359` and pyQIC `22bf4fb` finite-radius fields agree with independent adaptive quadrature at all audited radii.
- The regular-axis manufactured test removes `sqrt(s)` poloidal terms while preserving toroidal QI variation. Solovev axis results stay at roundoff for 11, 21, and 41 surfaces; interior refinement differences are below `2.3e-4` absolute.
- Angular refinement from 16 to 32 to 64 points reduces the maximum profile change by more than a factor of ten.
- State JVP agrees with centered finite differences (`rtol=3e-3`).
- LASYM sine fields change the result as expected and remain finite.
- Full bootstrap suite: 29 passed before the final angular-convergence addition; all focused final tests pass.
- VMEC2000 WOUT golden suite: 12 passed, including symmetric, 3-D, and LASYM cases. Old files load with schema 0.
- `booz_xform` 0.0.9 loads the extended WOUT and ignores the extra variables.
- Changed-line coverage: 100% (67/67 source lines).
- Ruff, mypy (55 source files), package build, strict Sphinx, manifest audit (82 modules, 1020 tests, 11 campaigns), and diff checks pass.
- Exact-head hosted CI run `30560219785` is green, including 100% coverage of all 67 changed executable lines.
- Exact-head GPU run `30561786179` passes converged LASYM free-boundary CPU/GPU parity, trapped-fraction value/gradient parity, and all seven physics-gradient families on both RTX A4000s without JAX platform environment pins. Independent audit of all 14 artifacts found a worst value relative difference of `4.01e-13` (Glasser) and a worst gradient relative difference of `3.37e-11` (DMerc); forward states were identical.

## Performance

On a synthetic 101-surface, 64x65-angle, 64-pitch case, the WOUT-only mapped evaluation reduced process peak memory from about 1.11 GiB to 189 MiB; steady evaluation was 0.047 s versus 0.053 s for the fully vectorized surface batch. On the small Solovev solve, the complete WOUT extension adds about 11 ms steady-state and 62 MiB process peak. No solver iteration path changes.

## Compatibility

No equilibrium, device, CLI, optimizer, or objective default changes. Existing standard WOUT fields keep their names, dimensions, dtypes, and values. Older WOUTs remain readable and are rewritten without the extension. The corrected pitch quadrature is a small accuracy correction to the existing public trapped-fraction kernel; established QA/QH results move by at most `2.7e-6` relative.

A README change is intentionally omitted: this is a reference/output contract, documented in the confinement and WOUT pages, and does not warrant enlarging the concise user entry point.

## Remaining before merge

- Rebase onto current `main` after the preceding Phase 2 stack is merged.
- Obtain scientific review of the pitch and regular-axis conventions.
- Keep this PR draft until those dependency and review gates are satisfied.