### PR TITLE
Fix the SciPy BFGS/L-BFGS-B stall: certified scalar lane with consistent trial walls

### DIFF
--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -318,11 +318,14 @@ and remained infeasible at the same short budget.  Use it when a hard
 constraint is the primary requirement, not as a generic basin escape.
 
 For SciPy BFGS-family methods, pass ``problem.fun`` and ``problem.grad`` as
-separate callbacks.  Line-search trial points then evaluate only the scalar
-value instead of solving an implicit adjoint for every rejected step.  At
-higher Fourier mode, optimize the scaled coordinates
-``x = problem.x0 + problem.scales * y`` as shown in
-``QI_optimization_scipy.py``.
+separate callbacks.  For objective-term problems both are served by the same
+certified residual/Jacobian lane least squares uses (value ``0.5 r.r``,
+gradient ``J^T r``), sharing the solve memo and perturbation warm starts; a
+trial whose equilibrium fails or stops far from a fixed point returns a
+smooth objective-scale wall with its exact gradient, which Wolfe line
+searches backtrack through instead of stalling.  At higher Fourier mode,
+optimize the scaled coordinates ``x = problem.x0 + problem.scales * y`` as
+shown in ``QI_optimization_scipy.py``.
 
 On the same accepted mode-5 basin (full constructed QI ``1.873e-3``), ten
 SciPy least-squares evaluations reached ``1.788e-3`` in 32 s.  Ten JAXopt LM

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -139,6 +139,8 @@
       "tests/test_implicit_multi_rhs.py::test_block_response_forward_transpose_and_fd",
       "tests/test_optimize.py::test_least_squares_implicit_jac_solver_block",
       "tests/test_optimize.py::test_public_problem_factory_validation",
+      "tests/test_optimize.py::test_scipy_bfgs_scalar_lane_completes_and_descends",
+      "tests/test_optimize.py::test_certified_trial_guards_reject_stale_or_missing_memo",
       "tests/test_optimize_penalty.py",
       "tests/test_bootstrap.py::test_least_squares_current_dofs_implicit",
       "tests/test_parallel.py::test_parallel_finite_difference_and_problem_ensemble"

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -71,6 +71,13 @@ def test_monitor_callback_fallbacks_and_problem_counters() -> None:
     with np.testing.assert_raises(ValueError):
         OptimizationMonitor(stream=None)({"x": np.array([1.0])})
 
+    # Legacy SciPy minimize callbacks pass the plain parameter vector: it is
+    # the iterate itself, never probed for an ``x`` attribute (which used to
+    # produce a 0-d NaN evaluation point).
+    legacy = OptimizationMonitor(problem, stream=None)
+    legacy(np.array([3.0]))
+    assert legacy.records[0].cost == 9.0
+
 
 def test_default_scipy_monitor_respects_an_explicit_callback() -> None:
     from vmex.core import optimize as opt

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -472,6 +472,12 @@ def test_scipy_bfgs_scalar_lane_completes_and_descends():
         x_scale=problem.scales, max_nfev=int(bfgs.nfev))
     assert float(reference.cost) < value0
 
