### PR TITLE
Document near-degenerate vacuum convergence

### DIFF
--- a/docs/vmec2000_compatibility.rst
+++ b/docs/vmec2000_compatibility.rst
@@ -584,6 +584,29 @@ AD / FD
    research-grade only for the exact map disclosed and independently checked
    over a stated parameter/regime envelope.
 
+Pressureless current-free vacuum limit
+--------------------------------------
+
+A pressureless, current-free, nearly axisymmetric vacuum can be harder to
+iterate than its simple boundary suggests.  In the axisymmetric limit the
+interior surfaces have a weak parameterization direction: the variational
+``m=1,n=0`` force changes little while the magnetic axis drifts.  Tiny
+three-dimensional boundary modes only weakly remove that direction.
+
+The public :download:`NFP=3 example
+<../examples/data/input.near_degenerate_vacuum_nfp3>` reproduces this limit.
+With ``LFORBAL=F``, VMEX and VMEC2000 follow the same trajectory and stop just
+above ``FTOL=1e-11`` after 3,500 iterations.  With ``LFORBAL=T``, both replace
+that one variational equation by VMEC2000's flux-averaged force balance and
+converge in 941 iterations to
+``(FSQR, FSQZ, FSQL) = (9.13e-12, 5.38e-12, 2.32e-12)``.  The primary WOUT
+geometry and field coefficients agree to better than ``5e-10`` relative.
+
+For this class of input, review ``LFORBAL`` first.  Loosening ``FTOL`` or
+removing genuinely unused high-order volume modes may also end the iteration,
+but changes the requested accuracy or discretization.  VMEX does none of
+these automatically.
+
 Open-PR ownership and merge preservation
 ----------------------------------------
 

--- a/examples/data/input.near_degenerate_vacuum_nfp3
+++ b/examples/data/input.near_degenerate_vacuum_nfp3
@@ -1,0 +1,38 @@
+&INDATA
+  ! Pressureless, current-free vacuum equilibrium with tiny n /= 0 modes.
+  ! LFORBAL removes the weak variational m=1,n=0 parameterization direction.
+  NFP = 3
+  LASYM = F
+
+  MPOL = 5
+  NTOR = 5
+  NTHETA = 18
+  NZETA = 16
+  NS_ARRAY = 25
+  NITER_ARRAY = 3500
+  FTOL_ARRAY = 1e-11
+
+  PHIEDGE = 0.03295687309
+  PMASS_TYPE = 'power_series'
+  AM = 0.0
+  PRES_SCALE = 1.0
+
+  NCURR = 1
+  CURTOR = 0.0
+  PCURR_TYPE = 'power_series'
+  AC = 0.0
+
+  DELT = 0.9
+  NSTEP = 200
+  LFORBAL = T
+
+  RBC( 0, 0) =  1.000000000000000e+00
+  RBC( 1, 0) =  1.132428904841995e-05
+  ZBS( 1, 0) =  3.109467908552061e-05
+  RBC(-1, 1) = -2.981090793306039e-05
+  ZBS(-1, 1) =  1.319356991672759e-05
+  RBC( 0, 1) =  3.848970406095167e-01
+  ZBS( 0, 1) =  2.835873833217062e-01
+  RBC( 1, 1) =  2.710568444616998e-05
+  ZBS( 1, 1) =  4.828592528079997e-05
+/

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -51,6 +51,7 @@
     ["tests/test_mgrid.py", "free-boundary", "unit", "fast", "cpu", "generated", "analytic", ["pr-parity-c1", "pr-fast", "full-core-j-m"]],
     ["tests/test_multigrid_interp.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-j-m"]],
     ["tests/test_multigrid_ladder.py", "equilibrium", "oracle", "slow", "cpu-gpu", "golden", "vmec2000", ["pr-parity-a2", "full-core-j-m"]],
