### PR TITLE
Differentiate presf_ns_scale in the free-boundary adjoint lanes

### DIFF
--- a/tests/test_freeboundary_implicit.py
+++ b/tests/test_freeboundary_implicit.py
@@ -244,3 +244,53 @@ def test_boundary_schur_current_gradient_matches_resolve_finite_difference():
     finite_difference = (values[1] - values[0]) / (2.0 * step)
     np.testing.assert_allclose(
         derivative, finite_difference, rtol=5.0e-2, atol=3.0e-4)
+
+
+def test_presf_ns_scale_is_differentiated_in_the_adjoint_lanes():
+    """``presf_ns_scale`` tracks ``am``; the adjoint lanes may not freeze it.
+
+    ``funct3d.f``'s edge force carries ``presf_ns_scale * pressure[-1]``, and
+    the ratio ``pmass(1)/pmass(hs*(ns-1.5))`` is a smooth function of ``am``,
+    which is a differentiated parameter.  Taking the host float computed from
+    the reference input gives the right value at the reference point and no
+    derivative at all -- the same failure mode as the frozen lasym ``delta``
+    branch, and invisible to any check that compares the traceable lane with
+    itself.  This deck is ``power_series`` with a live derivative; a
+    ``two_power`` deck has ``p(1) = 0`` and could not show it.
+    """
+    from vmex.core.freeboundary import (
+        _presf_ns_scale, _presf_ns_scale_traceable,
+    )
+
+    inp, ns = lasym_free_input(DATA), 9
+    assert inp.pmass_type == "power_series"
+    params = im.params_from_input(inp)
+    host = _presf_ns_scale(inp, ns)
+    np.testing.assert_allclose(
+        float(_presf_ns_scale_traceable(params, inp, ns)), host,
+        rtol=1e-14, atol=0.0)
+
+    am = np.asarray(inp.am, dtype=float)
+    active = int(np.max(np.nonzero(am)[0])) + 1
+    grad = jax.grad(lambda p: _presf_ns_scale_traceable(p, inp, ns))(params)
+    analytic = np.asarray(grad.am, dtype=float)[:active]
+
+    def shifted(k, delta):
+        return dataclasses.replace(
+            inp, am=np.where(np.arange(am.size) == k, am + delta, am))
+
+    finite = np.empty(active)
+    for k in range(active):
+        step = 1.0e-6 * max(abs(am[k]), 1.0)
+        finite[k] = (_presf_ns_scale(shifted(k, step), ns)
+                     - _presf_ns_scale(shifted(k, -step), ns)) / (2.0 * step)
+
+    # The frozen host float reported exactly zero for all of these, so the
+    # tolerance only has to separate a live derivative from a missing one.
+    # This deck's am coefficients reach 5e7 against a ratio of 0.32, which
+    # caps central differences on the host float at a few times 1e-4.
+    assert np.max(np.abs(finite)) > 1e-6, f"probe is degenerate: {finite}"
+    np.testing.assert_allclose(analytic, finite, rtol=1e-3, atol=0.0)
+
+    # pres_scale cancels in the ratio, so its derivative is genuinely zero.
+    assert float(np.asarray(grad.pres_scale)) == 0.0

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -1112,6 +1112,30 @@ def _presf_ns_scale(inp: VmecInput, ns: int) -> float:
     return p_one / p_edge
 
 
