### PR TITLE
Free boundary: flushed per-lane compile visibility, smaller traced lanes, sharper input-parity diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           sudo swapon /mnt/vmex-swap
       - name: Fetch the core parity fixture
         if: matrix.selector == 'pr-physics-core'
-        run: python tools/fetch_assets.py --bundle golden-v1
+        run: python tools/fetch_assets.py --bundle golden-v1 --bundle reference-nc
       - name: Run representative physics
         env:
           JAX_ENABLE_X64: "1"

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -44,6 +44,7 @@
     ["tests/test_implicit_device.py", "ad", "ad", "medium", "cpu-gpu", "none", "fd", ["pr-parity-c3", "gpu-smoke", "full-core-i"]],
     ["tests/test_implicit_grad.py", "ad", "ad", "campaign", "cpu-gpu", "golden", "fd", ["pr-gradient", "full-core-i-grad"]],
     ["tests/test_implicit_multi_rhs.py", "ad", "ad", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c3", "full-core-i"]],
+    ["tests/test_aphi_flux_normalization.py", "equilibrium", "unit", "fast", "cpu", "none", "vmec2000", ["pr-parity-c1", "pr-fast", "full-core-i"]],
     ["tests/test_input_profiles.py", "equilibrium", "unit", "fast", "cpu", "none", "analytic", ["pr-parity-c1", "pr-fast", "full-core-i"]],
     ["tests/test_lasym_free_convergence.py", "free-boundary", "campaign", "campaign", "cpu-gpu", "generated", "vmec2000", ["pr-full-only", "full-core-j-m"]],
     ["tests/test_lgradb.py", "diagnostics", "ad", "medium", "cpu-gpu", "none", "fd", ["pr-parity-c3", "full-core-j-m"]],
@@ -95,8 +96,14 @@
       "tests/test_implicit_grad.py::test_solovev_gradients_vs_fd",
       "tests/test_implicit_grad.py::test_jdotb_and_glasser_gradients_vs_frozen_path_fd[solovev]",
       "tests/test_freeboundary.py::test_nestor_skip_branch_matches_full_solve",
+      "tests/test_freeboundary.py::test_jac75_retry_rebuilds_vacuum_and_converges",
+      "tests/test_freeboundary.py::test_vacuum_step_skip_reuses_cached_matrix",
+      "tests/test_freeboundary.py::test_call_lane_emits_notice_once_before_compile",
+      "tests/test_freeboundary_multigrid.py",
       "tests/test_freeboundary_linear.py",
-      "tests/test_freeboundary_diff.py::test_synthetic_surface_gradient_fd_validates"
+      "tests/test_freeboundary_diff.py::test_synthetic_surface_gradient_fd_validates",
+      "tests/test_printing.py::test_compile_notice_variants",
+      "tests/test_printing.py::test_emit_flushed_writes_and_flushes"
     ],
     "pr-physics-mirror-spline": [
       "tests/mirror/test_analytic.py",

--- a/tests/test_aphi_flux_normalization.py
+++ b/tests/test_aphi_flux_normalization.py
@@ -1,0 +1,321 @@
+"""APHI toroidal-flux normalization semantics (VMEC2000 ``profil1d.f`` parity).
+
+VMEC2000 ground truth being pinned here:
+
+- ``Sources/Initialization_Cleanup/magnetic_fluxes.f`` (``torflux_deriv``,
+  lines 22-25): ``torflux_deriv = x*torflux_deriv + i*tf(i)`` accumulated from
+  the highest index down, i.e. ``Phi'(x) = sum_i i*aphi(i)*x**(i-1)`` — the
+  APHI coefficients parameterize the flux ``Phi(x) = sum_i aphi(i)*x**i``
+  itself, not its derivative; and (``torflux``, lines 70-77) ``torflux(x)`` is
+  the fixed 101-point trapezoid integral of ``torflux_deriv`` on ``[0, x]``.
+- ``Sources/Initialization_Cleanup/profil1d.f`` (lines 289-293):
+  ``torflux_edge = signgs*phiedge/twopi`` then ``torflux_edge =
+  torflux_edge/torflux(one)`` when ``torflux(one) /= 0``.  The radial flux
+  profile is therefore NORMALIZED: PHIEDGE is always the physical edge flux
+  no matter the overall scale of the APHI coefficients, and ``phips(i) =
+  torflux_edge*torflux_deriv(si)`` (line 311) never inherits that scale.
+- ``profil1d.f`` (lines 307, 313-314): the *profile argument* ``tf =
+  MIN(one, torflux(si))`` is the UNnormalized flux, clamped at 1 — iota,
+  current, and mass are evaluated at the clamped raw polynomial, so an
+  unnormalized APHI legitimately reshapes those profiles while leaving the
+  flux arrays untouched.
+
+An unnormalized coefficient set (``torflux(1) != 1``) must therefore leave
+``phips/chips/phipf/chipf/lamscale`` bit-identical when it only rescales the
+identity map, and must never rescale the equilibrium energy: ``wb`` scales as
+flux squared, so any missed normalization shows up as a ``torflux(1)**2``
+blow-up of the row-1 WMHD.  These tests pin that contract at three levels:
+the polynomial/trapezoid functions, the ``flux_profiles`` arrays, and full
+solver row-1 goldens for a public deck (plus an opt-in live comparison
+against a local ``xvmec2000``).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+jax.config.update("jax_enable_x64", True)
+
+from vmex.core.input import VmecInput
+from vmex.core.setup import _torflux_functions, flux_profiles, radial_grids
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "examples" / "data"
+FIXED_DECK = DATA_DIR / "input.cth_like_fixed_bdy"
+
+#: Scale-only set: ``Phi(x) = 8.578*x`` (``torflux(1) = 8.578``).
+APHI_SCALE = (8.578,)
+#: Multi-term unnormalized set: ``Phi(x) = 2x - 1.5x^2 + x^3``
+#: (``torflux(1) = 1.5`` up to trapezoid quadrature).
+APHI_MULTI = (2.0, -1.5, 1.0)
+
+_ROW_FIELD = re.compile(r"^\d\.\d{2}E[+-]\d{2}$")
+
+
+# ---------------------------------------------------------------------------
+# Reference transliterations of magnetic_fluxes.f
+# ---------------------------------------------------------------------------
+
+
+def _fortran_torflux_deriv(aphi, x: float) -> float:
+    """magnetic_fluxes.f lines 22-25 (Horner loop, highest index first)."""
+    y = 0.0
+    for i in range(len(aphi), 0, -1):
+        y = x * y + i * aphi[i - 1]
+    return y
+
+
+def _fortran_torflux(aphi, x: float) -> float:
+    """magnetic_fluxes.f lines 70-77 (101-point trapezoid on [0, x])."""
+    h = 1.0e-2 * x
+    total = sum(_fortran_torflux_deriv(aphi, (i - 1) * h) for i in range(1, 102))
+    total -= 0.5 * (_fortran_torflux_deriv(aphi, 0.0) + _fortran_torflux_deriv(aphi, x))
+    return h * total
+
+
+def _with_aphi(inp: VmecInput, aphi) -> VmecInput:
+    padded = np.zeros(20)
+    padded[: len(aphi)] = aphi
+    return dataclasses.replace(inp, aphi=padded)
+
+
+# ---------------------------------------------------------------------------
+# (a) unit level: flux polynomial and trapezoid vs the Fortran formula
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "aphi",
+    [(1.0,), APHI_SCALE, APHI_MULTI, (0.5, 0.25, 0.0, 1.25)],
+    ids=["identity", "scale", "multi", "quartic"],
+)
+def test_torflux_functions_match_fortran_formula(aphi) -> None:
+    """``_torflux_functions`` reproduces magnetic_fluxes.f for any scale."""
+    torflux, torflux_deriv = _torflux_functions(np.asarray(aphi))
+    for x in (0.0, 0.13, 0.5, 1.0):
+        np.testing.assert_allclose(
+            float(torflux_deriv(x)),
+            _fortran_torflux_deriv(aphi, x),
+            rtol=1e-14,
+            err_msg=f"torflux_deriv({x})",
+        )
+        np.testing.assert_allclose(
+            float(torflux(x)),
+            _fortran_torflux(aphi, x),
+            rtol=1e-13,
+            atol=1e-300,
+            err_msg=f"torflux({x})",
+        )
+
+
+def test_flux_profiles_normalize_torflux_edge_multi_term() -> None:
+    """profil1d.f lines 289-293/311: phips = signgs*phiedge/(2pi*Phi(1))*Phi'."""
+    inp = _with_aphi(VmecInput.from_file(FIXED_DECK), APHI_MULTI)
+    grids = radial_grids(15)
+    prof = flux_profiles(inp, grids, r00=np.asarray(0.78), signgs=-1)
+    edge = -1 * inp.phiedge / (2.0 * np.pi) / _fortran_torflux(APHI_MULTI, 1.0)
+    s_half = np.asarray(grids.s_half)
+    s_full = np.asarray(grids.s_full)
+    expected_half = edge * np.asarray(
+        [_fortran_torflux_deriv(APHI_MULTI, s) for s in s_half]
+    )
+    expected_half[0] = 0.0
+    expected_full = edge * np.asarray(
+        [_fortran_torflux_deriv(APHI_MULTI, s) for s in s_full]
+    )
+    np.testing.assert_allclose(np.asarray(prof["phips"]), expected_half, rtol=1e-13)
+    np.testing.assert_allclose(np.asarray(prof["phipf"]), expected_full, rtol=1e-13)
+
+
+def test_profile_argument_is_unnormalized_clamped_torflux() -> None:
+    """profil1d.f lines 307/313: tf = MIN(1, torflux(s)) stays unnormalized."""
+    text = """&INDATA
+    NFP = 3, MPOL = 3, NTOR = 0, NS_ARRAY = 11, PHIEDGE = 1.7,
+    NCURR = 0,
+    AI = 1.0, 1.0,
+    APHI = 8.578,
+    RBC(0,0) = 3.0, RBC(0,1) = 1.0, ZBS(0,1) = 1.0,
+    /
+    """
+    inp = VmecInput.from_indata_text(text)
+    grids = radial_grids(11)
+    prof = flux_profiles(inp, grids, r00=np.asarray(3.0), signgs=-1)
+    torflux, _ = _torflux_functions(inp.aphi)
+    expected = 1.0 + np.minimum(np.asarray(torflux(np.asarray(grids.s_half))), 1.0)
+    expected[0] = 0.0  # half-mesh axis slot is zeroed (profil1d.f DO i = 2, ns)
+    np.testing.assert_array_equal(np.asarray(prof["iotas"]), expected)
+
+
+# ---------------------------------------------------------------------------
+# (c) bit-identity: normalized decks and pure-scale coefficient sets
+# ---------------------------------------------------------------------------
+
+
+def _profiles_for(aphi=None) -> dict[str, np.ndarray]:
+    inp = VmecInput.from_file(FIXED_DECK)
+    if aphi is not None:
+        inp = _with_aphi(inp, aphi)
+    grids = radial_grids(15)
+    out = flux_profiles(inp, grids, r00=np.asarray(0.780906309727434), signgs=-1)
+    return {k: np.asarray(v) for k, v in out.items()}
+
+
+def test_default_and_explicit_identity_aphi_are_bit_identical() -> None:
+    """APHI absent and APHI = 1.0 (torflux(1) = 1) share every last bit."""
+    base = _profiles_for()
+    explicit = _profiles_for((1.0,))
+    for key, value in base.items():
+        np.testing.assert_array_equal(value, explicit[key], err_msg=key)
+
+
+def test_pure_scale_aphi_leaves_flux_arrays_bit_identical() -> None:
+    """torflux(1) = 8.578 with identity shape must not touch the flux arrays.
+
+    profil1d.f divides torflux_edge by torflux(1), so ``Phi(x) = 8.578*x``
+    yields exactly the same phips/chips/phipf/chipf/lamscale as the default
+    identity map — while mass/icurv legitimately move because their argument
+    ``tf = MIN(1, torflux(s))`` saturates (the unnormalized clamp above).
+    A missed normalization would scale phips by 8.578 and the row-1 energy
+    by 8.578**2 = 73.58.
+    """
+    base = _profiles_for()
+    scaled = _profiles_for(APHI_SCALE)
+    for key in ("phips", "chips", "phipf", "chipf", "lamscale"):
+        np.testing.assert_array_equal(base[key], scaled[key], err_msg=key)
+    # The clamp reshapes the pressure/current inputs; equality here would mean
+    # the clamp was silently normalized away.
+    assert not np.array_equal(base["mass"], scaled["mass"])
+    assert not np.array_equal(base["icurv"], scaled["icurv"])
+
+
+# ---------------------------------------------------------------------------
+# (b) row-1 goldens for the public deck with unnormalized APHI
+# ---------------------------------------------------------------------------
+
+
+def _deck_with_aphi(tmp_path: Path, aphi_line: str | None, niter: int) -> Path:
+    text = FIXED_DECK.read_text()
+    text = text.replace("NITER_array = 25000,", f"NITER_array = {niter},")
+    if aphi_line is not None:
+        text = text.replace("PHIEDGE = -0.035,", f"PHIEDGE = -0.035,\n{aphi_line}")
+    deck = tmp_path / "input.aphinorm"
+    deck.write_text(text)
+    return deck
+
+
+def _first_iteration_row(stdout: str) -> list[float]:
+    for line in stdout.splitlines():
+        tokens = line.split()
+        if (
+            len(tokens) >= 6
+            and tokens[0] == "1"
+            and _ROW_FIELD.match(tokens[1])
+        ):
+            return [float(tok) for tok in tokens[1:]]
+    raise AssertionError(f"no iteration-1 row found in output:\n{stdout}")
+
+
+def _run_vmex_cli(deck: Path, outdir: Path) -> str:
+    from vmex.core import cli
+
+    jax.config.update("jax_disable_jit", False)
+    try:
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            cli.main([str(deck), "--outdir", str(outdir)])
+    finally:
+        jax.config.update("jax_disable_jit", True)
+    return buffer.getvalue()
+
+
+def test_row1_goldens_with_unnormalized_aphi(tmp_path: Path) -> None:
+    """Row-1 FSQR/WMHD stay at the VMEC2000-parity goldens, not 73.6x off.
+
+    Golden row 1 for the public cth_like_fixed_bdy deck (both codes print
+    identical rows; xvmec2000 capture 2026-08):
+
+    - APHI absent:      FSQR 3.76E-02, FSQZ 9.68E-04, WMHD 4.5096E-02
+    - APHI = 8.578:     FSQR 4.02E-02, FSQZ 6.18E-03, WMHD 4.6403E-02
+    """
+    base_out = tmp_path / "base"
+    unnorm_out = tmp_path / "unnorm"
+    base_out.mkdir()
+    unnorm_out.mkdir()
+    base_row = _first_iteration_row(
+        _run_vmex_cli(_deck_with_aphi(tmp_path / "base", None, 25), base_out)
+    )
+    unnorm_row = _first_iteration_row(
+        _run_vmex_cli(
+            _deck_with_aphi(tmp_path / "unnorm", "APHI = 8.578,", 25), unnorm_out
+        )
+    )
+    fsqr, fsqz, _, _, _, wmhd = unnorm_row[:6]
+    np.testing.assert_allclose(fsqr, 4.02e-2, rtol=5e-3)
+    np.testing.assert_allclose(fsqz, 6.18e-3, rtol=5e-3)
+    np.testing.assert_allclose(wmhd, 4.6403e-2, rtol=2e-4)
+    # The direct regression guard: an unnormalized identity-shaped APHI must
+    # not rescale the starting energy (a missed torflux(1) division would
+    # multiply WMHD by 8.578**2 = 73.58 and blow FSQR up by orders).
+    wmhd_base = base_row[5]
+    np.testing.assert_allclose(wmhd_base, 4.5096e-2, rtol=2e-4)
+    assert 0.9 < wmhd / wmhd_base < 1.1
+    assert unnorm_row[0] / base_row[0] < 10.0
+
+
+# ---------------------------------------------------------------------------
+# live xvmec2000 comparison (opt-in, --run-vmec2000)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.vmec2000_live
+@pytest.mark.parametrize(
+    "aphi_line",
+    ["APHI = 8.578,", "APHI = 2.0, -1.5, 1.0,"],
+    ids=["scale", "multi"],
+)
+def test_row1_parity_live_vmec2000(pytestconfig, tmp_path: Path, aphi_line) -> None:
+    """Both codes print the identical row 1 for unnormalized-APHI decks."""
+    configured = str(pytestconfig.getoption("--vmec2000-executable")).strip()
+    candidates = [Path(configured)] if configured else []
+    discovered = shutil.which("xvmec2000")
+    if discovered:
+        candidates.append(Path(discovered))
+    executable = next((c for c in candidates if c.is_file()), None)
+    if executable is None:
+        pytest.fail(
+            "--run-vmec2000 requested but xvmec2000 was not found; pass "
+            "--vmec2000-executable PATH"
+        )
+
+    ref_dir = tmp_path / "vmec2000"
+    ref_dir.mkdir()
+    deck = _deck_with_aphi(ref_dir, aphi_line, 60)
+    completed = subprocess.run(
+        [str(executable), deck.name],
+        cwd=ref_dir,
+        text=True,
+        capture_output=True,
+        timeout=300,
+        check=False,
+    )
+    reference_row = _first_iteration_row(completed.stdout)
+
+    vmex_dir = tmp_path / "vmex"
+    vmex_dir.mkdir()
+    actual_row = _first_iteration_row(
+        _run_vmex_cli(_deck_with_aphi(vmex_dir, aphi_line, 60), vmex_dir)
+    )
+    # Print-precision fields (3 significant digits): identical rows parse to
+    # identical floats.
+    np.testing.assert_array_equal(
+        np.asarray(actual_row[:6]), np.asarray(reference_row[:6])
+    )

--- a/tests/test_cli_freeboundary.py
+++ b/tests/test_cli_freeboundary.py
@@ -81,6 +81,62 @@ def freeb_cli(tmp_path_factory) -> tuple[int, str, Path]:
 # ---------------------------------------------------------------------------
 
 
+def test_redirected_stdout_streams_banner_and_compile_notice(tmp_path):
+    """Cluster-log contract: with stdout redirected to a FILE, the ``NS =``
+    stage banner and a free-lane ``compiling NS = ...`` notice must be
+    readable in that file WHILE the solve is still running.
+
+    This pins two independent fixes: the CLI sink flushes every line
+    (otherwise block buffering hides hours of output on a batch node), and
+    every free-lane compile prints its attribution BEFORE the compile
+    starts (otherwise a large-grid run sits silently inside XLA).  The
+    subprocess is killed as soon as both lines are observed live.
+    """
+    import os
+    import subprocess
+    import sys
+    import time
+
+    deck = tmp_path / DECK.name
+    deck.write_text(DECK.read_text())
+    shutil.copyfile(MGRID, tmp_path / MGRID.name)
+    log = tmp_path / "run.log"
+
+    env = dict(os.environ)
+    env["JAX_ENABLE_X64"] = "1"
+    env["PYTHONPATH"] = os.pathsep.join(
+        p for p in (str(Path(__file__).resolve().parents[1]),
+                    env.get("PYTHONPATH")) if p
+    )
+    with open(log, "wb") as sink:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "vmex.core.cli", str(deck),
+             "--max-iter", "40", "--outdir", str(tmp_path / "out")],
+            stdout=sink, stderr=subprocess.DEVNULL, cwd=str(tmp_path),
+            env=env,
+        )
+        try:
+            seen_live = False
+            deadline = time.monotonic() + 600.0
+            while proc.poll() is None and time.monotonic() < deadline:
+                text = log.read_text(errors="replace")
+                if "NS = " in text and " compiling NS =" in text:
+                    seen_live = True
+                    break
+                time.sleep(0.05)
+        finally:
+            proc.kill()
+            proc.wait()
+    assert seen_live, (
+        "NS banner + compile notice never reached the redirected log while "
+        "the run was still executing; log contents:\n"
+        + log.read_text(errors="replace")[:4000]
+    )
+    # the observed notice is a tagged free-lane one, not a stray fragment
+    assert re.search(r" compiling NS = *\d+ .*executable\.\.\.",
+                     log.read_text(errors="replace"))
+
+
 def test_vacuum_banners_printed(freeb_cli):
     _, stdout, _ = freeb_cli
     assert "In VACUUM" in stdout

