### PR TITLE
Build the docs on the declared Python floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
           size_kb=$(du -sk --exclude=.git . | cut -f1)
           echo "working tree: ${size_kb} KiB"
           test "$size_kb" -lt 40960
+      - name: Load the docs configuration
+        # The `quality` job builds the docs on 3.12 only, so a 3.11+ construct
+        # in docs/conf.py (tomllib) used to reach main unnoticed and break the
+        # docs build on the declared floor. Executing conf.py needs no Sphinx.
+        run: python -c "import runpy; runpy.run_path('docs/conf.py')"
       - name: Run fast tests
         env:
           JAX_ENABLE_X64: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
           test "$size_kb" -lt 40960
       - name: Load the docs configuration
         # The `quality` job builds the docs on 3.12 only, so a 3.11+ construct
-        # in docs/conf.py (tomllib) used to reach main unnoticed and break the
-        # docs build on the declared floor. Executing conf.py needs no Sphinx.
+        # in docs/conf.py (tomllib, say) would break the docs build on the
+        # declared floor with no job noticing. Executing conf.py needs no Sphinx.
         run: python -c "import runpy; runpy.run_path('docs/conf.py')"
       - name: Run fast tests
         env:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import os
 import sys
-import tomllib
 from datetime import date
 from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - Python 3.10 fallback, matches tests/test_packaging_metadata.py
+    import tomli as tomllib
 
 
 # -- Path setup ----------------------------------------------------------------


### PR DESCRIPTION
## The gap

`pyproject.toml` declares `requires-python = ">=3.10"`, but `docs/conf.py` imported `tomllib` unguarded. `tomllib` is stdlib only from 3.11, so a docs build on the declared floor died at import:

```
File "docs/conf.py", line 5, in <module>
    import tomllib
ModuleNotFoundError: No module named 'tomllib'
```

Nothing caught it. The `quality` job that runs Sphinx pins 3.12, and the one lane that does run 3.10 (`fast`) never loads `conf.py`.

This was the only unguarded site in the repository. `tests/test_packaging_metadata.py` was already gated correctly, and `tomli` is already declared as a runtime dependency under the `python_version < "3.11"` marker, so no dependency change is needed.

## The fix

- `docs/conf.py` gates the import on `sys.version_info`, falling back to `tomli`, matching the convention already used in `tests/test_packaging_metadata.py`. Every `tomllib.load` call site is untouched.
- The `fast` job, whose matrix is `["3.10", "3.12"]`, now executes `docs/conf.py`. Loading it imports no Sphinx, so the step costs a fraction of a second while making the floor a gate rather than an assumption.

## Verification

| Interpreter | Before | After |
| --- | --- | --- |
| 3.10 + `tomli` | `ModuleNotFoundError: tomllib` | loads, `release = 0.5.0` |
| 3.13 | loads | loads, `release = 0.5.0` |

`python tools/check_docs_prose.py` is clean, and the full Sphinx build is unaffected on 3.11 (ReadTheDocs) and 3.12 (CI).