### PR TITLE
Certify optimization derivatives and expose solver budgets

### DIFF
--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -365,6 +365,22 @@ on the flagship campaigns they are *necessary*: the exact-axisymmetric seed
 is a saddle of the QS residual where finite differences stall, and on the
 QP class the implicit path selects a better basin.
 
+The high-level optimization APIs use ``adjoint_tol=1e-6`` and
+``adjoint_maxiter=300`` by default.  The tolerance is checked against the true
+linear residual, so VMEX never silently returns an unconverged adjoint.  The
+larger restart ceiling fixes stiff QI objectives without charging easier
+objectives for unused iterations; both controls remain ordinary keyword
+arguments for stricter studies.
+
+An optimizer's initial point is solved strictly before the run starts.  Later
+invalid trial boundaries use the status-returning implicit lane: the host
+callback returns a fixed-shape fallback and a status code, and the objective
+selects a finite differentiable penalty pointing back toward the valid seed.
+No Python exception crosses ``jax.pure_callback``, so rejected high-mode
+trials do not produce an opaque JAX traceback.  Use
+``problem.evaluate(x).status`` and its ``diagnostics`` mapping when a driver
+needs the typed failure rather than only the numerical penalty.
+
 The gradient stack: what makes a Jacobian cheap
 -----------------------------------------------
 

--- a/tests/test_omnigenity.py
+++ b/tests/test_omnigenity.py
@@ -162,11 +162,22 @@ def test_grad_wrt_state_is_finite_and_nonzero(qi_eq):
 
 @pytest.mark.full
 def test_least_squares_implicit_composes():
-    """QIResidual works as a jac='implicit' objective term (2 trial solves)."""
+    """Full QI boundary gradient is finite and agrees in both AD directions."""
     inp = VmecInput.from_file(DATA_DIR / "input.minimal_seed_nfp2")
     qi = omn.QIResidual((0.3, 0.7), mboz=8, nboz=8, nphi=41, nalpha=9, n_levels=6)
-    result = opt.least_squares(
-        [(qi, 0.0, 1.0), (opt.aspect_ratio, 6.0, 1.0)], inp, max_mode=1,
-        jac="implicit", use_ess=True, max_nfev=2, ftol=1e-12, xtol=1e-14)
-    assert np.all(np.isfinite(result.fun))
-    assert np.isfinite(float(result.cost))
+    problem = opt.VmecProblem.from_tuples(
+        inp,
+        [(qi, 0.0, 1.0), (opt.aspect_ratio, 6.0, 1.0)],
+        max_mode=1,
+    )
+    value, gradient = problem.value_and_grad(problem.x0)
+    residual, jacobian = problem.residual_and_jac(problem.x0)
+    assert np.isfinite(value)
+    assert np.all(np.isfinite(gradient))
+    assert np.all(np.isfinite(jacobian))
+    np.testing.assert_allclose(value, 0.5 * residual @ residual, rtol=1e-12)
+    gradient_from_jacobian = jacobian.T @ residual
+    relative_error = np.linalg.norm(gradient - gradient_from_jacobian) / max(
+        np.linalg.norm(gradient_from_jacobian), 1.0
+    )
+    assert relative_error < 5e-3

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -515,6 +515,7 @@ def test_least_squares_implicit_jac_solver_block(monkeypatch):
     assert accepted.result.converged
     with pytest.raises(RuntimeError, match="usable VMEC equilibrium"):
         problem.equilibrium_from_x(np.full_like(problem.x0, np.nan))
+    np.testing.assert_allclose(problem.residual_jac(problem.x0), weighted_jac)
     with pytest.raises(ValueError, match="ntheta"):
         opt.elongation_profile(
             accepted.state, accepted.runtime, ntheta=3, nphi=1

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -548,6 +548,9 @@ def test_least_squares_implicit_jac_solver_block(monkeypatch):
         problem.metadata["weight_description"]
         == "weight multiplies squared cost"
     )