--- a/tests/test_first_divergence.py
+++ b/tests/test_first_divergence.py
@@ -250,6 +250,104 @@ def test_nstep_inserted_when_missing_lowercase_indata(tmp_path):
 # (e) privacy: harness failures must never echo the deck path
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# (a2) threed1 input-echo parsing + C1 sub-stage comparison
+# ---------------------------------------------------------------------------
+
+_ECHO_HEAD = (
+    " R-Z FOURIER BOUNDARY COEFFICIENTS AND MAGNETIC AXIS INITIAL GUESS\n"
+    " --------------------------------------------------------------\n"
+    "   nb  mb     rbc         rbs         zbc         zbs       raxis(c)\n"
+)
+
+
+def _echo_from_input(deck: Path, doctor=None) -> str:
+    """A threed1-style boundary echo rendered from VMEX's own parse."""
+    import numpy as np
+
+    from vmex.core.input import VmecInput
+    inp = VmecInput.from_file(str(deck))
+    rbc, rbs = np.asarray(inp.rbc, float), np.asarray(inp.rbs, float)
+    zbc, zbs = np.asarray(inp.zbc, float), np.asarray(inp.zbs, float)
+    lines = [_ECHO_HEAD.rstrip("\n")]
+    for mb in range(int(inp.mpol)):
+        for nb in range(-int(inp.ntor), int(inp.ntor) + 1):
+            row = [rbc[inp.ntor + nb, mb], rbs[inp.ntor + nb, mb],
+                   zbc[inp.ntor + nb, mb], zbs[inp.ntor + nb, mb]]
+            if doctor is not None:
+                row = doctor(nb, mb, row)
+            if not any(abs(v) > 0 for v in row):
+                continue
+            vals = "  ".join(f"{v: .4E}" for v in row)
+            lines.append(f"   {nb:>2d}  {mb:>2d}  {vals}")
+    return "\n".join(lines) + "\n\n NEXT SECTION\n"
+
+
+def _run_echo_compare(ref_text: str, deck: Path) -> tuple[list[str], list[str]]:
+    stages: list[str] = []
+    klasses: list[str] = []
+
+    def stage(code: str, text: str) -> None:
+        stages.append(f"{code}: {text}")
+
+    fd._compare_parsed_inputs(ref_text, deck, stage, klasses.append, False)
+    return stages, klasses
+
+
+def test_threed1_scalar_and_coeff_parsers():
+    text = (
+        "    nfp      gamma      spres_ped    phiedge(wb)     curtor(A)        lRFP\n"
+        "      5  0.000E+00      1.000E+00     -3.500E-02     4.323E+04           F\n"
+        "  ncurr  niter   nsin  nstep  nvacskip      ftol     tcon0    lasym  lforbal lmove_axis lconm1\n"
+        "      1   2500     15    100         9  1.00E-10  1.00E+00        F        F        T        T\n"
+        " Pressure profile factor:  4.3229E+02 (multiplier for pressure)\n"
+        " MASS PROFILE COEFFICIENTS - newton/m**2 (EXPANSION IN NORMALIZED RADIUS):\n"
+        " PMASS parameterization type is 'two_power'\n"
+        " -----------------------------------\n"
+        "   1.000E+00   5.000E+00   1.000E+01\n"
+    )
+    scal = fd._threed1_scalars(text)
+    assert scal["nfp"] == 5 and scal["phiedge"] == pytest.approx(-0.035)
+    assert scal["curtor"] == pytest.approx(4.323e4)
+    assert scal["lforbal"] == 0.0 and scal["pres_scale"] == pytest.approx(432.29)
+    assert fd._threed1_coeffs(text, "MASS PROFILE COEFFICIENTS") == [1.0, 5.0, 10.0]
+    assert fd._threed1_coeffs(text, "IOTA PROFILE COEFFICIENTS") is None
+
+
+def test_parse_echo_matches_own_render():
+    deck = DATA / "input.cth_like_fixed_bdy"
+    stages, klasses = _run_echo_compare(_echo_from_input(deck), deck)
+    assert any("C1 PARSE_BOUNDARY: MATCH" in s for s in stages)
+    assert all(k == fd.MATCH for k in klasses)
+
+
+def test_parse_echo_flags_doctored_boundary_mode():
+    deck = DATA / "input.cth_like_fixed_bdy"
+
+    def doctor(nb, mb, row):
+        return [2.0 * v for v in row] if (nb, mb) == (0, 1) else row
+
+    stages, klasses = _run_echo_compare(
+        _echo_from_input(deck, doctor=doctor), deck)
+    line = next(s for s in stages if s.startswith("C1 PARSE_BOUNDARY"))
+    assert "DIVERGENT" in line and "(nb=0,mb=1)" in line
+    assert fd.DIVERGENT in klasses
+    # privacy: no coefficient values in the default (no --details) output
+    assert not re.search(r"\d\.\d{3,}E[+-]\d", line)
+
+
+def test_parse_echo_flags_vmex_only_mode():
+    """A mode VMEX parsed as nonzero but absent from the echo is a finding."""
+    deck = DATA / "input.cth_like_fixed_bdy"
+
+    def doctor(nb, mb, row):
+        return [0.0] * 4 if (nb, mb) == (0, 2) else row
+
+    stages, _ = _run_echo_compare(_echo_from_input(deck, doctor=doctor), deck)
+    line = next(s for s in stages if s.startswith("C1 PARSE_BOUNDARY"))
+    assert "DIVERGENT" in line and "(nb=0,mb=2)" in line
+
+
 def test_privacy_usage_error_hides_deck_path(tmp_path, capsys, monkeypatch):
     marker = "CONFIDENTIAL_MARKER_7QX"
     deck = tmp_path / marker / "input.private"  # directory does not exist