+    # Malformed decision vectors stay on the finite wall instead of raising.
+    bad_value, bad_gradient = problem.value_and_grad(
+        np.zeros(problem.x0.size + 1))
+    assert bad_value == 1.0e12
+    np.testing.assert_array_equal(bad_gradient, np.zeros_like(problem.x0))
+
 
 def test_least_squares_implicit_jac_chunking(solovev_eq):
     """The R17.1 chunked implicit Jacobian matches the unchunked one:

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -422,6 +422,57 @@ def test_minimize_scalarized_implicit_smoke(solovev_eq):
     assert isinstance(res.input, VmecInput)
 
 
+def test_scipy_bfgs_scalar_lane_completes_and_descends():
+    """SciPy BFGS and L-BFGS-B complete on the public scalar lane and descend.
+
+    Objective-term problems assemble ``value_and_grad`` from the same
+    certified residual/Jacobian lane as least squares (value ``0.5 r.r``,
+    gradient ``J^T r``), and uncertified trials get the smooth
+    objective-scale wall pair — so Wolfe line searches see consistent
+    value/slope data at every trial and terminate instead of collapsing on
+    stale gradients or 1e12-scale cliffs (the QI BFGS stall).  Measured on
+    this 2-dof problem: BFGS 3.89e-01 -> 1.55e-06 in 3 iterations (6
+    evaluations), L-BFGS-B -> 3.64e-05 in 2; bounds carry ample margin.
+    """
+    jax.config.update("jax_disable_jit", False)
+    import scipy.optimize
+
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+
+    def elongation_excess(state, runtime):
+        return jax.numpy.maximum(opt.max_elongation(state, runtime) - 8.0, 0.0)
+
+    problem = opt.VmecProblem.from_tuples(
+        inp,
+        [(opt.aspect_ratio, 4.0, 1.0), (elongation_excess, 0.0, 1.0)],
+        max_mode=1,
+        use_ess=True,
+    )
+    value0, gradient0 = problem.value_and_grad(problem.x0)
+    residual0, jacobian0 = problem.residual_and_jac(problem.x0)
+    np.testing.assert_allclose(
+        value0, 0.5 * float(residual0 @ residual0), rtol=1e-12)
+    np.testing.assert_allclose(gradient0, jacobian0.T @ residual0, rtol=1e-12)
+
+    bfgs = scipy.optimize.minimize(
+        problem.fun, problem.x0, jac=problem.grad, method="BFGS",
+        options={"maxiter": 3})
+    assert bfgs.nit >= 2
+    assert np.all(np.isfinite(bfgs.jac))
+    assert float(bfgs.fun) < 1.0e-3 < value0
+
+    lbfgsb = scipy.optimize.minimize(
+        problem.fun, problem.x0, jac=problem.grad, method="L-BFGS-B",
+        options={"maxiter": 2, "maxls": 8})
+    assert float(lbfgsb.fun) < 1.0e-2 < value0
+
+    # Same-budget least-squares reference on the identical problem object.
+    reference = scipy.optimize.least_squares(
+        problem.residual, problem.x0, jac=problem.residual_jac,
+        x_scale=problem.scales, max_nfev=int(bfgs.nfev))
+    assert float(reference.cost) < value0
+
+
 def test_least_squares_implicit_jac_chunking(solovev_eq):
     """The R17.1 chunked implicit Jacobian matches the unchunked one:
     ``jac_chunk_size`` only changes how the per-dof columns are batched
@@ -633,13 +684,19 @@ def test_least_squares_implicit_jac_solver_block(monkeypatch):
     def fail_device_get(_value):
         raise RuntimeError("synthetic transfer failure")
 
+    # A failed evaluation returns the smooth trial-wall PAIR — a value
+    # anchored at ten seed costs (never below 1.0) and its exact gradient
+    # (zero at the reference point) — so scalar line searches always see
+    # consistent value/slope data commensurate with the objective scale,
+    # never a stale gradient from a different point.
+    wall = max(10.0 * value, 1.0)
     monkeypatch.setattr(opt.jax, "device_get", fail_device_get)
     scalar._vg_cache = None
     failed_value, failed_gradient = scalar.value_and_grad(scalar.x0)
-    assert failed_value == 1.0e12
-    np.testing.assert_array_equal(failed_gradient, gradient)
-    assert scalar.fun(scalar.x0) == 1.0e12
-    holder["last_grad"] = None
+    assert failed_value == wall
+    np.testing.assert_array_equal(failed_gradient, np.zeros_like(scalar.x0))
+    assert scalar.fun(scalar.x0) == failed_value
+    holder["scalar_certified"] = False
     scalar._vg_cache = None
     with pytest.raises(RuntimeError, match="synthetic transfer failure"):
         scalar.value_and_grad(scalar.x0)
@@ -653,11 +710,11 @@ def test_least_squares_implicit_jac_solver_block(monkeypatch):
     scalar._vg_cache = None
     with pytest.raises(FloatingPointError, match="non-finite initial"):
         scalar.value_and_grad(scalar.x0)
-    holder["last_grad"] = gradient
+    holder["scalar_certified"] = True
     scalar._vg_cache = None
     failed_value, failed_gradient = scalar.value_and_grad(scalar.x0)
-    assert failed_value == 1.0e12
-    np.testing.assert_array_equal(failed_gradient, gradient)
+    assert failed_value == wall
+    np.testing.assert_array_equal(failed_gradient, np.zeros_like(scalar.x0))
     monkeypatch.setattr(opt.jax, "device_get", real_device_get)
 
     with pytest.raises(AttributeError, match="residuals"):

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -479,6 +479,90 @@ def test_scipy_bfgs_scalar_lane_completes_and_descends():
     np.testing.assert_array_equal(bad_gradient, np.zeros_like(problem.x0))
 
 
