### PR TITLE
Validate exact-JVP GMRES robustness

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -336,6 +336,17 @@ tokamak, a tie even on the aspect-100 case) — and peak memory is ≈30% higher
 to ~1e-10, so it changes the path, not the fixed point. Reach for it when the
 1D iteration count is the bottleneck or stalls, not as a blanket default.
 
+One such stall is reproducible on the aspect-100 case at ``ns=51`` and
+``FTOL=1e-11``.  With ``PRECON_TYPE='GMRES'`` and
+``PREC2D_THRESHOLD=1e-6``, VMEX converges in 18 iterations, while VMEC2000's
+finite-difference block GMRES remains at a maximum residual of ``2.05e-9``
+after 1,600 explicit ``PRE_NITER`` steps.  A separate VMEC2000 1-D solve
+converges and agrees with the VMEX result in ``wb`` to ``1.3e-11`` relative
+and in the primary geometry to better than ``1e-5``.  The opt-in live test
+``test_live_vmec2000_exact_jvp_gmres_robustness`` reproduces all three paths.
+This is a robustness result, not a CPU speed or memory claim: the small
+VMEC2000 1-D solve is still much cheaper than a cold JAX process.
+
 Memory
 ------
 

--- a/tests/test_vmec2000_live.py
+++ b/tests/test_vmec2000_live.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 import shutil
 import subprocess
 import sys
@@ -11,6 +12,7 @@ import numpy as np
 import pytest
 
 from vmex.core.wout import read_wout