--- a/tests/test_first_divergence.py
+++ b/tests/test_first_divergence.py
@@ -250,7 +250,7 @@ def test_nstep_inserted_when_missing_lowercase_indata(tmp_path):
 # (e) privacy: harness failures must never echo the deck path
 # ---------------------------------------------------------------------------
 
-def test_privacy_harness_error_hides_deck_path(tmp_path, capsys, monkeypatch):
+def test_privacy_usage_error_hides_deck_path(tmp_path, capsys, monkeypatch):
     marker = "CONFIDENTIAL_MARKER_7QX"
     deck = tmp_path / marker / "input.private"  # directory does not exist
     monkeypatch.setattr(sys, "argv", [
@@ -260,7 +260,51 @@ def test_privacy_harness_error_hides_deck_path(tmp_path, capsys, monkeypatch):
     captured = capsys.readouterr()
     assert rc == 3
     assert marker not in captured.out + captured.err
-    assert "C0 HARNESS_ERROR FileNotFoundError" in captured.out
+    assert "C0 USAGE_ERROR input file not found" in captured.out
+
+
+def test_usage_input_directory_is_path_free_hint(tmp_path, capsys, monkeypatch):
+    marker = "CONFIDENTIAL_MARKER_4TD"
+    deck_dir = tmp_path / marker
+    deck_dir.mkdir()
+    monkeypatch.setattr(sys, "argv", [
+        "first_divergence.py", str(deck_dir),
+        "--xvmec2000", str(tmp_path / "xvmec2000")])
+    rc = fd.main()
+    captured = capsys.readouterr()
+    assert rc == 3
+    assert marker not in captured.out + captured.err
+    assert "C0 USAGE_ERROR input is a directory" in captured.out
+
+
+def test_usage_executable_directory_without_binary(tmp_path, capsys, monkeypatch):
+    deck = tmp_path / "input.case"
+    deck.write_text("&INDATA\n  NSTEP = 5,\n/\n")
+    exe_dir = tmp_path / "build"
+    exe_dir.mkdir()
+    monkeypatch.setattr(sys, "argv", [
+        "first_divergence.py", str(deck), "--xvmec2000", str(exe_dir)])
+    rc = fd.main()
+    captured = capsys.readouterr()
+    assert rc == 3
+    assert "C0 USAGE_ERROR --xvmec2000 is a directory" in captured.out
+
+
+def test_usage_executable_directory_resolves_to_binary(tmp_path, capsys,
+                                                       monkeypatch):
+    deck = tmp_path / "input.case"
+    deck.write_text("&INDATA\n  NSTEP = 5,\n/\n")
+    exe_dir = tmp_path / "build"
+    exe_dir.mkdir()
+    (exe_dir / "xvmec2000").write_text("")  # not runnable: C1 must follow
+    monkeypatch.setattr(sys, "argv", [
+        "first_divergence.py", str(deck), "--xvmec2000", str(exe_dir)])
+    rc = fd.main()
+    captured = capsys.readouterr()
+    assert "USAGE_ERROR" not in captured.out
+    assert "using the xvmec2000 executable found inside" in captured.out
+    assert rc == 2  # proceeds into compare; the stub cannot actually run
+    assert "C1 PARSE: VMEC2000 run failed" in captured.out
 
 
 def test_privacy_missing_executable_hides_paths(tmp_path, capsys, monkeypatch):
@@ -274,9 +318,28 @@ def test_privacy_missing_executable_hides_paths(tmp_path, capsys, monkeypatch):
         "--xvmec2000", str(deck_dir / "missing_exe")])
     rc = fd.main()
     captured = capsys.readouterr()