+def _presf_ns_scale_traceable(params, inp: VmecInput, ns: int):
+    """:func:`_presf_ns_scale` as a function of the differentiated parameters.
+
+    The ratio is a smooth function of ``am`` and ``pres_scale``, both of which
+    are :class:`~vmex.core.implicit.ImplicitParams` fields, so the adjoint lanes
+    cannot take the host float computed from the reference input: the value
+    would be right at the reference point and the derivative silently absent.
+    Only ``pmass_type``, the spline knots and ``bloat`` are static here.
+    """
+    hs = 1.0 / float(ns - 1)
+    sedge = hs * (float(ns) - 1.5)
+    kwargs = dict(pres_scale=params.pres_scale, bloat=float(inp.bloat),
+                  spres_ped=1.0)
+    p_edge = _profiles.pressure(inp.pmass_type, params.am, inp.am_aux_s,
+                                inp.am_aux_f, sedge, **kwargs)
+    p_one = _profiles.pressure(inp.pmass_type, params.am, inp.am_aux_s,
+                               inp.am_aux_f, 1.0, **kwargs)
+    # A vanishing edge pressure is the two_power family's p(1) = 0, where the
+    # scale is defined to be zero; the safe denominator keeps the derivative
+    # finite instead of propagating a nan back through the ratio.
+    nonzero = p_edge != 0.0
+    return jnp.where(nonzero, p_one / jnp.where(nonzero, p_edge, 1.0), 0.0)
+
+
 # ---------------------------------------------------------------------------
 # Overlapped lane compilation (free-boundary compile scheduling)
 # ---------------------------------------------------------------------------

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -1115,11 +1115,10 @@ def _presf_ns_scale(inp: VmecInput, ns: int) -> float:
 def _presf_ns_scale_traceable(params, inp: VmecInput, ns: int):
     """:func:`_presf_ns_scale` as a function of the differentiated parameters.
 
-    The ratio is a smooth function of ``am`` and ``pres_scale``, both of which
-    are :class:`~vmex.core.implicit.ImplicitParams` fields, so the adjoint lanes
-    cannot take the host float computed from the reference input: the value
-    would be right at the reference point and the derivative silently absent.
-    Only ``pmass_type``, the spline knots and ``bloat`` are static here.
+    The ratio is smooth in ``am`` and ``pres_scale``, both
+    :class:`~vmex.core.implicit.ImplicitParams` fields, so the adjoint lanes
+    need it traced; only ``pmass_type``, the spline knots and ``bloat`` are
+    static.
     """
     hs = 1.0 / float(ns - 1)
     sedge = hs * (float(ns) - 1.5)
@@ -1130,8 +1129,8 @@ def _presf_ns_scale_traceable(params, inp: VmecInput, ns: int):
     p_one = _profiles.pressure(inp.pmass_type, params.am, inp.am_aux_s,
                                inp.am_aux_f, 1.0, **kwargs)
     # A vanishing edge pressure is the two_power family's p(1) = 0, where the
-    # scale is defined to be zero; the safe denominator keeps the derivative
-    # finite instead of propagating a nan back through the ratio.
+    # scale is zero by definition; the safe denominator keeps the derivative
+    # finite there.
     nonzero = p_edge != 0.0
     return jnp.where(nonzero, p_one / jnp.where(nonzero, p_edge, 1.0), 0.0)
 