+    ["tests/test_near_degenerate_vacuum.py", "equilibrium", "oracle", "slow", "cpu-gpu", "none", "vmec2000", ["pr-full-only", "full-core-n-s"]],
     ["tests/test_nonfinite_failfast.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-n-s"]],
     ["tests/test_omnigenity.py", "diagnostics", "ad", "slow", "cpu-gpu", "golden", "fd", ["pr-parity-c2", "full-core-n-s"]],
     ["tests/test_optimization_convergence.py", "optimization", "campaign", "campaign", "cpu-gpu", "golden", "external", ["pr-parity-c2"]],
@@ -93,6 +94,7 @@
   "selectors": {
     "pr-physics-core": [
       "tests/test_solver_end_to_end.py::test_converges_with_golden_iteration_count[solovev]",
+      "tests/test_near_degenerate_vacuum.py::test_current_free_vacuum_nonconvergence_suggests_lforbal",
       "tests/test_implicit_grad.py::test_solovev_gradients_vs_fd",
       "tests/test_implicit_grad.py::test_jdotb_and_glasser_gradients_vs_frozen_path_fd[solovev]",
       "tests/test_freeboundary.py::test_nestor_skip_branch_matches_full_solve",

--- a/tests/test_near_degenerate_vacuum.py
+++ b/tests/test_near_degenerate_vacuum.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -40,6 +41,24 @@ def test_current_free_vacuum_nonconvergence_suggests_lforbal():
     with pytest.raises(VmecConvergenceError) as excinfo:
         solver._finalize(carry, runtime)
     assert excinfo.value.hint == "increase NITER or loosen FTOL"
+
+
+@pytest.mark.full
+def test_variational_current_free_vacuum_stops_above_tolerance():
+    """The supplied LFORBAL=F trajectory remains explicit and reproducible."""
+    inp = dataclasses.replace(VmecInput.from_file(DECK), lforbal=False)
+    result = solve_multigrid(
+        inp, device="cpu", verbose=False, raise_on_max_iterations=False,
+    )
+    assert not result.converged
+    assert result.iterations == 3500
+    assert result.ier_flag == MORE_ITER_FLAG
+    np.testing.assert_allclose(
+        [result.fsqr, result.fsqz, result.fsql],
+        [1.3457723434504725e-11, 5.111345594168806e-12,
+         4.1293629542542975e-12],
+        rtol=2e-6,
+    )
 
 
 @pytest.mark.full

--- a/tests/test_near_degenerate_vacuum.py
+++ b/tests/test_near_degenerate_vacuum.py
@@ -1,0 +1,107 @@
+"""Current-free vacuum convergence at the weak variational m=1,n=0 limit."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from vmex.core import solver
+from vmex.core.errors import MORE_ITER_FLAG, VmecConvergenceError
+from vmex.core.input import VmecInput
+from vmex.core.multigrid import solve_multigrid
+from vmex.core.wout import wout_from_state
+
+DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
+DECK = DATA / "input.near_degenerate_vacuum_nfp3"
+pytestmark = pytest.mark.usefixtures("_module_jit_enabled")
+
+
+def test_current_free_vacuum_nonconvergence_suggests_lforbal():
+    carry = SimpleNamespace(
+        ier=MORE_ITER_FLAG,
+        fsqr=2e-11,
+        fsqz=1e-11,
+        fsql=1e-12,
+        iteration=3500,
+    )
+    runtime = SimpleNamespace(
+        lforbal=False,
+        ftol=1e-11,
+        setup=SimpleNamespace(ncurr=1, mass=np.zeros(3), icurv=np.zeros(3)),
+    )
+    with pytest.raises(VmecConvergenceError) as excinfo:
+        solver._finalize(carry, runtime)
+    assert "review LFORBAL=T" in excinfo.value.hint
+
+    runtime.setup.mass = np.ones(3)
+    with pytest.raises(VmecConvergenceError) as excinfo:
+        solver._finalize(carry, runtime)
+    assert excinfo.value.hint == "increase NITER or loosen FTOL"
+
+
+@pytest.mark.full
+def test_lforbal_current_free_vacuum_matches_vmec2000():
+    inp = VmecInput.from_file(DECK)
+    result = solve_multigrid(inp, device="cpu", verbose=False)
+    assert result.converged
+    assert result.iterations == 941
+    np.testing.assert_allclose(
+        [result.fsqr, result.fsqz, result.fsql],
+        [9.125353472079168e-12, 5.377544421551709e-12, 2.3166943756361613e-12],
+        rtol=2e-6,
+    )
+
+    wout = wout_from_state(
+        inp=inp,
+        state=result.state,
+        fsqr=float(result.fsqr),
+        fsqz=float(result.fsqz),
+        fsql=float(result.fsql),
+        niter=int(result.iterations),
+        converged=True,
+    )
+    np.testing.assert_allclose(
+        [
+            wout.volume_p,
+            wout.Rmajor_p,
+            wout.Aminor_p,
+            wout.aspect,
+            wout.b0,
+            wout.wb,
+        ],
+        [
+            2.154573046149519,
+            1.0000000011877124,
+            0.3303815150855631,
+            3.0268037269843306,
+            0.09382366056057204,
+            0.0002423456557482906,
+        ],
+        rtol=5e-10,
+        atol=1e-13,
+    )
+    np.testing.assert_allclose(
+        [
+            wout.rmnc[0, 0],
+            wout.rmnc[12, 0],
+            wout.rmnc[12, 11],
+            wout.zmns[12, 11],
+            wout.bmnc[12, 0],
+            wout.bmnc[-1, 1],
+            wout.iotaf[-1],
+        ],
+        [
+            0.9848767179889502,
+            0.9949157880476165,
+            0.28902906452588345,
+            0.19115540561752123,
+            0.09693177967085653,
+            -2.2158421531406352e-05,
+            -1.1631776764882045e-08,
+        ],
+        rtol=2e-8,
+        atol=2e-13,
+    )

--- a/tests/test_vmec2000_live.py
+++ b/tests/test_vmec2000_live.py
@@ -136,6 +136,46 @@ def test_live_vmec2000_fixed_boundary_parity(
     )
 
 
+def test_live_vmec2000_near_degenerate_vacuum(pytestconfig, tmp_path):
+    """The LFORBAL vacuum remedy converges to the same equilibrium."""
+    vmec2000_dir = tmp_path / "vmec2000_vacuum"
+    vmex_dir = tmp_path / "vmex_vacuum"
+    vmec2000_dir.mkdir()
+    vmex_dir.mkdir()
+    deck = DATA / "input.near_degenerate_vacuum_nfp3"
+    for directory in (vmec2000_dir, vmex_dir):
+        shutil.copy2(deck, directory / deck.name)
+
+    _run([str(_executable(pytestconfig)), deck.name], cwd=vmec2000_dir)
+    _run(
+        [
+            sys.executable,
+            "-m",
+            "vmex.core.cli",
+            str(vmex_dir / deck.name),
+            "--outdir",
+            str(vmex_dir),
+            "--device",
+            "cpu",
+        ],
+        cwd=ROOT,
+    )
+
+    suffix = deck.name.removeprefix("input.")
+    reference = read_wout(vmec2000_dir / f"wout_{suffix}.nc")
+    actual = read_wout(vmex_dir / f"wout_{suffix}.nc")
+    assert int(actual.ier_flag) == int(reference.ier_flag) == 0
+    assert (int(actual.niter), int(reference.niter)) == (941, 942)
+    for name in ("volume_p", "Rmajor_p", "Aminor_p", "aspect", "b0", "wb"):
+        np.testing.assert_allclose(
+            getattr(actual, name), getattr(reference, name), rtol=5e-10
+        )
+    for name in ("rmnc", "zmns", "bmnc", "iotaf"):
+        expected = np.asarray(getattr(reference, name))
+        error = np.linalg.norm(np.asarray(getattr(actual, name)) - expected)
+        assert error / np.linalg.norm(expected) < 1e-8, (name, error)
+
+
 def test_live_vmec2000_converged_lasym_free_boundary(pytestconfig, tmp_path):
     """Converged LASYM geometry, vacuum potential, and surface fields agree."""
     vmec2000_dir = tmp_path / "vmec2000_lasym"

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -2075,9 +2075,17 @@ def _finalize(carry: _LoopCarry, rt: SolverRuntime) -> SolveResult:
     if ier == SUCCESSFUL_TERM_FLAG:
         return _result_from_carry(carry, rt)
     if ier == MORE_ITER_FLAG:
+        hint = "increase NITER or loosen FTOL"
+        if (
+            not rt.lforbal
+            and rt.setup.ncurr == 1
+            and not np.any(np.asarray(rt.setup.mass))
+            and not np.any(np.asarray(rt.setup.icurv))
+        ):
+            hint += "; review LFORBAL=T for a weak vacuum m=1,n=0 direction"
         raise VmecConvergenceError(
             WERROR_MESSAGES[MORE_ITER_FLAG],
-            hint="increase NITER or loosen FTOL",
+            hint=hint,
             iteration=int(carry.iteration), fsq=fsq, ftol=rt.ftol,
         )
     if ier == NONFINITE_FLAG:


### PR DESCRIPTION
## Goal

Make a pressureless, current-free, nearly axisymmetric vacuum failure
understandable and reproducible without changing VMEX's equations or solver
defaults. This is the supplied NFP=3 case for which both VMEX and VMEC2000
stop just above `FTOL=1e-11` in the ordinary variational formulation.

## Achieved

- Add one small public deck with the measured `LFORBAL=T` remedy.
- Preserve and now execute the original `LFORBAL=F` behavior: VMEX never
  changes `LFORBAL`, `FTOL`, `NITER`, the Fourier spectrum, current, or
  pressure automatically.
- When a pressureless, prescribed-zero-current vacuum exhausts `NITER` with
  `LFORBAL=F`, extend the existing typed convergence hint to name the weak
  vacuum `m=1,n=0` direction and ask the user to review `LFORBAL=T`.
- Pin the original 3,500-iteration unresolved trajectory, the converged
  941-iteration remedy, primary WOUT fields, and a live VMEC2000 comparison.
- Document why the simple-looking boundary is ill-conditioned and the two
  less-preferred user choices: tolerance review or removal of genuinely
  unused volume modes.

The production change is nine executable lines on an error-only path. No
solver default or equilibrium equation changes.

## Results

- Original `LFORBAL=F`, VMEX and VMEC2000: 3,500 iterations and
  `(FSQR, FSQZ, FSQL) = (1.35e-11, 5.11e-12, 4.13e-12)`.
- `LFORBAL=T`, VMEX and VMEC2000: 941 VMEX solver iterations and
  `(9.13e-12, 5.38e-12, 2.32e-12)`.
- Primary VMEX/VMEC2000 WOUT geometry and field coefficients agree to better
  than `5e-10` relative.
- Fresh CPU, CUDA 0, and CUDA 1 processes on parent PR #96 all converge in 941
  iterations without JAX platform-selection variables. CUDA 0/1 state and
  WOUT hashes are identical; CPU/GPU L2-relative differences are below
  `8.7e-11`, and every state remains on the requested device.

## Validation

Current stacked head: `24912061` on parent PR #96.

- Focused post-rebase full/live suite: `4 passed in 10.13 s`
- Ruff and diff checks: pass
- Pre-rebase hosted run
  [`30623749338`](https://github.com/uwplasma/vmex/actions/runs/30623749338):
  all 11 protected jobs passed, including changed-line coverage
- Exact stacked hosted run
  [`30624545367`](https://github.com/uwplasma/vmex/actions/runs/30624545367):
  all 11 protected jobs passed, including changed-line coverage and the
  aggregate PR gate

## Compatibility

Routine converged solves are untouched. Non-vacuum convergence failures keep
the existing `increase NITER or loosen FTOL` hint. The new suggestion appears
only after iteration-budget exhaustion when pressure and prescribed current
are both zero and `LFORBAL` is false.

## Left

1. Merge parent device-runtime PR #96 first.
2. Rebase these two commits onto `main`, rerun the focused full/live and
   CPU/CUDA0/CUDA1 gates, and mark this PR ready for review.

This is troubleshooting documentation and a regression deck, not a README
showcase or an automatic solver-policy change.
