### PR TITLE
Stop the warm-failure test leaking a zero mask into the module caches

### DIFF
--- a/tests/test_freeboundary_implicit.py
+++ b/tests/test_freeboundary_implicit.py
@@ -80,8 +80,15 @@ def test_free_boundary_warm_failure_retries_once_from_cold(monkeypatch):
                                     max_iterations=20)
     runtime = im._template_runtime(cfg.implicit)
     state = im._initial_state(runtime.setup)
-    seed = object(); fbi._FREE_HOT_CACHE[cfg] = seed
-    fbi._FREE_MASK_CACHE[fbi._mask_key(cfg)] = jax.tree.map(jnp.zeros_like, state)
+    # setitem, not plain assignment: these are module-level caches keyed on
+    # (resolution, lconm1, ncurr), so the all-zero mask below would otherwise
+    # outlive this test and be handed to the next free-boundary case sharing
+    # that key -- which reaches the Schur lane as an edge basis with no
+    # columns.  monkeypatch restores both entries at teardown.
+    seed = object()
+    monkeypatch.setitem(fbi._FREE_HOT_CACHE, cfg, seed)
+    monkeypatch.setitem(fbi._FREE_MASK_CACHE, fbi._mask_key(cfg),
+                        jax.tree.map(jnp.zeros_like, state))
     calls = []
 
     def solve(*_args, initial_state=None, **_kwargs):

--- a/tests/test_freeboundary_implicit.py
+++ b/tests/test_freeboundary_implicit.py
@@ -80,11 +80,10 @@ def test_free_boundary_warm_failure_retries_once_from_cold(monkeypatch):
                                     max_iterations=20)
     runtime = im._template_runtime(cfg.implicit)
     state = im._initial_state(runtime.setup)
-    # setitem, not plain assignment: these are module-level caches keyed on
-    # (resolution, lconm1, ncurr), so the all-zero mask below would otherwise
-    # outlive this test and be handed to the next free-boundary case sharing
-    # that key -- which reaches the Schur lane as an edge basis with no
-    # columns.  monkeypatch restores both entries at teardown.
+    # These are module-level caches keyed on (resolution, lconm1, ncurr), so
+    # monkeypatch.setitem restores both entries at teardown; a bare assignment
+    # would hand the all-zero mask to the next free-boundary case sharing that
+    # key, which reaches the Schur lane as an edge basis with no columns.
     seed = object()
     monkeypatch.setitem(fbi._FREE_HOT_CACHE, cfg, seed)
     monkeypatch.setitem(fbi._FREE_MASK_CACHE, fbi._mask_key(cfg),


### PR DESCRIPTION
## What

`tests/test_freeboundary_implicit.py` fails when run as a whole file and passes test-by-test. On `main`:

```
FAILED test_boundary_schur_adjoint_reproduces_the_coupled_gcrot_gradient
ValueError: need at least one array to stack
```

`test_free_boundary_warm_failure_retries_once_from_cold` writes an all-zero mask and a sentinel hot state directly into the module-level caches:

```python
seed = object(); fbi._FREE_HOT_CACHE[cfg] = seed
fbi._FREE_MASK_CACHE[fbi._mask_key(cfg)] = jax.tree.map(jnp.zeros_like, state)
```

and never removes them. `monkeypatch` restores the patched `_solve_free_boundary_stage` but knows nothing about the dict writes, so the zero mask outlives the test.

`_mask_key` is `(resolution, lconm1, ncurr, "free")`, which the later Schur test shares. It picks up the poisoned mask, finds no active edge degrees of freedom, and builds an empty column list — reaching `np.stack(columns, axis=1)` at [freeboundary_implicit.py:496](https://github.com/uwplasma/vmex/blob/main/vmex/core/freeboundary_implicit.py#L496) with nothing to stack.

**The cache key is not at fault** — it is the writes. `monkeypatch.setitem` restores both entries at teardown.

## Why CI never saw it

The two tests are in **different manifest selectors**, `pr-physics-core` and `pr-physics-field`, so they never share a process on a pull request. `weekly-single-stage-free` runs the whole file and would hit it, as does anyone running the file locally. `pytest-randomly` is not installed, so the ordering is deterministic — this is a reliable failure, not a flake.

Worth noting for CI design generally: a selector split that keeps two tests apart also hides state leaking between them. An explicit teardown assertion that the module caches (`_FREE_MASK_CACHE`, `_FREE_HOT_CACHE`, `_PACK_TABLE_CACHE`, `_FREE_LAST_RESULT`) are clean would catch this class directly rather than depending on how the suite happens to be partitioned.

## Verification

Before, whole file on clean `origin/main`: 1 failed, 6 passed, 1 skipped.
After: **7 passed, 1 skipped**, no failures.