+    assert rc == 3
+    assert marker not in captured.out + captured.err
+    assert "C0 USAGE_ERROR --xvmec2000 executable not found" in captured.out
+
+
+def test_privacy_broken_executable_hides_paths(tmp_path, capsys, monkeypatch):
+    """A present-but-unrunnable executable exercises compare's internal C1
+    error path; the report must stay path-free."""
+    marker = "CONFIDENTIAL_MARKER_9ZK"
+    deck_dir = tmp_path / marker
+    deck_dir.mkdir()
+    deck = deck_dir / "input.case"
+    deck.write_text("&INDATA\n  NSTEP = 5,\n/\n")
+    broken = deck_dir / "broken_exe"
+    broken.write_text("")  # exists but is not runnable
+    monkeypatch.setattr(sys, "argv", [
+        "first_divergence.py", str(deck), "--xvmec2000", str(broken)])
+    rc = fd.main()
+    captured = capsys.readouterr()
     assert rc == 2
     assert marker not in captured.out + captured.err
-    assert "C1 PARSE: VMEC2000 run failed (FileNotFoundError)" in captured.out
+    assert "C1 PARSE: VMEC2000 run failed" in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_freeboundary.py
+++ b/tests/test_freeboundary.py
@@ -677,6 +677,34 @@ def test_cached_vacuum_executable_rechecks_dynamic_axis(monkeypatch):
     assert seen[0][2] is axis_z
 
 
+def test_call_lane_emits_notice_once_before_compile():
+    """Free-lane compile visibility: the first call of a lane structure
+    emits the tagged ``compile_notice`` BEFORE compiling/running; repeats of
+    the same structure stay silent (the pause happens once per process)."""
+    lane = jax.jit(lambda x: x + 1.0)
+    x = jnp.asarray(1.0)
+    tag = ("test_notice_lane", id(lane))  # unique per test run
+    notices: list[str] = []
+
+    def emit(text="", end="\n"):
+        notices.append(str(text) + str(end))
+
+    out = FB._call_lane(tag, lane, (x,),
+                        notice=(emit, 15, "steady vacuum loop"))
+    assert float(out) == 2.0
+    assert notices == [" compiling NS = 15 steady vacuum loop executable...\n"]
+
+    out = FB._call_lane(tag, lane, (x,),
+                        notice=(emit, 15, "steady vacuum loop"))
+    assert float(out) == 2.0
+    assert len(notices) == 1, "same-structure recall must not re-notice"
+
+    # non-verbose callers pass notice=None: never a print, same result.
+    out = FB._call_lane(("test_notice_lane_quiet", id(lane)), lane, (x,))
+    assert float(out) == 2.0
+    assert len(notices) == 1
+
+
 def test_cli_missing_mgrid_fallback_warns(tmp_path):
     """CLI policy: missing mgrid -> fixed-boundary fallback warning (VMEC2000)."""
     import types

--- a/tests/test_freeboundary.py
+++ b/tests/test_freeboundary.py
@@ -84,7 +84,8 @@ def ab_inputs():
         bz=np.asarray(bz_c) + bz_a,
         basis=basis, signgs=int(rt.setup.signgs),
     )
-    return dict(inp=inp, res=res, rt=rt, basis=basis, boundary=boundary, ext=ext)
+    return dict(inp=inp, res=res, rt=rt, basis=basis, boundary=boundary,
+                ext=ext, state=state, field=field, axis_r=axis_r, axis_z=axis_z)
 
 
 def test_nestor_skip_branch_matches_full_solve(ab_inputs):
@@ -578,6 +579,51 @@ def test_jac75_retry_rebuilds_vacuum_and_converges(capsys):
     assert max(result.fsqr, result.fsqz, result.fsql) <= 1.0e-10
 
 
+def test_vacuum_step_skip_reuses_cached_matrix(ab_inputs):
+    """``_vacuum_step`` cadence contract (vacuum.f): a skip step consumes the
+    full step's cached matrix/factor through the lane cache — with its own
+    tagged compile notice — and reproduces the full-step field at machine
+    precision on unchanged geometry."""
+    import types
+
+    inp, res, rt = ab_inputs["inp"], ab_inputs["res"], ab_inputs["rt"]
+    # the free driver populates the edge-pressure scale on its runtime
+    rt = dataclasses.replace(
+        rt, presf_ns_scale=FB._presf_ns_scale(inp, int(res.ns)))
+    basis_v, fused, _lane = FB._vacuum_executables(
+        res, mf=int(inp.mpol) + 1, nf=int(inp.ntor),
+        signgs=int(rt.setup.signgs), wint=np.asarray(rt.trig.wint),
+        modes=rt.modes, axis_r0=jnp.asarray(ab_inputs["axis_r"]),
+        axis_z0=jnp.asarray(ab_inputs["axis_z"]),
+    )
+    fb = FB.FreeBoundaryState()
+    fb.ivac = 0  # the IVAC0 host block has promoted -1 -> 0 before any step
+    carry = types.SimpleNamespace(state=ab_inputs["state"])
+    notices: list[str] = []
+
+    def emit(text="", end="\n"):
+        notices.append(str(text) + str(end))
+
+    FB._USED_LANE_KEYS.clear()  # earlier tests may have noticed these lanes
+    step = dict(carry=carry, rt=rt, fb=fb, basis=basis_v, fused_vac=fused,
+                field=ab_inputs["field"], emit=emit, verbose=True)
+    b_full = FB._vacuum_step(ivacskip=0, **step)
+    assert fb.mode_matrix is not None and fb.full_updates == 1
+    assert fb.ivac == 1  # vacuum.f first-call promotion + grid banner
+    b_skip = FB._vacuum_step(ivacskip=1, **step)
+    assert fb.full_updates == 1, "skip step must not rebuild the matrix"
+    output = "".join(notices)
+    assert "NESTOR full-update" in output and "NESTOR skip-update" in output
+    np.testing.assert_allclose(np.asarray(b_skip), np.asarray(b_full),
+                               rtol=1e-12, atol=1e-14)
+
+    # cache-bypassed fused vacuum (no cache_key): same skip result, direct call
+    step["fused_vac"] = dataclasses.replace(fused, cache_key=None)
+    b_direct = FB._vacuum_step(ivacskip=1, **step)
+    np.testing.assert_allclose(np.asarray(b_direct), np.asarray(b_full),
+                               rtol=1e-12, atol=1e-14)
+
+
 def test_bad_supplied_axis_is_reguessed_before_fused_filament(capsys):
     """Free boundary must share fixed boundary's first-bad-axis recovery."""
     inp = VmecInput.from_file(DECK)