+from vmex.core.input import VmecInput
 from vmex.core.mgrid import write_mgrid
 
 from tests.test_lasym_free_case import (
@@ -134,6 +136,79 @@ def test_live_vmec2000_fixed_boundary_parity(
         np.sign(np.asarray(actual.DMerc)[2:-1]),
         np.sign(np.asarray(reference.DMerc)[2:-1]),
     )
+
+
+def test_live_vmec2000_exact_jvp_gmres_robustness(pytestconfig, tmp_path):
+    """Exact-JVP GMRES converges where VMEC2000's block GMRES stalls."""
+    inp = replace(
+        VmecInput.from_file(DATA / "input.circular_tokamak_aspect_100"),
+        ns_array=np.asarray([51]),
+        niter_array=np.asarray([20000]),
+        ftol_array=np.asarray([1.0e-11]),
+        precon_type="GMRES",
+        prec2d_threshold=1.0e-6,
+    )
+    legacy_dir = tmp_path / "legacy_gmres"
+    reference_dir = tmp_path / "legacy_1d"
+    vmex_dir = tmp_path / "vmex_gmres"
+    for directory in (legacy_dir, reference_dir, vmex_dir):
+        directory.mkdir()
+    inp.to_indata(legacy_dir / "input.aspect100")
+    inp.to_indata(vmex_dir / "input.aspect100")
+    replace(inp, precon_type="NONE").to_indata(
+        reference_dir / "input.aspect100"
+    )
+
+    legacy = subprocess.run(
+        [str(_executable(pytestconfig)), "input.aspect100"],
+        cwd=legacy_dir,
+        text=True,
+        capture_output=True,
+        timeout=300,
+        check=False,
+    )
+    assert legacy.returncode == 0
+    assert "Beginning GMRES iterations" in legacy.stdout
+    assert "Try increasing NITER or PRE_NITER" in legacy.stdout
+    rows = []
+    for line in legacy.stdout.splitlines():
+        fields = line.split()
+        if len(fields) == 7 and fields[0].isdigit():
+            try:
+                rows.append((int(fields[0]), *(float(x) for x in fields[1:4])))
+            except ValueError:
+                pass
+    assert rows[-1][0] == 110
+    assert 1.0e-10 < max(rows[-1][1:]) < 1.0e-8
+
+    _run(
+        [str(_executable(pytestconfig)), "input.aspect100"],
+        cwd=reference_dir,
+    )
+    _run(
+        [
+            sys.executable,
+            "-m",
+            "vmex.core.cli",
+            str(vmex_dir / "input.aspect100"),
+            "--outdir",
+            str(vmex_dir),
+            "--device",
+            "cpu",
+        ],
+        cwd=ROOT,
+    )
+    reference = read_wout(reference_dir / "wout_aspect100.nc")
+    actual = read_wout(vmex_dir / "wout_aspect100.nc")
+    assert int(actual.ier_flag) == int(reference.ier_flag) == 0
+    assert max(float(actual.fsqr), float(actual.fsqz), float(actual.fsql)) < 1e-11
+    assert int(actual.niter) < int(reference.niter)
+    assert abs(float(actual.wb) - float(reference.wb)) / abs(reference.wb) < 1e-8
+    for name in ("rmnc", "zmns"):
+        got = np.asarray(getattr(actual, name))
+        expected = np.asarray(getattr(reference, name))
+        assert np.linalg.norm(got - expected) / np.linalg.norm(expected) < 1e-5
+    np.testing.assert_allclose(actual.iotaf, reference.iotaf, atol=2e-14)
 
 
 def test_live_vmec2000_converged_lasym_free_boundary(pytestconfig, tmp_path):


### PR DESCRIPTION
## Goal

Turn VMEX's existing exact-JVP 2-D preconditioner result into a reproducible
cross-code robustness gate. The claim is deliberately narrow: on one stiff
high-aspect equilibrium, VMEX's matrix-free Newton--GMRES converges where the
current VMEC2000 finite-difference block-GMRES trajectory stalls.

This PR does not change a solver, default, tolerance, device policy, WOUT
field, or derivative path. It does not claim that VMEX is generally faster or
smaller than VMEC2000.

## Achieved

- Build the comparison from the tracked public
  `input.circular_tokamak_aspect_100` deck at `ns=51`, `FTOL=1e-11`,
  `PRECON_TYPE='GMRES'`, and `PREC2D_THRESHOLD=1e-6`.
- Run the identical GMRES input through VMEX and VMEC2000.
- Run a separate converged VMEC2000 1-D solve as the independent fixed-point
  oracle.
- Assert the legacy GMRES activation and explicit NITER outcome, VMEX
  convergence, iteration reduction, energy parity, primary-geometry parity,
  and iota parity.
- Document the result next to the existing 2-D-preconditioner tradeoffs,
  including the fact that the small VMEC2000 1-D solve remains much cheaper
  than a cold JAX process.

The complete diff is one opt-in live integration test and eleven documentation
lines: 86 added lines, zero production lines.

## Results

- VMEX exact-JVP Newton--GMRES: 18 iterations,
  `(FSQR, FSQZ, FSQL) = (1.50e-14, 6.64e-15, 1.13e-15)`.
- VMEC2000 block GMRES: stops at iteration 110 with maximum residual
  `2.05e-9` on macOS. Explicit `PRE_NITER=100, 200, 400, 800, 1600`
  changes only the stopping iteration; the residual remains `2.04--2.05e-9`.
- Independent VMEC2000 1-D reference: converges in 97 printed iterations.
- VMEX GMRES versus the VMEC2000 1-D WOUT:
  - `wb`: `1.27e-11` relative
  - `rmnc`: `4.93e-7` L2-relative
  - `zmns`: `4.96e-6` L2-relative
  - `iotaf`: machine precision
- A second Linux VMEC2000 implementation
  (`hiddensymmetries/vmec2000` at `728af8b`) independently stops at iteration
  110 with maximum residual `1.97e-9`.
- Current STELLOPT `develop` at `c66fff09207c` has byte-identical
  `evolve.f` and `gmres_mod.f` to the local oracle source. There is no related
  public issue/PR, and `gmres_mod.f` has had no upstream commit since 2019.

## Validation

- New three-path live integration: `1 passed in 4.04 s`
- Complete live VMEC2000 module: `4 passed in 16.97 s`
- Existing full 2-D-preconditioner suite: `7 passed in 21.54 s`
- Strict Sphinx, Ruff, `mypy vmex`, and diff checks: pass
- Exact hosted run
  [`30624512475`](https://github.com/uwplasma/vmex/actions/runs/30624512475):
  all 11 protected jobs passed, including changed-line coverage and the
  aggregate PR gate
- Exact stacked head `035f69ce` on the office host:
  - CPU: converged in 18 iterations
  - CUDA 0: converged in 18 iterations
  - CUDA 1: converged in 18 iterations
  - CUDA 0/1 results are bitwise identical
  - every state leaf remains on the explicitly supplied JAX device

The CUDA-1 run requires parent PR #96. The older installed package reproduces
the nondefault-device defect; the exact stacked source fixes it.

## Left

1. Merge parent device-runtime PR #96 first.
2. Rebase this one-commit audit onto `main`, rerun the focused live and
   CPU/CUDA0/CUDA1 gates, and then mark it ready for review.

No implementation or scientific-method change is proposed by this PR.