--- a/vmex/core/freeboundary_implicit.py
+++ b/vmex/core/freeboundary_implicit.py
@@ -29,6 +29,7 @@ from . import implicit as im
 from .device import AUTO, resolve_implicit_device
 from .freeboundary import (
     _presf_ns_scale,
+    _presf_ns_scale_traceable,
     _solve_free_boundary_stage,
     _vacuum_executables,
     free_boundary_resolution,
@@ -155,9 +156,6 @@ def _projected_residual(
     # The executable/topology was fixed concretely when the config was built;
     # all equilibrium and coil values below remain dynamic traced arrays.
     fused = cfg.vacuum_program
-    pres_scale = jnp.asarray(
-        _presf_ns_scale(icfg.inp, int(icfg.resolution.ns)), dtype=jnp.float64
-    )
 
     @jax.jit
     def residual(z, params, field_parameters, frozen, rcon0, zcon0):
@@ -168,7 +166,8 @@ def _projected_residual(
         rt = dataclasses.replace(
             im.runtime_from_params(params, icfg), rcon0=rcon0, zcon0=zcon0,
             lfreeb=True, jmax=int(icfg.resolution.ns),
-            presf_ns_scale=pres_scale,
+            presf_ns_scale=_presf_ns_scale_traceable(
+                params, icfg.inp, int(icfg.resolution.ns)),
         )
         if fixed_bsqvac is None:
             external_field = cfg.field_from_parameters(field_parameters)
@@ -251,6 +250,10 @@ def _host_solve_and_mask_impl(
             rt, rcon0=rcon0, zcon0=zcon0, lfreeb=True,
             jmax=int(icfg.resolution.ns),
             bsqvac_edge=jax.lax.stop_gradient(stage.vacuum.bsqvac),
+            # Host value on purpose: this runtime only discovers which dofs
+            # have structural force support, a discrete answer that no
+            # derivative is taken through.  The adjoint lanes above use the
+            # traceable ratio instead.
             presf_ns_scale=jnp.asarray(
                 _presf_ns_scale(inp, int(icfg.resolution.ns))
             ),
@@ -429,12 +432,11 @@ def _host_boundary_schur_adjoint(
     icfg = cfg.implicit
     project = im._dof_projector(icfg, mask)
     field = cfg.field_from_parameters(field_parameters)
-    pres_scale = jnp.asarray(
-        _presf_ns_scale(icfg.inp, int(icfg.resolution.ns)), dtype=jnp.float64
-    )
     rt = dataclasses.replace(
         im.runtime_from_params(params, icfg), rcon0=rcon0, zcon0=zcon0,
-        lfreeb=True, jmax=int(icfg.resolution.ns), presf_ns_scale=pres_scale,
+        lfreeb=True, jmax=int(icfg.resolution.ns),
+        presf_ns_scale=_presf_ns_scale_traceable(
+            params, icfg.inp, int(icfg.resolution.ns)),
     )
     bsqvac = jax.lax.stop_gradient(cfg.vacuum_program.bsq(frozen, rt, field))
     frozen_residual = _projected_residual(


### PR DESCRIPTION
## What

`funct3d.f`'s edge force carries `presf_ns_scale * pressure[-1]`, where the scale is `pmass(1)/pmass(hs*(ns-1.5))`. That ratio is a smooth function of `am`, a differentiated parameter that the backward pass pulls through — but both adjoint lanes took it as a **host float computed from the reference input**:

```python
pres_scale = jnp.asarray(
    _presf_ns_scale(icfg.inp, int(icfg.resolution.ns)), dtype=jnp.float64
)
```

while `runtime_from_params(params, icfg)` traced `am` right beside it. The value was correct at the reference point and the derivative was absent — the same failure mode as the frozen LASYM `delta` branch in #126, and invisible for the same reason: the frozen lane is perfectly self-consistent, agreeing with itself to ~1e-6.

Affected call sites: `_projected_residual` (the default `coupled_gcrot` lane) and `_host_boundary_schur_adjoint`.

## Evidence

Relative error against the true residual, `cth_like_free_bdy_lasym_small` with `power_series` pressure:

| | am[0] | am[1] | am[2] |
|---|---|---|---|
| preconditioned lane (default) | 1.13 | 0.855 | 0.814 |
| raw Schur lane | 63.4 | 4.13 | 3.01 |

On the raw path the kept and dropped terms nearly cancel, so the frozen column points the wrong way entirely.

The traceable replacement matches the host value exactly (`|diff| = 0`) and its derivative matches central differences of the host to ~1e-10, where the frozen float reported zero against a true derivative of 16.0.

## Fix

`_presf_ns_scale_traceable(params, inp, ns)` takes `am` and `pres_scale` from the parameters, leaving only `pmass_type`, the spline knots and `bloat` static. The `p_edge == 0` early return becomes a safe-denominator `jnp.where`, so the `two_power` family's `p(1) = 0` keeps a finite derivative rather than propagating a nan back through the ratio.

The `_dof_mask` call site deliberately keeps the host float — it only discovers discrete structural support, and no derivative is taken through it — and now carries a comment saying so.

## Why nothing caught it

The shipped LASYM free-boundary deck **is** affected: it is `power_series` with `d(presf)/d(am)` up to 2.35e-4. Only `two_power` decks, where `p(1)` vanishes identically, were immune.

More importantly, `tests/test_implicit_grad.py::test_lasym_boundary_map_derivative_vs_fd` finite-differences the traceable map *against itself*. Both lanes freeze the same quantity, so that check is structurally blind to this whole class of defect. Replacing it with an AD-versus-host-reference comparison would catch this, #126, and anything else of the same shape; that is worth doing separately.

The new gate here fails on all eleven active coefficients against the frozen behaviour and passes at `rtol = 1e-3` with the fix — the tolerance set by host finite-difference noise on `am` coefficients reaching 5e7, and only needing to separate a live derivative from a missing one.

## Note on an unrelated pre-existing failure

`test_boundary_schur_adjoint_reproduces_the_coupled_gcrot_gradient` fails with `ValueError: need at least one array to stack` when `tests/test_freeboundary_implicit.py` is run as a whole file, and passes when run in isolation. **This reproduces identically on `main`** (verified on a clean `origin/main` worktree), so it is not introduced here. Filed as a separate concern.

## Tests

`ruff` and `mypy` clean. `tests/test_freeboundary_implicit.py`: 7 passed, 1 skipped, plus the pre-existing order-dependent failure above, which is present on `main` too.