### PR TITLE
Release v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vmex"
-version = "0.3.0"
+version = "0.4.0"
 description = "JAX implementation of VMEC2000 with differentiable fixed-boundary and branch-local free-boundary research paths."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump 0.3.0 -> 0.4.0 for the integrated wave (#102). Release notes are published with the GitHub release; PyPI publishes on release publication.