+def test_certified_trial_guards_reject_stale_or_missing_memo(monkeypatch):
+    """Certification refuses derivatives when the trial memo cannot vouch for x.
+
+    :func:`certified_trial` gates every scalar-lane derivative on the last
+    host solve belonging to exactly the requested ``x``.  Two failure modes
+    are forced here on both public lanes: the memo slot missing entirely
+    (writes dropped) and the memo belonging to different parameters (the
+    params key churned every call).  Either way the trial must fall onto the
+    smooth wall pair — ``max(10 * seed_cost, 1)`` with a zero gradient at
+    the seed — and count in ``holder["failed_trials"]``, never returning a
+    derivative of an uncertifiable state.  A malformed ``fun`` input takes
+    the flat 1e12 wall without solving.
+    """
+    import itertools
+
+    from vmex.core import implicit as implicit_module
+
+    jax.config.update("jax_disable_jit", False)
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    inp = inp.change_resolution(mpol=3, ntor=0, ntheta=12, nzeta=4)
+    inp = dataclasses.replace(
+        inp,
+        ns_array=np.asarray([5]),
+        ftol_array=np.asarray([1.0e-10]),
+        niter_array=np.asarray([1000]),
+    )
+
+    class _DropWrites(implicit_module._LAST_SOLVE.__class__):
+        def __setitem__(self, key, value):  # simulate an evicted memo slot
+            pass
+
+    problem = opt.VmecProblem.from_tuples(
+        inp, [(opt.aspect_ratio, 4.0, 1.0)], max_mode=1, use_ess=False,
+    )
+    holder = problem.metadata["holder"]
+    rows0 = problem.residual(problem.x0)
+    wall = max(10.0 * (0.5 * float(rows0 @ rows0)), 1.0)
+    value0, gradient0 = problem.value_and_grad(problem.x0)
+    assert np.isfinite(value0) and np.all(np.isfinite(gradient0))
+
+    with monkeypatch.context() as m:
+        m.setattr(implicit_module, "_LAST_SOLVE", _DropWrites())
+        problem._vg_cache = None
+        failed_before = holder["failed_trials"]
+        value, gradient = problem.value_and_grad(problem.x0)
+        assert np.isclose(value, wall, rtol=1e-12, atol=0.0)
+        np.testing.assert_array_equal(gradient, np.zeros_like(problem.x0))
+        assert holder["failed_trials"] == failed_before + 1
+
+    with monkeypatch.context() as m:
+        nonce = itertools.count()
+        m.setattr(
+            implicit_module, "_params_key",
+            lambda params: f"nonce-{next(nonce)}".encode(),
+        )
+        problem._vg_cache = None
+        failed_before = holder["failed_trials"]
+        value, gradient = problem.value_and_grad(problem.x0)
+        assert np.isclose(value, wall, rtol=1e-12, atol=0.0)
+        np.testing.assert_array_equal(gradient, np.zeros_like(problem.x0))
+        assert holder["failed_trials"] == failed_before + 1
+
+    scalar = opt.VmecProblem.from_loss(
+        inp,
+        lambda state, runtime: 0.5 * (opt.aspect_ratio(state, runtime) - 4.0) ** 2,
+        max_mode=1,
+        use_ess=False,
+    )
+    sholder = scalar.metadata["holder"]
+    svalue0 = float(scalar.fun(scalar.x0))
+    swall = max(10.0 * abs(svalue0), 1.0)
+    with monkeypatch.context() as m:
+        m.setattr(implicit_module, "_LAST_SOLVE", _DropWrites())
+        scalar._vg_cache = None
+        failed_before = sholder["failed_trials"]
+        value, gradient = scalar.value_and_grad(scalar.x0)
+        assert np.isclose(value, swall, rtol=1e-12, atol=0.0)
+        np.testing.assert_array_equal(gradient, np.zeros_like(scalar.x0))
+        assert sholder["failed_trials"] == failed_before + 1
+
+    # Malformed fun input: finite wall, no solve.
+    assert scalar.fun(np.zeros(scalar.x0.size + 1)) == 1.0e12
+
+
 def test_least_squares_implicit_jac_chunking(solovev_eq):
     """The R17.1 chunked implicit Jacobian matches the unchunked one:
     ``jac_chunk_size`` only changes how the per-dof columns are batched

--- a/tests/test_optimize_penalty.py
+++ b/tests/test_optimize_penalty.py
@@ -118,7 +118,7 @@ def test_implicit_lane_fun_penalty_path(monkeypatch, capsys):
 
 
 def test_minimize_penalty_path(monkeypatch, capsys):
-    """A failed scalarized trial reuses the last finite reverse gradient."""
+    """A failed scalarized trial gets the smooth consistent penalty pair."""
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
     real = im._host_solve
     calls = {"new": 0, "poisoned": 0}

--- a/vmex/core/monitoring.py
+++ b/vmex/core/monitoring.py
@@ -77,7 +77,14 @@ class OptimizationMonitor:
         return solves, rejected
 
     def __call__(self, intermediate_result: Any) -> None:
-        """Consume a SciPy ``OptimizeResult`` callback value."""
+        """Consume a SciPy callback value: ``OptimizeResult``, dict, or x.
+
+        Legacy SciPy ``minimize`` callbacks receive the plain parameter
+        vector; treat an array argument as that vector instead of probing
+        it for an ``x`` attribute (which silently produced a 0-d NaN).
+        """
+        if isinstance(intermediate_result, np.ndarray):
+            intermediate_result = {"x": intermediate_result}
         x = np.asarray(self._field(intermediate_result, "x"), dtype=float)
         cost = self._field(intermediate_result, "cost")
         raw_fun = self._field(intermediate_result, "fun")

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -1855,6 +1855,18 @@ def _traceable_term(fun: Callable) -> Callable:
         "l_grad_b_state alternatives.")
 
 
+# Scalar-lane trial certification (see ``value_and_grad`` below): a trial
+# whose host solve returned without converging is still a usable *sample* for
+# the least-squares rows (VMEC2000 trial policy), but derivatives are only
+# meaningful at (near-)fixed points.  A final force residual within this
+# factor of the solve tolerance is close enough for the implicit
+# linearization; beyond it the scalar lane substitutes the smooth penalty
+# pair instead of differentiating an uncertifiable state.  Measured on the
+# precise-QI nfp=2 seed: every accepted NITER-exhausted trial sits within
+# 1e3 x ftol, while genuinely off-basin states fail by many decades.
+_TRIAL_FSQ_SLACK = 1.0e6
+
+
 def _least_squares_implicit(
     objective_terms: Sequence[tuple[Callable, float, float]],
     inp: VmecInput,
@@ -2034,6 +2046,72 @@ def _least_squares_implicit(
         )
         row = gradient / np.sqrt(float(residual_size))
         return np.broadcast_to(row, (residual_size, ndof)).copy()
+
+    # Scalar-lane trial wall.  Any certified value of a descending run stays
+    # at or below the seed cost, so a wall of at least ten seed costs is
+    # never accepted by a Wolfe line search — while remaining commensurate
+    # with the objective scale.  The least-squares 1e6-row magnitude must NOT
+    # be reused here: against a ~1e15 cliff the dcsrch interpolation
+    # collapses its step to machine zero (measured |dy| ~ 1e-20 on the QI
+    # example) instead of backtracking geometrically into the basin.
+    seed_cost = (
+        0.5 * float(initial_rows @ initial_rows)
+        if traceable_scalar is None
+        else float(initial_rows[0])
+    )
+    scalar_wall_base = max(10.0 * abs(seed_cost), 1.0)
+
+    def failure_value_and_gradient(x: np.ndarray) -> tuple[float, np.ndarray]:
+        """Exact scalar pair of the smooth scalar-lane trial wall.
+
+        ``value = base * (1 + d)**2`` with ``d`` the scaled distance from
+        the seed and its exact derivative as the gradient, so a scalar line
+        search always sees a consistent, smooth, bounded (value, slope)
+        pair at rejected trials — never a stale gradient from a different
+        point.  A non-finite ``x`` gets the flat 1e12 / zero-gradient
+        fallback.
+        """
+        delta = (np.asarray(x, dtype=float) - x0) / x_penalty_scale_host
+        distance = float(np.linalg.norm(delta))
+        if not np.isfinite(distance):
+            return 1.0e12, np.zeros(ndof)
+        growth = 1.0 + distance
+        gradient = (
+            np.zeros(ndof)
+            if distance == 0.0
+            else (2.0 * scalar_wall_base * growth / distance)
+            * delta / x_penalty_scale_host
+        )
+        return scalar_wall_base * growth ** 2, gradient
+
+    def certified_trial(x: np.ndarray) -> bool:
+        """Whether the memoized solve at ``x`` is a usable fixed point.
+
+        True when the status callback recorded no failure and the last host
+        solve belongs to exactly this ``x`` and either converged or stopped
+        (NITER-exhausted) with a final force residual within
+        ``_TRIAL_FSQ_SLACK * cfg.ftol`` — near enough for the implicit
+        linearization behind exact derivatives.  Call only after the trial's
+        own evaluation so the memo and status slot describe ``x``.
+        """
+        x = np.asarray(x, dtype=float)
+        if x.shape != x0.shape:  # malformed input stays on the penalty path
+            return False
+        if imp._LAST_STATUS_ERROR.get(cfg) is not None:
+            return False
+        hit = imp._LAST_SOLVE.get(cfg)
+        if hit is None:
+            return False
+        params_np = jax.tree.map(
+            lambda a: np.asarray(a, dtype=np.float64), params_of(_place(x))
+        )
+        if hit[0] != imp._params_key(params_np):
+            return False
+        result = hit[1]
+        if bool(result.converged):
+            return True
+        fsq = float(result.fsqr) + float(result.fsqz) + float(result.fsql)
+        return bool(np.isfinite(fsq) and fsq <= _TRIAL_FSQ_SLACK * cfg.ftol)
 
     def residual_rows(x: jnp.ndarray) -> jnp.ndarray:
         params = params_of(x)
@@ -2479,35 +2557,77 @@ def _least_squares_implicit(
         return jac
 
     def value_and_grad(x: np.ndarray):
-        """Host scalar pair used by SciPy and the public problem object."""
+        """Host scalar pair used by SciPy and the public problem object.
+
+        Objective-term problems assemble the pair from the same certified
+        residual/Jacobian lane the least-squares driver uses (``0.5 r.r``,
+        ``J^T r``): one warm memoized host solve, the block-factorized
+        implicit Jacobian, and the perturbation warm-start stash — no
+        separate reverse-adjoint graph.  Scalar-loss problems keep the
+        single reverse adjoint.  Both lanes gate on
+        :func:`certified_trial`: a trial without a usable fixed point gets
+        the smooth consistent penalty pair instead of a derivative of an
+        uncertifiable state, so BFGS-family line searches always see
+        value/slope pairs they can digest.
+        """
+        xh = np.asarray(x, dtype=float)
+        if traceable_scalar is None:
+            residual = fun(xh)
+            if certified_trial(xh):
+                value = 0.5 * float(residual @ residual)
+                gradient = jac_fn(xh).T @ residual
+                if np.isfinite(value) and np.all(np.isfinite(gradient)):
+                    holder["scalar_certified"] = True
+                    return value, gradient
+            if imp._LAST_STATUS_ERROR.get(cfg) is None:
+                holder["failed_trials"] += 1  # raised solves counted by fun
+            return failure_value_and_gradient(xh)
+        scalar_fun_host(xh)  # establish the memoized trial solve and status
+        if not certified_trial(xh):
+            holder["failed_trials"] += 1
+            return failure_value_and_gradient(xh)
         try:
-            value, grad = value_grad_jit(_place(x))
+            value, grad = value_grad_jit(_place(xh))
             value = float(jax.device_get(value))
             grad = np.asarray(jax.device_get(grad), dtype=float)
-        except Exception as exc:
-            if holder.get("last_grad") is None:
+        except Exception:
+            if not holder.get("scalar_certified"):
                 raise
-            del exc
             holder["failed_trials"] += 1
-            return 1.0e12, holder["last_grad"]
+            return failure_value_and_gradient(xh)
         if np.isfinite(value) and np.all(np.isfinite(grad)):
-            holder["last_grad"] = grad
-            if imp._LAST_STATUS_ERROR.get(cfg) is not None:
-                holder["failed_trials"] += 1
+            holder["scalar_certified"] = True
             return value, grad
-        if holder.get("last_grad") is None:
+        if not holder.get("scalar_certified"):
             raise FloatingPointError("non-finite initial objective or gradient")
-        return 1.0e12, holder["last_grad"]
+        holder["failed_trials"] += 1
+        return failure_value_and_gradient(xh)
 
     def scalar_fun_host(x: np.ndarray) -> float:
-        """Host scalar value without forcing a reverse pass."""
+        """Host scalar value without derivative work, penalty-consistent.
+
+        Returns the exact objective at certified trials and the same smooth
+        penalty value :func:`value_and_grad` pairs with its penalty
+        gradient otherwise, so separate ``fun``/``jac`` callables (the SciPy
+        minimize contract) never disagree about a rejected trial.
+        """
+        xh = np.asarray(x, dtype=float)
+        if traceable_scalar is None:
+            residual = fun(xh)
+            if certified_trial(xh):
+                value = 0.5 * float(residual @ residual)
+                if np.isfinite(value):
+                    return value
+            return failure_value_and_gradient(xh)[0]
         try:
-            value = float(jax.device_get(scalar_loss_jit(_place(x))))
+            value = float(jax.device_get(scalar_loss_jit(_place(xh))))
         except Exception:
-            if holder.get("last_grad") is None:
+            if not holder.get("scalar_certified"):
                 raise
-            return 1.0e12
-        return value if np.isfinite(value) else 1.0e12
+            return failure_value_and_gradient(xh)[0]
+        if not (np.isfinite(value) and certified_trial(xh)):
+            return failure_value_and_gradient(xh)[0]
+        return value
 
     def input_from_x(x: np.ndarray) -> VmecInput:
         result_input = unpack_boundary(inp, np.asarray(x)[:nboundary], max_mode)

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -2068,10 +2068,13 @@ def _least_squares_implicit(
         the seed and its exact derivative as the gradient, so a scalar line
         search always sees a consistent, smooth, bounded (value, slope)
         pair at rejected trials — never a stale gradient from a different
-        point.  A non-finite ``x`` gets the flat 1e12 / zero-gradient
-        fallback.
+        point.  A non-finite or malformed ``x`` gets the flat 1e12 /
+        zero-gradient fallback.
         """