@@ -703,6 +749,17 @@ def test_call_lane_emits_notice_once_before_compile():
     out = FB._call_lane(("test_notice_lane_quiet", id(lane)), lane, (x,))
     assert float(out) == 2.0
     assert len(notices) == 1
+
+    # eager mode (jax_disable_jit) bypasses caching/notices entirely.
+    prev = bool(jax.config.jax_disable_jit)
+    jax.config.update("jax_disable_jit", True)
+    try:
+        out = FB._call_lane(tag, lane, (x,),
+                            notice=(emit, 15, "steady vacuum loop"))
+    finally:
+        jax.config.update("jax_disable_jit", prev)
+    assert float(out) == 2.0
+    assert len(notices) == 1, "eager passthrough must not notice"
 
 
 def test_cli_missing_mgrid_fallback_warns(tmp_path):

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -160,6 +160,30 @@ def test_compile_notice_variants():
     assert printing.compile_notice(31, prefetched=True) == (
         " compiling NS = 31 executable... (prefetched)\n"
     )
+    # free-boundary lane tags (freeboundary._call_lane): each free lane
+    # compiles as its own program, so the pause attribution names it.
+    assert printing.compile_notice(15, lane="steady vacuum loop") == (
+        " compiling NS = 15 steady vacuum loop executable...\n"
+    )
+    assert printing.compile_notice(15, lane="free-iteration", prefetched=True) == (
+        " compiling NS = 15 free-iteration executable... (prefetched)\n"
+    )
+
+
+def test_emit_flushed_writes_and_flushes(capsys):
+    """The CLI sink must flush every line so file-redirected cluster logs
+    stream in real time (an unflushed run shows nothing for hours)."""
+    import io
+    import unittest.mock as mock
+
+    printing.emit_flushed("hello", end="")
+    assert capsys.readouterr().out == "hello"
+
+    sink = io.StringIO()
+    with mock.patch.object(sink, "flush", wraps=sink.flush) as spy:
+        printing.emit_flushed("line", file=sink)
+    assert sink.getvalue() == "line\n"
+    assert spy.called, "emit_flushed must flush the target stream"
 
 
 def test_termination_summary_known_and_unknown_flags():

--- a/tools/first_divergence.py
+++ b/tools/first_divergence.py
@@ -11,7 +11,13 @@ prints numerical values and must never be shared for such a deck.
 
 Stages compared (first failure is the leading suspect):
 
-  C1 PARSE          acceptance and early-termination status of BOTH codes
+  C1 PARSE          acceptance and early-termination status of BOTH codes;
+                    sub-stages PARSE_SCALARS / PARSE_PROFILES /
+                    PARSE_BOUNDARY then compare VMEX's parsed values against
+                    VMEC2000's threed1 input echo (field names, counts, and
+                    at most one worst (nb, mb) mode index — values only with
+                    ``--details``), so a parser divergence is localized to
+                    the exact field instead of surfacing obscurely at C2/C3
   C2 AXIS_ROW1      the printed initial axis position (RAX at iteration 1)
   C3 ITER1_FORCES   the iteration-1 FSQR/FSQZ/FSQL residual triplet
   C4 TRAJECTORY     first iteration where any residual channel leaves the
@@ -195,6 +201,184 @@ def _klass(rel: float) -> str:
     return DIVERGENT
 
 
+#: threed1 echoes carry 4-5 significant digits, so exact parses differ from
+#: the echo by up to ~5e-4 relative; only grosser differences are parse bugs.
+_ECHO_TOL = 1.5e-3
+#: coefficients this small print as (or are omitted as) zero in the echo
+_ECHO_ZERO = 1e-13
+
+
+def _echo_equal(ref: float, got: float) -> bool:
+    if abs(ref) <= _ECHO_ZERO and abs(got) <= _ECHO_ZERO:
+        return True
+    return _rel(ref, got) <= _ECHO_TOL
+
+
+_FLOAT = r"[+-]?\d+\.\d+E[+-]\d+"
+
+
+def _threed1_boundary(text: str) -> dict[tuple[int, int], tuple[float, ...]]:
+    """(nb, mb) -> (rbc, rbs, zbc, zbs) from the threed1 boundary echo."""
+    rows: dict[tuple[int, int], tuple[float, ...]] = {}
+    m = re.search(r"nb\s+mb\s+rbc\s+rbs\s+zbc\s+zbs", text)
+    if not m:
+        return rows
+    row_re = re.compile(
+        rf"^\s*(-?\d+)\s+(\d+)((?:\s+{_FLOAT}){{4,8}})\s*$")
+    for line in text[m.end():].splitlines()[1:]:  # [0] = header-line tail
+        if not line.strip():
+            continue
+        rm = row_re.match(line)
+        if not rm:
+            break  # end of the table
+        vals = [float(v) for v in rm.group(3).split()]
+        rows[(int(rm.group(1)), int(rm.group(2)))] = tuple(vals[:4])
+    return rows
+
+
+def _threed1_scalars(text: str) -> dict[str, float]:
+    """Pure parse-through scalars from the threed1 parameter echo.
+
+    Deliberately excludes controls VMEC2000 re-defaults itself (nvacskip,
+    niter, nstep, ftol) — those differ lawfully without being parse bugs.
+    """
+    out: dict[str, float] = {}
+    m = re.search(
+        r"nfp\s+gamma\s+spres_ped\s+phiedge\(wb\)\s+curtor\(A\)\s+lRFP\s*\n"
+        rf"\s*(\d+)\s+({_FLOAT})\s+({_FLOAT})\s+({_FLOAT})\s+({_FLOAT})",
+        text)
+    if m:
+        out.update(nfp=float(m.group(1)), gamma=float(m.group(2)),
+                   spres_ped=float(m.group(3)), phiedge=float(m.group(4)),
+                   curtor=float(m.group(5)))
+    m = re.search(
+        r"ncurr\s+niter\s+nsin\s+nstep\s+nvacskip\s+ftol\s+tcon0\s+lasym"
+        rf"\s+lforbal[^\n]*\n\s*(\d+)\s+\d+\s+\d+\s+\d+\s+\d+\s+{_FLOAT}"
+        rf"\s+({_FLOAT})\s+([TF])\s+([TF])", text)
+    if m:
+        out.update(ncurr=float(m.group(1)), tcon0=float(m.group(2)),
+                   lasym=float(m.group(3) == "T"),
+                   lforbal=float(m.group(4) == "T"))
+    m = re.search(rf"Pressure profile factor:\s*({_FLOAT})", text)
+    if m:
+        out["pres_scale"] = float(m.group(1))
+    return out
+
+
+def _threed1_coeffs(text: str, header: str) -> list[float] | None:
+    """Coefficient lines following an echo ``header`` (skipping the
+    parameterization-type and separator lines), or None if not echoed."""
+    at = text.find(header)
+    if at < 0:
+        return None
+    coeffs: list[float] = []
+    num_line = re.compile(rf"^\s*(?:{_FLOAT}\s*)+$")
+    for line in text[at:].splitlines()[1:]:
+        if num_line.match(line):
+            coeffs.extend(float(v) for v in line.split())
+        elif coeffs:
+            break  # past the (possibly wrapped) coefficient lines
+        elif line.strip() and "----" not in line and "type is" not in line:
+            break  # a foreign section before any numbers appeared
+    return coeffs or None
+
+
+def _compare_parsed_inputs(ref_text: str, deck: Path, stage, note,
+                           details: bool) -> None:
+    """C1 sub-stages: the threed1 input echo vs VMEX's parsed values.
+
+    Localizes a parser divergence to the field (and, for the boundary, the
+    worst (nb, mb) index) BEFORE it surfaces obscurely in C2/C3.  Privacy:
+    field names, counts, and one mode-index pair only; values need
+    ``--details``.
+    """
+    import numpy as np
+
+    from vmex.core.input import VmecInput
+    inp = VmecInput.from_file(str(deck))
+
+    # scalars
+    echoed = _threed1_scalars(ref_text)
+    if echoed:
+        bad = [name for name, ref in echoed.items()
+               if not _echo_equal(ref, float(getattr(inp, name)))]
+        k = DIVERGENT if bad else MATCH
+        note(k)
+        body = f"{k} ({len(echoed)} compared)" if not bad else (
+            f"{k} " + " ".join(
+                f"{n}(ref={echoed[n]:.4e},vmex={float(getattr(inp, n)):.4e})"
+                if details else n for n in bad))
+        stage("C1 PARSE_SCALARS", body)
+
+    # profile parameterization types + coefficient arrays
+    parts, k_prof = [], MATCH
+    for label, header, type_field in (
+            ("aphi", "FLUX COEFFICIENTS aphi", None),
+            ("am", "MASS PROFILE COEFFICIENTS", "pmass_type"),
+            ("ac", "CURRENT DENSITY (*V') COEFFICIENTS ac", "pcurr_type"),
+            ("ai", "IOTA PROFILE COEFFICIENTS", "piota_type")):
+        ref_c = _threed1_coeffs(ref_text, header)
+        if ref_c is None:
+            continue
+        got_c = [float(v) for v in np.atleast_1d(
+            np.asarray(getattr(inp, label), dtype=float))]
+        width = max(len(ref_c), len(got_c))
+        ok = all(_echo_equal(r, g) for r, g in zip(
+            ref_c + [0.0] * (width - len(ref_c)),
+            got_c + [0.0] * (width - len(got_c))))
+        if type_field is not None:
+            tm = re.search(
+                rf"P{label[1:].upper()}\w* parameterization type is '(\w+)'",
+                ref_text)
+            vmex_type = str(getattr(inp, type_field, "")).strip().lower()
+            if tm and tm.group(1).strip().lower() != vmex_type:
+                ok = False
+        parts.append(label if ok else f"{label}=DIVERGENT")
+        if not ok:
+            k_prof = DIVERGENT
+    if parts:
+        note(k_prof)
+        stage("C1 PARSE_PROFILES", f"{k_prof} ({' '.join(parts)})")
+
+    # boundary coefficient table
+    ref_rows = _threed1_boundary(ref_text)
+    if ref_rows:
+        rbc = np.asarray(inp.rbc, dtype=float)
+        rbs = np.asarray(inp.rbs, dtype=float)
+        zbc = np.asarray(inp.zbc, dtype=float)
+        zbs = np.asarray(inp.zbs, dtype=float)
+        ntor, mpol = int(inp.ntor), int(inp.mpol)
+
+        def vmex_row(nb: int, mb: int) -> tuple[float, ...]:
+            if abs(nb) > ntor or not 0 <= mb < mpol:
+                return (0.0, 0.0, 0.0, 0.0)
+            return tuple(float(a[ntor + nb, mb]) for a in (rbc, rbs, zbc, zbs))
+
+        keys = set(ref_rows)
+        for mb in range(mpol):  # VMEX-nonzero modes VMEC2000 did not echo
+            for nb in range(-ntor, ntor + 1):
+                if any(abs(v) > 1e-10 for v in vmex_row(nb, mb)):
+                    keys.add((nb, mb))
+        bad_modes: list[tuple[float, int, int]] = []
+        for nb, mb in sorted(keys):
+            ref_v = ref_rows.get((nb, mb), (0.0,) * 4)
+            got_v = vmex_row(nb, mb)
+            worst_rel = max((_rel(r, g) for r, g in zip(ref_v, got_v)
+                             if not (abs(r) <= _ECHO_ZERO
+                                     and abs(g) <= _ECHO_ZERO)), default=0.0)
+            if not all(_echo_equal(r, g) for r, g in zip(ref_v, got_v)):
+                bad_modes.append((worst_rel, nb, mb))
+        k = DIVERGENT if bad_modes else MATCH
+        note(k)
+        if bad_modes:
+            rel, nb, mb = max(bad_modes)
+            stage("C1 PARSE_BOUNDARY",
+                  f"{k} {len(bad_modes)}/{len(keys)} modes, "
+                  f"worst (nb={nb},mb={mb}) rel={rel:.1e}")
+        else:
+            stage("C1 PARSE_BOUNDARY", f"{k} ({len(keys)} modes)")
+
+
 def _rel(a: float, b: float) -> float:
     scale = max(abs(a), abs(b), np.finfo(float).tiny)
     return abs(a - b) / scale
