### PR TITLE
Differentiate the LASYM theta normalization at delta = 0

### DIFF
--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -745,16 +745,12 @@ def test_lasym_delta_rotation_traceable():
 def test_lasym_delta_rotation_jacobian_at_zero_delta():
     """The rotation Jacobian is exact where ``delta == 0``.
 
-    ``readin.f`` skips the rotation loop when ``delta`` vanishes, which is a
-    runtime shortcut only: ``cos(0)/sin(0)`` make the loop the identity, so
-    reproducing the *value* there says nothing about the derivative.  A deck
-    with ``RBS(0, 1) == ZBC(0, 1)`` sits exactly on that point, and the true
-    Jacobian still carries a rank-one ``m*(partner)*d(delta)`` term along
-    ``RBS(0, 1) - ZBC(0, 1)`` because ``d(delta)/d(RBS(0, 1))`` and
-    ``d(delta)/d(ZBC(0, 1))`` are ``+-1/denom``.  Treating the skip as a frozen
-    discrete branch cost ~16% on that channel and left every other dof exact,
-    which is why the value checks above and the shipped LASYM decks (both
-    ``delta != 0``) never saw it.
+    ``readin.f`` skips the rotation loop when ``delta`` vanishes, where
+    ``cos(0)/sin(0)`` already make it the identity, so matching the value
+    there says nothing about the derivative.  A deck with
+    ``RBS(0, 1) == ZBC(0, 1)`` sits on that point and still carries a rank-one
+    ``m*(partner)*d(delta)`` term along ``RBS(0, 1) - ZBC(0, 1)``.  Both
+    shipped LASYM decks have ``delta != 0``, so this one is built on the spot.
     """
     from vmex.core import setup as setup_mod
 
@@ -783,8 +779,8 @@ def test_lasym_delta_rotation_jacobian_at_zero_delta():
             rbc, np.asarray(rbs_a), np.asarray(zbc_a), zbs, mpol=mpol, ntor=ntor)
         return np.concatenate([np.ravel(np.asarray(a)) for a in out])
 
-    # Value agreement is necessary but not sufficient; assert it, then the
-    # derivative along the channel the frozen branch used to drop.
+    # Value agreement is necessary but not sufficient, so check it and then
+    # the derivative along the antisymmetric channel.
     np.testing.assert_allclose(
         np.asarray(traceable(jnp.asarray(rbs), jnp.asarray(zbc))),
         reference(rbs, zbc), rtol=0.0, atol=1e-12)

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -742,6 +742,66 @@ def test_lasym_delta_rotation_traceable():
     assert np.all(np.isfinite(np.asarray(g)))
 
 
