### PR TITLE
Add dimensional input and WOUT scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ input-flag coverage is tracked separately in
   prints VMEC2000-format iteration output, and writes `wout_*.nc` files
   that load unchanged in simsopt and booz_xform.
 - **Batteries included.** Plotting (`vmex --plot`), Boozer transform
-  (`vmex --booz`), spline profiles, multigrid, hot restart, free boundary
+  (`vmex --booz`), dimensional scaling for fast-particle studies
+  (`vmex --scale`), spline profiles, multigrid, hot restart, free boundary
   from mgrid files or fields tabulated from coils,
   typed zero-crash errors — with the shared linear/adjoint solver layer
   factored out into [SOLVAX](https://pypi.org/project/solvax/).
@@ -95,6 +96,7 @@ cd vmex && pip install -e .
 vmex --doctor     # check the installation and JAX backend
 vmex --test       # solve the bundled QH case, write wout + plots
 vmex input.X      # run any VMEC2000 input deck (or structured JSON)
+vmex --plot --booz input.X  # solve, transform, and make both plot sets
 ```
 
 `vmex input.X` writes `wout_X.nc` next to the input (`--outdir` to
@@ -112,6 +114,27 @@ vmex --plot wout_nfp4_QH_warm_start.nc     # surfaces, |B|, profiles, 3D
 vmex --booz wout_nfp4_QH_warm_start.nc     # Boozer transform -> boozmn_*.nc
 vmex --plot boozmn_nfp4_QH_warm_start.nc   # Boozer |B| contours + spectrum
 ```
+
+Scale for fast-particle studies
+-------------------------------
+
+Scale an input or WOUT to the ARIES-CS reference dimensions
+(`|b0| = 5.7 T`, `Aminor_p = 1.7 m`), or give explicit multiplicative
+magnetic-field and size factors:
+
+```bash
+vmex --scale input.X             # writes input.X_scaled at ARIES-CS scale
+vmex --scale input.X 1.2 0.8     # B_scale=1.2, R_scale=0.8
+vmex --scale wout_X.nc           # writes wout_X_scaled.nc
+vmex --plot --booz input.X_scaled
+```
+
+Input and WOUT transforms obey the same dimensional similarity law and are
+tested to commute with reconverged fixed- and free-boundary solves. This makes
+it straightforward to set the physical field and size for fixed-energy orbit
+calculations, including 3.5 MeV alpha studies.
+See the [scaling reference](https://vmex.readthedocs.io/en/latest/scaling.html)
+for the field table, the bounded input probe, and free-boundary mgrid handling.
 
 ## Parity with VMEC2000
 
@@ -229,6 +252,7 @@ The status of each solver, device, and differentiation lane is defined by the
 | Typed zero-crash errors | ✅ | ❌ | ✅ |
 | Boozer transform built in (`--booz`) | ✅ | ❌ | ❌ |
 | Plotting built in (`--plot`) | ✅ | ❌ | ❌ |
+| Input/WOUT dimensional scaling (`--scale`) | ✅ | ❌ | ❌ |
 | GPU execution | ✅ | ❌ | ❌ |
 | Differentiable fixed boundary (implicit diff, O(1) memory) | ✅ | ❌ | ❌ |
 | Differentiable virtual-casing residual on a specified boundary | ✅ | ❌ | ❌ |

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -112,6 +112,9 @@ Outputs
 .. automodule:: vmex.core.wout
    :members:
 
+.. automodule:: vmex.core.scaling
+   :members:
+
 .. automodule:: vmex.core.nyquist
    :members:
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -16,6 +16,7 @@ Usage
    vmex --plot mout_*.nc       — straight-axis mirror diagnostics
    vmex --booz wout_*.nc       — run booz_xform_jax, write boozmn_*.nc
    vmex --plot boozmn_*.nc     — Boozer contour/spectrum plots
+   vmex --scale PATH [B R]     — dimensionally scale an input or WOUT
    vmex --doctor               — installation and JAX backend diagnostics
    vmex --test                 — run and plot the bundled quick-start case
 
@@ -37,6 +38,10 @@ Options
        a ``mout_*.nc`` file, plot horizontal straight-axis mirror diagnostics;
        with a ``boozmn_*.nc`` file, plot Boozer diagnostics; with an input
        file, solve first and plot the resulting WOUT.
+   * - ``--scale``
+     - Write a scaled input or WOUT. Optional positional factors are
+       ``B_scale R_scale``; with no factors the targets are
+       ``|b0| = 5.7 T`` and ``Aminor_p = 1.7 m`` (ARIES-CS).
    * - ``--booz``
      - Run ``booz_xform_jax`` after solving, or directly from a ``wout_*.nc``
        file, and write ``boozmn_*.nc``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,7 @@ Documentation
 
       installation
       quickstart
+      scaling
 
    .. toctree::
       :maxdepth: 1

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -65,6 +65,7 @@ plotted directly:
 
    vmex --plot wout_circular_tokamak.nc
    vmex input.circular_tokamak --plot     # solve, then plot in one command
+   vmex --plot --booz input.circular_tokamak  # solve + both plot sets
 
 This writes a set of figures next to the file (or into ``--outdir``): a
 summary panel, flux-surface cross-sections at several toroidal angles,
@@ -89,6 +90,22 @@ and surfaces are configurable:
 
    vmex wout_nfp4_QH_warm_start.nc --booz --mbooz 48 --nbooz 48 \
         --booz-surfaces "0.25, 0.5, 1.0"
+
+Physical scaling
+----------------
+
+``--scale`` applies one dimensional similarity transform to a parsed input or
+WOUT. With no factors it targets the ARIES-CS on-axis field and minor radius:
+
+.. code-block:: bash
+
+   vmex --scale input.nfp4_QH_warm_start
+   vmex --scale input.nfp4_QH_warm_start 1.2 0.8
+   vmex --scale wout_nfp4_QH_warm_start.nc
+
+The explicit factors are ``B_scale R_scale``. The output name gains
+``_scaled``. See :doc:`scaling` for the units, input probe, and free-boundary
+mgrid contract.
 
 Python API
 ----------

--- a/docs/scaling.rst
+++ b/docs/scaling.rst
@@ -1,0 +1,98 @@
+Dimensional scaling
+===================
+
+Ideal-MHD equilibria have a dimensional similarity transform. VMEX exposes it
+for physical orbit studies in which the particle energy and Larmor radius are
+fixed, such as 3.5 MeV alpha-particle calculations:
+
+.. code-block:: bash
+
+   vmex --scale input.case
+   vmex --scale input.case 1.2 0.8
+   vmex --scale wout_case.nc
+
+The optional numbers are positive multiplicative ``B_scale R_scale`` factors.
+Without them, VMEX targets the ARIES-CS reference magnitudes
+``|b0| = 5.7 T`` and ``Aminor_p = 1.7 m``. A positive magnetic factor preserves
+the flux direction. Output names gain ``_scaled``.
+
+After scaling, one command solves the deck, writes WOUT and Boozer files, and
+creates ordinary and Boozer-coordinate plots:
+
+.. code-block:: bash
+
+   vmex --plot --booz input.case_scaled
+
+Similarity law
+--------------
+
+Let :math:`B_s` and :math:`R_s` be the two factors. Normalized flux, rotational
+transform, beta, aspect ratio, spectral mode numbers, and profile shapes do not
+change. Dimensional quantities transform as follows.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 25
+
+   * - Quantity
+     - Factor
+   * - Boundary, magnetic axis, major/minor radii
+     - :math:`R_s`
+   * - Volume and Jacobian Fourier coefficients
+     - :math:`R_s^3`
+   * - Magnetic field
+     - :math:`B_s`
+   * - Covariant field and total/coil currents
+     - :math:`B_s R_s`
+   * - Contravariant field
+     - :math:`B_s/R_s`
+   * - Toroidal and poloidal flux
+     - :math:`B_s R_s^2`
+   * - Pressure and :math:`B^2`
+     - :math:`B_s^2`
+   * - Magnetic/pressure energy
+     - :math:`B_s^2 R_s^3`
+   * - :math:`\mathbf J\cdot\mathbf B`
+     - :math:`B_s^2/R_s`
+   * - VMEC WOUT ``DMerc``, ``DShear``, ``DWell``, ``DCurr``, ``DGeod``
+     - :math:`B_s^{-2}R_s^{-4}`
+   * - ``IonLarmor``
+     - :math:`B_s^{-1}`
+
+For inputs, pressure is scaled once through ``PRES_SCALE``. ``AM``,
+``AM_AUX_F``, current/iota profiles, and every normalized spline coordinate
+remain shape data. ``CURTOR`` scales only in prescribed-current mode.
+
+ARIES-CS targets from an input
+------------------------------
+
+A WOUT contains ``b0`` and ``Aminor_p``, so its factors are exact. A fixed
+boundary gives ``Aminor_p`` directly by Fourier quadrature, but ``b0`` depends
+on the converged internal field. VMEX therefore runs a bounded radial probe at
+``ns <= 9`` and ``ns <= 17`` rather than the requested full ladder. The final
+probe uses ``ftol = 1e-10``. The command prints both resolutions and the
+coarse-to-fine changes; these changes are the declared target uncertainty.
+
+For a free-boundary input the probe also determines the final minor radius.
+The scaled input and mgrid sidecar are then written together. Per-ampere
+(``mgrid_mode = S``) field tables scale as :math:`R_s^{-1}`; raw tables scale
+as :math:`B_s`, while their recorded currents and ``EXTCUR`` scale as
+:math:`B_sR_s`. Direct-coil inputs are rejected because their geometry and
+currents must be scaled before field tabulation.
+
+Validation contract
+-------------------
+
+The defining test is commutation:
+
+1. solve the original input and scale its WOUT;
+2. scale the input (and mgrid when present) and reconverge it;
+3. compare every physical WOUT scalar, profile, Fourier coefficient, Mercier
+   term, and NESTOR potential/surface field.
+
+VMEX runs this check for finite-pressure prescribed-current fixed boundary and
+for symmetric and LASYM free-boundary NESTOR cases. The structured functions
+:func:`vmex.core.scaling.scale_input`,
+:func:`vmex.core.scaling.scale_mgrid`, and
+:func:`vmex.core.scaling.scale_wout` use parsed objects; they never edit
+namelist text by prefix.

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -71,6 +71,7 @@
     ["tests/test_qi_free_boundary_stress.py", "free-boundary", "integration", "medium", "cpu-gpu", "generated", "analytic", ["pr-parity-a1", "full-core-n-s"]],
     ["tests/test_qi_sheet_gate.py", "free-boundary", "campaign", "campaign", "cpu-gpu", "generated", "vmec2000", ["pr-parity-a1"]],
     ["tests/test_recycle_drift.py", "optimization", "integration", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "full-core-n-s"]],
+    ["tests/test_scaling.py", "equilibrium", "oracle", "slow", "cpu-gpu", "reference-nc", "analytic", ["pr-parity-c2", "full-core-n-s"]],
     ["tests/test_setup.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "pr-fast", "full-core-n-s"]],
     ["tests/test_setup_extras.py", "equilibrium", "unit", "fast", "cpu", "none", "analytic", ["pr-parity-c2", "full-core-n-s"]],
     ["tests/test_single_stage_simultaneous.py", "optimization", "ad", "slow", "cpu-gpu", "reference-nc", "fd", ["pr-parity-c2", "optional", "full-core-n-s"]],

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -104,7 +104,8 @@
       "tests/test_freeboundary_linear.py",
       "tests/test_freeboundary_diff.py::test_synthetic_surface_gradient_fd_validates",
       "tests/test_printing.py::test_compile_notice_variants",
-      "tests/test_printing.py::test_emit_flushed_writes_and_flushes"
+      "tests/test_printing.py::test_emit_flushed_writes_and_flushes",
+      "tests/test_scaling.py"
     ],
     "pr-physics-mirror-spline": [
       "tests/mirror/test_analytic.py",

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -139,6 +139,7 @@ def finite_beta_similarity():
 
     def run(deck):
         result = solve_multigrid(deck, verbose=False)
+        assert result.converged
         return wout_from_state(
             inp=deck,
             state=result.state,
@@ -173,10 +174,13 @@ def _assert_wout_similarity(actual, expected):
         else:
             expected_array = np.asarray(expected_value)
             error = np.linalg.norm(np.asarray(actual_value) - expected_array)
+            # ``curr*`` applies a first radial difference, whose condition
+            # number grows as 2 / hs = 2 * (ns - 1).
+            condition = 2 * (expected.ns - 1) if name.startswith("curr") else 1
             limit = (
                 2e-8 * np.linalg.norm(expected_array)
                 + 2e-9 * np.sqrt(expected_array.size)
-            )
+            ) * condition
             assert error <= limit, (name, error, limit)
 
 
@@ -185,6 +189,7 @@ def _assert_free_boundary_similarity(
 ):
     def run(deck, grid, path):
         result = solve_free_boundary_multigrid(deck, mgrid_path=path, verbose=False)
+        assert result.converged
         return wout_from_state(
             inp=deck,
             state=result.state,
@@ -231,10 +236,11 @@ def test_scale_symmetric_free_boundary_commutes_through_nestor(tmp_path):
 
 @pytest.mark.full
 def test_scale_lasym_free_boundary_commutes_through_nestor(tmp_path):
-    from test_lasym_free_case import lasym_free_input, lasym_free_mgrid_data
+    from tests.test_lasym_free_case import lasym_free_input, lasym_free_mgrid_data
 
     mgrid = lasym_free_mgrid_data()
-    mgrid_path = write_mgrid(tmp_path / "mgrid_d3d_lasym.nc", mgrid)
+    mgrid_path = tmp_path / "mgrid_d3d_lasym.nc"
+    write_mgrid(mgrid_path, mgrid)
     _assert_free_boundary_similarity(
         lasym_free_input(DATA),
         mgrid,

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -1,0 +1,417 @@
+"""Dimensional similarity transforms for inputs, mgrid fields, and WOUT."""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import jax
+import numpy as np
+import pytest
+
+from vmex.core import cli
+from vmex.core.errors import INPUT_ERROR_FLAG
+from vmex.core.input import VmecInput
+from vmex.core.mgrid import MgridData, read_mgrid, write_mgrid
+from vmex.core.multigrid import solve_free_boundary_multigrid, solve_multigrid
+from vmex.core.scaling import (
+    aries_cs_scales,
+    input_minor_radius,
+    probe_input,
+    scale_input,
+    scale_mgrid,
+    scale_wout,
+)
+from vmex.core.wout import read_wout, wout_from_state, write_wout
+
+DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
+
+
+def test_input_scaling_changes_only_dimensional_quantities():
+    inp = VmecInput.from_file(DATA / "input.nfp2_QA_finite_beta")
+    scaled = scale_input(inp, b_scale=2.0, r_scale=3.0)
+    np.testing.assert_allclose(scaled.rbc, 3.0 * inp.rbc)
+    np.testing.assert_allclose(scaled.raxis_c, 3.0 * inp.raxis_c)
+    assert scaled.phiedge == 18.0 * inp.phiedge
+    assert scaled.pres_scale == 4.0 * inp.pres_scale
+    assert scaled.curtor == 6.0 * inp.curtor
+    for name in ("am", "am_aux_s", "am_aux_f", "ac", "ai", "aphi"):
+        np.testing.assert_array_equal(getattr(scaled, name), getattr(inp, name))
+
+    prescribed_iota = dataclasses.replace(inp, ncurr=0)
+    assert scale_input(
+        prescribed_iota, b_scale=2.0, r_scale=3.0
+    ).curtor == prescribed_iota.curtor
+    with pytest.raises(ValueError, match="finite and positive"):
+        scale_input(inp, b_scale=0.0)
+
+
+def test_input_minor_radius_uses_vmec_boundary_convention():
+    inp = VmecInput(
+        mpol=2,
+        ntor=0,
+        rbc=np.array([[4.0, 0.7]]),
+        zbs=np.array([[0.0, 0.7]]),
+    )
+    assert input_minor_radius(inp) == pytest.approx(0.7, abs=1e-14)
+    assert input_minor_radius(scale_input(inp, r_scale=2.5)) == pytest.approx(
+        1.75, abs=1e-14
+    )
+
+
+def test_free_boundary_probe_refines_without_full_ladder(monkeypatch):
+    from vmex.core import multigrid, wout
+
+    states = [object(), object()]
+    outputs = [
+        SimpleNamespace(b0=2.0, Aminor_p=0.5),
+        SimpleNamespace(b0=2.1, Aminor_p=0.55),
+    ]
+
+    def fake_solve(*args, **kwargs):
+        return SimpleNamespace(
+            state=states.pop(0),
+            fsqr=0.0,
+            fsqz=0.0,
+            fsql=0.0,
+            iterations=1,
+            converged=True,
+            vacuum=None,
+        )
+
+    monkeypatch.setattr(multigrid, "solve_free_boundary_multigrid", fake_solve)
+    monkeypatch.setattr(
+        multigrid, "interpolate_state", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(wout, "wout_from_state", lambda **kwargs: outputs.pop(0))
+    inp = VmecInput(
+        mpol=2,
+        ntor=0,
+        ns_array=[17],
+        lfreeb=True,
+        mgrid_file="mgrid.nc",
+        rbc=np.array([[3.0, 0.5]]),
+        zbs=np.array([[0.0, 0.5]]),
+    )
+    probe = probe_input(inp, mgrid_path="mgrid.nc", device="cpu")
+    assert (probe.coarse_ns, probe.fine_ns) == (9, 17)
+    assert probe.b0 == 2.1
+    assert probe.aminor == 0.55
+
+
+def test_mgrid_scaling_distinguishes_per_ampere_and_raw_tables():
+    data = MgridData(
+        rmin=1.0, rmax=2.0, zmin=-0.5, zmax=0.5,
+        ir=2, jz=2, kp=2, nfp=1, nextcur=1,
+        mgrid_mode="S", coil_groups=("coil",), raw_coil_cur=(10.0,),
+        br=np.ones((1, 2, 2, 2)),
+        bp=2.0 * np.ones((1, 2, 2, 2)),
+        bz=3.0 * np.ones((1, 2, 2, 2)),
+    )
+    scaled = scale_mgrid(data, b_scale=3.0, r_scale=2.0)
+    assert (scaled.rmin, scaled.rmax, scaled.zmin, scaled.zmax) == (
+        2.0, 4.0, -1.0, 1.0
+    )
+    assert scaled.raw_coil_cur == (60.0,)
+    np.testing.assert_allclose(scaled.br, data.br / 2.0)
+
+    raw = scale_mgrid(
+        dataclasses.replace(data, mgrid_mode="R"),
+        b_scale=3.0,
+        r_scale=2.0,
+    )
+    np.testing.assert_allclose(raw.br, 3.0 * data.br)
+
+
+@pytest.fixture(scope="module")
+def finite_beta_similarity():
+    jax.config.update("jax_disable_jit", False)
+    inp = VmecInput.from_file(DATA / "input.nfp2_QA_finite_beta")
+    inp = dataclasses.replace(
+        inp,
+        ns_array=np.array([7, 11]),
+        ftol_array=np.array([1e-9, 1e-10]),
+        niter_array=np.array([2000, 3000]),
+    )
+    scaled_inp = scale_input(inp, b_scale=2.3, r_scale=1.7)
+
+    def run(deck):
+        result = solve_multigrid(deck, verbose=False)
+        return wout_from_state(
+            inp=deck,
+            state=result.state,
+            fsqr=float(result.fsqr),
+            fsqz=float(result.fsqz),
+            fsql=float(result.fsql),
+            niter=int(result.iterations),
+            converged=bool(result.converged),
+        )
+
+    return run(inp), run(scaled_inp)
+
+
+def test_scale_wout_commutes_with_finite_beta_solve(finite_beta_similarity):
+    original, solved_scaled_input = finite_beta_similarity
+    scaled_wout = scale_wout(original, b_scale=2.3, r_scale=1.7)
+    _assert_wout_similarity(solved_scaled_input, scaled_wout)
+
+
+def _assert_wout_similarity(actual, expected):
+    operational = {
+        "mgrid_file", "niter", "itfsq", "fsql", "fsqr", "fsqz", "fsqt", "wdot",
+    }
+    for field in dataclasses.fields(expected):
+        name = field.name
+        if name in operational:
+            continue
+        expected_value = getattr(expected, name)
+        actual_value = getattr(actual, name)
+        if expected_value is None or isinstance(expected_value, (str, tuple, bool)):
+            assert actual_value == expected_value, name
+        else:
+            expected_array = np.asarray(expected_value)
+            error = np.linalg.norm(np.asarray(actual_value) - expected_array)
+            limit = (
+                2e-8 * np.linalg.norm(expected_array)
+                + 2e-9 * np.sqrt(expected_array.size)
+            )
+            assert error <= limit, (name, error, limit)
+
+
+def _assert_free_boundary_similarity(
+    inp, mgrid, mgrid_path, tmp_path, *, b_scale, r_scale,
+):
+    def run(deck, grid, path):
+        result = solve_free_boundary_multigrid(deck, mgrid_path=path, verbose=False)
+        return wout_from_state(
+            inp=deck,
+            state=result.state,
+            fsqr=float(result.fsqr),
+            fsqz=float(result.fsqz),
+            fsql=float(result.fsql),
+            niter=int(result.iterations),
+            converged=bool(result.converged),
+            vacuum_output=result.vacuum,
+            nextcur=grid.nextcur,
+            extcur=deck.extcur,
+            mgrid_mode=grid.mgrid_mode,
+            curlabel=grid.coil_groups,
+        )
+
+    original = run(inp, mgrid, mgrid_path)
+    scaled_input = scale_input(inp, b_scale=b_scale, r_scale=r_scale)
+    scaled_mgrid = scale_mgrid(
+        mgrid, b_scale=b_scale, r_scale=r_scale,
+    )
+    scaled_mgrid_path = tmp_path / f"{Path(mgrid_path).stem}_scaled.nc"
+    write_mgrid(scaled_mgrid_path, scaled_mgrid)
+    actual = run(scaled_input, scaled_mgrid, scaled_mgrid_path)
+    _assert_wout_similarity(
+        actual,
+        scale_wout(original, b_scale=b_scale, r_scale=r_scale),
+    )
+
+
+@pytest.mark.full
+def test_scale_symmetric_free_boundary_commutes_through_nestor(tmp_path):
+    mgrid_path = DATA / "mgrid_cth_like.nc"
+    if not mgrid_path.exists():
+        pytest.skip("mgrid_cth_like.nc not fetched (tools/fetch_assets.py)")
+    _assert_free_boundary_similarity(
+        VmecInput.from_file(DATA / "input.cth_like_free_bdy"),
+        read_mgrid(mgrid_path),
+        mgrid_path,
+        tmp_path,
+        b_scale=1.4,
+        r_scale=1.2,
+    )
+
+
+@pytest.mark.full
+def test_scale_lasym_free_boundary_commutes_through_nestor(tmp_path):
+    from test_lasym_free_case import lasym_free_input, lasym_free_mgrid_data
+
+    mgrid = lasym_free_mgrid_data()
+    mgrid_path = write_mgrid(tmp_path / "mgrid_d3d_lasym.nc", mgrid)
+    _assert_free_boundary_similarity(
+        lasym_free_input(DATA),
+        mgrid,
+        mgrid_path,
+        tmp_path,
+        b_scale=1.25,
+        r_scale=1.5,
+    )
+
+
+def test_aries_cs_wout_targets(finite_beta_similarity):
+    original, _ = finite_beta_similarity
+    inp = VmecInput.from_file(DATA / "input.nfp2_QA_finite_beta")
+    assert input_minor_radius(inp) == pytest.approx(original.Aminor_p, rel=2e-14)
+    b_scale, r_scale = aries_cs_scales(original)
+    scaled = scale_wout(original, b_scale=b_scale, r_scale=r_scale)
+    assert abs(scaled.b0) == pytest.approx(5.7)
+    assert scaled.Aminor_p == pytest.approx(1.7)
+    with pytest.raises(ValueError, match="nonzero b0"):
+        aries_cs_scales(dataclasses.replace(original, b0=0.0))
+
+
+def test_boozer_transform_obeys_same_similarity(finite_beta_similarity, tmp_path):
+    pytest.importorskip("booz_xform_jax")
+    netcdf4 = pytest.importorskip("netCDF4")
+    from vmex.core.boozer import run_booz_xform
+
+    original, scaled = finite_beta_similarity
+    paths = []
+    for name, wout in (("original", original), ("scaled", scaled)):
+        wout_path = write_wout(tmp_path / f"wout_{name}.nc", wout)
+        paths.append(run_booz_xform(
+            wout_path,
+            mbooz=12,
+            nbooz=12,
+            output_path=tmp_path / f"boozmn_{name}.nc",
+        ))
+
+    factors = {
+        "aspect_b": 1.0,
+        "toroidal_flux_b": 2.3 * 1.7**2,
+        "iota_b": 1.0,
+        "buco_b": 2.3 * 1.7,
+        "bvco_b": 2.3 * 1.7,
+        "bmnc_b": 2.3,
+        "rmnc_b": 1.7,
+        "zmns_b": 1.7,
+        "numns_b": 1.0,
+        "pmns_b": 1.0,
+        "gmn_b": 1.7 / 2.3,
+    }
+    with netcdf4.Dataset(paths[0]) as first, netcdf4.Dataset(paths[1]) as second:
+        for name, factor in factors.items():
+            np.testing.assert_allclose(
+                second.variables[name][...],
+                factor * first.variables[name][...],
+                rtol=2e-9,
+                atol=2e-11,
+            )
+
+
+def test_cli_explicit_input_and_default_wout_scaling(
+    finite_beta_similarity, tmp_path,
+):
+    input_path = DATA / "input.nfp2_QA_finite_beta"
+    assert cli.main([
+        "--scale", str(input_path), "2", "3", "--outdir", str(tmp_path), "--quiet",
+    ]) == 0
+    scaled_input = VmecInput.from_file(
+        tmp_path / "input.nfp2_QA_finite_beta_scaled"
+    )
+    original_input = VmecInput.from_file(input_path)
+    assert scaled_input.phiedge == 18.0 * original_input.phiedge
+
+    original_wout, _ = finite_beta_similarity
+    wout_path = write_wout(tmp_path / "wout_case.nc", original_wout)
+    assert cli.main([
+        "--scale", str(wout_path), "--outdir", str(tmp_path), "--quiet",
+    ]) == 0
+    scaled_wout = read_wout(tmp_path / "wout_case_scaled.nc")
+    assert abs(scaled_wout.b0) == pytest.approx(5.7)
+    assert scaled_wout.Aminor_p == pytest.approx(1.7)
+
+
+def test_cli_scales_free_boundary_mgrid_sidecar(tmp_path):
+    mgrid = MgridData(
+        rmin=1.0, rmax=2.0, zmin=-0.5, zmax=0.5,
+        ir=2, jz=2, kp=2, nfp=1, nextcur=1,
+        mgrid_mode="S", coil_groups=("coil",), raw_coil_cur=(10.0,),
+        br=np.ones((1, 2, 2, 2)),
+        bp=np.ones((1, 2, 2, 2)),
+        bz=np.ones((1, 2, 2, 2)),
+    )
+    write_mgrid(tmp_path / "mgrid.nc", mgrid)
+    input_path = VmecInput(
+        mpol=2,
+        ntor=0,
+        lfreeb=True,
+        mgrid_file="mgrid.nc",
+        extcur=[10.0],
+        rbc=np.array([[3.0, 0.5]]),
+        zbs=np.array([[0.0, 0.5]]),
+    ).to_indata(tmp_path / "input.free")
+    assert cli.main([
+        "--scale", str(input_path), "3", "2", "--outdir", str(tmp_path),
+    ]) == 0
+    scaled_input = VmecInput.from_file(tmp_path / "input.free_scaled")
+    assert scaled_input.mgrid_file == "mgrid_scaled.nc"
+    np.testing.assert_allclose(scaled_input.extcur, [60.0])
+    scaled_mgrid = read_mgrid(tmp_path / scaled_input.mgrid_file)
+    assert scaled_mgrid.rmax == 4.0
+    np.testing.assert_allclose(scaled_mgrid.br, 0.5)
+
+
+def test_cli_scaling_validation_and_json(tmp_path):
+    inp = VmecInput(
+        mpol=2,
+        ntor=0,
+        rbc=np.array([[3.0, 0.5]]),
+        zbs=np.array([[0.0, 0.5]]),
+    )
+    json_path = inp.to_json(tmp_path / "input.json")
+    assert cli.main([
+        "--scale", str(json_path), "2", "3", "--outdir", str(tmp_path), "--quiet",
+    ]) == 0
+    assert (tmp_path / "input_scaled.json").exists()
+    assert cli.main(["--scale", str(json_path), "2", "--quiet"]) == INPUT_ERROR_FLAG
+    assert cli.main([
+        "--scale", str(json_path), "0", "3", "--quiet",
+    ]) == INPUT_ERROR_FLAG
+    with pytest.raises(SystemExit):
+        cli.main([str(json_path), "2", "3"])
+    with pytest.raises(SystemExit):
+        cli.main(["--scale", str(json_path), "2", "3", "--booz"])
+
+    for name, mgrid_file in (
+        ("direct", "DIRECT_COILS"),
+        ("missing", "missing_mgrid.nc"),
+    ):
+        path = dataclasses.replace(
+            inp, lfreeb=True, mgrid_file=mgrid_file
+        ).to_indata(tmp_path / f"input.{name}")
+        assert cli.main([
+            "--scale", str(path), "2", "3", "--quiet",
+        ]) == INPUT_ERROR_FLAG
+
+
+def test_cli_default_input_scaling_reconverges_to_aries_cs(tmp_path, capsys):
+    input_path = VmecInput(
+        mpol=2,
+        ntor=0,
+        ns_array=[3],
+        ftol_array=[1e-10],
+        niter_array=[1000],
+        phiedge=1.0,
+        ai=np.array([0.4]),
+        rbc=np.array([[3.0, 0.5]]),
+        zbs=np.array([[0.0, 0.5]]),
+    ).to_indata(tmp_path / "input.tiny")
+    assert cli.main([
+        "--scale", str(input_path), "--outdir", str(tmp_path),
+        "--device", "cpu",
+    ]) == 0
+    output = capsys.readouterr().out
+    match = re.search(r"b0=.*?\(change ([0-9.eE+-]+)\)", output)
+    assert match is not None
+    declared_error = float(match.group(1))
+    scaled_input = VmecInput.from_file(tmp_path / "input.tiny_scaled")
+    result = solve_multigrid(scaled_input, verbose=False, device="cpu")
+    scaled_wout = wout_from_state(
+        inp=scaled_input,
+        state=result.state,
+        fsqr=float(result.fsqr),
+        fsqz=float(result.fsqz),
+        fsql=float(result.fsql),
+        niter=int(result.iterations),
+        converged=bool(result.converged),
+    )
+    assert abs(abs(scaled_wout.b0) / 5.7 - 1.0) <= 2.0 * declared_error
+    assert scaled_wout.Aminor_p == pytest.approx(1.7, rel=2e-12)

--- a/vmex/__init__.py
+++ b/vmex/__init__.py
@@ -14,6 +14,8 @@ Public API (lazily imported; ``import vmex as vj``):
 - :func:`~vmex.core.mgrid.read_mgrid` / :func:`~vmex.core.mgrid.write_mgrid`
   / :func:`~vmex.core.mgrid.tabulate_cartesian_field`
   / :class:`~vmex.core.mgrid.MgridField` (mgrid or tabulated direct field)
+- :func:`~vmex.core.scaling.scale_input` / :func:`~vmex.core.scaling.scale_wout`
+  — dimensional similarity transforms
 - ``vmex.optimize`` — objectives + least-squares driver (module)
 - ``vmex.implicit`` — implicit differentiation of the equilibrium (module)
 - ``vmex.parallel`` — concurrent ensembles of independent solves (module)
@@ -98,6 +100,10 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
     "read_mgrid": (".core.mgrid", "read_mgrid"),
     "tabulate_cartesian_field": (".core.mgrid", "tabulate_cartesian_field"),
     "write_mgrid": (".core.mgrid", "write_mgrid"),
+    # dimensional scaling
+    "scale_input": (".core.scaling", "scale_input"),
+    "scale_mgrid": (".core.scaling", "scale_mgrid"),
+    "scale_wout": (".core.scaling", "scale_wout"),
     # errors
     "VmecError": (".core.errors", "VmecError"),
     "VmecInputError": (".core.errors", "VmecInputError"),

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -133,6 +133,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  vmex --plot mout_*.nc  — straight-axis mirror diagnostics\n"
             "  vmex --booz wout_*.nc  — run booz_xform_jax, write boozmn_*.nc\n"
             "  vmex --plot boozmn_*.nc— Boozer contour/spectrum plots\n"
+            "  vmex --scale input.X [B R] — scale an input or WOUT\n"
             "  vmex --doctor          — installation and JAX backend diagnostics\n"
             "  vmex --test            — run and plot the bundled quick-start case\n"
         ),
@@ -146,6 +147,22 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "VMEC input file (input.* namelist or VMEC++ .json) to solve, or a "
             "wout_*.nc/mout_*.nc/boozmn_*.nc file for --plot/--booz."
+        ),
+    )
+    p.add_argument(
+        "scale_factors",
+        type=float,
+        nargs="*",
+        metavar="SCALE",
+        help="with --scale: optional multiplicative B_scale R_scale factors",
+    )
+    p.add_argument(
+        "--scale",
+        action="store_true",
+        help=(
+            "Write a dimensionally scaled input or WOUT. Two positional factors "
+            "mean B_scale R_scale; omitting them targets |b0|=5.7 T and "
+            "Aminor_p=1.7 m (ARIES-CS)."
         ),
     )
     p.add_argument(
@@ -815,7 +832,123 @@ def _run_bundled_test(args, parser: argparse.ArgumentParser, *, emit) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _scaled_path(path: Path, outdir: Path | None) -> Path:
+    directory = path.parent if outdir is None else outdir
+    if path.suffix.lower() in (".json", ".nc"):
+        name = f"{path.stem}_scaled{path.suffix}"
+    else:
+        name = f"{path.name}_scaled"
+    return directory / name
+
+
+def _scale_file(args, input_path: Path, outdir: Path | None, *, emit) -> int:
+    """Scale one parsed input or WOUT and write a sibling artifact."""
+    from dataclasses import replace
+    from math import isfinite
+
+    from .scaling import (
+        aries_cs_input_scales,
+        aries_cs_scales,
+        scale_input,
+        scale_mgrid,
+        scale_wout,
+    )
+
+    factors = list(args.scale_factors)
+    if len(factors) not in (0, 2):
+        raise VmecInputError(
+            WERROR_MESSAGES[INPUT_ERROR_FLAG],
+            hint="--scale takes either no factors or B_scale R_scale",
+        )
+    if factors and (
+        not all(isfinite(factor) for factor in factors)
+        or any(factor <= 0.0 for factor in factors)
+    ):
+        raise VmecInputError(
+            WERROR_MESSAGES[INPUT_ERROR_FLAG],
+            hint="B_scale and R_scale must be finite and positive",
+        )
+    output = _scaled_path(input_path, outdir)
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    if _is_wout_path(input_path):
+        from .wout import read_wout, write_wout
+
+        wout = read_wout(input_path)
+        b_scale, r_scale = factors or aries_cs_scales(wout)
+        write_wout(
+            output,
+            scale_wout(wout, b_scale=b_scale, r_scale=r_scale),
+        )
+    else:
+        inp = _read_input(input_path)
+        mgrid_path = None
+        if inp.lfreeb:
+            mgrid_name = str(inp.mgrid_file).strip().strip("'\"")
+            if mgrid_name.upper() == _DIRECT_COILS or args.coils:
+                raise VmecInputError(
+                    WERROR_MESSAGES[INPUT_ERROR_FLAG],
+                    hint="scale the direct-coil geometry and currents before tabulation",
+                )
+            mgrid_path = Path(mgrid_name).expanduser()
+            if not mgrid_path.is_absolute():
+                mgrid_path = (input_path.parent / mgrid_path).resolve()
+            if not mgrid_path.is_file():
+                raise VmecInputError(
+                    WERROR_MESSAGES[INPUT_ERROR_FLAG],
+                    hint=f"mgrid file not found: {mgrid_path}",
+                )
+
+        probe = None
+        if factors:
+            b_scale, r_scale = factors
+        else:
+            b_scale, r_scale, probe = aries_cs_input_scales(
+                inp,
+                mgrid_path=mgrid_path,
+                device=None if args.device == "none" else args.device,
+            )
+        scaled = scale_input(inp, b_scale=b_scale, r_scale=r_scale)
+
+        if mgrid_path is not None:
+            from .mgrid import read_mgrid, write_mgrid
+
+            mgrid_output = _scaled_path(mgrid_path, output.parent)
+            write_mgrid(
+                mgrid_output,
+                scale_mgrid(
+                    read_mgrid(mgrid_path),
+                    b_scale=b_scale,
+                    r_scale=r_scale,
+                ),
+            )
+            scaled = replace(scaled, mgrid_file=mgrid_output.name)
+            if not args.quiet:
+                emit(f" Wrote scaled mgrid: {mgrid_output}")
+
+        if input_path.suffix.lower() == ".json":
+            scaled.to_json(output)
+        else:
+            scaled.to_indata(output)
+        if probe is not None and not args.quiet:
+            emit(
+                f" ARIES-CS probe: ns={probe.coarse_ns},{probe.fine_ns}; "
+                f"b0={probe.b0:.8g} T (change {probe.b0_relative_change:.2e}), "
+                f"Aminor_p={probe.aminor:.8g} m "
+                f"(change {probe.aminor_relative_change:.2e})"
+            )
+
+    if not args.quiet:
+        emit(
+            f" Applied B_scale={b_scale:.12g}, R_scale={r_scale:.12g}\n"
+            f" Wrote scaled file: {output}"
+        )
+    return 0
+
+
 def _dispatch(args, parser: argparse.ArgumentParser, *, emit) -> int:
+    if args.scale_factors and not args.scale:
+        parser.error("scale factors require --scale")
     if bool(args.doctor):
         if args.input is not None:
             parser.error("--doctor does not take an input path")
@@ -847,6 +980,11 @@ def _dispatch(args, parser: argparse.ArgumentParser, *, emit) -> int:
     outdir = Path(args.outdir).expanduser().resolve() if args.outdir else None
     plot_outdir = outdir if outdir is not None else input_path.parent
     quiet = bool(args.quiet)
+
+    if bool(args.scale):
+        if plot_requested or bool(args.booz) or bool(args.test):
+            parser.error("--scale cannot be combined with --plot, --booz, or --test")
+        return _scale_file(args, input_path, outdir, emit=emit)
 
     if _is_boozmn_path(input_path):
         if not plot_requested:

--- a/vmex/core/scaling.py
+++ b/vmex/core/scaling.py
@@ -1,0 +1,262 @@
+"""Dimensionally scale VMEC inputs, mgrid fields, and WOUT data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .input import VmecInput
+from .mgrid import MgridData
+from .wout import WoutData
+
+ARIES_CS_B0 = 5.7
+ARIES_CS_AMINOR = 1.7
+
+_INPUT_LENGTHS = (
+    "raxis_c", "zaxis_s", "raxis_s", "zaxis_c",
+    "rbc", "zbs", "rbs", "zbc",
+)
+
+_WOUT_POWERS = {
+    # Scalars and one-dimensional profiles.
+    **{name: (2, 3) for name in ("wb", "wp")},
+    **{name: (0, 1) for name in (
+        "rmax_surf", "rmin_surf", "zmax_surf", "Aminor_p", "Rmajor_p",
+        "raxis_cc", "zaxis_cs", "raxis_cs", "zaxis_cc",
+        "rmnc", "zmns", "rmns", "zmnc",
+    )},
+    **{name: (1, 0) for name in ("b0", "volavgB", "bmnc", "bmns")},
+    **{name: (1, 1) for name in (
+        "rbtor0", "rbtor", "ctor", "extcur", "buco", "bvco", "jcuru",
+        "jcurv", "bsubumnc", "bsubvmnc", "bsubsmns", "bsubumns",
+        "bsubvmns", "bsubsmnc", "currumnc", "currvmnc", "currumns",
+        "currvmns", "potsin", "potcos", "bsubumnc_sur", "bsubvmnc_sur",
+        "bsubumns_sur", "bsubvmns_sur",
+    )},
+    **{name: (1, 2) for name in (
+        "phi", "phipf", "chi", "chipf", "phips",
+    )},
+    **{name: (2, 0) for name in ("presf", "mass", "pres", "bdotb")},
+    **{name: (0, 3) for name in ("volume_p", "vp", "gmnc", "gmns")},
+    **{name: (1, -1) for name in (
+        "bdotgradv", "bsupumnc", "bsupvmnc", "bsupumns", "bsupvmns",
+        "bsupumnc_sur", "bsupvmnc_sur", "bsupumns_sur", "bsupvmns_sur",
+    )},
+    "jdotb": (2, -1),
+    "IonLarmor": (-1, 0),
+    "over_r": (0, -1),
+    **{name: (-2, -4) for name in (
+        "DMerc", "DShear", "DWell", "DCurr", "DGeod",
+    )},
+}
+
+
+@dataclass(frozen=True)
+class ScaleProbe:
+    """Low-resolution input probe used to choose ARIES-CS factors."""
+
+    b0: float
+    aminor: float
+    b0_relative_change: float
+    aminor_relative_change: float
+    coarse_ns: int
+    fine_ns: int
+
+
+def _scales(b_scale: float, r_scale: float) -> tuple[float, float]:
+    b, r = float(b_scale), float(r_scale)
+    if not np.isfinite((b, r)).all() or b <= 0.0 or r <= 0.0:
+        raise ValueError("B_scale and R_scale must be finite and positive")
+    return b, r
+
+
+def _times(value: Any, factor: float) -> Any:
+    if value is None:
+        return None
+    scaled = np.asarray(value) * factor
+    return float(scaled) if scaled.ndim == 0 else scaled
+
+
+def scale_input(
+    inp: VmecInput, *, b_scale: float = 1.0, r_scale: float = 1.0,
+) -> VmecInput:
+    """Return ``inp`` at magnetic-field factor ``B_scale`` and size factor ``R_scale``."""
+    b, r = _scales(b_scale, r_scale)
+    changes = {name: _times(getattr(inp, name), r) for name in _INPUT_LENGTHS}
+    changes.update(
+        phiedge=inp.phiedge * b * r**2,
+        pres_scale=inp.pres_scale * b**2,
+        curtor=inp.curtor * b * r if inp.ncurr == 1 else inp.curtor,
+        extcur=_times(inp.extcur, b * r),
+    )
+    return replace(inp, **changes)
+
+
+def scale_mgrid(
+    data: MgridData, *, b_scale: float = 1.0, r_scale: float = 1.0,
+) -> MgridData:
+    """Scale a MAKEGRID table consistently with :func:`scale_input`."""
+    b, r = _scales(b_scale, r_scale)
+    raw = np.asarray(data.raw_coil_cur) * b * r
+    field_scale = 1.0 / r if data.mgrid_mode.upper().startswith("S") else b
+    return replace(
+        data,
+        rmin=data.rmin * r,
+        rmax=data.rmax * r,
+        zmin=data.zmin * r,
+        zmax=data.zmax * r,
+        raw_coil_cur=tuple(raw),
+        br=np.asarray(data.br) * field_scale,
+        bp=np.asarray(data.bp) * field_scale,
+        bz=np.asarray(data.bz) * field_scale,
+    )
+
+
+def scale_wout(
+    data: WoutData, *, b_scale: float = 1.0, r_scale: float = 1.0,
+) -> WoutData:
+    """Return the dimensional similarity transform of a converged WOUT."""
+    b, r = _scales(b_scale, r_scale)
+    changes = {
+        name: _times(getattr(data, name), b**b_power * r**r_power)
+        for name, (b_power, r_power) in _WOUT_POWERS.items()
+    }
+    return replace(data, **changes)
+
+
+def input_minor_radius(inp: VmecInput) -> float:
+    """Compute the VMEC ``Aminor_p`` convention directly from the input boundary."""
+    ntheta = max(int(inp.ntheta) or 0, 2 * int(inp.mpol) + 2, 16)
+    nzeta = max(int(inp.nzeta) or 0, 2 * int(inp.ntor) + 1, 1)
+    theta = 2.0 * np.pi * np.arange(ntheta) / ntheta
+    zeta = 2.0 * np.pi * np.arange(nzeta) / (nzeta * inp.nfp)
+    n = np.arange(-inp.ntor, inp.ntor + 1)
+    m = np.arange(inp.mpol)
+    angle = (
+        m[None, None, None, :] * theta[None, :, None, None]
+        - n[None, None, :, None] * inp.nfp * zeta[:, None, None, None]
+    )
+    r = np.sum(
+        inp.rbc[None, None, :, :] * np.cos(angle)
+        + inp.rbs[None, None, :, :] * np.sin(angle),
+        axis=(-2, -1),
+    )
+    zu = np.sum(
+        m[None, None, None, :] * (
+            inp.zbs[None, None, :, :] * np.cos(angle)
+            - inp.zbc[None, None, :, :] * np.sin(angle)
+        ),
+        axis=(-2, -1),
+    )
+    return float(np.sqrt(2.0 * abs(np.mean(r * zu))))
+
+
+def aries_cs_scales(data: WoutData) -> tuple[float, float]:
+    """Return positive ``(B_scale, R_scale)`` factors for ARIES-CS dimensions."""
+    if data.b0 == 0.0 or data.Aminor_p <= 0.0:
+        raise ValueError("ARIES-CS scaling requires nonzero b0 and positive Aminor_p")
+    return ARIES_CS_B0 / abs(data.b0), ARIES_CS_AMINOR / data.Aminor_p
+
+
+def probe_input(
+    inp: VmecInput,
+    *,
+    mgrid_path: str | Path | None = None,
+    external_field: Any = None,
+    device: Any = "auto",
+) -> ScaleProbe:
+    """Estimate ``b0`` and final minor radius without running the requested ladder."""
+    from .fourier import mode_table
+    from .multigrid import (
+        interpolate_state,
+        solve_free_boundary_multigrid,
+        solve_multigrid,
+    )
+    from .wout import wout_from_state
+
+    final_ns = int(np.max(np.asarray(inp.ns_array)))
+    coarse_ns, fine_ns = min(final_ns, 9), min(final_ns, 17)
+    niter = max(3000, int(np.max(np.asarray(inp.niter_array))))
+
+    def run(ns: int, ftol: float, initial_state=None):
+        deck = replace(
+            inp,
+            ns_array=np.asarray([ns]),
+            ftol_array=np.asarray([ftol]),
+            niter_array=np.asarray([niter]),
+            lfull3d1out=False,
+        )
+        common = dict(
+            initial_state=initial_state,
+            verbose=False,
+            device=device,
+            raise_on_max_iterations=True,
+            prefetch_compile=False,
+        )
+        if inp.lfreeb:
+            result = solve_free_boundary_multigrid(
+                deck,
+                mgrid_path=mgrid_path,
+                external_field=external_field,
+                **common,
+            )
+        else:
+            result = solve_multigrid(deck, mode="cli", **common)
+        wout = wout_from_state(
+            inp=deck,
+            state=result.state,
+            fsqr=float(result.fsqr),
+            fsqz=float(result.fsqz),
+            fsql=float(result.fsql),
+            niter=int(result.iterations),
+            converged=bool(result.converged),
+            vacuum_output=result.vacuum,
+        )
+        return result.state, wout
+
+    coarse_state, coarse = run(coarse_ns, 1e-8)
+    if fine_ns == coarse_ns:
+        initial = coarse_state
+    else:
+        initial = interpolate_state(
+            coarse_state,
+            ns_fine=fine_ns,
+            modes=mode_table(inp.mpol, inp.ntor),
+        )
+    _, fine = run(fine_ns, 1e-10, initial)
+
+    relative = lambda x, y: abs(x - y) / max(abs(y), np.finfo(float).tiny)  # noqa: E731
+    return ScaleProbe(
+        b0=float(fine.b0),
+        aminor=float(fine.Aminor_p),
+        b0_relative_change=relative(float(coarse.b0), float(fine.b0)),
+        aminor_relative_change=relative(
+            float(coarse.Aminor_p), float(fine.Aminor_p)
+        ),
+        coarse_ns=coarse_ns,
+        fine_ns=fine_ns,
+    )
+
+
+def aries_cs_input_scales(
+    inp: VmecInput,
+    **probe_kwargs: Any,
+) -> tuple[float, float, ScaleProbe]:
+    """Choose ARIES-CS factors from a bounded converged input probe."""
+    probe = probe_input(inp, **probe_kwargs)
+    if not inp.lfreeb:
+        probe = replace(
+            probe,
+            aminor=input_minor_radius(inp),
+            aminor_relative_change=0.0,
+        )
+    if probe.b0 == 0.0 or probe.aminor <= 0.0:
+        raise ValueError("ARIES-CS scaling requires nonzero b0 and positive Aminor_p")
+    return (
+        ARIES_CS_B0 / abs(probe.b0),
+        ARIES_CS_AMINOR / probe.aminor,
+        probe,
+    )


### PR DESCRIPTION
## Goal

Add one scientifically defined dimensional similarity transform for
fast-particle preparation. Users can run
`vmex --scale PATH B_scale R_scale` for explicit multiplicative field/size
factors or `vmex --scale PATH` to target ARIES-CS magnitudes
`|b0| = 5.7 T` and `Aminor_p = 1.7 m`. Scaling an input and reconverging it
must agree with scaling the original WOUT, including free-boundary mgrid and
NESTOR fields.

## Achieved

- Add structured `scale_input`, `scale_mgrid`, and `scale_wout` functions; no
  namelist prefix editing.
- Scale geometry by `R`, flux by `B R^2`, pressure through `PRES_SCALE` by
  `B^2`, and prescribed plasma/coil currents by `B R`.
- Keep normalized profile shapes and spline coordinates invariant, avoiding
  the supplied legacy script's pressure double scaling.
- Support VMEC text/JSON inputs and WOUT NetCDF files; outputs gain `_scaled`.
- Scale free-boundary mgrid coordinates, currents, and per-ampere/raw field
  tables consistently and write a sidecar mgrid.
- Reject direct-coil scaling with a typed error until coil geometry and
  current are scaled before tabulation.
- Derive fixed-boundary minor radius from boundary quadrature. A bounded
  `ns <= 9,17` solve estimates input `b0`; free boundary also probes the
  converged minor radius and reports coarse-to-fine uncertainty.
- Promote `vmex --plot --booz input.case` and dimensional scaling in the
  README/quick start, with a dedicated units and validation page.

The new path runs only when a scaling function or `--scale` is requested.

## Validation

Current head: `c4b8d2071ce62bf7c6a5ccf16ca98b74afbeb54b`, stacked on
device-contract PR #96 head `2ae5e90d`.

- The complete 13-test scaling module passes, including finite-beta fixed
  boundary, symmetric and LASYM free boundary, Boozer output, ARIES defaults,
  CLI, and mgrid scaling. Ruff, mypy, strict docs, and diff checks pass.
- Prior exact hosted run
  [`30595268316`](https://github.com/uwplasma/VMEX/actions/runs/30595268316)
  passed all 11 jobs. Production-identical exact run
  [`30601299078`](https://github.com/uwplasma/VMEX/actions/runs/30601299078)
  also passed all 11 jobs. Exact test-only-restack run
  [`30602757512`](https://github.com/uwplasma/VMEX/actions/runs/30602757512)
  also passed all 11 jobs.
- Nine exact-head scale-then-solve audits pass on CPU, `cuda:0`, and
  `cuda:1`, with `JAX_PLATFORMS` and `JAX_PLATFORM_NAME` unset:
  - finite-pressure/current fixed boundary: 89 WOUT fields, 246 iterations,
    worst tolerance ratio `0.0041`;
  - symmetric CTH free boundary: 97 fields, 573 iterations, worst ratio
    `0.0384`;
  - LASYM DIII-D free boundary: 116 fields, 516 iterations, worst ratio
    `0.355`.
  Original and scaled solves use the same iteration count on every device.
  GPU0 and GPU1 produce the same state hashes, residuals, and field errors.
- Independent VMEC2000 9.0: original/scaled decks both converge in 247
  iterations; all 88 compared WOUT fields obey the similarity table, with
  worst relative discrepancy `7.1e-10`.
- Boozer transforms obey their geometry, field, current, angle, and Jacobian
  factors to `4.5e-12`.
- The collaborator HSX deck passed factor-free ARIES-CS scaling. The bounded
  probe selected `B_scale=4.9848433022700371`,
  `R_scale=13.360420678068326`; the scaled input has
  `Aminor_p=1.7 m` by boundary quadrature and targets `|b0|=5.7 T` within
  the reported `3.15e-4` probe uncertainty.
- Invalid factors, missing mgrid data, direct coils, positional misuse, JSON
  naming, free-boundary sidecars, target failures, and refinement are covered
  by typed tests.

The device matrix exposed the last multigrid setup-context defect in PR #96:
a finite-beta two-stage GPU1 solve failed before scaling until radial
interpolation was moved into the selected context. The corrected exact stack
passes all nine audits without an outer device context.

## Compatibility

Positive factors preserve flux direction. WOUT scaling preserves provenance
and iteration metadata while transforming physical arrays. Free-boundary input
scaling writes a new mgrid rather than modifying the original. No environment
variable is required for device choice. Existing solve, plot, Boozer, and CLI
behavior is unchanged unless `--scale` or a scaling function is requested.

## Left

1. Clear PR #96's exact trusted-GPU gate.
2. Rebase onto merged PR #96, rerun the focused scaling suite, and mark this
   PR ready for review.
