### PR TITLE
Add the one-command GPU decision sweep for the two-GPU rig

### DIFF
--- a/benchmarks/run_gpu_matrix.py
+++ b/benchmarks/run_gpu_matrix.py
@@ -22,8 +22,22 @@ Usage (orchestrator):
     python benchmarks/run_gpu_matrix.py [--out benchmarks/gpu_baseline.json]
         [--only substr] [--timeout 1800] [--skip-tridiag]
 
+Office decision sweep (one command; produces every CPU-vs-GPU crossover
+curve: fixed-boundary per-iteration marginals on the ns x mnmax grid, the
+free-boundary NS sweep, the >512-mode FFT probe, and the fixed/free/gradient
+workflow profiles via ``profile_resources.py``):
+
+    python benchmarks/run_gpu_matrix.py --office \
+        --out benchmarks/gpu_office.json
+
+Repeat with ``--xla-flags "--xla_gpu_enable_command_buffer=FUSION,CUSTOM_CALL"``
+and a different ``--out`` for the CUDA-graph A/B; the flags are recorded in
+``meta`` and applied to every child process.
+
 Internal worker modes (spawned by the orchestrator):
-    --worker solve  --deck PATH --lane {multigrid,single_jit} --device {cpu,gpu}
+    --worker solve  --deck PATH --lane {multigrid,single_cli,single_jit}
+        --device {cpu,gpu}
+    --worker stepscan --deck150 PATH --deck450 PATH --lane ... --device ...
     --worker tridiag --dtype {f32,f64} --device {cpu,gpu}
 """
 
@@ -56,6 +70,17 @@ DECKS = [
 SYNTH_NS = [35, 75, 151]
 SYNTH_MODES = [(2, 2), (4, 4)]
 SYNTH_NITER = 150  # fixed iteration budget -> exact per-iteration throughput
+
+# --office decision grid: production radial range x mnmax 8..288 (the
+# device-policy calibration range), production CLI lane included, plus a
+# free-boundary NS sweep (vacuum steady lane / NESTOR cost per iteration)
+# and one >512-mode probe where the GPU default switches to the separable
+# FFT synthesis (device policy currently routes that regime to CPU).
+OFFICE_NS = [51, 101, 201]
+OFFICE_MODES = [(2, 2), (8, 8), (12, 12)]     # mnmax 8, 128, 288
+OFFICE_LANES = ("multigrid", "single_cli")
+OFFICE_FREE_NS = [15, 25, 51]
+OFFICE_HIGH_MODE = (51, 19, 14)               # mnmax 537 > GPU_MAX_SPECTRAL_MODES
 
 TRIDIAG_NS = [16, 35, 75, 151, 301, 601]
 TRIDIAG_NCOLS = [30, 150, 600, 2400]
@@ -103,14 +128,15 @@ def worker_solve(deck: str, lane: str, device: str) -> dict:
             res = vj.solve_multigrid(inp, verbose=False, device=device)
             wall = time.perf_counter() - t0
             return wall, _extract_iterations(res), True
-        elif lane == "single_jit":
+        elif lane in ("single_jit", "single_cli"):
             from vmex.core.input import VmecInput
             from vmex.core import solver
             from vmex.core.errors import VmecConvergenceError
             inp = VmecInput.from_file(deck)
+            mode = "jit" if lane == "single_jit" else "cli"
             t0 = time.perf_counter()
             try:
-                res = solver.solve(inp, mode="jit", verbose=False, device=device)
+                res = solver.solve(inp, mode=mode, verbose=False, device=device)
                 wall = time.perf_counter() - t0
                 return wall, int(res.iterations), True
             except VmecConvergenceError as e:
@@ -146,25 +172,35 @@ def worker_stepscan(deck150: str, deck450: str, lane: str, device: str) -> dict:
     """
     import jax
 
+    failures = 0
+
     def one(deck):
+        nonlocal failures
         if lane == "multigrid":
             import vmex as vj
             from vmex.core.input import VmecInput
+            from vmex.core.errors import VmecConvergenceError
             inp = VmecInput.from_file(deck)
             t0 = time.perf_counter()
             try:
                 vj.solve_multigrid(inp, verbose=False, device=device)
+            except VmecConvergenceError:
+                pass                # FTOL=1e-30 never converges, by design
             except Exception:
-                pass
+                failures += 1
             return time.perf_counter() - t0
         from vmex.core.input import VmecInput
         from vmex.core import solver
+        from vmex.core.errors import VmecConvergenceError
         inp = VmecInput.from_file(deck)
+        mode = "cli" if lane == "single_cli" else "jit"
         t0 = time.perf_counter()
         try:
-            solver.solve(inp, mode="jit", verbose=False, device=device)
+            solver.solve(inp, mode=mode, verbose=False, device=device)
+        except VmecConvergenceError:
+            pass                    # FTOL=1e-30 never converges, by design
         except Exception:
-            pass
+            failures += 1
         return time.perf_counter() - t0
 
     one(deck150)              # cold warmup (compile both shapes not needed; 150 only)
@@ -176,6 +212,7 @@ def worker_stepscan(deck150: str, deck450: str, lane: str, device: str) -> dict:
             "wall_150_s": round(w150, 3), "wall_450_s": round(w450, 3),
             "per_iter_ms_marginal": round(per_iter_ms, 4),
             "per_solve_overhead_s": round(w150 - 0.150 * per_iter_ms, 3),
+            "unexpected_failures": failures,
             "peak_device_mem_mb": _device_mem_mb()}
 
 
@@ -232,14 +269,35 @@ def make_synth_deck(ns: int, mpol: int, ntor: int, dest_dir: Path,
     return dest
 
 
+def make_synth_free_deck(ns: int, dest_dir: Path, niter: int) -> Path:
+    """Single-stage cth-like free-boundary deck at NS_ARRAY = ns.
+
+    FTOL 1e-30 never converges, so the marginal NITER=150/450 difference
+    times the steady vacuum lane (NESTOR cadence included).  Children must
+    run with ``cwd`` = ``examples/data`` so the deck's relative
+    ``MGRID_FILE`` resolves.
+    """
+    text = (DATA / "input.cth_like_free_bdy").read_text()
+    text = re.sub(r"NS_ARRAY\s*=\s*\d+", f"NS_ARRAY    = {ns}", text)
+    text = re.sub(r"NITER_ARRAY\s*=\s*\d+", f"NITER_ARRAY = {niter}", text)
+    text = re.sub(r"FTOL_ARRAY\s*=\s*[0-9.eEdD+-]+", "FTOL_ARRAY  = 1e-30", text)
+    dest = dest_dir / f"input.synthfree_ns{ns}_it{niter}"
+    dest.write_text(text)
+    return dest
+
+
+_CHILD_ENV: dict | None = None   #: orchestrator-set extra env (XLA_FLAGS)
+
+
 def run_cell(device: str, worker_args: list[str], timeout: int,
              cwd: Path | None = None) -> dict:
     cmd = [sys.executable, str(Path(__file__).resolve()),
            "--device", device] + worker_args
+    env = {**os.environ, **_CHILD_ENV} if _CHILD_ENV else None
     t0 = time.perf_counter()
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True,
-                              timeout=timeout, cwd=cwd)
+                              timeout=timeout, cwd=cwd, env=env)
     except subprocess.TimeoutExpired:
         return {"ok": False, "error": "timeout", "subprocess_wall_s": timeout}
     wall = time.perf_counter() - t0
@@ -259,7 +317,7 @@ def main() -> None:
     ap.add_argument("--deck")
     ap.add_argument("--deck150")
     ap.add_argument("--deck450")
-    ap.add_argument("--lane", choices=["multigrid", "single_jit"])
+    ap.add_argument("--lane", choices=["multigrid", "single_cli", "single_jit"])
     ap.add_argument("--device", choices=["cpu", "gpu"])
     ap.add_argument("--dtype", choices=["f32", "f64"], default="f64")
     ap.add_argument("--out", default=str(REPO / "benchmarks" / "gpu_baseline.json"))
@@ -267,7 +325,18 @@ def main() -> None:
     ap.add_argument("--timeout", type=int, default=1800)
     ap.add_argument("--skip-tridiag", action="store_true")
     ap.add_argument("--skip-matrix", action="store_true")
