### PR TITLE
Honor explicit nondefault devices during solver setup

### DIFF
--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -113,9 +113,11 @@
     "pr-physics-mirror-output": ["tests/mirror/test_output.py"],
     "pr-device": [
       "tests/test_device.py::test_fixed_boundary_builds_runtime_in_device_context",
+      "tests/test_device.py::test_fixed_boundary_honors_second_device_without_outer_context",
       "tests/test_device.py::test_put_numeric_leaves_preserves_metadata_and_none_contract",
       "tests/test_device.py::test_put_numeric_leaves_host_stages_cross_accelerator_copy",
       "tests/test_device.py::test_put_numeric_leaves_does_not_inspect_tracer_devices",
+      "tests/test_device.py::test_wout_builder_uses_state_device_context",
       "tests/test_gpu_ci.py::test_device_scope_second_host_device_gradient_equality",
       "tests/test_gpu_ci.py::test_second_host_device_unconverged_adjoint_raises_typed_error"
     ],

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -114,10 +114,13 @@
     "pr-device": [
       "tests/test_device.py::test_fixed_boundary_builds_runtime_in_device_context",
       "tests/test_device.py::test_fixed_boundary_honors_second_device_without_outer_context",
+      "tests/test_device.py::test_free_boundary_loads_mgrid_in_explicit_device_context[cpu-True]",
+      "tests/test_device.py::test_free_boundary_loads_mgrid_in_explicit_device_context[auto-False]",
       "tests/test_device.py::test_put_numeric_leaves_preserves_metadata_and_none_contract",
       "tests/test_device.py::test_put_numeric_leaves_host_stages_cross_accelerator_copy",
       "tests/test_device.py::test_put_numeric_leaves_does_not_inspect_tracer_devices",
       "tests/test_device.py::test_wout_builder_uses_state_device_context",
+      "tests/test_freeboundary_multigrid.py::test_stage_transfer_carries_vacuum_and_interpolates_final_xc",
       "tests/test_gpu_ci.py::test_device_scope_second_host_device_gradient_equality",
       "tests/test_gpu_ci.py::test_second_host_device_unconverged_adjoint_raises_typed_error"
     ],

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -112,6 +112,7 @@
     ],
     "pr-physics-mirror-output": ["tests/mirror/test_output.py"],
     "pr-device": [
+      "tests/test_device.py::test_fixed_boundary_builds_runtime_in_device_context",
       "tests/test_gpu_ci.py::test_device_scope_second_host_device_gradient_equality",
       "tests/test_gpu_ci.py::test_second_host_device_unconverged_adjoint_raises_typed_error"
     ],

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -113,6 +113,9 @@
     "pr-physics-mirror-output": ["tests/mirror/test_output.py"],
     "pr-device": [
       "tests/test_device.py::test_fixed_boundary_builds_runtime_in_device_context",
+      "tests/test_device.py::test_put_numeric_leaves_preserves_metadata_and_none_contract",
+      "tests/test_device.py::test_put_numeric_leaves_host_stages_cross_accelerator_copy",
+      "tests/test_device.py::test_put_numeric_leaves_does_not_inspect_tracer_devices",
       "tests/test_gpu_ci.py::test_device_scope_second_host_device_gradient_equality",
       "tests/test_gpu_ci.py::test_second_host_device_unconverged_adjoint_raises_typed_error"
     ],

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -267,6 +267,36 @@ def test_put_numeric_leaves_moves_registered_partial_captures():
     np.testing.assert_allclose(moved(jax.numpy.asarray([3.0])), 6.0)
 
 
+def test_put_numeric_leaves_host_stages_cross_accelerator_copy(monkeypatch):
+    class Device:
+        platform = "gpu"
+
+    class Array:
+        def devices(self):
+            return {Device()}
+
+        def __array__(self, dtype=None):
+            return np.asarray([1.0, 2.0], dtype=dtype)
+
+    target = Device()
+    monkeypatch.setattr(dev.jax, "Array", Array)
+    monkeypatch.setattr(
+        dev.jax, "device_put", lambda value, device: (np.asarray(value), device)
+    )
+    moved, placed = dev._put_numeric_leaves(Array(), target)
+    np.testing.assert_array_equal(moved, [1.0, 2.0])
+    assert placed is target
+
+
+def test_put_numeric_leaves_does_not_inspect_tracer_devices(monkeypatch):
+    target = SimpleNamespace(platform="gpu")
+    monkeypatch.setattr(dev.jax, "device_put", lambda value, _: value)
+    gradient = jax.grad(
+        lambda x: jax.numpy.sum(dev._put_numeric_leaves(x, target))
+    )(jax.numpy.ones(2))
+    np.testing.assert_array_equal(gradient, np.ones(2))
+
+
 def test_free_boundary_uses_shared_device_context(monkeypatch):
     resolution = _res(ns=11, mpol=6, ntor=0)
     seen = {}

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -163,7 +163,7 @@ def test_fixed_boundary_honors_second_device_without_outer_context():
         pytest.skip("two devices unavailable")
     inp = replace(
         VmecInput.from_file(DATA / "input.solovev"),
-        ns_array=[3], niter_array=[2], ftol_array=[1.0],
+        ns_array=[3, 5], niter_array=[2, 2], ftol_array=[1.0, 1.0],
     )
     reference = multigrid.solve_multigrid(
         inp, device=devices[0], verbose=False, prefetch_compile=False,
@@ -187,7 +187,11 @@ def test_fixed_boundary_honors_second_device_without_outer_context():
         )
 
     single = solver.solve(
-        inp, initial_state=reference.state, device=devices[1], verbose=False,
+        inp,
+        resolution=solver.resolution_from_input(inp, ns=5),
+        initial_state=reference.state,
+        device=devices[1],
+        verbose=False,
     )
     for name in ("rmnc", "zmns", "iotaf"):
         np.testing.assert_allclose(
@@ -217,6 +221,28 @@ def test_fixed_boundary_builds_runtime_in_device_context(monkeypatch):
     monkeypatch.setattr(multigrid, "prepare_runtime", prepare)
     with pytest.raises(RuntimeError, match="runtime reached"):
         multigrid.solve_multigrid(VmecInput(ns_array=[3]), device="cpu")
+
+
+def test_free_boundary_loads_mgrid_in_explicit_device_context(monkeypatch):
+    active = False
+
+    @contextlib.contextmanager
+    def context(*_):
+        nonlocal active
+        active = True
+        yield
+        active = False
+
+    def load(*_):
+        assert active
+        raise RuntimeError("mgrid reached")
+
+    monkeypatch.setattr(multigrid, "device_context", context)
+    monkeypatch.setattr(freeboundary, "_external_field_from_input", load)
+    with pytest.raises(RuntimeError, match="mgrid reached"):
+        multigrid.solve_free_boundary_multigrid(
+            VmecInput(lfreeb=True, mgrid_file="fake", ns_array=[3]), device="cpu"
+        )
 
 
 def test_resolve_implicit_device_defaults_to_cpu(monkeypatch):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -170,6 +170,26 @@ def test_fixed_boundary_honors_second_gpu_without_outer_context():
     } == {devices[1]}
 
 