+def test_lasym_delta_rotation_jacobian_at_zero_delta():
+    """The rotation Jacobian is exact where ``delta == 0``.
+
+    ``readin.f`` skips the rotation loop when ``delta`` vanishes, which is a
+    runtime shortcut only: ``cos(0)/sin(0)`` make the loop the identity, so
+    reproducing the *value* there says nothing about the derivative.  A deck
+    with ``RBS(0, 1) == ZBC(0, 1)`` sits exactly on that point, and the true
+    Jacobian still carries a rank-one ``m*(partner)*d(delta)`` term along
+    ``RBS(0, 1) - ZBC(0, 1)`` because ``d(delta)/d(RBS(0, 1))`` and
+    ``d(delta)/d(ZBC(0, 1))`` are ``+-1/denom``.  Treating the skip as a frozen
+    discrete branch cost ~16% on that channel and left every other dof exact,
+    which is why the value checks above and the shipped LASYM decks (both
+    ``delta != 0``) never saw it.
+    """
+    from vmex.core import setup as setup_mod
+
+    inp = VmecInput.from_file(str(DATA_DIR / "input.up_down_asymmetric_tokamak"))
+    cfg = im.make_config(inp, ftol=1e-12, max_iterations=10)
+    mpol, ntor = int(inp.mpol), int(inp.ntor)
+    rbc = np.asarray(inp.rbc, dtype=float)
+    zbc = np.asarray(inp.zbc, dtype=float)
+    zbs = np.asarray(inp.zbs, dtype=float)
+    rbs = np.asarray(inp.rbs, dtype=float).copy()
+    rbs[ntor, 1] = zbc[ntor, 1]  # put the reference exactly on delta == 0
+    denom0 = abs(rbc[ntor, 1]) + abs(zbs[ntor, 1])
+    assert denom0 > 0.0
+    assert float(np.arctan((rbs[ntor, 1] - zbc[ntor, 1]) / denom0)) == 0.0
+    inp = dataclasses.replace(inp, rbs=rbs)
+    cfg = dataclasses.replace(cfg, inp=inp)
+
+    def traceable(rbs_a, zbc_a):
+        out = im._lasym_delta_rotation_traceable(
+            jnp.asarray(rbc), rbs_a, zbc_a, jnp.asarray(zbs),
+            cfg, mpol=mpol, ntor=ntor)
+        return jnp.concatenate([jnp.ravel(a) for a in out])
+
+    def reference(rbs_a, zbc_a):
+        out = setup_mod._lasym_delta_rotation(
+            rbc, np.asarray(rbs_a), np.asarray(zbc_a), zbs, mpol=mpol, ntor=ntor)
+        return np.concatenate([np.ravel(np.asarray(a)) for a in out])
+
+    # Value agreement is necessary but not sufficient; assert it, then the
+    # derivative along the channel the frozen branch used to drop.
+    np.testing.assert_allclose(
+        np.asarray(traceable(jnp.asarray(rbs), jnp.asarray(zbc))),
+        reference(rbs, zbc), rtol=0.0, atol=1e-12)
+
+    direction = np.zeros_like(rbs)
+    direction[ntor, 1] = 1.0
+    _, jvp = jax.jvp(traceable, (jnp.asarray(rbs), jnp.asarray(zbc)),
+                     (jnp.asarray(direction), jnp.asarray(-direction)))
+    h = 1e-6
+    fd = (reference(rbs + h * direction, zbc - h * direction)
+          - reference(rbs - h * direction, zbc + h * direction)) / (2.0 * h)
+    scale = max(float(np.max(np.abs(fd))), 1e-30)
+    err = float(np.max(np.abs(np.asarray(jvp) - fd))) / scale
+    assert scale > 1e-3, f"the probe direction must move the rotation: {scale:.2e}"
+    assert err <= 1e-7, f"delta-rotation Jacobian on RBS(0,1)-ZBC(0,1): {err:.2e}"
+
+
 def test_lasym_runtime_from_params_matches_run_setup(lasym):
     """The lasym traceable map reproduces ``prepare_runtime`` at the base
     parameters (all four boundary families, rcon0/zcon0)."""

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -470,23 +470,14 @@ def _lasym_delta_rotation_traceable(rbc, rbs, zbc, zbs, cfg: ImplicitConfig,
     """Traceable ``readin.f`` lasym theta-normalization.
 
     Reproduces :func:`vmex.core.setup._lasym_delta_rotation`: rotate theta so
-    ``RBS(0, 1) = ZBC(0, 1)``, every ``(n, m)`` pair mixed by ``m*delta``.  Only
-    the genuinely structural cases are frozen from the reference input
-    ``cfg.inp`` (``mpol < 2``, and a zero denominator, which is a division by
-    zero rather than a choice); the ``delta`` value and the
-    ``cos(m*delta)/sin(m*delta)`` family mixing are smooth functions of the
-    ``(0, 1)`` coefficients and are traced.
+    ``RBS(0, 1) = ZBC(0, 1)``, mixing every ``(n, m)`` pair by ``m*delta``.
 
-    ``readin.f``'s ``IF (delta .ne. zero)`` is *not* frozen with them.  It is a
-    runtime shortcut with no semantic content — ``cos(0) = 1``, ``sin(0) = 0``
-    make the loop the identity — so skipping the body at ``delta == 0``
-    reproduces the value but silently drops the derivative.  The rotation is
-    the identity there in value only: ``d(delta)/d(RBS(0, 1))`` and
-    ``d(delta)/d(ZBC(0, 1))`` are ``+-1/denom``, so the true Jacobian carries a
-    rank-one ``m*(partner coefficient)*d(delta)`` term along
-    ``RBS(0, 1) - ZBC(0, 1)``.  Freezing it cost ~16% on that channel for a
-    reference deck with ``RBS(0, 1) == ZBC(0, 1)`` while leaving every other
-    dof exact.
+    ``delta`` and the ``cos(m*delta)/sin(m*delta)`` mixing are smooth in the
+    ``(0, 1)`` coefficients, so both are traced; only the structural ``mpol <
+    2`` and zero-denominator cases come from ``cfg.inp``.  At ``delta == 0``
+    the rotation is the identity in value while its derivative is not, since
+    ``d(delta)/d(RBS(0, 1)) = -d(delta)/d(ZBC(0, 1)) = 1/denom`` carries a
+    rank-one term along ``RBS(0, 1) - ZBC(0, 1)``, so the body runs there too.
     """
     r0 = np.asarray(cfg.inp.rbc, dtype=float)
     z0 = np.asarray(cfg.inp.zbs, dtype=float)

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -470,23 +470,30 @@ def _lasym_delta_rotation_traceable(rbc, rbs, zbc, zbs, cfg: ImplicitConfig,
     """Traceable ``readin.f`` lasym theta-normalization.
 
     Reproduces :func:`vmex.core.setup._lasym_delta_rotation`: rotate theta so
-    ``RBS(0, 1) = ZBC(0, 1)``, every ``(n, m)`` pair mixed by ``m*delta``.  The
-    *discrete* rotate/don't-rotate decision (``mpol < 2``, a zero denominator,
-    or ``delta == 0`` — each a measure-zero surface in parameter space) is
-    frozen from the reference input ``cfg.inp``, exactly like ``lflip``; the
-    ``delta`` value and the ``cos(m*delta)/sin(m*delta)`` family mixing are
-    smooth functions of the ``(0, 1)`` coefficients and are traced.
+    ``RBS(0, 1) = ZBC(0, 1)``, every ``(n, m)`` pair mixed by ``m*delta``.  Only
+    the genuinely structural cases are frozen from the reference input
+    ``cfg.inp`` (``mpol < 2``, and a zero denominator, which is a division by
+    zero rather than a choice); the ``delta`` value and the
+    ``cos(m*delta)/sin(m*delta)`` family mixing are smooth functions of the
+    ``(0, 1)`` coefficients and are traced.
+
+    ``readin.f``'s ``IF (delta .ne. zero)`` is *not* frozen with them.  It is a
+    runtime shortcut with no semantic content — ``cos(0) = 1``, ``sin(0) = 0``
+    make the loop the identity — so skipping the body at ``delta == 0``
+    reproduces the value but silently drops the derivative.  The rotation is
+    the identity there in value only: ``d(delta)/d(RBS(0, 1))`` and
+    ``d(delta)/d(ZBC(0, 1))`` are ``+-1/denom``, so the true Jacobian carries a
+    rank-one ``m*(partner coefficient)*d(delta)`` term along
+    ``RBS(0, 1) - ZBC(0, 1)``.  Freezing it cost ~16% on that channel for a
+    reference deck with ``RBS(0, 1) == ZBC(0, 1)`` while leaving every other
+    dof exact.
     """
     r0 = np.asarray(cfg.inp.rbc, dtype=float)
-    s0 = np.asarray(cfg.inp.rbs, dtype=float)
-    c0 = np.asarray(cfg.inp.zbc, dtype=float)
     z0 = np.asarray(cfg.inp.zbs, dtype=float)
     if mpol < 2:
         return rbc, rbs, zbc, zbs
     denom0 = abs(r0[ntor, 1]) + abs(z0[ntor, 1])
     if denom0 == 0.0:
-        return rbc, rbs, zbc, zbs
-    if float(np.arctan((s0[ntor, 1] - c0[ntor, 1]) / denom0)) == 0.0:
         return rbc, rbs, zbc, zbs
     denom = jnp.abs(rbc[ntor, 1]) + jnp.abs(zbs[ntor, 1])
     delta = jnp.arctan((rbs[ntor, 1] - zbc[ntor, 1]) / denom)


### PR DESCRIPTION
## What

`readin.f` normalizes an asymmetric boundary by a poloidal-angle shift `delta` chosen so `RBS(0,1) = ZBC(0,1)`, and guards the rotation loop with `IF (delta .ne. zero)`. The traceable port froze that guard from the reference input, alongside the structural `mpol < 2` and zero-denominator cases.

The Fortran guard is a runtime shortcut with no semantic content — `cos(0) = 1` and `sin(0) = 0` already make the loop the identity. `delta = 0` is not a discontinuity: it is where the map is the identity **in value but not in derivative**. The true Jacobian still carries `m*(partner)*d(delta)` for every `(n, m)`, and `d(delta)/d(RBS(0,1))` and `d(delta)/d(ZBC(0,1))` are `+-1/denom`. Skipping the body reproduced the value exactly while dropping a rank-one term along `RBS(0,1) - ZBC(0,1)`, leaving every other degree of freedom correct.

Past the reference point the frozen branch also made the *value* wrong, so the exact and finite-difference lanes were solving different boundaries.

## Evidence

Measured end to end on a LASYM quasi-axisymmetric problem, against central differences:

| direction | before | after |
|---|---|---|
| `RBS(0,1) - ZBC(0,1)` | 1.599e-1 | 1.58e-7 |
| `RBS(0,1) + ZBC(0,1)` | 2.9e-9 | 2.9e-9 |
| `RBS(±1,1) ± ZBC(±1,1)` | ~1e-8 | ~1e-8 |
| `ZBS(0,1)` (symmetric control) | 8.2e-10 | 8.2e-10 |

Before the fix the per-dof error was flat at 3.0e-2 across `h = 1e-4 … 1e-7`, which is what distinguishes an analytic-derivative error from finite-difference noise; after it, it converges with the step (3.9e-5 -> 2.0e-5 -> 2.7e-8).

## Why it matters

Every shipped stellarator-asymmetry example seeds `RBS(1,1)`/`ZBC(1,1)` and leaves `RBS(0,1) = ZBC(0,1) = 0`, so all four families (nfp = 1..4) were on the frozen branch and were being optimized with a wrong Jacobian — and, once the optimizer moved off `RBS(0,1) = ZBC(0,1)`, against a boundary that the exact lane and the finite-difference lane no longer agreed on.

### End-to-end payoff

Measured with quasisymmetry as the sole objective, from an identical seed (QS 1.209e-2) and an identical budget, at zero seed asymmetry so both lanes start from the same configuration:

| run | dofs | final QS | reduction |
|---|---|---|---|
| symmetric | 8 | 2.445e-4 | 49.5x |
| LASYM, before this fix | 16 | 2.436e-4 | 49.6x |
| LASYM, after this fix | 16 | **1.599e-4** | **75.6x** |

Before the fix the LASYM lane could only *match* symmetric — its eight extra asymmetric degrees of freedom bought nothing, which is what a Jacobian that is wrong in the asymmetric m=1 channel predicts. After it, LASYM beats symmetric by 1.52x, which is what that extra freedom should buy given the symmetric optimum lies inside its search space.

Two earlier harnesses failed to show this and are worth recording so the result is not over-read. A 12-evaluation run with an iota-floor row was dominated by that row (`min|iota|` ~ 0.01 against a 0.42 target at weight 10) and moved quasisymmetry in neither lane. A run with an aspect-ratio row showed LASYM *worse* on QS — because the extra dofs were being spent on aspect (7.36 against symmetric's 7.78) for a lower total cost. Only with a single unambiguous objective is "final QS" the thing being minimized.

This also means the asymmetry examples' underperformance is only partly this bug; the rest is objective weighting and an `ASYMMETRY_PERTURBATION = 0.01` seed that degrades QS 38x before the first evaluation. That is an examples question, tracked separately, not a defect in this lane.

## Why nothing caught it

Both LASYM decks in the tree have `delta != 0` (`up_down_asymmetric_tokamak` 0.4636, `cth_like_free_bdy_lasym_small` 0.00236), and the existing coverage asserted values plus `isfinite` on the gradient. The new gate puts the reference exactly on `delta = 0` and compares the JVP along `RBS(0,1) - ZBC(0,1)` with central differences of the `setup` reference: it fails at 2.5 without the fix and passes at 1e-7 with it, in 0.6 s.

## Ruled out

The m=1 constraint machinery in `residuals.py` was audited and is correct: `_m1_rotate_asym` is exactly invertible at n=0 (round trip 2.2e-16), its n=0 block is `[[1,1],[1,-1]]` at alpha=1 with the exact inverse at alpha=0.5, and it matches `readin.f:678-692`, which applies the constraint over the whole n range including n=0. No `custom_vjp`/`stop_gradient`/`pure_callback` sits on that path, and the m=1 force masks are built from static mode tables.

## Tests

`tests/test_implicit_grad.py`: 24 passed, 5 skipped with the fix, plus the new gate.



