### PR TITLE
Project the Boozer tables onto the whole grid Nyquist band

### DIFF
--- a/tests/test_boozer_tables.py
+++ b/tests/test_boozer_tables.py
@@ -196,6 +196,53 @@ def test_lasym_tables_match_the_wout_asymmetric_families(lasym_solved):
                                    err_msg=key)
 
 
+@pytest.mark.parametrize("deck", ["symmetric_eq", "lasym_solved"])
+def test_projection_closes_at_the_grid_nyquist_band(deck, request):
+    """The mode set reaches the grid Nyquist, with the self-conjugate weight.
+
+    ``wrout.f`` sizes the wout Nyquist table from the grid itself
+    (``mnyq = ntheta1/2``, ``nnyq = nzeta/2``) and halves the closing
+    ``cosmui``/``cosnv`` column, because on an even grid that row and column
+    are self-conjugate: ``(m, n)`` and ``(m, -n)`` share a single grid basis
+    function.  Stopping one mode short of it is silent — every surviving mode
+    stays exact — but on ``input.basic_non_stellsym_simsopt``
+    (ntheta = nzeta = 10) it drops 2.5% of ``bmnc`` and 2.6% of ``bmns`` in
+    relative L2, which is what the LASYM Boozer gate used to absorb.
+    """
+    eq = request.getfixturevalue(deck)
+    wout, res = eq.wout, eq.runtime.resolution
+    nfp, mnyq, nnyq = int(res.nfp), res.ntheta1 // 2, res.nzeta // 2
+    j = int(np.asarray(wout.iotas).shape[0]) // 2
+    tables = boozer_input_tables(eq.state, eq.runtime, j)
+    xm = np.asarray(tables["xm"], dtype=int)
+    xn = np.asarray(tables["xn"], dtype=int)
+
+    # the projection carries exactly the wout Nyquist mode table
+    assert (xm.max(), np.abs(xn).max()) == (mnyq, nnyq * nfp)
+    assert set(zip(xm.tolist(), xn.tolist())) == set(
+        zip(np.asarray(wout.xm_nyq, dtype=int).tolist(),
+            np.asarray(wout.xn_nyq, dtype=int).tolist()))
+
+    # ... and the band the old m/n limits dropped matches the wout row exactly
+    band = (xm > mnyq - 1) | (np.abs(xn) > max(nnyq - 1, 0) * nfp)
+    assert band.any()
+    for key, wout_arr in (("bmnc", wout.bmnc), ("bmns", wout.bmns)):
+        if wout_arr is None:
+            continue
+        ref, mask = _match_wout_row(wout.xm_nyq, wout.xn_nyq, wout_arr, j, xm, xn)
+        atol = 1e-13 * float(np.max(np.abs(ref[mask])))
+        assert np.max(np.abs(ref[band])) > 1e3 * atol   # the band is not noise
+        np.testing.assert_allclose(np.asarray(tables[key])[band], ref[band],
+                                   rtol=0.0, atol=atol, err_msg=key)
+
+    # Both angles fold on the self-conjugate corners, which are real on the
+    # grid: their sine partners must be exact zeros, not sin(pi*i) round-off.
+    if wout.bmns is not None:
+        corner = np.isin(xm, [0, mnyq]) & np.isin(np.abs(xn), [0, nnyq * nfp])
+        assert corner.sum() >= 4
+        np.testing.assert_array_equal(np.asarray(tables["bmns"])[corner], 0.0)
+
+
 def _synthesize(cos_table, sin_table, xm, xn, nfp, n_angles=64):
     """Field on a periodic (theta, zeta) grid from a cos/sin mode table."""
     angles = np.linspace(0.0, 2.0 * np.pi, n_angles, endpoint=False)

--- a/tests/test_boozer_tables.py
+++ b/tests/test_boozer_tables.py
@@ -354,3 +354,20 @@ def test_tables_are_jittable(solved):
     # jit-vs-eager reassociation noise only
     np.testing.assert_allclose(got, np.asarray(tables["bmnc"]), rtol=1e-6,
                                atol=1e-14)