+def test_fixed_boundary_builds_runtime_in_device_context(monkeypatch):
+    active = False
+
+    @contextlib.contextmanager
+    def context(*_):
+        nonlocal active
+        active = True
+        yield
+        active = False
+
+    def prepare(*_, **__):
+        assert active
+        raise RuntimeError("runtime reached")
+
+    monkeypatch.setattr(multigrid, "device_context", context)
+    monkeypatch.setattr(multigrid, "prepare_runtime", prepare)
+    with pytest.raises(RuntimeError, match="runtime reached"):
+        multigrid.solve_multigrid(VmecInput(ns_array=[3]), device="cpu")
+
+
 def test_resolve_implicit_device_defaults_to_cpu(monkeypatch):
     monkeypatch.delenv("JAX_PLATFORMS", raising=False)
     monkeypatch.delenv("JAX_PLATFORM_NAME", raising=False)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -205,6 +205,17 @@ def test_fixed_boundary_honors_second_device_without_outer_context():
 
 def test_fixed_boundary_builds_runtime_in_device_context(monkeypatch):
     active = False
+    seen = []
+    seed = SimpleNamespace(R_cos=np.zeros((2, 1)))
+    runtime = SimpleNamespace(modes=object())
+    carry = SimpleNamespace(
+        ier=multigrid.MORE_ITER_FLAG,
+        state=SimpleNamespace(R_cos=np.zeros((3, 1))),
+        fsqr=1.0,
+        fsqz=2.0,
+        fsql=3.0,
+    )
+    result = object()
 
     @contextlib.contextmanager
     def context(*_):
@@ -215,15 +226,55 @@ def test_fixed_boundary_builds_runtime_in_device_context(monkeypatch):
 
     def prepare(*_, **__):
         assert active
-        raise RuntimeError("runtime reached")
+        seen.append("runtime")
+        return runtime
+
+    def interpolate(*_, **__):
+        assert active
+        seen.append("interpolate")
+        return carry.state
+
+    def hot_restart(*_):
+        assert active
+        seen.append("hot restart")
+        return carry.state
+
+    def baselines(*_, **__):
+        assert active
+        seen.append("baselines")
+        return runtime
+
+    def solve(*_, **__):
+        assert active
+        return carry
+
+    def unconverged(*_):
+        assert active
+        return result
 
     monkeypatch.setattr(multigrid, "device_context", context)
     monkeypatch.setattr(multigrid, "prepare_runtime", prepare)
-    with pytest.raises(RuntimeError, match="runtime reached"):
-        multigrid.solve_multigrid(VmecInput(ns_array=[3]), device="cpu")
+    monkeypatch.setattr(multigrid, "interpolate_state", interpolate)
+    monkeypatch.setattr(multigrid, "hot_restart_state", hot_restart)
+    monkeypatch.setattr(multigrid, "runtime_with_baselines", baselines)
+    monkeypatch.setattr(multigrid, "_solve_stage", solve)
+    monkeypatch.setattr(multigrid, "_result_from_carry", unconverged)
+    actual = multigrid.solve_multigrid(
+        VmecInput(ns_array=[3]),
+        initial_state=seed,
+        device="cpu",
+        raise_on_max_iterations=False,
+    )
+    assert actual is result
+    assert seen == ["runtime", "interpolate", "hot restart", "baselines"]
 
 
-def test_free_boundary_loads_mgrid_in_explicit_device_context(monkeypatch):
+@pytest.mark.parametrize(
+    ("device", "expected_active"), [("cpu", True), (dev.AUTO, False)]
+)
+def test_free_boundary_loads_mgrid_in_explicit_device_context(
+    monkeypatch, device, expected_active
+):
     active = False
 
     @contextlib.contextmanager
@@ -234,14 +285,14 @@ def test_free_boundary_loads_mgrid_in_explicit_device_context(monkeypatch):
         active = False
 
     def load(*_):
-        assert active
+        assert active is expected_active
         raise RuntimeError("mgrid reached")
 
     monkeypatch.setattr(multigrid, "device_context", context)
     monkeypatch.setattr(freeboundary, "_external_field_from_input", load)
     with pytest.raises(RuntimeError, match="mgrid reached"):
         multigrid.solve_free_boundary_multigrid(
-            VmecInput(lfreeb=True, mgrid_file="fake", ns_array=[3]), device="cpu"
+            VmecInput(lfreeb=True, mgrid_file="fake", ns_array=[3]), device=device
         )
 
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,13 +1,14 @@
 """Unit tests for :mod:`vmex.core.device` — the CPU/GPU placement policy.
 
-Pure host-side logic (no solves), so this is fast.  On a CPU-only runner the
-GPU branches resolve to ``None`` (nothing to place); the tests assert the
-decision, not the presence of an accelerator.
+Most tests exercise host-side policy.  One tiny solve verifies that final
+arrays stay on a selected nondefault CPU or GPU.  Accelerator-only branches
+skip when the required hardware is unavailable.
 """
 
 from __future__ import annotations
 
 import contextlib
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -149,16 +150,23 @@ def test_gpu_request_on_cpu_machine_raises():
             dev.resolve_device("gpu", _res(ns=11, mpol=6, ntor=0))
 
 
