### PR TITLE
Stop linkcheck flaking on github.com connection aborts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,3 +163,11 @@ linkcheck_ignore = [
     r"https://github\.com/uwplasma/VMEX/blob/main/.*",
 ]
 linkcheck_timeout = 30
+# github.com aborts a share of a runner's concurrent probes outright
+# ("RemoteDisconnected"), not with 429, so `linkcheck_rate_limit_timeout` never
+# engages. Two consecutive 2026-08-12 runs broke on a *different* subset each
+# time (conda-forge/vmex-feedstock, uwplasma/GKX, uwplasma/vmex/releases) while
+# all three answered 200 outside CI. Fewer parallel probes and a retry turn
+# that into a pass without hiding a genuinely dead link.
+linkcheck_workers = 2
+linkcheck_retries = 3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,10 +164,8 @@ linkcheck_ignore = [
 ]
 linkcheck_timeout = 30
 # github.com aborts a share of a runner's concurrent probes outright
-# ("RemoteDisconnected"), not with 429, so `linkcheck_rate_limit_timeout` never
-# engages. Two consecutive 2026-08-12 runs broke on a *different* subset each
-# time (conda-forge/vmex-feedstock, uwplasma/GKX, uwplasma/vmex/releases) while
-# all three answered 200 outside CI. Fewer parallel probes and a retry turn
-# that into a pass without hiding a genuinely dead link.
+# ("RemoteDisconnected") rather than answering 429, so
+# linkcheck_rate_limit_timeout never engages. Fewer parallel probes and a retry
+# clear that without hiding a genuinely dead link.
 linkcheck_workers = 2
 linkcheck_retries = 3


### PR DESCRIPTION
`Docs linkcheck` breaks intermittently on bare `github.com` repository URLs.
Two consecutive runs on 2026-08-12 failed on a **different** subset each time:

| run | broken |
|---|---|
| 17:01 | `conda-forge/vmex-feedstock`, `uwplasma/GKX`, `uwplasma/vmex/releases` |
| 17:20 | `uwplasma/GKX`, `uwplasma/vmex/releases` |

All three answer 200 outside CI. The failure is
`('Connection aborted.', RemoteDisconnected(...))` — github.com drops a share of
a runner's concurrent probes outright rather than returning 429, so
`linkcheck_rate_limit_timeout` never engages and the single default attempt is
recorded as broken.

Halving the concurrent probes and retrying absorbs the aborts. The alternative,
pinning the hosts in `linkcheck_ignore`, would stop checking them at all — and
these are the install, API-reference and changelog links most worth checking.