-        delta = (np.asarray(x, dtype=float) - x0) / x_penalty_scale_host
+        x = np.asarray(x, dtype=float)
+        if x.shape != x0.shape:
+            return 1.0e12, np.zeros(ndof)
+        delta = (x - x0) / x_penalty_scale_host
         distance = float(np.linalg.norm(delta))
         if not np.isfinite(distance):
             return 1.0e12, np.zeros(ndof)
@@ -2571,6 +2574,8 @@ def _least_squares_implicit(
         value/slope pairs they can digest.
         """
         xh = np.asarray(x, dtype=float)
+        if xh.shape != x0.shape:  # malformed input: no solve, finite wall
+            return failure_value_and_gradient(xh)
         if traceable_scalar is None:
             residual = fun(xh)
             if certified_trial(xh):
@@ -2612,6 +2617,8 @@ def _least_squares_implicit(
         minimize contract) never disagree about a rejected trial.
         """
         xh = np.asarray(x, dtype=float)
+        if xh.shape != x0.shape:  # malformed input: no solve, finite wall
+            return failure_value_and_gradient(xh)[0]
         if traceable_scalar is None:
             residual = fun(xh)
             if certified_trial(xh):


### PR DESCRIPTION
Stacked on #108 (`rogeriojorge/precision-qi-workflow`); retarget to `main` when the train lands.

## Problem

`examples/optimization/QI_optimization_scipy.py` with `METHOD = "BFGS"` or `"L-BFGS-B"` stalls: hours inside the first Wolfe line search with no output, while `least_squares` on the same problem finishes its 20-evaluation budget in 77 s.

## Root cause (measured on the QI example, laptop CPU, faulthandler + per-call instrumentation)

The scalar lane (`value_and_grad`) was a separately compiled `jax.value_and_grad` reverse-adjoint graph, and Wolfe line searches evaluate it at every trial point — including points without a usable equilibrium:

1. **Reverse GCROT adjoint at uncertified trial states.** The first BFGS trial's host solve exhausted NITER far off the basin (final force residual `fsq = 3.1` vs `ftol = 1e-13`). The implicit adjoint then linearized off the fixed point, ground through its restart budget for 112 s, was NaN-poisoned by the convergence check, and the fallback returned `(1e12, stale gradient from x0)`.
2. **Inconsistent value/slope pairs.** `problem.fun` at the same trial returned the sampled cost (2.62) while `problem.grad`'s fallback reported 1e12 with a gradient from a different point. `dcsrch` received contradictory `phi/phi'` data and collapsed its step to `|dy| ~ 1e-20`, then kept requesting ~1-2-minute gradients at machine-epsilon steps — the observed stall.
3. **Baseline cost and compile.** Even at certified points the reverse adjoint cost ~52 s per gradient versus 0.5 s for the block-factorized Jacobian the least-squares lane uses, on top of a separate 103 s compile.

A penalty-magnitude pathology completed the failure: reusing the least-squares 1e6-row penalty magnitude for the scalar value puts a ~1e15 cliff next to a ~1.2 objective, and the `dcsrch` interpolation against that cliff jumps straight to machine-zero steps instead of backtracking.

## Fix

* **Objective-term problems serve `fun`/`grad`/`value_and_grad` from the same certified residual/Jacobian lane as `least_squares`** (`vmex/core/optimize.py`): value `0.5 r.r` from the memoized penalty-aware rows, gradient `J^T r` from the block-factorized implicit Jacobian. The scalar lane inherits the solve memo, the perturbation warm-start stash, and the derivative fallback ladder; its compile is the graphs the residual lane already builds (first-gradient latency 103 s -> 20 s here). Scalar-loss problems keep the single reverse adjoint.
* **Trial certification.** Scalar derivatives are only taken at (near-)fixed points: converged solves, or NITER-exhausted solves whose final `fsq` is within `1e6 x ftol`. Measured on the working least-squares campaign, every accepted exhausted trial sits within `1e3 x ftol` while off-basin states miss by many decades. The least-squares rows keep the VMEC2000 usable-sample trial policy unchanged.
* **Consistent smooth trial wall.** Uncertified trials return `base * (1 + d)^2` and its exact gradient, with `base = max(10 x seed cost, 1)` and `d` the scaled distance from the seed — always above any certified value of a descending run, never a stale gradient, and commensurate with the objective scale so line searches backtrack geometrically. `problem.fun` and `problem.grad` agree at every point, and malformed decision vectors hit a flat finite wall before any solve.
* **Monitor robustness** (`vmex/core/monitoring.py`): legacy SciPy `minimize` callbacks pass the plain parameter vector; probing it for `.x` silently produced a 0-d NaN evaluation point (masked by the old catch-all 1e12 fallback, a crash after it). Arrays are now consumed as the iterate itself.

## Evidence (QI example, `MAX_MODE=1`, budget 20, same laptop)

| method | before | after |
| --- | --- | --- |
| least_squares | 77 s, cost 1.208 -> 5.36e-2 | unchanged |
| BFGS | stalled indefinitely in the first line search | completes in 153 s, cost 1.208 -> 6.27e-1, 5 accepted iterations |
| L-BFGS-B | stalled | completes, cost 1.208 -> 9.45e-1 |

Tiny 2-dof problem (new acceptance test): BFGS 3.89e-1 -> 1.55e-6 in 3 iterations (6 evaluations), L-BFGS-B -> 3.64e-5 in 2; least squares at the same evaluation budget reaches 8.83e-3.

Honest gap on QI stage 1: Gauss-Newton least squares remains clearly ahead (5.4e-2 vs 6.3e-1 at budget 20) — it exploits the residual structure and needs ~1 evaluation per accepted step, while BFGS pays a multi-point line search on a landscape whose trial solves are NITER-limited and value-noisy at `ftol = 1e-13`. BFGS-family methods are now robust, bounded, and descending; closing the remaining gap is optimizer tuning, not correctness.

## Reference notes

The `J^T r`-from-one-certified-lane shape follows the `objective_and_gradient` surface explored in `codex/public-residual-jacobian` and the simsopt-side `VmexSurfaceProblem`; both were adapted to the existing `VmecProblem` factory instead of introducing a parallel context class.

## Verification

* `tests/test_optimize.py::test_scipy_bfgs_scalar_lane_completes_and_descends` — new acceptance test: bounded BFGS and L-BFGS-B runs with strict cost decrease, scalar pair equal to the residual lane at the seed, finite wall for malformed input.
* Loss-lane fallback assertions reworked to the consistent wall pair; monitor legacy-callback regression test.
* `ruff`, `mypy vmex`, `tools/test_manifest.py check` clean; `tests/test_optimize.py`, `tests/test_optimize_penalty.py`, `tests/test_problem.py`, `tests/test_monitoring.py`: 55 passed.