-def test_fixed_boundary_honors_second_gpu_without_outer_context():
-    try:
-        devices = jax.devices("gpu")
-    except RuntimeError:
-        devices = []
+def test_fixed_boundary_honors_second_device_without_outer_context():
+    devices = []
+    for platform in ("gpu", "cpu"):
+        try:
+            devices = jax.devices(platform)
+        except RuntimeError:
+            pass
+        if len(devices) >= 2:
+            break
     if len(devices) < 2:
-        pytest.skip("two GPUs unavailable")
-    inp = VmecInput.from_file(DATA / "input.li383_low_res")
+        pytest.skip("two devices unavailable")
+    inp = replace(
+        VmecInput.from_file(DATA / "input.solovev"),
+        ns_array=[3], niter_array=[2], ftol_array=[1.0],
+    )
     reference = multigrid.solve_multigrid(
-        inp, device="cpu", verbose=False, prefetch_compile=False,
+        inp, device=devices[0], verbose=False, prefetch_compile=False,
     )
     result = multigrid.solve_multigrid(
         inp,
@@ -178,12 +186,17 @@ def test_fixed_boundary_honors_second_gpu_without_outer_context():
             rtol=5e-9, atol=1e-12,
         )
 
-    single = solver.solve(inp, device=devices[1], verbose=False)
-    for name in ("rmnc", "zmns", "iotaf", "fsq_history"):
+    single = solver.solve(
+        inp, initial_state=reference.state, device=devices[1], verbose=False,
+    )
+    for name in ("rmnc", "zmns", "iotaf"):
         np.testing.assert_allclose(
             getattr(single, name), getattr(reference, name),
             rtol=5e-9, atol=1e-12,
         )
+    bad_state = replace(reference.state, R_cos=reference.state.R_cos[:-1])
+    with pytest.raises(ValueError, match="interpolate_state"):
+        solver.solve(inp, initial_state=bad_state, device=devices[1], verbose=False)
 
 
 def test_fixed_boundary_builds_runtime_in_device_context(monkeypatch):
@@ -279,7 +292,10 @@ def test_wout_builder_uses_state_device_context(monkeypatch):
         return "wout"
 
     monkeypatch.setattr(jax, "default_device", context)
-    assert wout_module._on_state_device(build)(state=state) == "wout"
+    wrapped = wout_module._on_state_device(build)
+    assert wrapped(state=state) == "wout"
+    state.R_cos.device = None
+    assert wout_module._on_state_device(lambda **_: "wout")(state=state) == "wout"
 
 
 def test_put_numeric_leaves_preserves_metadata_and_none_contract():

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -302,7 +302,7 @@ def test_put_numeric_leaves_preserves_metadata_and_none_contract():
     resolution = _res(ns=11, mpol=6, ntor=0)
     assert dev._placement_device(None, resolution) is None
     cpu = jax.devices("cpu")[0]
