### PR TITLE
Post-0.5 hygiene: solvax pin rationale, worker-count docstring accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The defaults are exact implicit derivatives, automatic Jacobian direction, one-c
 - `implicit_jacobian_method` and `jacobian_batch_size` for response assembly and memory/compile tradeoffs;
 - `forward_ftol` and `forward_max_iterations` for the final forward-solve stage;
 - `max_fsq_ratio` for the largest under-converged `FSQ / ftol` that may be differentiated;
-- `workers` for parallel finite differences, scans, and ensembles. `None` uses the CPUs available to the process and respects scheduler or container limits.
+- `workers` for parallel finite differences, scans, and ensembles. `None` uses the CPUs available to the process and respects scheduler limits.
 
 `problem.value_and_grad` and `problem.jax_value_and_grad` expose the same scalar contract. `problem.evaluate(x)` reports solve effort, failed trials, derivative fallbacks, `fsq`, `fsq_ratio`, and whether the implicit derivative was certified. The runnable examples show SciPy least squares, BFGS/L-BFGS-B, JAXopt, Optax Adam, QI/QS objectives, high-accuracy final solves, input/wout output, and plotting.
 

--- a/docs/howto/optimize-a-boundary.md
+++ b/docs/howto/optimize-a-boundary.md
@@ -113,4 +113,4 @@ The accepted optimization state hot-starts the high-resolution solve and avoids 
 
 ## Shared and HPC machines
 
-Leave `workers=None` to use the CPUs visible to the process; VMEX respects scheduler and container affinity. Set an explicit smaller value when sharing a node. One equilibrium already uses XLA threading, while `parallel.solve_ensemble` and finite-difference probes parallelize independent solves. Select accelerators with `device=` and follow {doc}`run-on-gpu`.
+Leave `workers=None` to use the CPUs visible to the process; VMEX respects scheduler affinity. Set an explicit smaller value when sharing a node. One equilibrium already uses XLA threading, while `parallel.solve_ensemble` and finite-difference probes parallelize independent solves. Select accelerators with `device=` and follow {doc}`run-on-gpu`.

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -19,7 +19,7 @@ VMEX 0.5 makes converged equilibria optimizer-neutral building blocks:
 - `VmecExtender` provides SIMSOPT-style field queries beyond the LCFS, using
   direct vacuum fields or the finite-beta plasma-current virtual-casing branch.
 - Automatic ensemble and finite-difference worker counts respect process CPU
-  limits on shared, containerized, and scheduler-managed machines.
+  limits on shared and scheduler-managed machines.
 
 Upgrade notes:
 

--- a/docs/reference/optimization.rst
+++ b/docs/reference/optimization.rst
@@ -484,8 +484,8 @@ Resources and reproducibility
 -----------------------------
 
 A single equilibrium uses XLA threading. Parallel finite differences and
-ensembles use process-available CPUs by default, respecting scheduler and
-container affinity; set ``workers`` explicitly when sharing a node. Device
+ensembles use process-available CPUs by default, respecting scheduler
+affinity; set ``workers`` explicitly when sharing a node. Device
 selection is controlled by ``device=`` and the policies in
 :doc:`/howto/run-on-gpu`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   # JAX's persistent compilation cache uses file locks across processes.
   "filelock",
   "booz_xform_jax",
-  # 0.8.8 adds the checked tridiagonal fallback used by VMEX's preconditioner.
+  # vmex drives gcrot(m, k) recycling (incl. its recycle-drift certificate), block_thomas_factor/solve, tridiagonal_solve_checked, and chunk_map — all absent before solvax 0.8.8.
   "solvax>=0.8.8",
   "tomli; python_version < '3.11'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ dependencies = [
   # JAX's persistent compilation cache uses file locks across processes.
   "filelock",
   "booz_xform_jax",
-  # vmex drives gcrot(m, k) recycling (incl. its recycle-drift certificate), block_thomas_factor/solve, tridiagonal_solve_checked, and chunk_map — all absent before solvax 0.8.8.
+  # 0.8.8 is the floor for gcrot(m, k) recycling and its recycle-drift
+  # certificate, block_thomas_factor/solve, tridiagonal_solve_checked, and
+  # chunk_map, all of which vmex drives.
   "solvax>=0.8.8",
   "tomli; python_version < '3.11'",
 ]

--- a/vmex/core/parallel.py
+++ b/vmex/core/parallel.py
@@ -73,9 +73,8 @@ def available_cpus() -> int:
 def default_workers(n_items: int, workers: int | None = None) -> int:
     """Resolve the worker count for an ``n_items`` ensemble.
 
-    ``None`` uses the CPUs available to this process, including
-    scheduler affinity limits.  An explicit value is clamped to
-    ``[1, n_items]``.
+    ``None`` uses the CPUs available to this process, including scheduler
+    affinity limits.  An explicit value is clamped to ``[1, n_items]``.
     """
     n_items = max(int(n_items), 1)
     if workers is None:

--- a/vmex/core/parallel.py
+++ b/vmex/core/parallel.py
@@ -73,7 +73,7 @@ def available_cpus() -> int:
 def default_workers(n_items: int, workers: int | None = None) -> int:
     """Resolve the worker count for an ``n_items`` ensemble.
 
-    ``None`` uses the CPUs available to this process, including container and
+    ``None`` uses the CPUs available to this process, including
     scheduler affinity limits.  An explicit value is clamped to
     ``[1, n_items]``.
     """


### PR DESCRIPTION
Small post-0.5 hygiene sweep (Track D).

- **pyproject.toml**: the `solvax>=0.8.8` floor now documents the full API surface vmex drives — `gcrot(m, k)` recycling (incl. its recycle-drift certificate), `block_thomas_factor`/`block_thomas_solve`, `tridiagonal_solve_checked`, and `chunk_map` — all absent in older solvax.
- **vmex/core/parallel.py + docs sync**: `default_workers` docstring no longer claims container-limit detection; `available_cpus` reads process/affinity CPU counts and scheduler env vars (SLURM/PBS/SGE/LSF), not cgroup quotas. The same wording fix is applied to the four prose spots that carried the claim — the README `workers` bullet, `docs/howto/optimize-a-boundary.md`, `docs/reference/optimization.rst`, and the 0.5 entry in `docs/project/changelog.md` — so code and prose agree everywhere.

Audited but already clean (scrubbed in the #115 squash): personal paths/hostnames in `tests/test_bootstrap.py`, the QA/QH bootstrap examples, `benchmarks/run_freeboundary_multigrid.py`, `benchmarks/baseline.json`, `docs/_static/figures/readme_runtime_compare.json` (host is a neutral label), `docs/_static/figures/pr20_wout_parity_summary.json`; the dev `ruff` pin is already unpinned with an explicit `[tool.ruff.lint]` select; the README already carries the vmec_jax -> vmex rename note.

Verified: ruff clean, mypy clean (62 files), test manifest check passes, `tests/test_bootstrap.py` collects (30 tests), `test_parallel.py` + `test_performance_docs.py` pass; docs build clean with the CI command (`sphinx -W -j auto -b html`) and `test_docs_nav.py` + `test_capability_docs.py` pass.