+    ap.add_argument("--office", action="store_true",
+                    help="one-command decision sweep: ns x mnmax stepscan grid "
+                         "(production CLI lane), free-boundary NS sweep, "
+                         ">512-mode probe, and profile_resources workflows")
+    ap.add_argument("--xla-flags", default=None,
+                    help="XLA_FLAGS for every child (e.g. the command-buffer "
+                         "A/B); recorded in meta")
     args = ap.parse_args()
+
+    global _CHILD_ENV
+    if args.xla_flags:
+        _CHILD_ENV = {"XLA_FLAGS": args.xla_flags}
 
     if args.worker == "solve":
         print(MARKER + json.dumps(worker_solve(args.deck, args.lane, args.device)))
@@ -296,9 +365,11 @@ def main() -> None:
         results = {"matrix": {}, "tridiag": {}}
     results["meta"] = {"host": os.uname().nodename,
                        "date": time.strftime("%Y-%m-%d %H:%M"),
-                       "synth_niter": SYNTH_NITER}
+                       "synth_niter": SYNTH_NITER,
+                       "xla_flags": args.xla_flags or os.environ.get("XLA_FLAGS"),
+                       "office": bool(args.office)}
     for name, deck in cases:
-        if args.skip_matrix:
+        if args.skip_matrix or args.office:
             break
         if args.only and args.only not in name:
             continue
@@ -316,33 +387,74 @@ def main() -> None:
                       f" ok={r.get('ok')}", flush=True)
                 Path(args.out).write_text(json.dumps(results, indent=1))
 
+    def stepscan_cell(name, d150, d450, device, lane, cwd=None):
+        key = f"{device}/{lane}"
+        print(f"=== stepscan {name} [{key}] ===", flush=True)
+        r = run_cell(device,
+                     ["--worker", "stepscan",
+                      "--deck150", str(d150), "--deck450", str(d450),
+                      "--lane", lane], args.timeout, cwd=cwd)
+        results["stepscan"].setdefault(name, {})[key] = r
+        print(f"    per_iter_ms={r.get('per_iter_ms_marginal')}"
+              f" overhead_s={r.get('per_solve_overhead_s')}"
+              f" ok={r.get('ok')}", flush=True)
+        Path(args.out).write_text(json.dumps(results, indent=1))
+
     # True per-iteration step time (marginal NITER=150 vs 450) on the
     # synthetic size scan — solve() retraces per call, so plain warm walls
     # overstate iteration cost; see worker_stepscan.
     results.setdefault("stepscan", {})
     if not args.only:
-        for ns in SYNTH_NS:
-            for mpol, ntor in SYNTH_MODES:
+        ns_grid = OFFICE_NS if args.office else SYNTH_NS
+        mode_grid = OFFICE_MODES if args.office else SYNTH_MODES
+        lanes = OFFICE_LANES if args.office else ("multigrid", "single_jit")
+        for ns in ns_grid:
+            for mpol, ntor in mode_grid:
                 d150 = make_synth_deck(ns, mpol, ntor, synth_dir, niter=150)
                 d450 = make_synth_deck(ns, mpol, ntor, synth_dir, niter=450)
-                name = f"ns{ns}_mpol{mpol}_ntor{ntor}"
-                results["stepscan"][name] = {}
                 for device in ("cpu", "gpu"):
-                    for lane in ("multigrid", "single_jit"):
-                        key = f"{device}/{lane}"
-                        print(f"=== stepscan {name} [{key}] ===", flush=True)
-                        r = run_cell(device,
-                                     ["--worker", "stepscan",
-                                      "--deck150", str(d150),
-                                      "--deck450", str(d450),
-                                      "--lane", lane], args.timeout)
-                        results["stepscan"][name][key] = r
-                        print(f"    per_iter_ms={r.get('per_iter_ms_marginal')}"
-                              f" overhead_s={r.get('per_solve_overhead_s')}"
-                              f" ok={r.get('ok')}", flush=True)
-                        Path(args.out).write_text(json.dumps(results, indent=1))
+                    for lane in lanes:
+                        stepscan_cell(f"ns{ns}_mpol{mpol}_ntor{ntor}",
+                                      d150, d450, device, lane)
 