@@ -329,6 +513,15 @@ def compare(deck: Path, xvmec2000: Path, *, niter: int | None,
         note(k)
         stage("C1 PARSE", f"{k} ref={_acceptance(ref_term)} "
                           f"vmex={_acceptance(vmex_term, vmex_detail)}")
+
+        # C1 sub-stages: parsed VALUES via the threed1 input echo, so a
+        # parser divergence is localized to a field instead of surfacing
+        # obscurely as a C2/C3 mismatch.
+        if ref_ok and vmex_ok:
+            try:
+                _compare_parsed_inputs(ref_text, deck_j, stage, note, details)
+            except Exception as exc:  # noqa: BLE001 - class name only
+                stage("C1 PARSE_ECHO", f"SKIPPED ({type(exc).__name__})")
 
         ref = _rows(ref_text)
         got = _rows(vmex_text)

--- a/tools/first_divergence.py
+++ b/tools/first_divergence.py
@@ -41,6 +41,10 @@ Failure handling: any harness failure is reported as
 ``C0 HARNESS_ERROR <ExceptionClassName>`` — the exception class name only,
 never a traceback, so private paths, deck contents, or input-derived values
 cannot escape.  ``--details`` remains the only mode that prints values.
+Argument mistakes are caught up front as ``C0 USAGE_ERROR <hint>`` with a
+path-free hint (e.g. a directory passed where a file is expected); a
+directory passed as ``--xvmec2000`` is resolved to an ``xvmec2000``
+executable inside it when one exists.
 
 Usage::
 
@@ -478,6 +482,33 @@ def compare(deck: Path, xvmec2000: Path, *, niter: int | None,
     return 0 if worst != DIVERGENT else 1
 
 
+def _usage_error(hint: str) -> int:
+    """Path-free usage diagnostics (safe to share for a confidential deck)."""
+    print(f"C0 USAGE_ERROR {hint}")
+    return 3
+
+
+def _resolve_args(args: argparse.Namespace) -> int | None:
+    """Validate paths up front; returns an exit code on a usage error."""
+    if args.input.is_dir():
+        return _usage_error(
+            "input is a directory (pass the input.<case> file itself)")
+    if not args.input.is_file():
+        return _usage_error("input file not found")
+    if args.xvmec2000.is_dir():
+        candidate = args.xvmec2000 / "xvmec2000"
+        if not candidate.is_file():
+            return _usage_error(
+                "--xvmec2000 is a directory with no xvmec2000 executable "
+                "inside (pass the executable itself)")
+        print("note: --xvmec2000 was a directory; using the xvmec2000 "
+              "executable found inside it")
+        args.xvmec2000 = candidate
+    if not args.xvmec2000.is_file():
+        return _usage_error("--xvmec2000 executable not found")
+    return None
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("input", type=Path)
@@ -489,6 +520,9 @@ def main() -> int:
     ap.add_argument("--details", action="store_true",
                     help="print values; NEVER share for a confidential deck")
     args = ap.parse_args()
+    usage_rc = _resolve_args(args)
+    if usage_rc is not None:
+        return usage_rc
     try:
         return compare(args.input, args.xvmec2000, niter=args.niter,
                        timeout=args.timeout, details=args.details)

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -889,7 +889,10 @@ def main(argv: list[str] | None = None) -> int:
     """
     parser = build_parser()
     args = parser.parse_args(argv)
-    emit = print
+    # Flushing sink: with stdout redirected to a file (cluster batch logs),
+    # the default block buffering can hide hours of iteration rows and
+    # compile notices; every CLI line must reach the file immediately.
+    from .printing import emit_flushed as emit
 
     try:
         return _dispatch(args, parser, emit=emit)

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -387,6 +387,12 @@ def _jacobian_ok(state: SpectralState, rt: SolverRuntime,
     ``analyt.f``'s ``log``/``sqrt`` kernels a degenerate boundary, and the
     resulting non-finite ``bsqvac`` turns funct3d.f's recoverable restart
     into a fatal NON-FINITE FORCE EVALUATION.
+
+    Used by the host-stepped activation passes only.  The traced steady
+    vacuum lane computes the same flag from its own single per-pass
+    synthesis (``_make_vacuum_lane``), which the force evaluation then
+    reuses — inlining this helper there duplicated a full geometry
+    synthesis inside the compiled free-lane program.
     """
     _, geometry = _geometry(state, rt, use_fft=use_fft)
     return jnp.logical_not(
@@ -1391,10 +1397,20 @@ def _make_vacuum_lane(fused: FusedVacuum, *, use_fft: bool = False):
         it = c.iteration
         fsq_rz = c.fsqr + c.fsqz
 
+        # funct3d.f computes geometry and its Jacobian ONCE per pass, before
+        # bcovar/IVAC0, and the force build shares them.  Synthesize once
+        # here: the Jacobian sign feeds the vacuum-source gate below and the
+        # same synthesis is handed to the force evaluation at the end of the
+        # pass (``evaluation_synthesis``), instead of inlining a second full
+        # geometry synthesis into this traced lane (the old ``_jacobian_ok``
+        # call).  Same ops on the same state — rows are bit-identical.
+        coeffs, geometry = _geometry(c.state, rt, use_fft=use_fft)
+        jacobian = half_mesh_jacobian(geometry, s=rt.setup.s_full)
+
         # NESTOR must never consume a sign-changed state (full funct3d.f/
         # evolve.f rationale: _jacobian_ok): feed it xstore and force a full
         # update whenever the current state is invalid.
-        good = _jacobian_ok(c.state, rt, use_fft=use_fft)
+        good = jnp.logical_not(jacobian.jacobian_sign_changed)
         vac_state = jax.tree.map(
             lambda a, b: jnp.where(good, a, b), c.state, c.xstore)
 
@@ -1447,7 +1463,12 @@ def _make_vacuum_lane(fused: FusedVacuum, *, use_fft: bool = False):
             vc.delbsq_traj, delbsq[None], idx, axis=0)
 
         # -- one eqsolve iteration with the refreshed edge field ------------
-        new_carry = _make_body(replace(rt_vac, bsqvac_edge=bsqvac), use_fft=use_fft)(c)
+        # The force pass reuses the pass's single synthesis (funct3d.f
+        # ordering: forces consume the geometry computed before IVAC0).
+        new_carry = _make_body(
+            replace(rt_vac, bsqvac_edge=bsqvac), use_fft=use_fft,
+            evaluation_synthesis=(coeffs, geometry, jacobian),
+        )(c)
 
         return _VacuumLoopCarry(
             carry=new_carry, rcon0=rcon0, zcon0=zcon0, bsqvac=bsqvac,

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -68,7 +68,8 @@ from .input import VmecInput
 from .mgrid import MgridField
 from .preconditioner_2d import Prec2DConfig
 from .printing import (
-    FORCE_ITERATIONS_BANNER, improved_axis_block, screen_header, screen_line,
+    FORCE_ITERATIONS_BANNER, compile_notice, improved_axis_block,
+    screen_header, screen_line,
     stage_banner,
     vacuum_banner,
 )
@@ -999,6 +1000,7 @@ def _vacuum_step(
     cached matrix/factor/RHS stay on the selected plasma device across
     iterations. Only a few diagnostic scalars reach Python.
     """
+    ns_notice = int(rt.resolution.ns)
     if (
         int(ivacskip) == 0
         or fb.mode_matrix is None
@@ -1008,18 +1010,29 @@ def _vacuum_step(
         if fused_vac.cache_key is None:
             out = fused_vac.full(carry.state, rt, field)
         else:
-            out = _call_lane(("fb_vacfull", fused_vac.cache_key),
-                             fused_vac.full, (carry.state, rt, field))
+            out = _call_lane(
+                ("fb_vacfull", fused_vac.cache_key),
+                fused_vac.full, (carry.state, rt, field),
+                notice=(emit, ns_notice, "NESTOR full-update")
+                if verbose else None,
+            )
         fb.mode_matrix = out["mode_matrix"]
         fb.mode_factor = out["mode_factor"]
         fb.mode_pivots = out["mode_pivots"]
         fb.bvec_nonsing = out["bvec_nonsing"]
         fb.full_updates += 1
     else:
-        out = fused_vac.skip(
-            carry.state, rt, field, fb.bvec_nonsing,
-            fb.mode_factor, fb.mode_pivots,
-        )
+        skip_args = (carry.state, rt, field, fb.bvec_nonsing,
+                     fb.mode_factor, fb.mode_pivots)
+        if fused_vac.cache_key is None:
+            out = fused_vac.skip(*skip_args)
+        else:
+            out = _call_lane(
+                ("fb_vacskip", fused_vac.cache_key),
+                fused_vac.skip, skip_args,
+                notice=(emit, ns_notice, "NESTOR skip-update")
+                if verbose else None,
+            )
     bsqvac = out["bsqvac"]
     fb.rbsq = out["rbsq"]
     fb.potvac = out["potvac"]
@@ -1117,7 +1130,8 @@ def _fb_lane_signature(tag: Any, args: tuple) -> tuple:
 
 
 def _call_lane(tag: Any, lane: Any, args: tuple,
-               static: dict[str, Any] | None = None) -> Any:
+               static: dict[str, Any] | None = None,
+               *, notice: tuple | None = None) -> Any:
     """Run ``lane(*args, **static)``, preferring a prefetched executable.
 
     ``static`` holds jit static kwargs (baked into a prefetched executable's
@@ -1127,15 +1141,30 @@ def _call_lane(tag: Any, lane: Any, args: tuple,
     ``finally``, so the wait always terminates).  A structural/placement
     mismatch — the executable's argument validation precedes execution, so
     ``args`` are intact — falls back to the ordinary jitted lane.
+
+    ``notice = (emit, ns, label)`` extends the fixed-boundary
+    ``compile_notice`` convention to the free lanes: the first call for a
+    given structure in this process emits the one-line attribution BEFORE
+    the compile (or before joining an in-flight background compile), so a
+    file-redirected cluster log shows what a silent multi-minute pause is
+    building.  The caller passes it only when verbose; the emit must flush
+    (the CLI sink does).
     """
     kwargs = static or {}
-    if jax.config.jax_disable_jit or (
-            not _LANE_EXECUTABLES and not _FB_PREFETCH_ATTEMPTED):
+    if jax.config.jax_disable_jit:
+        return lane(*args, **kwargs)
+    if notice is None and not _LANE_EXECUTABLES and not _FB_PREFETCH_ATTEMPTED:
         return lane(*args, **kwargs)
     key = _fb_lane_signature(tag, args)
-    _USED_LANE_KEYS.add(key)
     with _FB_LOCK:
         pending = _FB_INFLIGHT.get(key)
+    if notice is not None and key not in _USED_LANE_KEYS:
+        emit, ns, label = notice
+        emit(compile_notice(
+            int(ns), lane=str(label),
+            prefetched=(pending is not None or key in _LANE_EXECUTABLES),
+        ), end="")
+    _USED_LANE_KEYS.add(key)
     if pending is not None:
         pending.wait()
     executable = _LANE_EXECUTABLES.get(key)
@@ -1744,6 +1773,13 @@ def _solve_free_boundary_stage(
             lmove_axis=bool(rt.lmove_axis), vacuum_on=bool(vacuum_active),
             entry_lanes=False,
         )
+
+    def _lane_notice(label: str):
+        """Verbose ``compile_notice`` payload for the free lanes: every
+        free-lane compile pause is attributed in the (flushed) log BEFORE
+        the compile starts."""
+        return (emit, ns, label) if verbose else None
+
     try:
         if verbose:
             emit(stage_banner(ns, resolution.mnmax, rt.ftol, rt.max_iterations), end="")
@@ -1795,7 +1831,8 @@ def _solve_free_boundary_stage(
         # axis-dependent NESTOR filament/executables, then repeat iteration 1
         # once with ijacob=1.  The discarded triggering pass is not printed.
         carry = _call_lane(("fb_iter", use_fft), _iter_lane,
-                           (carry, rt_initial), {"use_fft": use_fft})
+                           (carry, rt_initial), {"use_fft": use_fft},
+                           notice=_lane_notice("free-iteration"))
         if (allow_initial_axis_reguess
                 and int(carry.ier) == AXIS_REGUESS_FLAG
                 and int(carry.ijacob) == 0 and ns >= 3):
@@ -1865,7 +1902,8 @@ def _solve_free_boundary_stage(
                 residuals=(carry.fsqr, carry.fsqz, carry.fsql),
             )
             carry = _call_lane(("fb_iter", use_fft), _iter_lane,
-                               (carry, rt_initial), {"use_fft": use_fft})
+                               (carry, rt_initial), {"use_fft": use_fft},
+                               notice=_lane_notice("free-iteration"))
         _emit_due(final=False)
 
         int_dtype = carry.iteration.dtype
@@ -1878,7 +1916,8 @@ def _solve_free_boundary_stage(
                 # runs as ONE jitted while_loop; the lane exits precisely where
                 # the per-pass driver would have entered the IVAC0 block below.
                 carry = _call_lane(("fb_preact", use_fft), _preactivation_lane,
-                                   (carry, rt_fixed), {"use_fft": use_fft})
+                                   (carry, rt_fixed), {"use_fft": use_fft},
+                                   notice=_lane_notice("pre-vacuum loop"))
                 _emit_due(final=False)
                 if bool(carry.done):
                     break
@@ -1890,7 +1929,8 @@ def _solve_free_boundary_stage(
                 # carried bsqvac once; iteration 2 performs the first full update
                 # against freshly selected resolution-specific NESTOR programs.
                 carry = _call_lane(("fb_iter", use_fft), _iter_lane,
-                                   (carry, rt_freeb), {"use_fft": use_fft})
+                                   (carry, rt_freeb), {"use_fft": use_fft},
+                                   notice=_lane_notice("free-iteration"))
                 _emit_due(final=False)
                 continue
             elif (fb.turned_on and not fb.banner_pending
@@ -1922,7 +1962,8 @@ def _solve_free_boundary_stage(
                     full_updates=jnp.asarray(fb.full_updates, dtype=int_dtype),
                 )
                 vc = _call_lane(("fb_vac", fused_vac.cache_key), vacuum_lane,
-                                (vc, rt_freeb, external_field))
+                                (vc, rt_freeb, external_field),
+                                notice=_lane_notice("steady vacuum loop"))
                 carry = vc.carry
                 rt_freeb = replace(rt_freeb, rcon0=vc.rcon0, zcon0=vc.zcon0,
                                    bsqvac_edge=vc.bsqvac)
@@ -2004,12 +2045,14 @@ def _solve_free_boundary_stage(
 
             if turnon_evaluation_state is None:
                 carry = _call_lane(("fb_iter", use_fft), _iter_lane,
-                                   (carry, rt_use), {"use_fft": use_fft})
+                                   (carry, rt_use), {"use_fft": use_fft},
+                                   notice=_lane_notice("free-iteration"))
             else:
                 carry = _call_lane(
                     ("fb_turnon", use_fft), _turnon_iter_lane,
                     (carry, rt_use, turnon_evaluation_state),
-                    {"use_fft": use_fft})
+                    {"use_fft": use_fft},
+                    notice=_lane_notice("vacuum turn-on"))
 
             if fb.banner_pending:
                 if verbose:

--- a/vmex/core/printing.py
+++ b/vmex/core/printing.py
@@ -87,16 +87,34 @@ def improved_axis_block(
     return "\n".join(lines) + "\n"
 
 
-def compile_notice(ns: int, *, prefetched: bool = False) -> str:
+def compile_notice(ns: int, *, lane: str | None = None,
+                   prefetched: bool = False) -> str:
     """One-line attribution for an XLA compile pause at a rung boundary.
 
     Emitted when a rung's iteration executable is not already available in
     this process, so cold-start pauses in the console output are
     attributable; ``prefetched`` marks executables built ahead of time by
-    the multigrid compile-overlap thread.
+    the multigrid compile-overlap thread.  ``lane`` tags the free-boundary
+    lanes (entry iteration, pre-vacuum loop, NESTOR full/skip updates,
+    vacuum turn-on, steady vacuum loop), which compile as several distinct
+    programs per rung — a large-grid free run pauses several times, and a
+    file-redirected cluster log must show which program each pause builds.
     """
     suffix = " (prefetched)" if prefetched else ""
-    return f" compiling NS = {int(ns)} executable...{suffix}\n"
+    what = f"{lane} executable" if lane else "executable"
+    return f" compiling NS = {int(ns)} {what}...{suffix}\n"
+
+
+def emit_flushed(*args, **kwargs) -> None:
+    """``print`` that always flushes.
+
+    The CLI's console sink: with stdout redirected to a file (cluster batch
+    logs), Python block-buffers ~8 KiB, so an unflushed long free-boundary
+    run shows nothing for hours.  Every emitted line must reach the file
+    immediately; callers may still pass ``flush=False`` explicitly.
+    """
+    kwargs.setdefault("flush", True)
+    print(*args, **kwargs)
 
 
 def stage_banner(ns: int, mnmax: int, ftol: float, niter: int) -> str:

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -1040,6 +1040,7 @@ def _evaluate(
     fsq_rz_previous: Array | None = None,
     *, collect_health: bool = False,
     use_fft: bool = False,
+    synthesis: tuple | None = None,
 ) -> _EvalResult:
     """One funct3d.f pass (fixed boundary), pure and jit-friendly.
 
@@ -1052,6 +1053,13 @@ def _evaluate(
     ``fsqr1/fsqz1/fsql1``).  On a Jacobian sign change VMEC skips everything
     past the Jacobian; here the computation proceeds (traced) and the caller
     discards results, while the cache refresh is suppressed exactly.
+
+    ``synthesis`` optionally supplies the pass's already-computed
+    ``((R_cos, R_sin, Z_cos, Z_sin), geometry, jacobian)`` for ``state``
+    (funct3d.f computes them ONCE per pass and shares them with the vacuum
+    gate).  It must have been produced by the same ``_geometry``/
+    ``half_mesh_jacobian`` calls this function would make — the traced
+    free-boundary lane hoists exactly those, so results are bit-identical.
     """
     setup = rt.setup
     res = rt.resolution
@@ -1059,10 +1067,13 @@ def _evaluate(
     ns = int(s.shape[0])
     hs = setup.hs
 
-    (R_cos, R_sin, Z_cos, Z_sin), geometry = _geometry(
-        state, rt, use_fft=use_fft
-    )
-    jacobian = half_mesh_jacobian(geometry, s=s)
+    if synthesis is None:
+        (R_cos, R_sin, Z_cos, Z_sin), geometry = _geometry(
+            state, rt, use_fft=use_fft
+        )
+        jacobian = half_mesh_jacobian(geometry, s=s)
+    else:
+        (R_cos, R_sin, Z_cos, Z_sin), geometry, jacobian = synthesis
     jac_changed = jacobian.jacobian_sign_changed
 
     metrics = metric_elements(geometry, s=s)
@@ -1325,6 +1336,7 @@ def _make_body(
     *,
     evaluation_state: SpectralState | None = None,
     use_fft: bool = False,
+    evaluation_synthesis: tuple | None = None,
 ) -> Callable[[_LoopCarry], _LoopCarry]:
     """Build the traced single-iteration body shared by both lanes.
 
@@ -1334,6 +1346,16 @@ def _make_body(
     the already-computed geometry.  Supplying the pre-restart state here
     reproduces that one pass while momentum still evolves ``carry.state``
     (the restored best state).  Normal iterations leave it as ``None``.
+
+    ``evaluation_synthesis`` optionally hands the first funct3d pass its
+    already-computed ``((R_cos, R_sin, Z_cos, Z_sin), geometry, jacobian)``
+    (the ``_evaluate`` ``synthesis`` seam) — the free-boundary steady lane
+    synthesizes geometry once per pass, feeds its Jacobian sign to the
+    vacuum-source gate, and reuses it here, exactly as ``funct3d.f`` computes
+    the Jacobian ONCE before ``bcovar``/IVAC0 and shares it with the force
+    build.  It must correspond to the state the first pass evaluates
+    (``carry.state``, or ``evaluation_state`` when given); the restart
+    re-evaluation always re-synthesizes at the restored state.
     """
     ftol = rt.ftol
     max_iter = rt.max_iterations
@@ -1346,7 +1368,8 @@ def _make_body(
         # ---- funct3d (evolve.f) -------------------------------------------
         state_e1 = carry.state if evaluation_state is None else evaluation_state
         e1 = _evaluate(state_e1, carry.cache, it, carry.iter1, carry.fsqz, rt,
-                       carry.fsqr + carry.fsqz, use_fft=use_fft)
+                       carry.fsqr + carry.fsqz, use_fft=use_fft,
+                       synthesis=evaluation_synthesis)
         jac1 = e1.jacobian_sign_changed
         nonfinite1 = (~jac1) & (~_evaluation_is_finite(e1))
         # On irst=2 funct3d skips residue: the module residuals stay stale.


### PR DESCRIPTION
Free-boundary runs with file-redirected stdout could show no output for hours, and the diagnostic comparator gave unhelpful errors on argument mistakes. This PR fixes the visibility failure, shrinks the free-lane compile, and sharpens the privacy-safe diagnostics.

## Output visibility (the silent-run bug)

- **Root cause:** the CLI emitted through an unflushed `print`; file-redirected stdout block-buffers (~8 KiB), so a healthy run showed nothing until process exit — indistinguishable from a hang during long high-mode compiles. Every CLI line now funnels through a flush-by-default sink (`printing.emit_flushed`).
- Every free-boundary lane (free-iteration, pre-vacuum loop, NESTOR full/skip update, vacuum turn-on, steady vacuum loop, each rung) prints a flushed one-line notice **before** compiling, extending the fixed-boundary `compiling NS = ...` convention with a lane tag.
- New subprocess test redirects CLI stdout to a file and asserts the NS banner and a compile notice are readable **while the process is still running**.

## Free-lane compile size

- The steady vacuum lane inlined a second full geometry synthesis for the Jacobian gate (funct3d.f computes the Jacobian once and shares it). The lane now synthesizes geometry once per pass, derives the vacuum-source gate sign from it, and shares the same synthesis with the force evaluation via an optional `synthesis` seam in the solver body (default unchanged for all other callers).
- **Byte-identical** verbose iteration rows verified on the CTH free ladder (573 iters), a 238-mode free single stage (MPOL=13/NTOR=9, 210 iters), and a Jacobian-75 recovery case (706 iters).
- Measured: steady-lane StableHLO −16% at 238 modes; 238-mode steady-lane compile ~3 min / 6.8 GB peak RSS (arm64, cold, cache disabled); compile wall is flat in the angular grid (36×36 → 120×120), i.e. mode count, not `NZETA`/`NTHETA`, drives compile.

## Diagnostics (privacy-safe comparator)

- `tools/first_divergence.py` argument mistakes are now path-free `C0 USAGE_ERROR` hints instead of a bare exception class; a directory passed as `--xvmec2000` resolves to an `xvmec2000` executable inside it.
- New C1 sub-stages `PARSE_SCALARS` / `PARSE_PROFILES` / `PARSE_BOUNDARY` compare VMEX's parsed values against VMEC2000's `threed1` input echo (scalars, profile types and coefficients, full boundary table), localizing a parser divergence to the exact field and worst `(nb, mb)` mode index — field names, counts, and one index only; values still require `--details`.
- `tests/test_aphi_flux_normalization.py` pins the verified APHI toroidal-flux semantics against the VMEC2000 formulas (`magnetic_fluxes.f`, `profil1d.f`): coefficient-set unit tests including unnormalized sets, `torflux(1)` normalization, bit-identity of flux arrays under a pure APHI rescale, and row-1 goldens for an unnormalized-APHI public deck with a live-`xvmec2000`-gated parity lane.

## Verification

- ruff and `mypy vmex` clean; 258 targeted tests green locally (comparator, APHI, free-boundary, multigrid, CLI, printing, profiles).
- Row byte-identity artifacts captured for all three free-boundary cases before/after the geometry-reuse change.
