### PR TITLE
Default CLI multigrid compilation to lower memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ bottleneck or stalls.
 **High-mode HSX QHS deck** (`MPOL=18, NTOR=24, NZETA=100, ns→101`; 858 modes),
 sequentially on an idle Apple Silicon CPU. VMEX was measured once with an
 empty persistent compilation cache and twice in fresh processes reusing that
-cache; VMEC++ was measured twice:
+cache; those recorded VMEX runs used compilation prefetch. VMEC++ was
+measured twice:
 
 | code | wall | peak RSS | outcome |
 | --- | ---: | ---: | --- |
@@ -176,8 +177,8 @@ memory of ten-thread VMEC++; an empty-cache run is 2.68× slower. VMEX remains
 ``1.02e-11`` in ``bmnc``, and ``2.37e-11`` in core ``iota``. The runtime
 is therefore about the 2.5× target for this PR; the remaining XLA
 executable/full-radial memory gap is stated explicitly rather than treated as
-closed. For memory-constrained cold runs, ``--no-prefetch-compile`` trades
-startup latency for a lower peak.
+closed. The CLI compiles multigrid rungs sequentially to bound peak memory;
+``--prefetch-compile`` opts into overlapping the next rung's compilation.
 
 ![Wall-clock comparison against VMEC2000 and a reference C++ implementation](docs/_static/figures/readme_runtime_compare.png)
 
@@ -563,7 +564,7 @@ options:
                          cuda, rocm, or tpu; applies to all solve paths
   --ftol F               override the final-stage FTOL_ARRAY tolerance
   --max-iter N           override the final-stage NITER_ARRAY cap
-  --no-prefetch-compile  lower peak memory by compiling lanes sequentially
+  --prefetch-compile     overlap next-rung compilation (higher peak memory)
   --coils PATH           ESSOS-style coils file: tabulate its Biot-Savart
                          field in memory instead of reading an mgrid file
   --mbooz/--nbooz N      Boozer spectral resolution (default 32/32)

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -62,10 +62,10 @@ Options
      - Override the final-stage ``FTOL_ARRAY`` tolerance.
    * - ``--max-iter N``
      - Override the final-stage ``NITER_ARRAY`` iteration cap.
-   * - ``--no-prefetch-compile``
-     - Compile solver lanes sequentially to reduce peak memory. The default
-       overlaps compilation to reduce cold-start latency; numerical results
-       are identical.
+   * - ``--prefetch-compile`` / ``--no-prefetch-compile``
+     - Opt in to or out of overlapping the next multigrid rung's compilation.
+       Sequential compilation is the default and uses less peak memory;
+       numerical results are identical.
    * - ``--jacobian-retries N``
      - Retry a stage from its best finite checkpoint after the VMEC2000
        75-Jacobian-reset condition, using a reduced ``DELT`` (default 2).

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -386,9 +386,12 @@ unaffected.  Library :func:`~vmex.core.multigrid.solve_multigrid` and
 :func:`~vmex.core.multigrid.solve_free_boundary_multigrid` retain warm stage
 executables by default (the right policy for scans and repeated solves) and
 accept ``release_stage_cache=True`` to opt into the one-shot behaviour.
-The CLI normally overlaps compilation to reduce cold-start latency.  On
-memory-constrained hosts, ``--no-prefetch-compile`` instead compiles solver
-lanes sequentially; the library equivalent is ``prefetch_compile=False``.
+The CLI and library compile solver lanes sequentially by default.
+``--prefetch-compile`` (or ``prefetch_compile=True`` in the library) overlaps
+the next rung's compilation.  This can reduce cold-start latency on a
+core-rich host, but increases peak memory and can contend with the active
+solve when the available CPU set is small.  ``--no-prefetch-compile`` remains
+an explicit spelling of the default.
 
 Implicit-storage experiments (recorded so they are not repeated)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_cli_device.py
+++ b/tests/test_cli_device.py
@@ -12,7 +12,10 @@ from vmex.core import cli, multigrid
 def test_device_option_parses_supported_choices():
     parser = cli.build_parser()
     assert parser.parse_args(["input.case"]).device == "auto"
-    assert parser.parse_args(["input.case"]).prefetch_compile is True
+    assert parser.parse_args(["input.case"]).prefetch_compile is False
+    assert parser.parse_args(
+        ["input.case", "--prefetch-compile"]
+    ).prefetch_compile is True
     assert parser.parse_args(
         ["input.case", "--no-prefetch-compile"]
     ).prefetch_compile is False
@@ -24,7 +27,8 @@ def test_device_option_parses_supported_choices():
 
 @pytest.mark.parametrize(("choice", "expected"), [("none", None), ("cpu", "cpu")])
 def test_fixed_boundary_cli_forwards_device(monkeypatch, tmp_path, choice, expected):