-    if not args.skip_tridiag and not args.only:
+    if args.office and not args.only:
+        # Free-boundary NS sweep: steady vacuum-lane iteration cost
+        # (children run from DATA so the relative MGRID_FILE resolves).
+        for ns in OFFICE_FREE_NS:
+            d150 = make_synth_free_deck(ns, synth_dir, niter=150)
+            d450 = make_synth_free_deck(ns, synth_dir, niter=450)
+            for device in ("cpu", "gpu"):
+                stepscan_cell(f"free_ns{ns}", d150, d450, device,
+                              "multigrid", cwd=DATA)
+        # >512-mode probe: GPU default switches to FFT synthesis here and
+        # the auto device policy routes this regime to CPU — measure both.
+        ns, mpol, ntor = OFFICE_HIGH_MODE
+        d150 = make_synth_deck(ns, mpol, ntor, synth_dir, niter=150)
+        d450 = make_synth_deck(ns, mpol, ntor, synth_dir, niter=450)
+        for device in ("cpu", "gpu"):
+            stepscan_cell(f"highmode_ns{ns}_mpol{mpol}_ntor{ntor}",
+                          d150, d450, device, "single_cli")
+        # Workflow profiles (fixed/free/gradient, cold+warm+memory) via the
+        # resource harness, one JSON per device, embedded under "resources".
+        results.setdefault("resources", {})
+        for device in ("cpu", "gpu"):
+            dest = Path(synth_dir) / f"resources_{device}.json"
+            cmd = [sys.executable,
+                   str(REPO / "benchmarks" / "profile_resources.py"),
+                   "--device", device, "--cases", "fixed,free,implicit",
+                   "--out", str(dest)]
+            print(f"=== profile_resources [{device}] ===", flush=True)
+            env = {**os.environ, **_CHILD_ENV} if _CHILD_ENV else None
+            proc = subprocess.run(cmd, capture_output=True, text=True,
+                                  timeout=4 * args.timeout, env=env)
+            if dest.exists():
+                results["resources"][device] = json.loads(dest.read_text())
+            else:
+                results["resources"][device] = {
+                    "ok": False, "error": (proc.stderr or proc.stdout)[-2000:]}
+            Path(args.out).write_text(json.dumps(results, indent=1))
+
+    if not args.skip_tridiag and not args.only and not args.office:
         for device, dtype in [("cpu", "f64"), ("gpu", "f64"), ("gpu", "f32")]:
             key = f"{device}/{dtype}"
             print(f"=== tridiag microbench [{key}] ===", flush=True)

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -550,6 +550,28 @@ sizes: the tridiagonal preconditioner solve, for instance, measures identical
 fp32/fp64 GPU times (~15 us per radial row, independent of the number of
 spectral columns).
 
+GPU decision sweep (office rig)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One command produces every CPU-vs-GPU crossover curve on a dual-GPU host —
+warm per-iteration marginals on the ``ns x mnmax`` grid (``ns`` 51/101/201,
+``mnmax`` 8/128/288) for the production CLI lane and the multigrid ladder,
+the free-boundary NS sweep (steady vacuum lane, NESTOR included), the
+537-mode probe where the GPU default switches to FFT synthesis, and the
+fixed/free/gradient workflow profiles (cold+warm+memory)::
+
+   python benchmarks/run_gpu_matrix.py --office --out benchmarks/gpu_office.json
+
+Each cell is a fresh subprocess selecting hardware through the public
+``device=`` API.  For the CUDA-graph A/B, repeat with command buffers and a
+second output file, then compare the two ``stepscan`` sections::
+
+   python benchmarks/run_gpu_matrix.py --office \
+       --xla-flags "--xla_gpu_enable_command_buffer=FUSION,CUSTOM_CALL" \
+       --out benchmarks/gpu_office_cmdbuf.json
+
+The applied ``XLA_FLAGS`` are recorded in the artifact's ``meta`` block.
+
 Reproducing the numbers
 -----------------------
 


### PR DESCRIPTION
One command per configuration produces the decisive CPU-vs-GPU curves (warm per-iteration marginals over ns x mnmax for the CLI lane and multigrid ladder, a free-boundary steady-lane NS sweep, a 537-mode GPU-FFT probe, and fixed/free/gradient workflow profiles) in a single provenance-bearing JSON, with an XLA command-buffer A/B variant. Instructions added to docs/performance.rst outside the generated block. Groundwork for the ranked GPU performance plan (pivot-mask caching at the preconditioner refresh, CPU-resident NESTOR factors, gated NS4 cache assembly, jitted setup assembly); no solver behavior changes in this PR.