-    resident = jax.numpy.ones(2)
+    resident = jax.device_put(np.ones(2), cpu)
     assert dev._put_numeric_leaves(resident, cpu) is resident
     moved = dev._put_numeric_leaves(
         {"array": np.ones(2), "metadata": "kept"}, cpu,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -8,6 +8,7 @@ decision, not the presence of an accelerator.
 from __future__ import annotations
 
 import contextlib
+from pathlib import Path
 from types import SimpleNamespace
 
 import jax
@@ -17,6 +18,9 @@ import pytest
 from vmex.core import device as dev
 from vmex.core import freeboundary, multigrid, solver
 from vmex.core.fourier import Resolution
+from vmex.core.input import VmecInput
+
+DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
 
 
 def _res(ns: int, mpol: int, ntor: int, nfp: int = 1) -> Resolution:
@@ -143,6 +147,27 @@ def test_gpu_request_on_cpu_machine_raises():
     if jax.default_backend() == "cpu":
         with pytest.raises(RuntimeError):
             dev.resolve_device("gpu", _res(ns=11, mpol=6, ntor=0))
+
+
+def test_fixed_boundary_honors_second_gpu_without_outer_context():
+    try:
+        devices = jax.devices("gpu")
+    except RuntimeError:
+        devices = []
+    if len(devices) < 2:
+        pytest.skip("two GPUs unavailable")
+    result = multigrid.solve_multigrid(
+        VmecInput.from_file(DATA / "input.li383_low_res"),
+        device=devices[1],
+        verbose=False,
+        prefetch_compile=False,
+    )
+    assert result.converged
+    assert {
+        leaf.device
+        for leaf in jax.tree.leaves(result.state)
+        if hasattr(leaf, "device")
+    } == {devices[1]}
 
 
 def test_resolve_implicit_device_defaults_to_cpu(monkeypatch):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -302,6 +302,8 @@ def test_put_numeric_leaves_preserves_metadata_and_none_contract():
     resolution = _res(ns=11, mpol=6, ntor=0)
     assert dev._placement_device(None, resolution) is None
     cpu = jax.devices("cpu")[0]
+    resident = jax.numpy.ones(2)
+    assert dev._put_numeric_leaves(resident, cpu) is resident
     moved = dev._put_numeric_leaves(
         {"array": np.ones(2), "metadata": "kept"}, cpu,
     )

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 
 from vmex.core import device as dev
-from vmex.core import freeboundary, multigrid, solver
+from vmex.core import freeboundary, multigrid, solver, wout as wout_module
 from vmex.core.fourier import Resolution
 from vmex.core.input import VmecInput
 
@@ -156,8 +156,12 @@ def test_fixed_boundary_honors_second_gpu_without_outer_context():
         devices = []
     if len(devices) < 2:
         pytest.skip("two GPUs unavailable")
+    inp = VmecInput.from_file(DATA / "input.li383_low_res")
+    reference = multigrid.solve_multigrid(
+        inp, device="cpu", verbose=False, prefetch_compile=False,
+    )
     result = multigrid.solve_multigrid(
-        VmecInput.from_file(DATA / "input.li383_low_res"),
+        inp,
         device=devices[1],
         verbose=False,
         prefetch_compile=False,
@@ -168,6 +172,18 @@ def test_fixed_boundary_honors_second_gpu_without_outer_context():
         for leaf in jax.tree.leaves(result.state)
         if hasattr(leaf, "device")
     } == {devices[1]}
+    for name in ("rmnc", "zmns", "iotaf", "fsq_history"):
+        np.testing.assert_allclose(
+            getattr(result, name), getattr(reference, name),
+            rtol=5e-9, atol=1e-12,
+        )
+
+    single = solver.solve(inp, device=devices[1], verbose=False)
+    for name in ("rmnc", "zmns", "iotaf", "fsq_history"):
+        np.testing.assert_allclose(
+            getattr(single, name), getattr(reference, name),
+            rtol=5e-9, atol=1e-12,
+        )
 
 
 def test_fixed_boundary_builds_runtime_in_device_context(monkeypatch):
@@ -243,6 +259,27 @@ def test_device_context_wraps_default_device_for_explicit_cpu():
     assert not isinstance(ctx, contextlib.nullcontext)
     with ctx:
         pass
+
+
+def test_wout_builder_uses_state_device_context(monkeypatch):
+    active = False
+    target = SimpleNamespace(platform="gpu")
+    state = SimpleNamespace(R_cos=SimpleNamespace(device=target))
+
+    @contextlib.contextmanager
+    def context(device):
+        nonlocal active
+        assert device is target
+        active = True
+        yield
+        active = False
+
+    def build(**_):
+        assert active
+        return "wout"
+
+    monkeypatch.setattr(jax, "default_device", context)
+    assert wout_module._on_state_device(build)(state=state) == "wout"
 
 
 def test_put_numeric_leaves_preserves_metadata_and_none_contract():

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -735,6 +735,25 @@ def test_second_gpu_relocation_preserves_values():
 
 
 @_requires_gpu
+def test_second_gpu_runtime_profiles_preserve_values():
+    """Profile quadrature constants must follow the selected accelerator."""
+    gpus = _second_gpus()
+    inp = VmecInput.from_file(DATA_DIR / "input.cth_like_free_bdy")
+    resolution = solver.resolution_from_input(inp, ns=15)
+    runtimes = []
+    for device in gpus[:2]:
+        with jax.default_device(device):
+            runtime = solver.prepare_runtime(inp, resolution)
+        assert {leaf.device for leaf in jax.tree.leaves(runtime)} == {device}
+        runtimes.append(runtime)
+    assert np.any(np.asarray(runtimes[0].setup.icurv) != 0.0)
+    for left, right in zip(
+        jax.tree.leaves(runtimes[0]), jax.tree.leaves(runtimes[1]), strict=True
+    ):
+        np.testing.assert_array_equal(left, right)
+
+
+@_requires_gpu
 def test_second_gpu_explicit_values_and_gradients():
     """The supported scoped path runs on a NON-DEFAULT GPU.
 

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -402,6 +402,17 @@ def test_converged_lasym_free_boundary_cpu_gpu_parity(monkeypatch):
         for platform, result in results.items()
     }
     for name in (
+        "rmnc", "zmns", "rmns", "zmnc", "lmns", "lmnc",
+        "bmnc", "bmns", "iotaf",
+    ):
+        np.testing.assert_allclose(
+            getattr(wouts["gpu"], name),
+            getattr(wouts["cpu"], name),
+            rtol=5e-4,
+            atol=1e-9,
+            err_msg=name,
+        )
+    for name in (
         "potsin",
         "potcos",
         "bsubumnc_sur",

--- a/tests/test_gpu_ci.py
+++ b/tests/test_gpu_ci.py
@@ -321,7 +321,8 @@ def test_converged_lasym_free_boundary_cpu_gpu_parity(monkeypatch):
     monkeypatch.setattr(
         freeboundary, "_solve_free_boundary_stage", recording_solve_stage,
     )
-    for platform in ("cpu", "gpu"):
+    gpu_target = jax.devices("gpu")[-1]
+    for platform, target in (("cpu", "cpu"), ("gpu", gpu_target)):
         active_platform[0] = platform
         lines = []
         results[platform] = multigrid.solve_free_boundary_multigrid(
@@ -331,7 +332,7 @@ def test_converged_lasym_free_boundary_cpu_gpu_parity(monkeypatch):
             emit=lambda *args, _lines=lines, **kwargs: _lines.append(
                 args[0] if args else ""
             ),
-            device=platform,
+            device=target,
         )
         output[platform] = "".join(lines)
 
@@ -348,6 +349,9 @@ def test_converged_lasym_free_boundary_cpu_gpu_parity(monkeypatch):
     assert stage_devices["gpu"][1] == {
         "field": {"gpu"}, "state": {"gpu"}, "vacuum": {"gpu"},
     }
+    assert all(
+        leaf.device == gpu_target for leaf in jax.tree.leaves(results["gpu"].state)
+    )
     assert solve_devices == {"cpu": None, "gpu": "cpu"}
     np.testing.assert_allclose(
         [results["gpu"].fsqr, results["gpu"].fsqz, results["gpu"].fsql],
@@ -424,7 +428,10 @@ def test_converged_lasym_free_boundary_cpu_gpu_parity(monkeypatch):
         return solve_stage(*args, **kwargs)
 
     monkeypatch.setattr(freeboundary, "_solve_free_boundary_stage", recording_restart)
-    for target, source in (("gpu", "cpu"), ("cpu", "gpu")):
+    for platform, target, source in (
+        ("gpu", gpu_target, "cpu"),
+        ("cpu", "cpu", "gpu"),
+    ):
         seed = results[source].state
         seed = dataclasses.replace(
             seed,
@@ -440,8 +447,8 @@ def test_converged_lasym_free_boundary_cpu_gpu_parity(monkeypatch):
             max_iterations=1,
             error_on_no_convergence=False, initial_state=seed, device=target,
         )
-        assert _platform(restarted.state.R_cos) == target
-        assert _platform(restart_inputs[-1].R_cos) == target
+        assert _platform(restarted.state.R_cos) == platform
+        assert _platform(restart_inputs[-1].R_cos) == platform
         for family in ("R_cos", "R_sin", "Z_sin", "Z_cos"):
             np.testing.assert_array_equal(
                 getattr(restart_inputs[-1], family)[-1],
@@ -715,6 +722,16 @@ def _second_gpus():
     if len(gpus) < 2:
         pytest.skip("needs at least two GPUs")
     return gpus
+
+
+@_requires_gpu
+def test_second_gpu_relocation_preserves_values():
+    """Cross-accelerator placement must not trust unsafe peer copies."""
+    source, target = _second_gpus()[:2]
+    values = jax.device_put(np.arange(16.0), source)
+    moved = device_policy._put_numeric_leaves(values, target)
+    np.testing.assert_array_equal(np.asarray(moved), np.asarray(values))
+    assert moved.devices() == {target}
 
 
 @_requires_gpu

--- a/vmex/core/device.py
+++ b/vmex/core/device.py
@@ -273,14 +273,15 @@ def _put_numeric_leaves(value: Any, device: Any):
     def put(leaf):
         if not isinstance(leaf, (jax.Array, np.ndarray)):
             return leaf
-        if (
-            isinstance(leaf, jax.Array)
-            and not isinstance(leaf, jax.core.Tracer)
-            and getattr(device, "platform", None) != "cpu"
-            and device not in leaf.devices()
-            and any(source.platform != "cpu" for source in leaf.devices())
-        ):
-            leaf = np.asarray(leaf)
+        if isinstance(leaf, jax.Array) and not isinstance(leaf, jax.core.Tracer):
+            sources = leaf.devices()
+            if device in sources:
+                return leaf
+            if (
+                getattr(device, "platform", None) != "cpu"
+                and any(source.platform != "cpu" for source in sources)
+            ):
+                leaf = np.asarray(leaf)
         return jax.device_put(leaf, device)
 
     return jax.tree.map(

--- a/vmex/core/device.py
+++ b/vmex/core/device.py
@@ -275,7 +275,7 @@ def _put_numeric_leaves(value: Any, device: Any):
             return leaf
         if isinstance(leaf, jax.Array) and not isinstance(leaf, jax.core.Tracer):
             sources = leaf.devices()
-            if device in sources:
+            if sources == {device}:
                 return leaf
             if (
                 getattr(device, "platform", None) != "cpu"

--- a/vmex/core/device.py
+++ b/vmex/core/device.py
@@ -269,8 +269,21 @@ def _put_numeric_leaves(value: Any, device: Any):
     """Move registered-pytree array leaves while preserving metadata/objects."""
     if value is None or device is None:
         return value
+
+    def put(leaf):
+        if not isinstance(leaf, (jax.Array, np.ndarray)):
+            return leaf
+        if (
+            isinstance(leaf, jax.Array)
+            and not isinstance(leaf, jax.core.Tracer)
+            and getattr(device, "platform", None) != "cpu"
+            and device not in leaf.devices()
+            and any(source.platform != "cpu" for source in leaf.devices())
+        ):
+            leaf = np.asarray(leaf)
+        return jax.device_put(leaf, device)
+
     return jax.tree.map(
-        lambda leaf: jax.device_put(leaf, device)
-        if isinstance(leaf, (jax.Array, np.ndarray)) else leaf,
+        put,
         value,
     )

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -363,18 +363,18 @@ def solve_multigrid(
                 precon_type=precon_type, prec2d_threshold=prec2d_threshold,
                 prec2d=prec2d, use_fft=stage_use_fft,
             )
-        state = _put_numeric_leaves(
-            state, _placement_device(device, resolution)
-        )
-        if state is not None and int(state.R_cos.shape[0]) != nsval:
-            state = interpolate_state(state, ns_fine=nsval, modes=rt.modes)
-        if state is not None:
-            if first_executed:
-                # user-provided hot-restart seed: adapt to this input's boundary
-                state = hot_restart_state(rt, state)
-            # funct3d.f: rcon0/zcon0 are set from the state at iter2 == iter1,
-            # i.e. from THIS stage's starting state, not the interior guess.
-            rt = runtime_with_baselines(rt, state, use_fft=stage_use_fft)
+            state = _put_numeric_leaves(
+                state, _placement_device(device, resolution)
+            )
+            if state is not None and int(state.R_cos.shape[0]) != nsval:
+                state = interpolate_state(state, ns_fine=nsval, modes=rt.modes)
+            if state is not None:
+                if first_executed:
+                    # user-provided hot-restart seed: adapt to this input's boundary
+                    state = hot_restart_state(rt, state)
+                # funct3d.f: rcon0/zcon0 are set from the state at iter2 == iter1,
+                # i.e. from THIS stage's starting state, not the interior guess.
+                rt = runtime_with_baselines(rt, state, use_fft=stage_use_fft)
         # Overlapped compilation (see the docstring): start building rung
         # igrid+1's executable now, so it is (mostly) ready when this rung's
         # iterations finish.  Equal-structure next rungs reuse this rung's
@@ -577,7 +577,13 @@ def solve_free_boundary_multigrid(
     )
 
     if external_field is None:
-        external_field = _external_field_from_input(inp, mgrid_path)
+        if device is not None and not (
+            isinstance(device, str) and device.strip().lower() == AUTO
+        ):
+            with device_context(device):
+                external_field = _external_field_from_input(inp, mgrid_path)
+        else:
+            external_field = _external_field_from_input(inp, mgrid_path)
 
     state = initial_state
     interpolation_source = initial_state
@@ -600,8 +606,9 @@ def solve_free_boundary_multigrid(
             # initialize_radial.f interpolates pxstore only when ns increases;
             # an equal-grid entry returns before allocation/interpolation and
             # therefore reruns the current xc state unchanged.
-            state = interpolate_state(
-                interpolation_source, ns_fine=nsval, modes=modes)
+            with device_context(device, resolution):
+                state = interpolate_state(
+                    interpolation_source, ns_fine=nsval, modes=modes)
 
         # Overlapped compilation across rungs (see the docstring): while this
         # rung iterates, a background thread AOT-compiles rung igrid+1's lane

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -363,6 +363,9 @@ def solve_multigrid(
                 precon_type=precon_type, prec2d_threshold=prec2d_threshold,
                 prec2d=prec2d, use_fft=stage_use_fft,
             )
+        state = _put_numeric_leaves(
+            state, _placement_device(device, resolution)
+        )
         if state is not None and int(state.R_cos.shape[0]) != nsval:
             state = interpolate_state(state, ns_fine=nsval, modes=rt.modes)
         if state is not None:

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -462,9 +462,10 @@ def solve_multigrid(
             _PREFETCH_ATTEMPTED.clear()
             gc.collect()
 
-    if int(carry.ier) == MORE_ITER_FLAG and not raise_on_max_iterations:
-        return _result_from_carry(carry, rt)
-    return _finalize(carry, rt)
+    with device_context(device, resolution):
+        if int(carry.ier) == MORE_ITER_FLAG and not raise_on_max_iterations:
+            return _result_from_carry(carry, rt)
+        return _finalize(carry, rt)
 
 
 def solve_free_boundary_multigrid(

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -355,13 +355,14 @@ def solve_multigrid(
         nsval = int(ns_arr[igrid])
         resolution = resolution_from_input(inp, ns=nsval)
         stage_use_fft = _resolve_use_fft(use_fft, device, resolution)
-        rt = prepare_runtime(
-            inp, resolution, ftol=float(ftol_arr[igrid]),
-            max_iterations=int(niter_arr[igrid]), lconm1=lconm1,
-            time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
-            precon_type=precon_type, prec2d_threshold=prec2d_threshold,
-            prec2d=prec2d, use_fft=stage_use_fft,
-        )
+        with device_context(device, resolution):
+            rt = prepare_runtime(
+                inp, resolution, ftol=float(ftol_arr[igrid]),
+                max_iterations=int(niter_arr[igrid]), lconm1=lconm1,
+                time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
+                precon_type=precon_type, prec2d_threshold=prec2d_threshold,
+                prec2d=prec2d, use_fft=stage_use_fft,
+            )
         if state is not None and int(state.R_cos.shape[0]) != nsval:
             state = interpolate_state(state, ns_fine=nsval, modes=rt.modes)
         if state is not None:

--- a/vmex/core/profiles.py
+++ b/vmex/core/profiles.py
@@ -74,13 +74,13 @@ MU0 = 4e-7 * np.pi
 # ``LIBSTELL/Sources/Miscel/profile_functions.f`` (``gln = 10``, ``glx/glw``)
 # so the integrated 'two_power'/'gauss_trunc' current profiles are bit-exact
 # against VMEC2000 (a higher-order rule would be *less* parity-accurate).
-_GL_X = jnp.asarray([
+_GL_X = np.asarray([
     0.01304673574141414, 0.06746831665550774, 0.1602952158504878,
     0.2833023029353764, 0.4255628305091844, 0.5744371694908156,
     0.7166976970646236, 0.8397047841495122, 0.9325316833444923,
     0.9869532642585859,
 ])
-_GL_W = jnp.asarray([
+_GL_W = np.asarray([
     0.03333567215434407, 0.0747256745752903, 0.1095431812579910,
     0.1346333596549982, 0.1477621123573764, 0.1477621123573764,
     0.1346333596549982, 0.1095431812579910, 0.0747256745752903,
@@ -207,8 +207,10 @@ def _integrate_0_to_x(fun, coefficients, x):
     the hard-coded ``[0, 1]`` nodes/weights above (exact VMEC2000 parity).
     """
     x = jnp.asarray(x)
-    t = x[..., None] * _GL_X[None, :]
-    return x * jnp.sum(_GL_W[None, :] * fun(coefficients, t), axis=-1)
+    nodes = jnp.asarray(_GL_X, dtype=x.dtype)
+    weights = jnp.asarray(_GL_W, dtype=x.dtype)
+    t = x[..., None] * nodes[None, :]
+    return x * jnp.sum(weights[None, :] * fun(coefficients, t), axis=-1)
 
 
 def _pcurr_two_power_ip(coefficients, x):

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -129,6 +129,7 @@ from .device import (
     AUTO,
     GPU_MAX_SPECTRAL_MODES,
     _placement_device,
+    _put_numeric_leaves,
     device_context,
 )
 from .errors import (
@@ -2173,6 +2174,9 @@ def solve(
     if resolution is None:
         raise ValueError("solve(RunSetup) requires a Resolution")
     use_fft_resolved = _resolve_use_fft(use_fft, device, resolution)
+    initial_state = _put_numeric_leaves(
+        initial_state, _placement_device(device, resolution)
+    )
     with device_context(device, resolution):
         rt = prepare_runtime(
             source, resolution, ftol=ftol, max_iterations=max_iterations,

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -2173,29 +2173,30 @@ def solve(
     if resolution is None:
         raise ValueError("solve(RunSetup) requires a Resolution")
     use_fft_resolved = _resolve_use_fft(use_fft, device, resolution)
-    rt = prepare_runtime(
-        source, resolution, ftol=ftol, max_iterations=max_iterations,
-        time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
-        lconm1=lconm1, precon_type=precon_type,
-        prec2d_threshold=prec2d_threshold, prec2d=prec2d,
-        use_fft=use_fft_resolved,
-    )
-    if initial_state is not None:
-        ns, mnmax = rt.resolution.ns, rt.modes.mnmax
-        if tuple(initial_state.R_cos.shape) != (ns, mnmax):
-            raise ValueError(
-                f"initial_state has shape {tuple(initial_state.R_cos.shape)}, "
-                f"expected ({ns}, {mnmax}); interpolate with "
-                "vmex.core.multigrid.interpolate_state first"
-            )
-        initial_state = hot_restart_state(rt, initial_state)
-        rt = runtime_with_baselines(
-            rt, initial_state, use_fft=use_fft_resolved
-        )  # funct3d.f iter2==iter1
+    with device_context(device, resolution):
+        rt = prepare_runtime(
+            source, resolution, ftol=ftol, max_iterations=max_iterations,
+            time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
+            lconm1=lconm1, precon_type=precon_type,
+            prec2d_threshold=prec2d_threshold, prec2d=prec2d,
+            use_fft=use_fft_resolved,
+        )
     with device_context(device, rt.resolution):
+        if initial_state is not None:
+            ns, mnmax = rt.resolution.ns, rt.modes.mnmax
+            if tuple(initial_state.R_cos.shape) != (ns, mnmax):
+                raise ValueError(
+                    f"initial_state has shape {tuple(initial_state.R_cos.shape)}, "
+                    f"expected ({ns}, {mnmax}); interpolate with "
+                    "vmex.core.multigrid.interpolate_state first"
+                )
+            initial_state = hot_restart_state(rt, initial_state)
+            rt = runtime_with_baselines(
+                rt, initial_state, use_fft=use_fft_resolved
+            )  # funct3d.f iter2==iter1
         carry = _solve_stage(
             rt, initial_state, mode=mode, verbose=verbose, emit=emit,
             use_fft=use_fft_resolved,
             jacobian_retries=jacobian_retries,
         )
-    return _finalize(carry, rt)
+        return _finalize(carry, rt)

--- a/vmex/core/wout.py
+++ b/vmex/core/wout.py
@@ -33,6 +33,7 @@ remaining VMEC2000 output quantities (``eqfor.f``/``spectrum.f``/
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass, fields as _dc_fields
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -541,6 +542,22 @@ def _ftolv_from_input(inp) -> float:
     return float(ftol_arr[min(idx, ftol_arr.size - 1)])
 
 
+def _on_state_device(fun):
+    """Run postprocessing where the committed equilibrium state lives."""
+    @functools.wraps(fun)
+    def wrapped(*args, **kwargs):
+        target = getattr(kwargs["state"].R_cos, "device", None)
+        target = target() if callable(target) else target
+        if target is None:
+            return fun(*args, **kwargs)
+        import jax
+
+        with jax.default_device(target):
+            return fun(*args, **kwargs)
+    return wrapped
+
+
+@_on_state_device
 def wout_from_state(
     *,
     inp,


### PR DESCRIPTION
## Goal

Make the public `device=` contract true for every local device ordinal. An
explicit JAX device such as `jax.devices("gpu")[1]` must own fixed- and
free-boundary runtime/state arrays and return the same physics as CPU/GPU0,
without an outer `jax.default_device(...)` context or a platform-selection
environment variable.

## Root causes

Six independent placement failures were reproduced on a two-GPU host:

1. `solve_multigrid` constructed `SolverRuntime` before entering the selected
   device context.
2. With JAX 0.11.0/CUDA 13 on this host, a direct `jax.device_put` peer copy
   from `cuda:0` to `cuda:1` silently returned zero-filled arrays.
3. The Gauss–Legendre current-profile tables were module-scope JAX arrays.
   Import committed them to GPU0, so preparing a `two_power`/`gauss_trunc`
   current profile in a GPU1 context produced a zero `icurv`. In a CTH
   free-boundary solve this removed the plasma current, changed NESTOR's
   forcing, and converged to a different equilibrium.
4. Solver finalization and WOUT construction occurred after leaving the
   selected-device context. The converged state on GPU1 was correct, but
   primary returned arrays such as `rmnc`, `zmns`, and `iotaf` could be
   corrupted by postprocessing on default GPU0.
5. Fixed-boundary hot starts accepted a state committed to another
   accelerator without relocating it. A same-GPU restart converged, while
   GPU0-to-GPU1 restart of the identical state raised a false Jacobian error.
6. Fixed- and free-boundary radial interpolation ran between device contexts,
   and an internally loaded mgrid was materialized before entering one. A
   two-stage finite-beta ladder therefore converged on CPU/GPU0 but raised a
   false initial-Jacobian error on GPU1 unless the caller wrapped the whole
   solve in `jax.default_device(gpu1)`.

The last three issues were found only after comparing complete physical state
and WOUT arrays, not just device ownership and final residuals.

## Achieved

- Construct each fixed-boundary runtime inside the selected-device context.
- Host-stage only concrete accelerator-to-different-accelerator pytree
  transfers. Same-device, CPU/GPU, traced AD, AUTO, and `None` paths retain
  their prior behavior.
- Keep profile quadrature tables as device-neutral NumPy constants and
  materialize them in the active JAX context.
- Keep hot restarts, final solver results, multigrid result assembly, and WOUT
  construction in the equilibrium-state device context.
- Relocate fixed-boundary single-grid and multigrid restart states to the
  explicit stage device, using the same host-staged peer-transfer policy as
  free boundary.
- Build fixed-boundary interpolation/baselines, free-boundary interpolation,
  and internally loaded mgrid fields in the selected stage/device context.
- Leave concrete arrays unchanged when they already live on exactly the
  requested device. This preserves JAX's uncommitted sharding and executable
  reuse; arrays sharded over multiple devices are still collapsed to the
  explicit target.
- Add real two-GPU value, ownership, runtime-profile, solve, implicit-AD, and
  LASYM free-boundary/hot-restart regressions.
- Add a fast three-surface hosted two-device regression for result arrays, hot
  restart, WOUT context, peer transfer, metadata, and traced AD.

The equations, tolerances, public signatures, and default placement policy are
unchanged.

## Validation

Current head: `2ae5e90d08f2bfca0e8169ad6200d56f21ac7bb8`.

Completed on the current production code:

- Complete local CPU suite with reference assets: 888 passed, 130 skipped,
  2 expected failures in 14m36s.
- Cold three-rung multigrid compiles exactly three lane executables; the
  structurally warm ladder and the direct solve after it compile none. The
  full ladder module passes 15 tests with 2 expected failures.
- Exact-head hosted run
  [`30595258517`](https://github.com/uwplasma/vmex/actions/runs/30595258517)
  passed all 11 jobs, including changed-line coverage and the forced
  two-device lane.
- Focused hosted two-device regression: 8 passed in 48.6s on two forced CPU
  devices; its three-surface solve takes 5.3s when run alone.
- Ruff, mypy, and diff checks pass.
- The strengthened two-device regression now executes a two-stage radial
  ladder. Device, multigrid, and free-boundary focused suites pass locally:
  49 passed, 7 skipped, and 2 expected failures. The forced two-CPU-device
  regression passes independently.
- Two-RTX-A4000 runtime audit: all 35 `SolverRuntime` leaves, all six initial
  free-boundary vacuum scalars, and all 17 fused NESTOR outputs are bit-for-bit
  equal on GPU0 and GPU1.
- File-backed CTH free-boundary solve:
  - CPU: 573 iterations;
  - GPU0: 573 iterations;
  - GPU1: 573 iterations;
  - GPU0/GPU1 states and residuals are bit-for-bit equal;
  - CPU/GPU state difference is `1.09e-12` relative;
  - residuals are `(9.96e-11, 2.03e-11, 3.77e-11)`.
- The new two-GPU runtime-profile regression passes in 3.76 seconds.
- The supplied near-degenerate NFP=3 vacuum deck with `LFORBAL=T` converges
  in 941 iterations on CPU, GPU0, and GPU1. GPU0/GPU1 are identical; relative
  GPU/CPU differences are `1.89e-11` for `rmnc`, `4.99e-11` for `zmns`,
  `4.01e-10` over all state leaves, and `3.69e-10` for iota.
- The real second-GPU fixed-boundary result regression passed in 344.96s and
  now checks primary result arrays, not only ownership and residuals.
- The exact ordered GPU-smoke suite passed on two RTX A4000s: 56 passed and
  6 host-only skips in 7m04s. This includes GPU0-to-GPU1 hot restart, the
  sequence-sensitive LASYM free-boundary solve, NESTOR WOUT fields, and
  implicit AD.

Earlier validation retained by this head:

- Hosted run
  [`30579046020`](https://github.com/uwplasma/vmex/actions/runs/30579046020):
  11/11 jobs passed at the previous production head.
- Trusted two-RTX-A4000 run
  [`30577859489`](https://github.com/uwplasma/vmex/actions/runs/30577859489):
  all placement/solve/AD tests and all 14 CPU/GPU0/GPU1 physics-gradient
  reports passed without `JAX_PLATFORMS` or `JAX_PLATFORM_NAME`.
- LASYM free-boundary/NESTOR on `cuda:1`: CPU/GPU state, residual, WOUT,
  vacuum-field, and CPU↔GPU hot-restart parity passed.

The earlier trusted two-GPU run
[`30587419000`](https://github.com/uwplasma/vmex/actions/runs/30587419000)
passed at the profile/runtime-fix head. It used normal JAX hardware discovery
(`JAX_PLATFORMS` and `JAX_PLATFORM_NAME` were both unset) and completed:

- placement, fixed/free-boundary solve, hot-restart, and implicit-AD gates;
- MHD energy, magnetic well, DMerc, `jdotb`, Glasser \(D_R\),
  quasisymmetry, and quasi-isodynamic value/gradient parity on GPU0 and GPU1;
- all 14 metric/device reports passed, with maximum CPU/GPU gradient
  difference `3.04e-11`, maximum value difference `4.01e-13`, and exact
  CPU/GPU forward-state equality for the audit deck.

That run predates the result/WOUT and hot-start corrections and is retained as
physics-gradient evidence, not as the final merge gate. Hosted run
[`30590663182`](https://github.com/uwplasma/vmex/actions/runs/30590663182)
passed every package, quality, core/mirror physics, and two-device job on the
result/WOUT production code; only changed-line coverage failed because the new
three-surface and WOUT tests were not in its coverage selector. The current
head adds that routing and the fixed-boundary hot-start relocation.

Trusted run
[`30592841189`](https://github.com/uwplasma/vmex/actions/runs/30592841189)
passed the ordered placement/solve suite and all 14 CPU/GPU0/GPU1
physics-gradient reports on the preceding hot-start head. Both platform
environment selectors were unset. The maximum relative value and gradient
differences were `4.01e-13` and `3.04e-11`; every audited CPU/GPU forward
state was bit-for-bit equal. Exact-head trusted run
[`30595282896`](https://github.com/uwplasma/vmex/actions/runs/30595282896)
passed the placement/solve/AD gate and all 14 CPU/GPU0/GPU1 physics-gradient
reports. Both platform environment selectors were unset. Every report passed;
the maximum relative value and gradient differences were `4.01e-13` and
`3.04e-11`, and every audited CPU/GPU forward state was bit-for-bit equal.
It predates only the radial-interpolation/mgrid-context correction.

On the current production code, the exact finite-beta GPU1 case that exposed
the remaining defect now converges in 246 iterations without an outer device
context. Scaling and reconvergence commute across all 89 compared WOUT fields;
the worst error uses only `0.21%` of its tolerance. The final commit adds no
production change: it routes the setup-context regressions through the
changed-line coverage lane. Exact hosted run
[`30602729337`](https://github.com/uwplasma/VMEX/actions/runs/30602729337)
passed all 11 jobs with 100% coverage over all 58 changed executable lines.
Trusted run
[`30601463117`](https://github.com/uwplasma/VMEX/actions/runs/30601463117)
tested the same production code at the preceding test-only head and passed
the placement/solve/AD gate plus all 14 CPU/GPU0/GPU1 physics reports. Every
forward state was bit-for-bit equal; maximum relative value and gradient
differences were `4.01e-13` and `3.04e-11`, and both platform selectors were
unset. Exact final-head trusted run
[`30602820294`](https://github.com/uwplasma/VMEX/actions/runs/30602820294)
also passed the placement/solve/AD gate and all 14 CPU/GPU0/GPU1 reports.
Every forward state was bit-for-bit equal; maximum relative value and
gradient differences were `4.01e-13` and `3.04e-11`, and both platform
selectors were unset.

## Compatibility

Ordinary CPU, GPU0, AUTO, and `device=None` behavior is unchanged. Only
relocation between distinct accelerators incurs a host hop, required for
correctness on unsafe peer-copy runtimes. Same-device relocation is now a
no-op, avoiding copies and preserving compilation-cache signatures. The
quadrature change preserves the same float64 constants and operation order; it
only defers their JAX placement until use.

## Left

No implementation or validation gate remains. Merge this device-correctness
PR before reviewing its resource-profiler and dimensional-scaling dependants.

Merge this PR before those stacked PRs.
