### PR TITLE
Report accepted iterations and harden derivative fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ The recommended pattern releases all harmonics in one problem and uses
 from dataclasses import replace
 import jax.numpy as jnp
 from scipy.optimize import least_squares
+from vmex import OptimizationMonitor
 from vmex import optimize as opt
 
 max_mode = 5
@@ -454,6 +455,7 @@ problem.compile_residual_and_jacobian()  # optional visible first compilation
 result = least_squares(
     problem.residual, problem.x0, jac=problem.residual_jac,
     x_scale=problem.scales,
+    callback=OptimizationMonitor(problem),
 )
 optimized_input = problem.input_from_x(result.x)
 optimized_equilibrium = problem.equilibrium_from_x(result.x)
@@ -505,7 +507,8 @@ For scalar methods, pass `problem.value_and_grad` to
 `scipy.optimize.minimize(..., jac=True)`. `problem.jax_value_and_grad` and
 `problem.jax_residual` provide the same physics to JAXopt and Optax. The
 existing `opt.least_squares()` and `opt.minimize()` functions remain concise
-compatibility adapters.
+compatibility adapters. Monitoring is callback-based, so it reports accepted
+iterations rather than every trial evaluation.
 
 VMEX sets JAX's logging level to `ERROR` at import time, removing repeated
 PjRt persistent-cache compatibility messages while retaining VMEX errors.

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -160,6 +160,37 @@ comparisons can select ``"block_tridiagonal"``, ``"forward_gmres"``, or
 the older compatibility drivers retain their established ``jac_solver``
 spelling.
 
+Accepted-iteration monitoring
+-----------------------------
+
+Objective evaluation is silent by default.  Printing from an objective is
+misleading because trust-region and line-search methods deliberately evaluate
+rejected points, so their raw costs need not decrease monotonically.  Attach
+an :class:`~vmex.core.monitoring.OptimizationMonitor` to report optimizer
+callbacks instead:
+
+.. code-block:: python
+
+   from vmex import OptimizationMonitor
+
+   monitor = OptimizationMonitor(problem)
+   result = scipy.optimize.least_squares(
+       problem.residual,
+       problem.x0,
+       jac=problem.residual_jac,
+       x_scale=problem.scales,
+       callback=monitor,
+   )
+
+The stable columns are iteration, cost, accepted reduction, optimality when
+the backend supplies it, equilibrium solves, and failed/rejected trials.
+``monitor.records`` contains immutable records for plotting or tests.
+JAXopt, Optax, and custom loops call ``monitor.record(...)`` with the value
+and optimality they already computed, so monitoring never dictates the
+optimizer.  The compatibility least-squares driver uses SciPy's concise
+accepted-iteration table for ``verbose=1``; scalar ``minimize`` uses this
+same monitor.
+
 The compatibility drivers
 -------------------------
 
@@ -380,6 +411,13 @@ No Python exception crosses ``jax.pure_callback``, so rejected high-mode
 trials do not produce an opaque JAX traceback.  Use
 ``problem.evaluate(x).status`` and its ``diagnostics`` mapping when a driver
 needs the typed failure rather than only the numerical penalty.
+
+The vector-Jacobian path normally uses the amortized block factorization.  If
+its warm corrector is non-finite at a difficult accepted point, VMEX retries
+the independent certified per-column GMRES lane before the optimizer sees the
+Jacobian.  ``derivative_fallbacks`` and ``failed_trials`` are exposed on the
+compatibility ``OptimizeResult`` and in ``problem.evaluate(x).diagnostics``;
+the fast path and its defaults are unchanged.
 
 The gradient stack: what makes a Jacobian cheap
 -----------------------------------------------

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -51,6 +51,7 @@
     ["tests/test_lgradb.py", "diagnostics", "ad", "medium", "cpu-gpu", "none", "fd", ["pr-parity-c3", "full-core-j-m"]],
     ["tests/test_maxj.py", "diagnostics", "ad", "slow", "cpu-gpu", "none", "fd", ["pr-parity-c2", "full-core-j-m"]],
     ["tests/test_mgrid.py", "free-boundary", "unit", "fast", "cpu", "generated", "analytic", ["pr-parity-c1", "pr-fast", "full-core-j-m"]],
+    ["tests/test_monitoring.py", "optimization", "unit", "fast", "cpu", "none", "analytic", ["pr-parity-d", "pr-fast", "pr-implicit-response", "full-core-n-s"]],
     ["tests/test_multigrid_interp.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-j-m"]],
     ["tests/test_multigrid_ladder.py", "equilibrium", "oracle", "slow", "cpu-gpu", "golden", "vmec2000", ["pr-parity-a2", "full-core-j-m"]],
     ["tests/test_near_degenerate_vacuum.py", "equilibrium", "oracle", "slow", "cpu-gpu", "none", "vmec2000", ["pr-full-only", "full-core-n-s"]],

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -24,7 +24,7 @@ REPO = Path(__file__).resolve().parents[1]
 EXAMPLES = REPO / "examples"
 DATA_DIR = EXAMPLES / "data"
 
