### PR TITLE
Republish the reference assets and take pull requests off them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,10 @@ jobs:
           sudo swapon /mnt/vmex-swap
       - name: Fetch the core parity fixture
         if: matrix.selector == 'pr-physics-core'
-        run: python tools/fetch_assets.py --bundle golden-v1 --bundle reference-nc
+        # golden-v1 only (2 MB): every pull-request lane now runs on git-tracked
+        # decks, generated fixtures, and the golden digests.  The released
+        # netCDF bundle stays a nightly/weekly dependency.
+        run: python tools/fetch_assets.py --bundle golden-v1
       - name: Run representative physics
         env:
           JAX_ENABLE_X64: "1"

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -3,36 +3,57 @@
   "bundles": [
     {
       "name": "reference-nc",
-      "url": "https://github.com/uwplasma/vmex/releases/download/assets-20260316-nc/vmec_jax_assets_20260316_nc_only.tar.gz",
-      "sha256": "3344fc2401fffed240ee57ae741ec521594c592627c76dae203503f485e4c0d8",
-      "size_bytes": 81559426,
+      "url": "https://github.com/uwplasma/vmex/releases/download/assets-20260812-nc/vmex_assets_reference_nc.tar.gz",
+      "sha256": "68d6237846ab07be9af703be9b081413c444fa283ea733be2dc497dcbd0da46d",
+      "size_bytes": 35846671,
       "source": "VMEX reference NetCDF and mgrid release assets",
       "license": "MIT; see repository LICENSE",
-      "generator_revision": "4ead9b814f8333d4dfbc3034d127085667743fd8",
+      "generator_revision": "5d6ceffaa1c003b32ce98000f444e9072c1eb811",
       "destination": "repository",
       "default": true,
       "common_paths": [
         "examples/data/mgrid_cth_like.nc",
         "examples/data/mgrid_d3d_ef.nc",
-        "examples/data/wout_*_reference.nc",
-        "examples/data/single_grid/mgrid_cth_like.nc",
-        "examples/data/single_grid/mgrid_d3d_ef.nc",
-        "examples/data/single_grid/wout_*_reference.nc"
+        "examples/data/wout_*.nc",
+        "examples/data/single_grid/mgrid_*.nc",
+        "examples/data/single_grid/wout_*.nc"
+      ],
+      "mirrors": [
+        {
+          "source": "examples/data",
+          "target": "examples/data/single_grid",
+          "names": [
+            "mgrid_cth_like.nc",
+            "mgrid_cth_like_lasym_small.nc",
+            "mgrid_d3d_ef.nc",
+            "wout_ITERModel_reference.nc",
+            "wout_LandremanPaul2021_QA_lowres_reference.nc",
+            "wout_LandremanPaul2021_QA_reactorScale_lowres_reference.nc",
+            "wout_LandremanPaul2021_QH_reactorScale_lowres_reference.nc",
+            "wout_LandremanSengupta2019_section5.4_B2_A80_reference.nc",
+            "wout_LandremanSenguptaPlunk_section5p3_low_res_reference.nc",
+            "wout_basic_non_stellsym_pressure_reference.nc",
+            "wout_circular_tokamak_aspect_100_reference.nc",
+            "wout_circular_tokamak_reference.nc",
+            "wout_purely_toroidal_field_reference.nc",
+            "wout_shaped_tokamak_pressure_reference.nc",
+            "wout_solovev_reference.nc",
+            "wout_up_down_asymmetric_tokamak_reference.nc"
+          ]
+        }
       ]
     },
     {
       "name": "wout-fixtures",
-      "url": "https://github.com/uwplasma/vmex/releases/download/assets-20260526-wout-fixtures/vmec_jax_wout_fixtures_20260526.tar.gz",
-      "sha256": "e9fd844a4ebed043576eec8ac2b17f7ff3e2a0e0a1b5adfc89742139101e00f9",
-      "size_bytes": 9801091,
-      "source": "VMEX generated and reference WOUT fixtures",
+      "url": "https://github.com/uwplasma/vmex/releases/download/assets-20260812-wout-fixtures/vmex_assets_wout_fixtures.tar.gz",
+      "sha256": "27a0ef9fc5eaf11b2ea02623dc9918799ab1258886e865c1e0ca98af057c1adc",
+      "size_bytes": 5051094,
+      "source": "VMEX generated and reference WOUT fixtures for the documentation galleries",
       "license": "MIT; see repository LICENSE",
-      "generator_revision": "3d839e4fd8cfa66d19752bbaa4a6d526b51995b6",
+      "generator_revision": "5d6ceffaa1c003b32ce98000f444e9072c1eb811",
       "destination": "repository",
       "default": true,
       "common_paths": [
-        "examples/data/wout_*.nc",
-        "examples/data/single_grid/wout_*.nc",
         "docs/_static/readme_best_cases/*/wout_*.nc",
         "docs/_static/qi_readme_cases/*/wout_*.nc"
       ]

--- a/docs/project/contributing.rst
+++ b/docs/project/contributing.rst
@@ -64,6 +64,28 @@ source, license, generator revision, and installed paths to
 ``python tools/fetch_assets.py --bundle golden-v1``. CI rejects any tracked
 file larger than 1 MiB.
 
+**Pull-request lanes must not depend on a released bundle.** A release can be
+deleted, and when ``assets-20260316-nc`` was, every pull request went red on
+the download step while the lane it fed lost exactly one test. PR selectors run
+on git-tracked decks, generated fixtures, and ``tests/golden_digests.json``;
+only the nightly and weekly lanes fetch ``reference-nc``. Prefer a generated
+fixture to a released one whenever the assertion is about solver behaviour
+rather than a specific machine: ``tests/test_lasym_free_case.py`` (a converged
+free-boundary case as 90 Chebyshev coefficients) and
+``tests/test_qi_free_boundary_case.py`` (analytic modular coils tabulated with
+``tabulate_cartesian_field``) are the two that PR lanes build on, and modules
+that need neither declare ``"asset": "generated"`` in ``tests/manifest.json``.
+
+Cut a new bundle with ``python tools/pack_reference_assets.py``, which packs
+the git-ignored netCDF files under each bundle's roots into a byte-reproducible
+tarball and prints the manifest fields. It applies two slimming rules, both
+measured lossless: MAKEGRID's ``ar_``/``ap_``/``az_`` vector potential is
+dropped (neither VMEX nor ``xvmec2000`` reads it back — half of
+``mgrid_cth_like.nc``), and duplicate ``single_grid/`` copies are re-created on
+extraction from the manifest's ``mirrors`` rule instead of shipped. Mirroring
+is also what keeps the tracked ``mgrid_cth_like_lasym_small.nc`` and its
+``single_grid/`` copy in step.
+
 Documentation builds must pass strict mode::
 
   python -m sphinx -W -j auto -b html docs docs/_build/html

--- a/examples/data/README.md
+++ b/examples/data/README.md
@@ -10,6 +10,9 @@ examples, tests, and documentation.
 - Large reference WOUT, mgrid, Boozer, and JXB files are ignored by git and are
   fetched on demand with `python tools/fetch_assets.py`. The command verifies
   the release size and SHA-256 recorded in `assets/manifest.json`.
+- `single_grid/` copies that duplicate a file here are not shipped in the
+  release; `fetch_assets.py` re-creates them from this folder on extraction, so
+  the mirrored `mgrid_cth_like_lasym_small.nc` is always the tracked file.
 
 Keep new example inputs small.  Put generated output files in ignored output
 directories, not in this data folder.

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,7 +25,10 @@ marker identifies high-resolution campaigns that also stay out of the nightly
 matrix. Pull requests run fast API tests plus representative fixed-boundary,
 free-boundary/NESTOR, mirror, device, and AD selectors. Nightly runs the
 complete integration/oracle matrix; weekly runs the high-mode free-boundary
-ladder and exterior-mirror resolution study.
+ladder and exterior-mirror resolution study. PR lanes fetch only the 2 MB
+`golden-v1` cache: they run on tracked decks, `asset: "generated"` fixtures,
+and `tests/golden_digests.json`, so a deleted release cannot redden a pull
+request. Modules declaring `asset: "reference-nc"` belong to nightly/weekly.
 `vmec2000_live` tests additionally require `--run-vmec2000` and accept
 `--vmec2000-executable PATH`; they are never part of ordinary offline CI. The
 live lane includes fixed-boundary current/Mercier profiles and a converged

--- a/tests/test_fetch_assets.py
+++ b/tests/test_fetch_assets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import io
 import json
@@ -144,6 +145,88 @@ def test_fetch_assets_safe_extract_rejects_special_files(tmp_path) -> None:
     with tarfile.open(fileobj=payload, mode="r:gz") as tf:
         with pytest.raises(SystemExit, match="special archive member"):
             module._safe_extract(tf, tmp_path)
+
+
+def _bundle_with(module, tmp_path, *, members: dict[str, bytes], mirrors=()):
+    """A local ``file://`` bundle carrying ``members``, sized and hashed."""
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as tf:
+        for name, data in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    blob = payload.getvalue()
+    archive = tmp_path / "bundle.tar.gz"
+    archive.write_bytes(blob)
+    return module.AssetBundle(
+        name="mirrored",
+        url=archive.as_uri(),
+        sha256=hashlib.sha256(blob).hexdigest(),
+        size_bytes=len(blob),
+        source="test",
+        license="test",
+        generator_revision="0" * 40,
+        destination="repository",
+        default=False,
+        common_paths=(),
+        mirrors=tuple(mirrors),
+    )
+
+
+def test_mirrors_recreate_the_single_grid_copies(tmp_path) -> None:
+    """Copies the bundle deliberately omits are re-created on extraction.
+
+    ``examples/data/single_grid`` was 16 byte-identical duplicates of its
+    ``examples/data`` siblings; they are mirrored instead of shipped.
+    """
+    module = _load_fetch_assets()
+    dest = tmp_path / "checkout"
+    (dest / "examples" / "data").mkdir(parents=True)
+    # stands in for the git-tracked small mgrid, which is never shipped
+    (dest / "examples" / "data" / "tracked.nc").write_bytes(b"tracked")
+
+    bundle = _bundle_with(
+        module, tmp_path,
+        members={"examples/data/shipped.nc": b"shipped"},
+        mirrors=({"source": "examples/data",
+                  "target": "examples/data/single_grid",
+                  "names": ["shipped.nc", "tracked.nc"]},),
+    )
+    module._download_and_extract_bundle(bundle, dest=dest, force=False)
+
+    mirrored = dest / "examples" / "data" / "single_grid"
+    assert (mirrored / "shipped.nc").read_bytes() == b"shipped"
+    assert (mirrored / "tracked.nc").read_bytes() == b"tracked"
+
+
+def test_mirror_reports_a_missing_source(tmp_path) -> None:
+    module = _load_fetch_assets()
+    dest = tmp_path / "checkout"
+    (dest / "examples" / "data").mkdir(parents=True)
+    bundle = _bundle_with(
+        module, tmp_path,
+        members={"examples/data/shipped.nc": b"shipped"},
+        mirrors=({"source": "examples/data",
+                  "target": "examples/data/single_grid",
+                  "names": ["absent.nc"]},),
+    )
+
+    with pytest.raises(SystemExit, match="Mirror source missing"):
+        module._download_and_extract_bundle(bundle, dest=dest, force=False)
+
+
+def test_unreachable_release_reports_the_bundle(monkeypatch) -> None:
+    """A deleted release must name itself, not raise a bare urllib traceback."""
+    module = _load_fetch_assets()
+    bundle = module.BUNDLES_BY_NAME["reference-nc"]
+
+    def _gone(_url):
+        raise module.urllib.error.HTTPError(bundle.url, 404, "Not Found", {}, None)
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", _gone)
+
+    with pytest.raises(SystemExit, match="Could not download bundle 'reference-nc'"):
+        module._read_bundle(bundle)
 
 
 def test_no_tracked_file_exceeds_one_mib() -> None:

--- a/tests/test_freeboundary.py
+++ b/tests/test_freeboundary.py
@@ -37,6 +37,10 @@ from vmex.core.solver import (  # noqa: E402
     _initial_state, prepare_runtime, resolution_from_input,
 )
 
+from tests.test_lasym_free_case import (  # noqa: E402
+    lasym_free_field, lasym_free_input,
+)
+
 pytestmark = pytest.mark.usefixtures("_module_jit_enabled")  # vacuum solves: run jitted
 
 REPO = Path(__file__).resolve().parents[1]
@@ -547,19 +551,30 @@ def test_missing_mgrid_raises(tmp_path):
 
 
 def test_jac75_retry_rebuilds_vacuum_and_converges(capsys):
-    """A recovered free-boundary stage rebuilds NESTOR at its checkpoint."""
-    if not CONV_MGRID.exists():
-        pytest.skip(
-            "converged public CTH mgrid asset unavailable; run "
-            "examples/data/fetch_assets.py"
-        )
+    """A recovered free-boundary stage rebuilds NESTOR at its checkpoint.
+
+    Runs on the generated LASYM fixture rather than the released CTH mgrid:
+    the assertions are about the recovery mechanism -- VMEC2000's ceiling of
+    75 Jacobian resets, the checkpoint restart, and NESTOR being rebuilt
+    afterwards -- none of which depend on which converging external field
+    supplies the vacuum.  ``DELT = 1e4`` is the same forcing the CTH case
+    used and reproduces the same ceiling here (a decade lower, ``1e3``,
+    never trips it).  Measured: 75 resets, recovery at ``DELT = 0.5``,
+    vacuum on at 51, converged in 958 iterations at ``fsq = 9.9e-11``.
+    """
     inp = dataclasses.replace(
-        VmecInput.from_file(CONV_DECK), delt=1.0e4,
+        lasym_free_input(REPO / "examples" / "data"),
+        delt=1.0e4,
+        ns_array=np.asarray([16]),
+        ftol_array=np.asarray([1.0e-10]),
+        niter_array=np.asarray([2500]),
     )
+    field = lasym_free_field()
+
     with pytest.raises(VmecJacobianError) as exc:
         FB.solve_free_boundary(
             inp,
-            mgrid_path=CONV_MGRID,
+            external_field=field,
             max_iterations=2500,
             jacobian_retries=0,
         )
@@ -567,7 +582,7 @@ def test_jac75_retry_rebuilds_vacuum_and_converges(capsys):
 
     result = FB.solve_free_boundary(
         inp,
-        mgrid_path=CONV_MGRID,
+        external_field=field,
         max_iterations=2500,
         jacobian_retries=2,
         verbose=True,

--- a/tools/README.md
+++ b/tools/README.md
@@ -12,6 +12,20 @@ This directory contains developer-facing tools, not end-user examples.
   python tools/fetch_assets.py --bundle golden-v1
   ```
 
+- `pack_reference_assets.py`: the other half of that contract — packs the
+  release tarballs `fetch_assets.py` downloads. A bundle is exactly the
+  git-ignored netCDF files under its roots, so a new reference fixture joins
+  the next release by being added and ignored. Tarballs are byte-reproducible
+  (sorted members, zeroed mtime/uid/gid, fixed gzip header), so the recorded
+  SHA-256 can be re-derived rather than trusted. Vector-potential arrays and
+  duplicate `single_grid/` copies are dropped; the latter come back from the
+  manifest's `mirrors` rule on extraction. Run it against a checkout that
+  already has the assets installed:
+
+  ```console
+  python tools/pack_reference_assets.py --outdir dist/assets
+  ```
+
 - `profile_hotpaths.py`: cold-vs-warm wall-time + peak-RSS profile of the
   production hot paths (fixed-boundary solve and the differentiable
   `value_and_grad` adjoint). Backend-agnostic — the same script produces the

--- a/tools/fetch_assets.py
+++ b/tools/fetch_assets.py
@@ -13,6 +13,7 @@ import io
 import json
 import shutil
 import tarfile
+import urllib.error
 import urllib.request
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -36,6 +37,11 @@ class AssetBundle:
     destination: str
     default: bool
     common_paths: tuple[str, ...]
+    #: Copies re-created on extraction instead of shipped as duplicate archive
+    #: members; each rule is ``{"source", "target", "names"}`` relative to the
+    #: destination.  ``examples/data/single_grid`` was 16 byte-identical copies
+    #: of its ``examples/data`` siblings (59 of the bundle's 118 MB).
+    mirrors: tuple[dict, ...] = ()
 
     @property
     def marker_name(self) -> str:
@@ -47,7 +53,12 @@ def _load_bundles() -> tuple[AssetBundle, ...]:
     if data.get("schema") != "vmex.release-assets/1":
         raise RuntimeError(f"unsupported asset manifest schema in {MANIFEST_PATH}")
     bundles = tuple(
-        AssetBundle(**{**record, "common_paths": tuple(record["common_paths"])}) for record in data["bundles"]
+        AssetBundle(**{
+            **record,
+            "common_paths": tuple(record["common_paths"]),
+            "mirrors": tuple(record.get("mirrors", ())),
+        })
+        for record in data["bundles"]
     )
     if any(bundle.destination not in {"cache", "repository"} for bundle in bundles):
         raise RuntimeError(f"invalid asset destination in {MANIFEST_PATH}")
@@ -119,6 +130,42 @@ def _migrate_release_asset_paths(dest: Path) -> None:
                 shutil.copy2(old_path, new_path)
 
 
+def _apply_mirrors(bundle: AssetBundle, dest: Path) -> None:
+    """Re-create the copies the bundle deliberately does not ship.
+
+    Mirroring rather than shipping also fixes the direction of a past bug: the
+    mirrored ``mgrid_cth_like_lasym_small.nc`` is now always the git-tracked
+    file, never a release copy that can drift from it.
+    """
+    for rule in bundle.mirrors:
+        source, target = dest / rule["source"], dest / rule["target"]
+        missing = [name for name in rule["names"] if not (source / name).is_file()]
+        if missing:
+            raise SystemExit(f"Mirror source missing for {bundle.name!r}: {sorted(missing)}")
+        target.mkdir(parents=True, exist_ok=True)
+        for name in rule["names"]:
+            if not (target / name).exists():
+                shutil.copy2(source / name, target / name)
+
+
+def _read_bundle(bundle: AssetBundle) -> bytes:
+    """Download ``bundle``, reporting an unreachable release as a clear error.
+
+    A deleted release otherwise surfaces as a bare ``urllib`` traceback, which
+    is what a CI log showed when ``assets-20260316-nc`` disappeared.
+    """
+    try:
+        with urllib.request.urlopen(bundle.url) as resp:
+            return resp.read()
+    except (urllib.error.URLError, OSError) as exc:
+        raise SystemExit(
+            f"Could not download bundle {bundle.name!r} from {bundle.url}\n"
+            f"  {type(exc).__name__}: {exc}\n"
+            f"  The release asset recorded in {MANIFEST_PATH.relative_to(REPO_ROOT)} "
+            f"is unreachable; check that its release still exists."
+        ) from exc
+
+
 def _selected_default_bundles(names: Sequence[str] | None) -> tuple[AssetBundle, ...]:
     if not names or "all" in names:
         return DEFAULT_BUNDLES
@@ -139,12 +186,12 @@ def _download_and_extract_bundle(bundle: AssetBundle, *, dest: Path, force: bool
         if marker.read_text().splitlines() == [bundle.url, bundle.sha256]:
             print(f"Assets already installed for bundle {bundle.name!r} at {dest}. Use --force to re-download.")
             _migrate_release_asset_paths(dest)
+            _apply_mirrors(bundle, dest)
             return
         print(f"Replacing stale marker for bundle {bundle.name!r}")
 
     print(f"Downloading {bundle.name} assets from: {bundle.url}")
-    with urllib.request.urlopen(bundle.url) as resp:
-        data = resp.read()
+    data = _read_bundle(bundle)
 
     if bundle.size_bytes and len(data) != bundle.size_bytes:
         raise SystemExit(f"Size mismatch for {bundle.name}: expected {bundle.size_bytes}, got {len(data)}")
@@ -170,6 +217,7 @@ def _download_and_extract_bundle(bundle: AssetBundle, *, dest: Path, force: bool
             _safe_extract(tf, dest)
 
     _migrate_release_asset_paths(dest)
+    _apply_mirrors(bundle, dest)
     marker.write_text(f"{bundle.url}\n{digest}\n")
 
 

--- a/tools/pack_reference_assets.py
+++ b/tools/pack_reference_assets.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Pack the released reference-asset tarballs from a populated checkout.
+
+A bundle is exactly the set of git-ignored netCDF files under its roots --
+the same invariant ``examples/data/README.md`` states ("large reference WOUT,
+mgrid, Boozer, and JXB files are ignored by git and are fetched on demand").
+Enumerating from ``git`` rather than a hand-kept list means a new reference
+fixture joins the next release by being added and ignored, with nothing here
+to update.
+
+Two slimming rules apply, both measured to be lossless (2026-08-12):
+
+1. MAKEGRID writes a vector potential (``ar_``/``ap_``/``az_``) alongside the
+   field.  Neither code reads it back: VMEX's ``read_mgrid`` matches only
+   ``^(br|bp|bz)_(\\d{3})$``, and ``xvmec2000`` on the stripped
+   ``mgrid_cth_like.nc`` produced a byte-identical
+   ``wout_cth_like_free_bdy.nc`` (sha256 644f597f..., EXECUTION TERMINATED
+   NORMALLY).  It is exactly half of that file: 35.26 -> 17.63 MB.
+2. ``examples/data/single_grid/`` was shipped as 16 byte-identical copies of
+   its ``examples/data/`` siblings.  They are dropped here and re-created on
+   extraction from the ``mirrors`` rule in ``assets/manifest.json``, which
+   also guarantees the mirrored ``mgrid_cth_like_lasym_small.nc`` is the
+   git-tracked file rather than a bundle copy that can drift from it.
+
+Tarballs are byte-reproducible: members sorted, mtime/uid/gid zeroed, and a
+fixed gzip header.  Re-running on the same inputs reproduces the recorded
+SHA-256, so ``assets/manifest.json`` can be re-derived instead of trusted.
+
+Usage::
+
+    python tools/pack_reference_assets.py --outdir dist/assets
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import subprocess
+import tarfile
+import tempfile
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: bundle name -> roots enumerated for git-ignored netCDF payload.
+BUNDLE_ROOTS: dict[str, tuple[str, ...]] = {
+    "reference-nc": ("examples/data",),
+    "wout-fixtures": (
+        "docs/_static/readme_best_cases",
+        "docs/_static/qi_readme_cases",
+    ),
+}
+
+#: Files re-created on extraction instead of shipped (see module docstring).
+MIRROR_TARGET = "examples/data/single_grid"
+
+_POTENTIAL_PREFIXES = ("ar_", "ap_", "az_")
+
+
+def _ignored_netcdf(root: Path, source: Path) -> list[str]:
+    """Return repository-relative git-ignored ``.nc`` paths under ``root``."""
+    result = subprocess.run(
+        ["git", "ls-files", "--others", "--ignored", "--exclude-standard", "-z", "--", str(root)],
+        cwd=source, check=True, capture_output=True,
+    )
+    names = result.stdout.decode().rstrip("\0").split("\0")
+    return sorted(name for name in names if name.endswith(".nc"))
+
+
+def _strip_vector_potential(path: Path, into: Path) -> Path:
+    """Copy an mgrid without its unread vector-potential arrays."""
+    import netCDF4  # noqa: PLC0415 - optional heavy dependency
+
+    out = into / path.name
+    with netCDF4.Dataset(str(path)) as src:
+        keep = [name for name in src.variables if not name.startswith(_POTENTIAL_PREFIXES)]
+        if len(keep) == len(src.variables):
+            return path
+        used = {dim for name in keep for dim in src.variables[name].dimensions}
+        with netCDF4.Dataset(str(out), "w", format="NETCDF3_CLASSIC") as dst:
+            for name, dim in src.dimensions.items():
+                if name in used:
+                    dst.createDimension(name, len(dim))
+            for name in keep:
+                var = src.variables[name]
+                dst.createVariable(name, var.dtype, var.dimensions)[:] = var[:]
+    return out
+
+
+def _member(name: str) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(name)
+    info.mode, info.uid, info.gid, info.mtime = 0o644, 0, 0, 0
+    info.uname = info.gname = ""
+    return info
+
+
+def _pack(payload: Sequence[tuple[str, Path]], out: Path) -> tuple[int, str]:
+    """Write a byte-reproducible ``.tar.gz`` and return its size and digest."""
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as tf:
+        for name, path in sorted(payload):
+            info = _member(name)
+            info.size = path.stat().st_size
+            with path.open("rb") as handle:
+                tf.addfile(info, handle)
+    blob = gzip.compress(raw.getvalue(), compresslevel=9, mtime=0)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(blob)
+    return len(blob), hashlib.sha256(blob).hexdigest()
+
+
+def _revision(source: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=source, check=True, capture_output=True,
+    )
+    return result.stdout.decode().strip()
+
+
+def build(bundle: str, source: Path, outdir: Path, scratch: Path) -> dict:
+    """Pack one bundle and return the record to paste into the manifest."""
+    names: list[str] = []
+    for root in BUNDLE_ROOTS[bundle]:
+        names.extend(_ignored_netcdf(Path(root), source))
+
+    mirrored: list[str] = []
+    payload: list[tuple[str, Path]] = []
+    for name in names:
+        path = source / name
+        parent, filename = str(Path(name).parent), Path(name).name
+        if parent == MIRROR_TARGET and (source / "examples" / "data" / filename).is_file():
+            mirrored.append(filename)
+            continue
+        if filename.startswith("mgrid_"):
+            path = _strip_vector_potential(path, scratch)
+        payload.append((name, path))
+
+    # ``mgrid_cth_like_lasym_small.nc`` is git-tracked under examples/data, so
+    # mirroring it (rather than shipping the single_grid copy) is what keeps
+    # the two in step -- a stale bundle copy overwriting the tracked file is
+    # what poisoned the nightly free-boundary golden on 2026-07-12.
+    tracked_small = "mgrid_cth_like_lasym_small.nc"
+    if bundle == "reference-nc" and (source / "examples" / "data" / tracked_small).is_file():
+        mirrored.append(tracked_small)
+    mirrored = sorted(set(mirrored))
+
+    out = outdir / f"vmex_assets_{bundle.replace('-', '_')}.tar.gz"
+    size, digest = _pack(payload, out)
+    record = {
+        "name": bundle,
+        "path": str(out),
+        "size_bytes": size,
+        "sha256": digest,
+        "generator_revision": _revision(source),
+        "members": [name for name, _ in sorted(payload)],
+        "mirrors": (
+            [{"source": "examples/data", "target": MIRROR_TARGET, "names": mirrored}]
+            if mirrored else []
+        ),
+    }
+    return record
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--source", type=Path, default=REPO_ROOT,
+                   help="checkout with the reference assets already installed")
+    p.add_argument("--outdir", type=Path, default=REPO_ROOT / "dist" / "assets")
+    p.add_argument("--bundle", action="append", choices=tuple(BUNDLE_ROOTS),
+                   help="bundle to pack; repeatable, defaults to all")
+    args = p.parse_args(list(argv) if argv is not None else None)
+
+    source = args.source.expanduser().resolve()
+    bundles = args.bundle or list(BUNDLE_ROOTS)
+    with tempfile.TemporaryDirectory() as tmp:
+        records = [build(name, source, args.outdir.resolve(), Path(tmp)) for name in bundles]
+
+    for record in records:
+        print(f"\n{record['name']}: {len(record['members'])} members, "
+              f"{record['size_bytes'] / 1e6:.1f} MB")
+        print(f"  {record['path']}")
+        print(f"  sha256 {record['sha256']}")
+        if record["mirrors"]:
+            print(f"  mirrors {len(record['mirrors'][0]['names'])} files into {MIRROR_TARGET}")
+    print("\nManifest fields:")
+    print(json.dumps(
+        {r["name"]: {k: r[k] for k in ("sha256", "size_bytes", "generator_revision", "mirrors")}
+         for r in records},
+        indent=2,
+    ))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The failure

`assets/manifest.json` pointed two of its three bundles at deleted releases:

| bundle | recorded release | status |
|---|---|---|
| `reference-nc` | `assets-20260316-nc` | **404** |
| `wout-fixtures` | `assets-20260526-wout-fixtures` | **404** |
| `golden-v1` | `golden-v1` | 200 |

Both are `default: true`, so the documented `python tools/fetch_assets.py` was
broken for everyone, along with `nightly.yml`, `weekly.yml` and
`docs/reference/performance.rst`. Every pull request went red on "Fetch the
core parity fixture".

## Republished, 2.2x smaller

`assets-20260812-nc` (36 MB, was 82 MB) and `assets-20260812-wout-fixtures`.
Both slimming rules are measured lossless, not assumed:

- MAKEGRID's `ar_`/`ap_`/`az_` vector potential is dropped. `read_mgrid` matches
  only `^(br|bp|bz)_(\d{3})$`, and `xvmec2000` run on the stripped
  `mgrid_cth_like.nc` writes a **byte-identical** `wout_cth_like_free_bdy.nc`
  (sha256 `644f597f`, `EXECUTION TERMINATED NORMALLY`). It is exactly half of
  that file: 35.26 -> 17.63 MB.
- `examples/data/single_grid/` shipped 16 byte-identical copies of its
  `examples/data` siblings — 59 of the bundle's 118 MB. They are re-created on
  extraction from a new `mirrors` manifest rule, which also guarantees the
  mirrored `mgrid_cth_like_lasym_small.nc` is the git-tracked file rather than
  a release copy that can drift from it (the 2026-07-12 nightly failure).

The two bundles no longer overlap, so nothing is fetched twice.
`tools/pack_reference_assets.py` packs both from the git-ignored netCDF files
under each bundle's roots, byte-reproducibly, and prints the manifest fields;
a new reference fixture now joins the next release by being added and ignored.

## Pull requests no longer depend on a release

The core lane paid an 82 MB download to feed one test, which skipped silently
whenever the asset was missing. `test_jac75_retry_rebuilds_vacuum_and_converges`
now runs on the generated LASYM fixture: `DELT = 1e4` reproduces the same
75-reset ceiling (`1e3` never trips it), recovery at `DELT = 0.5`, vacuum on at
51, converged in 958 iterations at `fsq = 9.9e-11`.

`fetch_assets.py` reports an unreachable release instead of a bare urllib
traceback.

## Verification

- `pr-physics-core` on a clean checkout with no released assets: **71 passed,
  0 skipped in 114 s** (was 70 passed, 1 skipped, 173 s).
- `python tools/fetch_assets.py` and `--bundle golden-v1 --bundle reference-nc`
  both download, verify size and SHA-256, extract and mirror; all 60 netCDF
  consumer paths present.
- `test_free_boundary_converged_golden` passes against a VMEC2000 golden
  generated from the stripped mgrid, so the CTH parity ladder is unchanged.
- `tools/test_manifest.py check`, `ruff check`, `tools/check_docs_prose.py` clean.

## Follow-ups, not in this PR

- `mgrid_d3d_ef.nc` (13 MB of the new bundle) has no reader left; it was
  superseded by the 90-coefficient Chebyshev compression in
  `tests/test_lasym_free_case.py`. Dropping it would take the bundle to 23 MB.
- `test_free_boundary_converged_golden` skips in CI regardless of this change:
  `golden-v1` carries nine cases and `cth_like_free_bdy` is not one of them.

A `Docs linkcheck` flake this PR triggers (it runs on `docs/**`) is unrelated
and fixed separately in #121; it breaks on bare `github.com` URLs in files
this PR does not touch.