+
+
+def test_refine_booz_grids_is_the_identity_at_oversample_one():
+    """``oversample = 1`` returns the transform's own grid untouched.
+
+    The refinement multiplies ``booz_xform_jax``'s pinned
+    ``2*(2*mboz+1)`` by ``2*(2*nboz+1)`` quadrature, so asking for no
+    refinement has to hand back the very same constants and grids rather than
+    rebuild an equivalent pair -- the transform reads its Fourier
+    normalization back off those counts.
+    """
+    from vmex.core.omnigenity import _refine_booz_grids
+
+    constants, grids = object(), object()
+    same_constants, same_grids = _refine_booz_grids(constants, grids, 1, 3)
+    assert same_constants is constants
+    assert same_grids is grids

--- a/tests/test_boozer_tables.py
+++ b/tests/test_boozer_tables.py
@@ -204,10 +204,10 @@ def test_projection_closes_at_the_grid_nyquist_band(deck, request):
     (``mnyq = ntheta1/2``, ``nnyq = nzeta/2``) and halves the closing
     ``cosmui``/``cosnv`` column, because on an even grid that row and column
     are self-conjugate: ``(m, n)`` and ``(m, -n)`` share a single grid basis
-    function.  Stopping one mode short of it is silent — every surviving mode
-    stays exact — but on ``input.basic_non_stellsym_simsopt``
-    (ntheta = nzeta = 10) it drops 2.5% of ``bmnc`` and 2.6% of ``bmns`` in
-    relative L2, which is what the LASYM Boozer gate used to absorb.
+    function.  Stopping one mode short of it leaves every surviving mode
+    exact, so the loss is silent: on ``input.basic_non_stellsym_simsopt``
+    (ntheta = nzeta = 10) it is 2.5% of ``bmnc`` and 2.6% of ``bmns`` in
+    relative L2.
     """
     eq = request.getfixturevalue(deck)
     wout, res = eq.wout, eq.runtime.resolution

--- a/tests/test_omnigenity.py
+++ b/tests/test_omnigenity.py
@@ -144,8 +144,7 @@ def test_lasym_boozer_spectra_and_qi_derivative(lasym_eq):
     # 2*(2*mboz+1) x 2*(2*nboz+1) grid, so compare at oversample=1.  With the
     # full Nyquist projection in boozer_input_tables the two routes agree to a
     # measured 1.06e-5 (bmnc_b) / 1.03e-4 (bmns_b) relative L2; the tolerances
-    # below keep ~10x margin.  Truncating the projection one mode short of the
-    # grid Nyquist used to leave 1.6e-2 / 2.9e-2 here.
+    # below keep ~10x margin.
     trace = omn.boozer_bmnc_state(
         lasym_eq.state, lasym_eq.runtime, surfaces=[0.53], mboz=6, nboz=6,
         oversample=1)

--- a/tests/test_omnigenity.py
+++ b/tests/test_omnigenity.py
@@ -140,9 +140,16 @@ def test_lasym_boozer_spectra_and_qi_derivative(lasym_eq):
     """LASYM cosine/sine spectra retain host parity and an FD-checked JVP."""
     host = opt.boozer_modes_from_wout(
         lasym_eq, surfaces=[0.53], mboz=6, nboz=6)
+    # Matched quadrature: the host runs booz_xform on its own unrefined
+    # 2*(2*mboz+1) x 2*(2*nboz+1) grid, so compare at oversample=1.  With the
+    # full Nyquist projection in boozer_input_tables the two routes agree to a
+    # measured 1.06e-5 (bmnc_b) / 1.03e-4 (bmns_b) relative L2; the tolerances
+    # below keep ~10x margin.  Truncating the projection one mode short of the
+    # grid Nyquist used to leave 1.6e-2 / 2.9e-2 here.
     trace = omn.boozer_bmnc_state(
-        lasym_eq.state, lasym_eq.runtime, surfaces=[0.53], mboz=6, nboz=6)
-    for name, tolerance in (("bmnc_b", 0.02), ("bmns_b", 0.03)):
+        lasym_eq.state, lasym_eq.runtime, surfaces=[0.53], mboz=6, nboz=6,
+        oversample=1)
+    for name, tolerance in (("bmnc_b", 1.1e-4), ("bmns_b", 1.1e-3)):
         actual, expected = np.asarray(trace[name]), np.asarray(host[name])
         error = np.linalg.norm(actual - expected) / np.linalg.norm(expected)
         assert error < tolerance

--- a/vmex/core/boozer_tables.py
+++ b/vmex/core/boozer_tables.py
@@ -122,7 +122,11 @@ def boozer_input_tables(state: SpectralState, rt: SolverRuntime, j: int) -> dict
     # uniform-grid Fourier projection onto the grid-representable modes
     theta = 2.0 * np.pi * np.arange(ntheta1) / ntheta1
     zeta = 2.0 * np.pi * np.arange(nzeta) / (nfp * nzeta)
-    m_max, n_max = ntheta1 // 2 - 1, max(nzeta // 2 - 1, 0)
+    # VMEC sizes the wout Nyquist table from the grid itself (wrout.f:
+    # mnyq = ntheta1/2, nnyq = nzeta/2), so the closing row/column belongs to
+    # the projection.  Dropping it left a few percent of bmnc/bmns on coarse
+    # decks (ntheta = nzeta = 10) unrepresented.
+    m_max, n_max = ntheta1 // 2, nzeta // 2
     ml, nl = [], []
     for m in range(0, m_max + 1):
         for n in range(-n_max, n_max + 1):
@@ -133,9 +137,24 @@ def boozer_input_tables(state: SpectralState, rt: SolverRuntime, j: int) -> dict
     xm, xn = np.asarray(ml), np.asarray(nl)
     ang = theta[:, None, None] * xm[None, None, :] - zeta[None, :, None] * xn[None, None, :]
     cos_t, sin_t = jnp.asarray(np.cos(ang)), jnp.asarray(np.sin(ang))
-    w = 2.0 / (ntheta1 * nzeta) * np.ones(xm.shape)
+    # The factor of two is the real-basis DFT norm for modes strictly inside
+    # the band.  On an even grid the closing m = ntheta1/2 row and the
+    # n = nzeta/2 column are self-conjugate — exp(i*(ntheta1/2)*theta_i)
+    # equals its own reflection — so (m, n) and (m, -n) share a single grid
+    # basis function and each carries half the amplitude.  That is wrout.f's
+    # ``cosmui(:,mnyq) *= 0.5`` / ``cosnv(:,nnyq) *= 0.5`` half-weight; odd
+    # ntheta1/nzeta have no exact Nyquist mode and keep the plain factor.
+    m_folds = (ntheta1 % 2 == 0) & (xm == ntheta1 // 2)
+    n_folds = (nzeta % 2 == 0) & (np.abs(xn) == (nzeta // 2) * nfp)
+    w = 2.0 / (ntheta1 * nzeta) * np.where(m_folds, 0.5, 1.0) * np.where(n_folds, 0.5, 1.0)
     w[(xm == 0) & (xn == 0)] = 1.0 / (ntheta1 * nzeta)
     w = jnp.asarray(w)
+    # Where both angles fold — m in {0, ntheta1/2} and |n| in {0, nzeta/2} —
+    # the mode is real on the grid and has no sine partner at all.  Zero those
+    # columns so round-off in sin(pi*i) cannot emit a spurious sine table
+    # entry where VMEC writes an exact zero.
+    sine_free = ((xm == 0) | m_folds) & ((xn == 0) | n_folds)
+    sin_t = jnp.where(jnp.asarray(sine_free)[None, None, :], 0.0, sin_t)
 
     def project(f, parity):
         return w * jnp.einsum("tz,tzm->m", f, cos_t if parity == "cos" else sin_t)

--- a/vmex/core/boozer_tables.py
+++ b/vmex/core/boozer_tables.py
@@ -123,9 +123,9 @@ def boozer_input_tables(state: SpectralState, rt: SolverRuntime, j: int) -> dict
     theta = 2.0 * np.pi * np.arange(ntheta1) / ntheta1
     zeta = 2.0 * np.pi * np.arange(nzeta) / (nfp * nzeta)
     # VMEC sizes the wout Nyquist table from the grid itself (wrout.f:
-    # mnyq = ntheta1/2, nnyq = nzeta/2), so the closing row/column belongs to
-    # the projection.  Dropping it left a few percent of bmnc/bmns on coarse
-    # decks (ntheta = nzeta = 10) unrepresented.
+    # mnyq = ntheta1/2, nnyq = nzeta/2), so the closing row and column belong
+    # to the projection; on a coarse deck they carry a few percent of
+    # bmnc/bmns.
     m_max, n_max = ntheta1 // 2, nzeta // 2
     ml, nl = [], []
     for m in range(0, m_max + 1):

--- a/vmex/core/omnigenity.py
+++ b/vmex/core/omnigenity.py
@@ -68,6 +68,7 @@ Scope notes
 
 from __future__ import annotations
 
+import dataclasses
 from typing import Any, Iterable
 
 import numpy as np
@@ -206,7 +207,32 @@ def _nearest_half_mesh_rows(ns: int, surfaces) -> tuple[np.ndarray, np.ndarray]:
     return s_half, np.asarray(rows, dtype=int)
 
 
-def _boozer_lasym_state(state, rt, *, rows, s_half, mboz, nboz):
+def _refine_booz_grids(constants, grids, oversample, nfp):
+    """booz_xform_jax constants/grids on an ``oversample``-times finer grid.
+
+    ``prepare_booz_xform_constants`` pins the angle-transform quadrature at
+    ``2*(2*mboz+1)`` by ``2*(2*nboz+1)`` points, but the transform reads the
+    counts back off ``constants`` for its Fourier normalization, so an integer
+    refinement of the flattened ``(theta, zeta)`` grid is a drop-in — the same
+    aliasing control the symmetric lane gets from its zero-padded FFT grid.
+    """
+    factor = int(oversample)
+    if factor == 1:
+        return constants, grids
+    ntheta = factor * int(constants.ntheta)
+    nzeta = factor * int(constants.nzeta) if int(constants.nzeta) > 1 else 1
+    theta = 2.0 * np.pi * np.arange(ntheta) / ntheta
+    zeta = 2.0 * np.pi * np.arange(nzeta) / (nzeta * int(nfp))
+    return (
+        dataclasses.replace(constants, ntheta=ntheta, nzeta=nzeta,
+                            nu2_b=ntheta // 2 + 1),
+        dataclasses.replace(grids,
+                            theta_grid=jnp.asarray(np.repeat(theta, nzeta)),
+                            zeta_grid=jnp.asarray(np.tile(zeta, ntheta))),
+    )
+
+
+def _boozer_lasym_state(state, rt, *, rows, s_half, mboz, nboz, oversample):
     """LASYM state tables through booz_xform_jax's validated full transform."""
     from booz_xform_jax.jax_api import (
         booz_xform_jax_impl,
@@ -226,6 +252,8 @@ def _boozer_lasym_state(state, rt, *, rows, s_half, mboz, nboz):
         constants, grids = prepare_booz_xform_constants(
             nfp=int(rt.resolution.nfp), mboz=int(mboz), nboz=int(nboz),
             asym=True, xm=xm, xn=xn, xm_nyq=xm, xn_nyq=xn)
+        constants, grids = _refine_booz_grids(
+            constants, grids, oversample, rt.resolution.nfp)
         xm_b = np.asarray(grids.xm_b, dtype=float)
         xn_b = np.asarray(grids.xn_b, dtype=float)
     out = booz_xform_jax_impl(
@@ -276,7 +304,9 @@ def boozer_bmnc_state(
     outputs align with ``surfaces``).  ``oversample`` refines the quadrature
     grid by trigonometric (FFT zero-pad) interpolation before the Boozer
     angle transform, reducing the aliasing of ``cos(m theta_B - n zeta_B)``
-    products; ``mboz``/``nboz`` are capped at the fine grid's Nyquist.
+    products; ``mboz``/``nboz`` are capped at the fine grid's Nyquist.  LASYM
+    states run through booz_xform_jax's full transform, where the same factor
+    refines that code's own ``(theta, zeta)`` quadrature grid.
 
     Returns ``{bmnc_b (nsurf, nmodes), xm_b, xn_b (physical), iota_b, G_b,
     I_b, nfp, s_b, psi_b, psi_edge}``; ``psi_b`` and ``psi_edge`` are the
@@ -299,7 +329,8 @@ def boozer_bmnc_state(
     s_half_np, rows = _nearest_half_mesh_rows(ns, surfaces)
     if bool(setup.lasym):
         return _boozer_lasym_state(
-            state, rt, rows=rows, s_half=s_half_np, mboz=mboz, nboz=nboz)
+            state, rt, rows=rows, s_half=s_half_np, mboz=mboz, nboz=nboz,
+            oversample=oversample)
 
     # -- half-mesh field tables (the QS-residual field chain) ----------------
     _, geometry = _geometry(state, rt)


### PR DESCRIPTION
## What

`boozer_input_tables` built its Fourier mode set from `ntheta1 // 2 - 1` and `nzeta // 2 - 1`, one row and one column short of the set VMEC itself uses. `wrout.f` sizes the wout Nyquist table from the grid as `mnyq = ntheta1/2`, `nnyq = nzeta/2`, so the closing row and column belong to the projection. On a coarse deck (`ntheta = nzeta = 10`) that is 41 modes where the wout has 61, and the dropped band carries **2.47% of `bmnc` and 2.62% of `bmns`** in L2.

That truncation was the entire content of the loose LASYM Boozer gate. Truncating the host reference to vmex's 41 modes collapses the discrepancy from 1.60e-2 / 2.89e-2 to 1.06e-5 / 1.03e-4 — nothing else was wrong.

## Weights

Widening the mode set is not enough on its own. On an even grid the closing `m = ntheta1/2` row and `n = nzeta/2` column are self-conjugate, so they carry `2/(ntheta1*nzeta) * h_m * h_n` with `h = 0.5` on a fold, which is what `wrout.f`'s `cosmui(:,mnyq) *= 0.5` / `cosnv(:,nnyq) *= 0.5` amounts to. Odd grids have no exact Nyquist mode and keep the plain factor of two.

The sine projection vanishes only at the four **self-conjugate corners**, not across the whole Nyquist row: at `m = ntheta1/2` with `n != 0, ±nzeta/2`, `sin(pi*i - 2*pi*n*k/Z) = -(-1)^i sin(2*pi*n*k/Z)` is genuinely nonzero and the wout carries it (`bmns(5, 1..4) = 2.029e-4, -3.026e-5, 4.107e-5, -4.606e-5`, reproduced to all digits). Only the corners are zeroed.

## Verification

The projection now reaches the wout Nyquist mode set exactly on four decks spanning both grid parities, both symmetries, and nfp = 1 and 3:

| deck | modes / `mnmax_nyq` | band error |
|---|---|---|
| `basic_non_stellsym_simsopt` (LASYM, nfp=1) | 61 / 61 | bmnc 9.46e-17, bmns 1.43e-15 |
| `solovev` (symmetric, `nzeta=1` odd) | 10 / 10 | bmnc 1.12e-15 |
| `li383_low_res` (symmetric, nfp=3, both folds) | 83 / 83 | bmnc 1.13e-16 |
| `basic_non_stellsym_pressure` (LASYM, ns=51) | 61 / 61 | bmnc 7.91e-17, bmns 1.34e-15 |
| `up_down_asymmetric_tokamak` (LASYM, `nzeta=1` odd) | 9 / 9 | bmnc 6.66e-16, bmns 2.87e-14 |

Agreement holds on every mode including the new band — worst case 2.87e-14, typically ~1e-16.

## Gate

`tests/test_omnigenity.py` tightened from `0.02 / 0.03` to `1.1e-4 / 1.1e-3` against a measured 1.055e-5 / 1.025e-4, roughly 10x margin. New `test_projection_closes_at_the_grid_nyquist_band[symmetric_eq|lasym_solved]` asserts the mode set equals the wout Nyquist table as a set, that the band the old limits dropped is non-negligible, that it matches wout at `atol = 1e-13*scale`, and that the self-conjugate corner sines are exactly zero.

Also: `_boozer_lasym_state` now honours the `oversample` argument the symmetric branch already did.

## Blast radius

The symmetric `boozer_bmnc_state` lane builds its tables inline and never calls `boozer_input_tables`, so this only affected LASYM Boozer spectra and direct `boozer_input_tables` callers. In particular it does **not** touch the QA/QH/QP asymmetry examples, which use the real-space `QuasisymmetryRatioResidual`.

## Tests

`tests/test_omnigenity.py tests/test_boozer_tables.py` — 18 passed. `ruff` and `mypy` clean.