-    args = cli.build_parser().parse_args(["input.case", "--quiet", "--device", choice])
+    args = cli.build_parser().parse_args(
+        ["input.case", "--quiet", "--device", choice, "--prefetch-compile"])
     inp = SimpleNamespace(lfull3d1out=False)
     seen = {}
 

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -204,13 +204,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--ftol", type=float, default=None, help="Override the final-stage FTOL_ARRAY tolerance.")
     p.add_argument("--max-iter", type=int, default=None, help="Override the final-stage NITER_ARRAY iteration cap.")
     p.add_argument(
-        "--no-prefetch-compile",
-        dest="prefetch_compile",
-        action="store_false",
-        default=True,
+        "--prefetch-compile",
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help=(
-            "Compile solver lanes sequentially to lower peak memory; the "
-            "default overlaps compilation for lower cold-start latency."
+            "Overlap compilation of the next multigrid rung (default: off "
+            "to bound peak memory)."
         ),
     )
     p.add_argument(
@@ -618,7 +617,7 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
             raise_on_max_iterations=not bool(inp.lfull3d1out),
             device=None if args.device == "none" else args.device,
             release_stage_cache=True,
-            # Cold-run overlap is a CLI concern (library default False).
+            # Opt-in cold-run overlap; the library default is also False.
             prefetch_compile=bool(args.prefetch_compile),
             jacobian_retries=int(args.jacobian_retries),
             **freeb_plan.solver_kwargs,
@@ -638,9 +637,8 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
             raise_on_max_iterations=not bool(effective_inp.lfull3d1out),
             device=None if args.device == "none" else args.device,
             release_stage_cache=True,
-            # Cold-run overlap is a CLI concern: the library default is
-            # False so embedding programs and test farms never gain
-            # background compile threads implicitly.
+            # Opt-in cold-run overlap; background compiler threads otherwise
+            # contend with the solve and raise peak memory on constrained CPUs.
             prefetch_compile=bool(args.prefetch_compile),
             jacobian_retries=int(args.jacobian_retries),
         )


### PR DESCRIPTION
## Goal

Reduce one-shot CLI peak memory without changing equilibrium mathematics,
device placement, library defaults, or numerical results. The high-resolution
HSX profile showed that compiling the next multigrid rung concurrently can
contend with the active solve and retain both rungs' compiler state.

## What changed

- CLI runs now compile multigrid rungs sequentially by default, matching the
  existing `solve_multigrid(..., prefetch_compile=False)` and free-boundary
  library defaults.
- `--prefetch-compile` opts into the previous overlapping behavior.
- The existing `--no-prefetch-compile` spelling remains accepted.
- README and CLI/performance documentation describe the measured tradeoff.

No solver kernel, tolerance, iteration rule, free-boundary/NESTOR operator,
device policy, WOUT field, or AD path changed.

## Measured result

Input:
`input.testing_hsxtools`, SHA-256
`00db56d85a3068fd2f661a7021cc1fbfb178f961a602bbf3990c162420643cf1`;
`ns=101`, `mpol=18`, `ntor=24`, 858 modes. Every run used JAX's public
`device="cpu"` placement on the same idle office host. Both JAX platform
environment selectors were unset. Each result converged in 2,737 iterations.

| available CPUs | compilation | wall time | peak RSS |
|---:|---|---:|---:|
| 10 | overlap | 658.8 s | 4.219 GB |
| 10 | sequential | 428.7 s | 3.800 GB |
| 36 | overlap | 428.1 s | 6.620 GB |
| 36 | sequential | 448.5 s | 4.302 GB |

On ten CPUs, sequential compilation was 34.9% faster and used 9.9% less peak
memory. On all 36 CPUs, overlap bought only 4.5% wall time at a 53.9% peak-RSS
cost. The sequential runs reproduced the corresponding overlap state and
residual trajectory; differences between the 10- and 36-CPU hashes reflect
parallel reduction order.

An experimental fused native CPU force/projection kernel was also tested and
rejected rather than included here. It took 419.5 s and 5.804 GB on ten CPUs:
only 2.2% faster than sequential pure JAX while using 52.7% more memory, before
adding LASYM, free-boundary, GPU, or derivative support.

## Validation

- CLI parser and fixed/free solver forwarding: 4 passed
- fixed-boundary prefetch parity/bookkeeping: passed
- full opt-in free-boundary NESTOR prefetch parity: passed (`RUN_FULL=1`)
- real `vmex --test` default-CLI solve/WOUT/five-figure workflow: passed
- Ruff and mypy: passed
- strict Sphinx build: passed
- wheel build and diff checks: passed
- protected hosted CI: all 11 checks passed
- trusted CPU/CUDA0/CUDA1 placement and seven-metric gradient audit:
  [run 30621450163](https://github.com/uwplasma/vmex/actions/runs/30621450163)
  passed at exact head `b4947772`

## Left before merge

Independent review of the CLI default change and measured tradeoff. No
implementation or validation gate remains open.