-_COST_RE = re.compile(r"\[least_squares\] cost = ([0-9.eE+-]+)")
+_COST_RE = re.compile(r"^\s*\d+\s+\d+\s+([0-9.eE+-]+)", re.MULTILINE)
 
 
 def _run_example(script: Path, cwd: Path, timeout: int = 2400,
@@ -44,7 +44,7 @@ def _run_example(script: Path, cwd: Path, timeout: int = 2400,
 
 def _assert_cost_decreased(stdout: str, name: str) -> None:
     costs = [float(c) for c in _COST_RE.findall(stdout)]
-    assert len(costs) >= 2, f"{name}: expected verbose cost lines, got {costs}"
+    assert len(costs) >= 2, f"{name}: expected scipy iteration rows, got {costs}"
     assert min(costs) < costs[0], (
         f"{name}: least-squares cost did not decrease: first {costs[0]:.6e}, "
         f"best {min(costs):.6e}")

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,110 @@
+"""Fast contracts for accepted-iteration monitoring."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+from scipy.optimize import OptimizeResult
+
+from vmex.core.monitoring import OptimizationMonitor
+from vmex.core.problem import FunctionProblem
+
+
+def test_monitor_records_scipy_and_manual_iterations() -> None:
+    stream = io.StringIO()
+    monitor = OptimizationMonitor(stream=stream)
+    monitor(OptimizeResult(x=np.ones(2), fun=np.array([2.0, 0.0]), nit=1))
+    monitor.record(np.zeros(2), cost=0.5, optimality=0.25, iteration=2)
+
+    assert [item.cost for item in monitor.records] == [2.0, 0.5]
+    assert monitor.records[1].reduction == 1.5
+    output = stream.getvalue()
+    assert output.count("cost") == 1
+    assert "reduction" in output
+    assert "2.500000e-01" in output
+
+
+def test_monitor_print_every_and_silent_collection() -> None:
+    silent = OptimizationMonitor(stream=None)
+    silent.record(np.zeros(1), cost=3.0)
+    assert len(silent.records) == 1
+
+    stream = io.StringIO()
+    monitor = OptimizationMonitor(stream=stream, print_every=2)
+    for i, cost in enumerate((3.0, 2.0, 1.0)):
+        monitor.record(np.zeros(1), cost=cost, iteration=i)
+    assert len(stream.getvalue().splitlines()) == 3  # header + iterations 0 and 2
+    with np.testing.assert_raises(ValueError):
+        OptimizationMonitor(print_every=0)
+
+
+def test_monitor_callback_fallbacks_and_problem_counters() -> None:
+    problem = FunctionProblem(
+        [2.0],
+        fun=lambda x: float(x @ x),
+        metadata={"holder": {"failed_trials": 3}},
+    )
+    monitor = OptimizationMonitor(problem, stream=None)
+    monitor(SimpleNamespace(x=np.array([2.0]), nit=4, jac=np.array([4.0])))
+    assert monitor.records[0].cost == 4.0
+    assert monitor.records[0].optimality == 4.0
+    assert monitor.records[0].rejected_trials == 3
+    assert monitor.records[0].equilibrium_solves is None
+
+    from vmex.core import implicit as imp
+
+    class Config:
+        pass
+
+    config = Config()
+    problem.metadata["config"] = config
+    imp._SOLVE_STATS[config] = {"solves": 7}
+    try:
+        monitor(SimpleNamespace(x=np.array([2.0]), fun=4.0, nit=5))
+    finally:
+        imp._SOLVE_STATS.pop(config, None)
+    assert monitor.records[-1].equilibrium_solves == 7
+
+    with np.testing.assert_raises(ValueError):
+        OptimizationMonitor(stream=None)({"x": np.array([1.0])})
+
+
+def test_compatibility_least_squares_failure_is_silent_and_counted(monkeypatch) -> None:
+    """Rejected finite-difference trials update diagnostics without chatter."""
+    import scipy.optimize
+
+    from vmex.core import optimize as opt
+    from vmex.core.input import VmecInput
+
+    inp = VmecInput.from_file(
+        Path(__file__).resolve().parents[1] / "examples/data/input.solovev"
+    )
+    calls = {"solve": 0}
+
+    def fake_solve(_trial, **kwargs):
+        del kwargs
+        calls["solve"] += 1
+        if calls["solve"] > 1:
+            raise RuntimeError("synthetic rejected trial")
+        return SimpleNamespace(state=np.zeros(1), value=2.0)
+
+    def fake_least_squares(fun, x0, *, jac, verbose, **kwargs):
+        del jac, verbose, kwargs
+        initial = fun(x0)
+        rejected = np.asarray(x0).copy()
+        rejected[0] += 0.1
+        assert np.all(fun(rejected) == 1.0e6)
+        return OptimizeResult(x=np.asarray(x0), fun=initial, cost=0.5)
+
+    monkeypatch.setattr(opt, "solve_equilibrium", fake_solve)
+    monkeypatch.setattr(scipy.optimize, "least_squares", fake_least_squares)
+    result = opt.least_squares(
+        [(lambda equilibrium: np.atleast_1d(equilibrium.value), 0.0, 1.0)],
+        inp,
+        max_mode=1,
+        jac=None,
+    )
+    assert result.failed_trials == 1

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -72,6 +72,38 @@ def test_monitor_callback_fallbacks_and_problem_counters() -> None:
         OptimizationMonitor(stream=None)({"x": np.array([1.0])})
 
 
+def test_default_scipy_monitor_respects_an_explicit_callback() -> None:
+    from vmex.core import optimize as opt
+
+    kwargs = {}
+    monitor = opt._configure_scipy_monitor(
+        np.zeros(1),
+        lambda x: (float(x @ x), 2.0 * x),
+        object(),
+        {"failed_trials": 0},
+        1,
+        kwargs,
+    )
+    assert isinstance(monitor, OptimizationMonitor)
+    assert kwargs["callback"] is monitor
+
+    callback = object()
+    explicit = {"callback": callback}
+    assert (
+        opt._configure_scipy_monitor(
+            np.zeros(1), lambda x: (0.0, x), object(), {}, 1, explicit
+        )
+        is None
+    )
+    assert explicit["callback"] is callback
+    assert (
+        opt._configure_scipy_monitor(
+            np.zeros(1), lambda x: (0.0, x), object(), {}, 0, {}
+        )
+        is None
+    )
+
+
 def test_compatibility_least_squares_failure_is_silent_and_counted(monkeypatch) -> None:
     """Rejected finite-difference trials update diagnostics without chatter."""
     import scipy.optimize

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -549,6 +549,68 @@ def test_least_squares_implicit_jac_solver_block(monkeypatch):
         problem.metadata["weight_description"]
         == "weight multiplies squared cost"
     )
+
+    # A non-finite block result retries the independently certified GMRES
+    # implementation; if both lanes raise, the last certified Jacobian is
+    # returned and the failed-trial counter remains observable.
+    real_device_get = opt.jax.device_get
+    poisoned = {"done": False}
+
+    def nonfinite_primary(value):
+        host = real_device_get(value)
+        if not poisoned["done"] and np.shape(host) == weighted_jac.shape:
+            poisoned["done"] = True
+            return np.full(weighted_jac.shape, np.nan)
+        return host
+
+    monkeypatch.setattr(opt.jax, "device_get", nonfinite_primary)
+    problem._rj_cache = None
+    np.testing.assert_allclose(problem.residual_jac(problem.x0), weighted_jac)
+    assert problem.metadata["holder"]["derivative_fallbacks"] == 1
+
+    def reject_both(value):
+        host = real_device_get(value)
+        if np.shape(host) == weighted_jac.shape:
+            raise RuntimeError("synthetic derivative failure")
+        return host
+
+    monkeypatch.setattr(opt.jax, "device_get", reject_both)
+    problem._rj_cache = None
+    np.testing.assert_allclose(problem.residual_jac(problem.x0), weighted_jac)
+    assert problem.metadata["holder"]["failed_trials"] >= 1
+
+    certified = problem.metadata["holder"]["last_jac"]
+    problem.metadata["holder"]["last_jac"] = None
+    problem._rj_cache = None
+    with pytest.raises(RuntimeError, match="synthetic derivative failure"):
+        problem.residual_jac(problem.x0)
+
+    def reject_with_nonfinite(value):
+        host = real_device_get(value)
+        if np.shape(host) == weighted_jac.shape:
+            return np.full(weighted_jac.shape, np.nan)
+        return host
+
+    monkeypatch.setattr(opt.jax, "device_get", reject_with_nonfinite)
+    problem._rj_cache = None
+    with pytest.raises(FloatingPointError, match="non-finite initial"):
+        problem.residual_jac(problem.x0)
+    problem.metadata["holder"]["last_jac"] = certified
+
+    monkeypatch.setattr(opt.jax, "device_get", real_device_get)
+    problem.metadata["holder"]["lin"] = None
+    failed_before = problem.metadata["holder"]["failed_trials"]
+
+    def reject_residual(_value):
+        raise RuntimeError("synthetic residual failure")
+
+    monkeypatch.setattr(opt.jax, "device_get", reject_residual)
+    assert np.all(problem.residual(problem.x0) == 1.0e6)
+    assert problem.metadata["holder"]["failed_trials"] >= failed_before + 1
+    monkeypatch.setattr(opt.jax, "device_get", real_device_get)
+
+    from vmex.core import implicit as implicit_module
+
     evaluation = problem.evaluate(problem.x0)
     assert evaluation.success
     assert evaluation.diagnostics["solve_stats"]["solves"] >= 1
@@ -600,7 +662,6 @@ def test_least_squares_implicit_jac_solver_block(monkeypatch):
 
     with pytest.raises(AttributeError, match="residuals"):
         scalar.residual(scalar.x0)
-    from vmex.core import implicit as implicit_module
     from vmex.core.problem import Evaluation, FunctionProblem
 
     config = problem.metadata["config"]

--- a/tests/test_optimize_penalty.py
+++ b/tests/test_optimize_penalty.py
@@ -76,8 +76,11 @@ def test_fd_lane_penalty_path(monkeypatch, capsys):
                             diff_step=1e-4, verbose=1)
     out = capsys.readouterr().out
     assert calls["failed"] == 1
-    assert "trial solve failed" in out  # the penalty branch executed
+    assert "Cost" in out
+    assert "VmecJacobianError" not in out
+    assert "Traceback" not in out
     assert np.isfinite(res.cost)
+    assert res.failed_trials == 1
     assert isinstance(res.input, VmecInput)
 
 
@@ -107,7 +110,7 @@ def test_implicit_lane_fun_penalty_path(monkeypatch, capsys):
                             max_nfev=4, verbose=1)
     out = capsys.readouterr().out
     assert calls["poisoned"] >= 1
-    assert "cost" in out                 # finite penalty evaluations were reported
+    assert "Cost" in out                 # scipy accepted-iteration table
     assert "VmecJacobianError" not in out
     assert "Traceback" not in out        # no exception crossed pure_callback
     assert np.isfinite(res.cost)
@@ -135,10 +138,10 @@ def test_minimize_penalty_path(monkeypatch, capsys):
         options={"maxiter": 2, "maxls": 3})
     out = capsys.readouterr().out
     assert calls["poisoned"] >= 1
-    assert "cost" in out
     assert "VmecJacobianError" not in out
     assert "Traceback" not in out
     assert np.isfinite(res.cost)
+    assert res.monitor is not None
 
 
 def test_implicit_lane_status_penalty_and_diagnostic_resolve(monkeypatch, capsys):

--- a/vmex/__init__.py
+++ b/vmex/__init__.py
@@ -17,6 +17,7 @@ Public API (lazily imported; ``import vmex as vj``):
 - :func:`~vmex.core.scaling.scale_input` / :func:`~vmex.core.scaling.scale_wout`
   — dimensional similarity transforms
 - ``vmex.optimize`` — objectives + least-squares driver (module)
+- :class:`~vmex.core.monitoring.OptimizationMonitor` — accepted iterations
 - ``vmex.implicit`` — implicit differentiation of the equilibrium (module)
 - ``vmex.parallel`` — concurrent ensembles of independent solves (module)
 - ``vmex.errors`` — typed zero-crash exceptions (also exported directly)
@@ -123,6 +124,8 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
     "Evaluation": (".core.problem", "Evaluation"),
     "FunctionProblem": (".core.problem", "FunctionProblem"),
     "VmecProblem": (".core.problem", "VmecProblem"),
+    "OptimizationMonitor": (".core.monitoring", "OptimizationMonitor"),
+    "OptimizationRecord": (".core.monitoring", "OptimizationRecord"),
     # external fields
     "MgridData": (".core.mgrid", "MgridData"),
     "MgridField": (".core.mgrid", "MgridField"),

--- a/vmex/core/monitoring.py
+++ b/vmex/core/monitoring.py
@@ -1,0 +1,163 @@
+"""Accepted-iteration reporting independent of optimization algorithms."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import sys
+from typing import Any, cast, TextIO
+
+import numpy as np
+
+from .problem import FunctionProblem
+
+
+_DEFAULT_STREAM = object()
+
+
+@dataclass(frozen=True)
+class OptimizationRecord:
+    """One optimizer callback, normally one accepted iteration."""
+
+    iteration: int
+    cost: float
+    reduction: float | None
+    optimality: float | None
+    equilibrium_solves: int | None
+    rejected_trials: int | None
+
+
+class OptimizationMonitor:
+    """Record and optionally print accepted optimizer iterations.
+
+    Pass the instance as a SciPy ``callback``.  SciPy invokes callbacks after
+    an iteration, unlike objective functions which are also called for rejected
+    line-search or trust-region trials.  JAXopt, Optax, and custom loops can
+    call :meth:`record` with values they already computed.
+
+    The monitor never chooses steps or changes an optimizer.  If ``problem``
+    is supplied, VMEX solve/failure counters are read without evaluating the
+    objective again.
+    """
+
+    def __init__(
+        self,
+        problem: FunctionProblem | None = None,
+        *,
+        stream: TextIO | None | object = _DEFAULT_STREAM,
+        print_every: int = 1,
+    ) -> None:
+        if print_every < 1:
+            raise ValueError("print_every must be at least 1")
+        self.problem = problem
+        self.stream: TextIO | None = (
+            sys.stdout if stream is _DEFAULT_STREAM else cast(TextIO | None, stream)
+        )
+        self.print_every = int(print_every)
+        self.records: list[OptimizationRecord] = []
+
+    @staticmethod
+    def _field(result: Any, name: str, default: Any = None) -> Any:
+        if isinstance(result, dict):
+            return result.get(name, default)
+        return getattr(result, name, default)
+
+    def _counters(self) -> tuple[int | None, int | None]:
+        if self.problem is None:
+            return None, None
+        metadata = self.problem.metadata
+        holder = metadata.get("holder", {})
+        rejected = holder.get("failed_trials")
+        cfg = metadata.get("config")
+        if cfg is None:
+            return None, rejected
+        from . import implicit as imp
+
+        stats = imp._SOLVE_STATS.get(cfg)
+        solves = None if stats is None else int(stats.get("solves", 0))
+        return solves, rejected
+
+    def __call__(self, intermediate_result: Any) -> None:
+        """Consume a SciPy ``OptimizeResult`` callback value."""
+        x = np.asarray(self._field(intermediate_result, "x"), dtype=float)
+        cost = self._field(intermediate_result, "cost")
+        raw_fun = self._field(intermediate_result, "fun")
+        if cost is None and raw_fun is not None:
+            values = np.asarray(raw_fun, dtype=float)
+            cost = (float(values) if values.ndim == 0
+                    else 0.5 * float(values.ravel() @ values.ravel()))
+        if cost is None:
+            if self.problem is None:
+                raise ValueError("callback did not provide cost or fun")
+            cost = self.problem.fun(x)
+        iteration = self._field(intermediate_result, "nit", len(self.records))
+        optimality = self._field(intermediate_result, "optimality")
+        if optimality is None:
+            gradient = self._field(intermediate_result, "jac")
+            if gradient is not None and np.asarray(gradient).ndim == 1:
+                optimality = np.linalg.norm(np.asarray(gradient), ord=np.inf)
+        self.record(
+            x,
+            cost=float(cost),
+            optimality=None if optimality is None else float(optimality),
+            iteration=int(iteration),
+        )
+
+    def record(
+        self,
+        x: Any,
+        *,
+        cost: float,
+        optimality: float | None = None,
+        iteration: int | None = None,
+        equilibrium_solves: int | None = None,
+        rejected_trials: int | None = None,
+    ) -> OptimizationRecord:
+        """Append one already-computed accepted iterate and return its record."""
+        del x  # accepted for a uniform callback/manual-loop interface
+        if iteration is None:
+            iteration = len(self.records)
+        if equilibrium_solves is None or rejected_trials is None:
+            solves, rejected = self._counters()
+            if equilibrium_solves is None:
+                equilibrium_solves = solves
+            if rejected_trials is None:
+                rejected_trials = rejected
+        reduction = None
+        if self.records:
+            reduction = self.records[-1].cost - float(cost)
+        item = OptimizationRecord(
+            iteration=int(iteration),
+            cost=float(cost),
+            reduction=reduction,
+            optimality=optimality,
+            equilibrium_solves=equilibrium_solves,
+            rejected_trials=rejected_trials,
+        )
+        self.records.append(item)
+        if self.stream is not None and (len(self.records) - 1) % self.print_every == 0:
+            self._print(item)
+        return item
+
+    @staticmethod
+    def _number(value: float | int | None, *, integer: bool = False) -> str:
+        if value is None:
+            return "-"
+        return str(int(value)) if integer else f"{float(value):.6e}"
+
+    def _print(self, item: OptimizationRecord) -> None:
+        if len(self.records) == 1:
+            print(
+                " iter          cost     reduction   optimality  eq solves  rejected",
+                file=self.stream,
+            )
+        print(
+            f"{item.iteration:5d}  {item.cost:12.6e}  "
+            f"{self._number(item.reduction):>12}  "
+            f"{self._number(item.optimality):>11}  "
+            f"{self._number(item.equilibrium_solves, integer=True):>9}  "
+            f"{self._number(item.rejected_trials, integer=True):>8}",
+            file=self.stream,
+        )
+
+
+__all__ = ["OptimizationMonitor", "OptimizationRecord"]

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -117,11 +117,14 @@ from .statephysics import (
 )
 from .wout import WoutData, wout_from_state
 from .problem import Evaluation, FunctionProblem, VmecProblem, _run_with_progress
+from .monitoring import OptimizationMonitor, OptimizationRecord
 
 __all__ = [
     "VmecProblem",
     "FunctionProblem",
     "Evaluation",
+    "OptimizationMonitor",
+    "OptimizationRecord",
     "make_problem",
     "Equilibrium",
     "solve_equilibrium",
@@ -1510,7 +1513,12 @@ def least_squares(
                                    k_cur, ac_scale)
         return trial
 
-    state_holder: dict[str, Any] = {"hot": None, "eq": None, "nres": None}
+    state_holder: dict[str, Any] = {
+        "hot": None,
+        "eq": None,
+        "nres": None,
+        "failed_trials": 0,
+    }
     single_stage = int(np.asarray(inp.ns_array).size) == 1
 
     def fun(x: np.ndarray) -> np.ndarray:
@@ -1520,25 +1528,25 @@ def least_squares(
             eq = solve_equilibrium(trial, initial_state=seed, **solve_kwargs)
             parts = [w * (_call_term(f, eq) - t) for (f, t, w) in objective_terms]
             residual = np.concatenate(parts)
-        except Exception as exc:  # zero-crash policy: penalize, don't die
+        except Exception:  # zero-crash policy: penalize, don't die
             if state_holder["nres"] is None:
                 raise  # the very first evaluation must succeed (sizes scipy's residual)
-            if verbose:
-                print(f"[least_squares] trial solve failed: {exc}")
+            state_holder["failed_trials"] += 1
             return np.full((state_holder["nres"],), 1.0e6)
         if not np.all(np.isfinite(residual)):
             residual = np.where(np.isfinite(residual), residual, 1.0e6)
         state_holder["hot"] = eq.state
         state_holder["eq"] = eq
         state_holder["nres"] = residual.size
-        if verbose:
-            print(f"[least_squares] cost = {0.5 * float(residual @ residual):.6e}")
         return residual
 
     result = scipy.optimize.least_squares(fun, np.asarray(x0, dtype=float),
-                                          jac="2-point", **scipy_kwargs)
+                                          jac="2-point",
+                                          verbose=(2 if verbose else 0),
+                                          **scipy_kwargs)
     result.input = unpack_full(result.x)
     result.equilibrium = state_holder["eq"]
+    result.failed_trials = state_holder["failed_trials"]
     return result
 
 
@@ -2107,12 +2115,18 @@ def _least_squares_implicit(
     else:
         jac_impl = jacobian_rows
     jac_jit = jax.jit(jac_impl)
+    gmres_jit = jax.jit(jacobian_rows)
     reverse_jit = jax.jit(jax.jacrev(residual_rows))
 
     # The strict seed preflight above already evaluated and validated every
     # residual row.  Carry that known shape instead of compiling ``rows_jit``
     # eagerly while the public factory is still returning.
-    holder: dict[str, Any] = {"nres": residual_size, "lin": None}
+    holder: dict[str, Any] = {
+        "nres": residual_size,
+        "lin": None,
+        "failed_trials": 0,
+        "derivative_fallbacks": 0,
+    }
     if recycle:
         # An all-zero pair is a cold start (gcrot's warm-start QR masks the
         # rank-deficient columns out); shapes are static so jac_jit compiles
@@ -2170,16 +2184,16 @@ def _least_squares_implicit(
         except Exception as exc:  # zero-crash policy: penalize, don't die
             if holder["nres"] is None:
                 raise
-            if verbose:
-                print(f"[least_squares] trial solve failed: {exc}")
+            del exc
+            holder["failed_trials"] += 1
             return np.full((holder["nres"],), 1.0e6)
         finally:
             imp._PERTURB_SEED.pop(cfg, None)  # one-shot: never leak a seed
         if not np.all(np.isfinite(residual)):
             residual = np.where(np.isfinite(residual), residual, 1.0e6)
+        if imp._LAST_STATUS_ERROR.get(cfg) is not None:
+            holder["failed_trials"] += 1
         holder["nres"] = residual.size
-        if verbose:
-            print(f"[least_squares] cost = {0.5 * float(residual @ residual):.6e}")
         return residual
 
     def jac_fn(x: np.ndarray) -> np.ndarray:
@@ -2204,6 +2218,7 @@ def _least_squares_implicit(
             jac = failure_jacobian(x)
             holder["last_jac"] = jac
             return jac
+        primary_error = None
         try:
             reverse = (
                 not recycle
@@ -2220,8 +2235,6 @@ def _least_squares_implicit(
             elif recycle:
                 rows, C, U, drift = jac_jit(_place(x), *holder["recycle"])
                 holder["recycle_drift"] = float(drift)
-                if verbose and holder["recycle_drift"] > 0.0:
-                    print(f"[least_squares] recycle drift {holder['recycle_drift']:.2e}")
                 holder["recycle"] = (C, U)  # deflate the next jac evaluation
                 jac = np.asarray(jax.device_get(rows), dtype=float)
             else:
@@ -2229,16 +2242,36 @@ def _least_squares_implicit(
                 if warm_start == "perturbation":
                     _stash_linearization(np.asarray(x, dtype=float), dz_cols)
                 jac = np.asarray(jax.device_get(rows), dtype=float)
-        except Exception as exc:  # zero-crash policy (mirrors fun): a trial whose
-            # equilibrium fails (e.g. VmecJacobianError from a self-intersecting
-            # boundary) must be *rejected*, not crash the optimization.  Reuse
-            # the last valid Jacobian so scipy's trust region steps back off the
-            # bad point (fun already returns a large penalty residual there).
-            if holder.get("last_jac") is None:
-                raise
-            if verbose:
-                print(f"[least_squares] trial jacobian failed: {exc}")
-            return holder["last_jac"]
+        except Exception as exc:
+            primary_error = exc
+            jac = None
+
+        # The amortized block factorization is fastest, but a difficult new
+        # accepted point can occasionally make its warm corrector non-finite.
+        # Retry through the independent certified per-column GMRES lane before
+        # rejecting the derivative.  This fallback is paid only on failure.
+        if jac is None or not np.all(np.isfinite(jac)):
+            if not recycle and jac_solver in ("auto", "block"):
+                try:
+                    rows, dz_cols = gmres_jit(_place(x))
+                    candidate = np.asarray(jax.device_get(rows), dtype=float)
+                    if np.all(np.isfinite(candidate)):
+                        holder["derivative_fallbacks"] += 1
+                        if warm_start == "perturbation":
+                            _stash_linearization(np.asarray(x, dtype=float), dz_cols)
+                        holder["last_jac"] = candidate
+                        return candidate
+                except Exception as exc:
+                    primary_error = exc
+            # A failed trial already has a finite penalty residual.  Returning
+            # the last certified Jacobian makes SciPy shorten its step; the
+            # counter exposes this compatibility fallback in result diagnostics.
+            holder["failed_trials"] += 1
+            if holder.get("last_jac") is not None:
+                return holder["last_jac"]
+            if primary_error is not None:
+                raise primary_error
+            raise FloatingPointError("non-finite initial residual Jacobian")
         if np.all(np.isfinite(jac)):
             holder["last_jac"] = jac
         return jac
@@ -2252,13 +2285,13 @@ def _least_squares_implicit(
         except Exception as exc:
             if holder.get("last_grad") is None:
                 raise
-            if verbose:
-                print(f"[minimize] trial solve/gradient failed: {exc}")
+            del exc
+            holder["failed_trials"] += 1
             return 1.0e12, holder["last_grad"]
         if np.isfinite(value) and np.all(np.isfinite(grad)):
             holder["last_grad"] = grad
-            if verbose:
-                print(f"[minimize] cost = {value:.6e}")
+            if imp._LAST_STATUS_ERROR.get(cfg) is not None:
+                holder["failed_trials"] += 1
             return value, grad
         if holder.get("last_grad") is None:
             raise FloatingPointError("non-finite initial objective or gradient")
@@ -2378,10 +2411,20 @@ def _least_squares_implicit(
             },
         )
 
+    monitor = None
     if minimize_method is None:
+        scipy_kwargs.setdefault("verbose", 2 if verbose else 0)
         result = scipy.optimize.least_squares(
             fun, np.asarray(x0, dtype=float), jac=jac_fn, **scipy_kwargs)
     else:
+        if verbose and "callback" not in scipy_kwargs:
+            monitor_problem = FunctionProblem(
+                np.asarray(x0, dtype=float),
+                value_and_grad=value_and_grad,
+                metadata={"config": cfg, "holder": holder},
+            )
+            monitor = OptimizationMonitor(monitor_problem)
+            scipy_kwargs["callback"] = monitor
         result = scipy.optimize.minimize(
             value_and_grad, np.asarray(x0, dtype=float), jac=True,
             method=minimize_method, **scipy_kwargs)
@@ -2389,12 +2432,15 @@ def _least_squares_implicit(
             result.fun, result.jac = value_and_grad(result.x)
         result.cost = float(result.fun)
         result.optimality = float(np.linalg.norm(result.jac, ord=np.inf))
+        result.monitor = monitor
     result.input = unpack_boundary(inp, result.x[:nboundary], max_mode)
     if k_cur:
         result.input = _apply_current(result.input, result.x[nboundary:],
                                       k_cur, ac_scale)
     stats = imp._SOLVE_STATS.get(cfg)
     result.solve_stats = None if stats is None else dict(stats)
+    result.failed_trials = holder["failed_trials"]
+    result.derivative_fallbacks = holder["derivative_fallbacks"]
     try:
         # Hot-seed the diagnostic re-solve from the stage's last converged
         # trial state (plan R25.1): the optimizer's final x was just solved

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -2417,14 +2417,9 @@ def _least_squares_implicit(
         result = scipy.optimize.least_squares(
             fun, np.asarray(x0, dtype=float), jac=jac_fn, **scipy_kwargs)
     else:
-        if verbose and "callback" not in scipy_kwargs:
-            monitor_problem = FunctionProblem(
-                np.asarray(x0, dtype=float),
-                value_and_grad=value_and_grad,
-                metadata={"config": cfg, "holder": holder},
-            )
-            monitor = OptimizationMonitor(monitor_problem)
-            scipy_kwargs["callback"] = monitor
+        monitor = _configure_scipy_monitor(
+            x0, value_and_grad, cfg, holder, verbose, scipy_kwargs
+        )
         result = scipy.optimize.minimize(
             value_and_grad, np.asarray(x0, dtype=float), jac=True,
             method=minimize_method, **scipy_kwargs)
@@ -2459,3 +2454,24 @@ def _least_squares_implicit(
     except Exception:  # pragma: no cover - diagnostic attribute only
         result.equilibrium = None
     return result
+
+
+def _configure_scipy_monitor(
+    x0: np.ndarray,
+    value_and_grad: Callable,
+    cfg: Any,
+    holder: dict[str, Any],
+    verbose: int,
+    scipy_kwargs: dict[str, Any],
+) -> OptimizationMonitor | None:
+    """Install VMEX's monitor unless SciPy already has a callback."""
+    if not verbose or "callback" in scipy_kwargs:
+        return None
+    problem = FunctionProblem(
+        np.asarray(x0, dtype=float),
+        value_and_grad=value_and_grad,
+        metadata={"config": cfg, "holder": holder},
+    )
+    monitor = OptimizationMonitor(problem)
+    scipy_kwargs["callback"] = monitor
+    return monitor

--- a/vmex/core/problem.py
+++ b/vmex/core/problem.py
@@ -450,6 +450,11 @@ class VmecProblem(FunctionProblem):
         stats = imp._SOLVE_STATS.get(cfg)
         if stats is not None:
             diagnostics["solve_stats"] = dict(stats)
+        holder = self.metadata.get("holder", {})
+        diagnostics["failed_trials"] = int(holder.get("failed_trials", 0))
+        diagnostics["derivative_fallbacks"] = int(
+            holder.get("derivative_fallbacks", 0)
+        )
         error = imp._LAST_STATUS_ERROR.get(cfg)
         if error is None:
             return replace(evaluation, diagnostics=diagnostics)


### PR DESCRIPTION
## Summary

- add a small optimizer-neutral `OptimizationMonitor` and immutable `OptimizationRecord` for SciPy callbacks, JAXopt, Optax, and custom loops
- make compatibility least-squares verbosity use SciPy's accepted-iteration table instead of printing every trial objective evaluation
- report scalar-minimize progress through the same public monitor
- count failed trials and derivative fallbacks in `OptimizeResult` and `Evaluation` diagnostics
- retry a non-finite amortized block Jacobian through the independently certified per-column GMRES lane before returning it to SciPy

## Rationale

Trust-region and line-search algorithms intentionally evaluate rejected points, so raw objective calls are neither iterations nor expected to decrease monotonically. Progress output now follows optimizer callbacks or SciPy iteration reporting. Objective evaluation remains silent.

The ordinary block-tridiagonal path is unchanged. Only a non-finite derivative at an accepted point retries the existing certified GMRES implementation, and the event remains observable through diagnostics. Failed equilibrium trials already take the exact finite-penalty path introduced in #104.

The PjRt logging policy also lives in #104, so the earliest public-problem branch is independently quiet.

## Validation

- real precise-QI mode-5 objective: initial cost 1.225006 with 120 boundary variables and finite exact derivatives
- accepted-iteration and automatic SciPy callback contracts covered by dedicated monitor tests
- failed-trial and derivative-fallback counters covered without parsing incidental objective prints
- monitor, external problem, and parallel interface modules: 28 passed, 2 hardware-dependent skips
- cumulative optimization/penalty physics lane: 31 passed in 216.13 s
- Ruff and Sphinx with warnings as errors: passed

## Review

This is PR 3 of the sequence in `docs/optimization_api_plan.md` and is stacked on #105, which is stacked on #104. Please merge in that order and retarget each successor to `main`.

## Standards pass

- No standards changes were needed on this branch: it adds only core
  monitoring code, tests, and documentation with clear names and no committed
  artifacts.
- Rebased on the reworked #105; Ruff, `mypy vmex`, and
  `tools/test_manifest.py check` pass.