+    evaluation = problem.evaluate(problem.x0)
+    assert evaluation.success
+    assert evaluation.diagnostics["solve_stats"]["solves"] >= 1
     scalar = opt.VmecProblem.from_loss(
         inp,
         lambda state, runtime: 0.5 * (opt.aspect_ratio(state, runtime) - 4.0) ** 2,
@@ -596,6 +599,21 @@ def test_least_squares_implicit_jac_solver_block(monkeypatch):
 
     with pytest.raises(AttributeError, match="residuals"):
         scalar.residual(scalar.x0)
+    from vmex.core import implicit as implicit_module
+    from vmex.core.problem import Evaluation, FunctionProblem
+
+    config = problem.metadata["config"]
+    implicit_module._LAST_STATUS_ERROR[config] = ValueError("rejected boundary")
+    monkeypatch.setattr(
+        FunctionProblem,
+        "evaluate",
+        lambda self, x, derivatives=True: Evaluation(x=np.asarray(x)),
+    )
+    failed = problem.evaluate(problem.x0)
+    assert failed.status == "failed_solve"
+    assert failed.message == "rejected boundary"
+    assert failed.diagnostics["exception_type"] == "ValueError"
+    implicit_module._LAST_STATUS_ERROR.pop(config, None)
     with pytest.raises(ValueError, match="jac_solver"):
         opt.least_squares(obj, inp, max_mode=1, jac="implicit",
                           jac_solver="svd", max_nfev=1)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -604,6 +604,11 @@ def test_least_squares_implicit_jac_solver_block(monkeypatch):
 
     config = problem.metadata["config"]
     implicit_module._LAST_STATUS_ERROR[config] = ValueError("rejected boundary")
+
+    def rejected_equilibrium(_x):
+        raise RuntimeError("no converged equilibrium for this point")
+
+    monkeypatch.setattr(problem, "_equilibrium_from_x", rejected_equilibrium)
     monkeypatch.setattr(
         FunctionProblem,
         "evaluate",

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -75,6 +75,9 @@ def test_vmec_problem_maps_inputs_and_reuses_equilibria():
     accepted, x = problem.equilibrium_from_x([5.0, 6.0])
     assert accepted is equilibrium
     np.testing.assert_array_equal(x, [5.0, 6.0])
+    evaluation = problem.evaluate([1.0, 2.0], derivatives=False)
+    assert evaluation.value == 3.0
+    assert evaluation.diagnostics == {}
 
     bad = SimpleNamespace(coefficients=np.ones(3))
     with pytest.raises(ValueError, match="decision-vector shape"):

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -2190,7 +2190,14 @@ def _least_squares_implicit(
             lambda a: np.asarray(a, dtype=np.float64), params_of(_place(x))
         )
         hit = imp._LAST_SOLVE.get(cfg)
-        if hit is None or hit[0] != imp._params_key(params_np):
+        if (
+            hit is None
+            or hit[0] != imp._params_key(params_np)
+            or imp._LAST_STATUS_ERROR.get(cfg) is not None
+        ):
+            # A cached converged point can be revisited after a different trial
+            # failed.  Refresh the status callback in that rare case so the old
+            # error cannot turn this point's exact Jacobian into a penalty row.
             jax.device_get(rows_jit(_place(x)))
         if imp._LAST_STATUS_ERROR.get(cfg) is not None:
             holder["lin"] = None

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -1225,7 +1225,7 @@ def make_problem(
 
     ``adjoint_tol`` is a relative Krylov tolerance with a certified true
     residual check; ``adjoint_maxiter`` is the restart budget.  The defaults
-    are sufficient for the QI alex_qi seed while remaining much cheaper than
+    are sufficient for the precise-QI nfp=2 seed while remaining much cheaper than
     one finite-difference equilibrium solve per variable.
     """
     if (objective_terms is None) == (loss is None):

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -1170,6 +1170,8 @@ def make_problem(
     weight_semantics: str = "cost",
     jacobian_batch_size: int | str | None = 1,
     implicit_jacobian_method: str = "auto",
+    adjoint_tol: float = 1e-6,
+    adjoint_maxiter: int = 300,
     hot_restart: bool = True,
     warm_start: str | None = "perturbation",
     use_ess: bool = True,
@@ -1220,6 +1222,11 @@ def make_problem(
     :meth:`VmecProblem.residual` / :meth:`VmecProblem.residual_jac` to a
     nonlinear least-squares package, or :meth:`VmecProblem.value_and_grad` to
     any scalar gradient optimizer.
+
+    ``adjoint_tol`` is a relative Krylov tolerance with a certified true
+    residual check; ``adjoint_maxiter`` is the restart budget.  The defaults
+    are sufficient for the QI alex_qi seed while remaining much cheaper than
+    one finite-difference equilibrium solve per variable.
     """
     if (objective_terms is None) == (loss is None):
         raise ValueError("provide exactly one of objective_terms or loss")
@@ -1263,6 +1270,8 @@ def make_problem(
             current_dofs=current_dofs,
             jac_chunk_size=jacobian_batch_size,
             jac_solver=jac_solver,
+            adjoint_tol=adjoint_tol,
+            adjoint_maxiter=adjoint_maxiter,
             recycle=False,
             warm_start=(warm_start if hot_restart else None),
             solve_kwargs=dict(solve_kwargs or {}),
@@ -1304,6 +1313,8 @@ def least_squares(
     jac: str | None = None,
     jac_chunk_size: int | str | None = "auto",
     jac_solver: str = "auto",
+    adjoint_tol: float = 1e-6,
+    adjoint_maxiter: int = 300,
     recycle: bool = False,
     hot_restart: bool = True,
     warm_start: str | None = "perturbation",
@@ -1393,6 +1404,11 @@ def least_squares(
     the same Jacobian to solver tolerance.  ``recycle=True`` takes
     precedence.
 
+    ``adjoint_tol`` and ``adjoint_maxiter`` control the certified linear
+    response solves.  All public optimization paths allow 300 restarts by
+    default so QI derivatives cannot fail merely because of the former
+    hard-coded 30-restart cap.  Easier problems normally stop far earlier.
+
     ``recycle`` carries a GCROT deflation pair across the per-dof
     implicit-Jacobian solves and successive trust-region Jacobian
     evaluations, at the exact ``adjoint_tol`` / ``adjoint_maxiter`` budget
@@ -1444,6 +1460,7 @@ def least_squares(
                 objective_terms, current, max_mode=mm,
                 current_dofs=current_dofs, jac=jac,
                 jac_chunk_size=jac_chunk_size, jac_solver=jac_solver,
+                adjoint_tol=adjoint_tol, adjoint_maxiter=adjoint_maxiter,
                 recycle=recycle, hot_restart=hot_restart,
                 warm_start=warm_start, use_ess=use_ess,
                 ess_alpha=ess_alpha, device=device, solve_kwargs=solve_kwargs,
@@ -1468,6 +1485,7 @@ def least_squares(
             objective_terms, inp, max_mode=max_mode, x0=x0,
             current_dofs=current_dofs,
             jac_chunk_size=jac_chunk_size, jac_solver=jac_solver,
+            adjoint_tol=adjoint_tol, adjoint_maxiter=adjoint_maxiter,
             recycle=recycle,
             warm_start=(warm_start if hot_restart else None),
             solve_kwargs=dict(solve_kwargs or {}),
@@ -1536,6 +1554,8 @@ def minimize(
     solve_kwargs: dict | None = None,
     verbose: int = 0,
     method: str = "L-BFGS-B",
+    adjoint_tol: float = 1e-6,
+    adjoint_maxiter: int = 300,
     **scipy_kwargs,
 ):
     """Minimize the scalarized residual norm with one adjoint per gradient.
@@ -1556,6 +1576,10 @@ def minimize(
     :func:`least_squares`.  Plain state hot restarts are used because the
     first-order perturbation warm start requires the forward state-response
     columns that this lower-storage path deliberately avoids.
+
+    ``adjoint_tol`` / ``adjoint_maxiter`` are exposed explicitly.  Their
+    defaults are certified on the QI, QS, ``L_grad_B``, ``DMerc`` and ``D_R``
+    objective lanes; an unconverged adjoint is never returned as a gradient.
     """
     modes_schedule = ([int(max_mode)] if np.isscalar(max_mode)
                       else [int(m) for m in max_mode])
@@ -1569,7 +1593,8 @@ def minimize(
                 objective_terms, current, max_mode=mm,
                 current_dofs=current_dofs, hot_restart=hot_restart,
                 device=device, solve_kwargs=solve_kwargs, verbose=verbose,
-                method=method, **scipy_kwargs)
+                method=method, adjoint_tol=adjoint_tol,
+                adjoint_maxiter=adjoint_maxiter, **scipy_kwargs)
             stage_results.append(result)
             current = result.input
         result.stage_results = stage_results
@@ -1578,6 +1603,7 @@ def minimize(
         objective_terms, inp, max_mode=modes_schedule[0], x0=x0,
         current_dofs=current_dofs, jac_solver="reverse", recycle=False,
         warm_start=("state" if hot_restart else None),
+        adjoint_tol=adjoint_tol, adjoint_maxiter=adjoint_maxiter,
         solve_kwargs=dict(solve_kwargs or {}), device=device, verbose=verbose,
         minimize_method=method, **scipy_kwargs)
 
@@ -1628,6 +1654,8 @@ def _least_squares_implicit(
     current_dofs: int | None = None,
     jac_chunk_size: int | str | None = "auto",
     jac_solver: str = "auto",
+    adjoint_tol: float = 1e-6,
+    adjoint_maxiter: int = 300,
     recycle: bool = False,
     warm_start: str | None = "perturbation",
     solve_kwargs: dict,
@@ -1702,20 +1730,22 @@ def _least_squares_implicit(
     ndof = nboundary + (k_cur + 1 if k_cur else 0)
     # multigrid=True routes the host solve through solve_multigrid so
     # NITER-exhausted trials are penalized instead of raising (same trial
-    # policy as the finite-difference path).  Loose adjoint budget: the
-    # trust region only needs ~1e-3 gradient accuracy; row-norm deviation vs
-    # the tight (1e-11, 300) diagnostics default is <~1e-4 at a fraction of
-    # the cost.  hot_restart / warm_start semantics: see least_squares.
+    # policy as the finite-difference path). Public problem/minimize defaults
+    # retain the inexpensive 1e-6 tolerance but allow enough restarts for QI.
+    # hot_restart / warm_start semantics: see least_squares.
     if warm_start not in ("perturbation", "state", None):
         raise ValueError(
             "warm_start must be 'perturbation', 'state' or None, "
             f"got {warm_start!r}")
     if recycle and warm_start == "perturbation":
         warm_start = "state"  # the recycled variant carries (C, U) instead
-    cfg = imp.make_config(inp, multigrid=True,
-                          hot_restart=(warm_start is not None),
-                          adjoint_tol=1e-6, adjoint_maxiter=30,
-)
+    cfg = imp.make_config(
+        inp,
+        multigrid=True,
+        hot_restart=(warm_start is not None),
+        adjoint_tol=adjoint_tol,
+        adjoint_maxiter=adjoint_maxiter,
+    )
     # Pin the residual/Jacobian graphs to the fastest device for this
     # launch-bound path (CPU by default; explicit device= honored; None
     # leaves placement untouched).  The resolved device is ALSO carried in

--- a/vmex/core/problem.py
+++ b/vmex/core/problem.py
@@ -434,6 +434,18 @@ class VmecProblem(FunctionProblem):
             return evaluation
         from . import implicit as imp
 
+        # A cached value/Jacobian can be revisited after an unrelated rejected
+        # trial.  Confirm that the requested point still maps to the cached
+        # converged equilibrium before consulting the process-local last-error
+        # slot, otherwise that older failure would incorrectly mark this
+        # successful evaluation as failed.
+        try:
+            self.equilibrium_from_x(evaluation.x)
+        except (AttributeError, RuntimeError):
+            pass
+        else:
+            imp._LAST_STATUS_ERROR.pop(cfg, None)
+
         diagnostics = dict(evaluation.diagnostics)
         stats = imp._SOLVE_STATS.get(cfg)
         if stats is not None:

--- a/vmex/core/problem.py
+++ b/vmex/core/problem.py
@@ -9,7 +9,7 @@ lightweight tests and does not introduce an import cycle with
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import sys
 from threading import Event, RLock, Thread
 import time
@@ -425,6 +425,29 @@ class VmecProblem(FunctionProblem):
         if self._equilibrium_from_x is None:
             raise AttributeError("this problem does not provide equilibria")
         return self._equilibrium_from_x(self._x(x))
+
+    def evaluate(self, x: Array, *, derivatives: bool = True) -> Evaluation:
+        """Evaluate and attach VMEC solve/adjoint status diagnostics."""
+        evaluation = super().evaluate(x, derivatives=derivatives)
+        cfg = self.metadata.get("config")
+        if cfg is None:
+            return evaluation
+        from . import implicit as imp
+
+        diagnostics = dict(evaluation.diagnostics)
+        stats = imp._SOLVE_STATS.get(cfg)
+        if stats is not None:
+            diagnostics["solve_stats"] = dict(stats)
+        error = imp._LAST_STATUS_ERROR.get(cfg)
+        if error is None:
+            return replace(evaluation, diagnostics=diagnostics)
+        diagnostics["exception_type"] = type(error).__name__
+        return replace(
+            evaluation,
+            status="failed_solve",
+            message=str(error),
+            diagnostics=diagnostics,
+        )
 
 
 __all__ = ["Evaluation", "FunctionProblem", "VmecProblem"]


### PR DESCRIPTION
## Summary

- expose the certified adjoint tolerance and restart budget through every public optimization path
- raise the default restart ceiling from the former fixed 30 to 300 while preserving early termination on easier systems
- attach forward-solve statistics and the original typed failed-trial diagnostic to `VmecProblem.evaluate()`
- strengthen the full QI test so the scalar reverse gradient is checked against the residual forward Jacobian
- retain independent derivative gates for QI, `L_grad_B`, `DMerc`, `<J·B>`, and Glasser `D_R`

## Motivation

The previous high-level path fixed `adjoint_maxiter=30`. The precise-QI objective can require more Krylov restarts, so a usable derivative could fail only because the public wrapper imposed too small a budget. The new defaults are `adjoint_tol=1e-6` and `adjoint_maxiter=300`; the true linear residual is certified, and easy objectives stop without consuming the ceiling.

The strict-versus-status callback boundary and finite rejected-trial penalty now live in #104. This PR builds on that numerical contract by exposing its typed diagnostic through `problem.evaluate(x)` and by certifying the exact derivative paths rather than duplicating failure transport.

## Numerical validation

- full low-resolution QI equilibrium-to-boundary derivative gate: passed in 136.92 s on the rebased stack
- scalar value equals `0.5 * residual @ residual`; reverse gradient agrees with `jacobian.T @ residual` to the certified criterion
- representative QI, `L_grad_B`, `DMerc`, `<J·B>`, and Glasser `D_R` derivative gates retained
- cumulative optimization/penalty regression lane: 31 passed, with the full QI test separated from the ordinary fast lane
- Sphinx with warnings as errors, Ruff, compile checks, and clean diff checks: passed

## Review

This is PR 2 of the sequence documented in `docs/optimization_api_plan.md` and is stacked on #104. Please merge #104 first and then retarget this PR to `main`.

## Standards pass

- `vmex/core/optimize.py`: the `VmecProblem` factory docstring now names the
  QI seed neutrally (no external study name).
- No file renames, JSON artifacts, or example scripts are introduced by this
  PR, so the remaining standards items do not apply here.
- Rebased on the reworked #104; Ruff, `mypy vmex`, and
  `tools/test_manifest.py check` pass.

