### PR TITLE
Add traceable gmnc/bsupu/bsupv/bsubs tables for guiding-centre coupling

### DIFF
--- a/tests/test_boozer_tables.py
+++ b/tests/test_boozer_tables.py
@@ -1,12 +1,15 @@
 """A/B tests for :mod:`vmex.core.boozer_tables` vs the host wout engine.
 
 ``boozer_input_tables`` promises (see its docstring) wout-convention
-single-surface tables computed entirely in JAX: ``bmnc`` matching the host
-wout engine at ~1e-10 relative (identical quadrature), ``lmns``/``bsub*``
-at the wout engine's own half-mesh finite-difference level, and traced
-``iota``/``G``/``I`` equal to the wout ``iotas``/``bvco``/``buco`` rows.
-This module checks exactly those claims on the solovev deck, plus
-jit-compatibility of the whole table construction.
+single-surface tables computed entirely in JAX: ``bmnc`` and the
+``gmnc``/``bsupumnc``/``bsupvmnc``/``bsubsmns`` families matching the host
+wout engine at quadrature level (identical grid and mode weights),
+``lmns``/``bsub*`` at the wout engine's own half-mesh finite-difference
+level, and traced ``iota``/``G``/``I`` equal to the wout
+``iotas``/``bvco``/``buco`` rows.  This module checks exactly those claims
+on the solovev deck (plus a finite-pressure LASYM deck for the field
+tables), jit-compatibility of the whole table construction, and the forward
+boundary tangent of the field tables.
 """
 
 from __future__ import annotations
@@ -70,6 +73,23 @@ def lasym_solved():
     inp = dataclasses.replace(
         inp, ns_array=np.array([11]), ftol_array=np.array([1e-12]),
         niter_array=np.array([4000]))
+    eq = opt.solve_equilibrium(inp)
+    assert eq.result.converged
+    return eq
+
+
+@pytest.fixture(scope="module")
+def lasym_beta_eq():
+    """Finite-pressure up-down-asymmetric tokamak (test_stability deck, ns=13)."""
+    import dataclasses
+
+    from vmex.core import optimize as opt
+
+    inp = VmecInput.from_file(str(DATA_DIR / "input.up_down_asymmetric_tokamak"))
+    inp = dataclasses.replace(
+        inp, ns_array=np.array([13]), ftol_array=np.array([1e-10]),
+        niter_array=np.array([5000]), am=np.array([1.0, -1.0]),
+        pres_scale=5000.0)
     eq = opt.solve_equilibrium(inp)
     assert eq.result.converged
     return eq
@@ -194,6 +214,59 @@ def test_lasym_tables_match_the_wout_asymmetric_families(lasym_solved):
         np.testing.assert_allclose(np.asarray(tables[key])[mask], ref[mask],
                                    rtol=1e-8, atol=1e-10 * np.max(np.abs(rows)),
                                    err_msg=key)
+
+
+@pytest.mark.parametrize("deck", ["symmetric_eq", "lasym_beta_eq"])
+def test_field_tables_match_wout_rows_at_quadrature_level(deck, request):
+    """``gmnc``/``bsup*``/``bsubs*`` equal the wout engine rows exactly.
+
+    ``wrout.f`` writes ``sqrt(g)`` and ``B^u``/``B^v`` unfiltered on the full
+    Nyquist set and ``B_s`` (``bss.f``) as the full-mesh average of
+    consecutive half-mesh rows, so — unlike the jxbforce-filtered
+    ``bsubumnc``/``lmns`` — these tables share the engine's quadrature and
+    must match every mode of every interior row at round-off level
+    (measured <= 7.8e-15 relative on both decks).
+    """
+    eq = request.getfixturevalue(deck)
+    wout = eq.wout
+    ns = int(np.asarray(wout.iotas).shape[0])
+    lasym = wout.gmns is not None
+    tables = {j: boozer_input_tables(eq.state, eq.runtime, j)
+              for j in range(1, ns)}
+    xm, xn = tables[1]["xm"], tables[1]["xn"]
+
+    half_mesh = [("gmnc", wout.gmnc), ("bsupumnc", wout.bsupumnc),
+                 ("bsupvmnc", wout.bsupvmnc)]
+    full_mesh = [("bsubsmns", wout.bsubsmns)]
+    if lasym:
+        half_mesh += [("gmns", wout.gmns), ("bsupumns", wout.bsupumns),
+                      ("bsupvmns", wout.bsupvmns)]
+        full_mesh += [("bsubsmnc", wout.bsubsmnc)]
+
+    for key, wout_arr in half_mesh:
+        scale = float(np.max(np.abs(np.asarray(wout_arr)[1:])))
+        assert scale > 0.0, key                        # the family is populated
+        for j in range(1, ns):
+            ref, mask = _match_wout_row(wout.xm_nyq, wout.xn_nyq, wout_arr, j,
+                                        xm, xn)
+            np.testing.assert_allclose(
+                np.asarray(tables[j][key])[mask], ref[mask], rtol=0.0,
+                atol=1e-13 * scale, err_msg=f"{key} row {j}")
+
+    # B_s is half-mesh native here; the wout file stores the wrout.f full-mesh
+    # convention (row i = mean of half-mesh rows i and i+1), and the
+    # projection is linear, so the averaged tables must land on the wout rows.
+    for key, wout_arr in full_mesh:
+        scale = float(np.max(np.abs(np.asarray(wout_arr)[1:-1])))
+        assert scale > 0.0, key
+        for i in range(1, ns - 1):
+            ref, mask = _match_wout_row(wout.xm_nyq, wout.xn_nyq, wout_arr, i,
+                                        xm, xn)
+            got = 0.5 * (np.asarray(tables[i][key])
+                         + np.asarray(tables[i + 1][key]))
+            np.testing.assert_allclose(got[mask], ref[mask], rtol=0.0,
+                                       atol=1e-13 * scale,
+                                       err_msg=f"{key} row {i}")
 
 
 @pytest.mark.parametrize("deck", ["symmetric_eq", "lasym_solved"])
@@ -354,6 +427,69 @@ def test_tables_are_jittable(solved):
     # jit-vs-eager reassociation noise only
     np.testing.assert_allclose(got, np.asarray(tables["bmnc"]), rtol=1e-6,
                                atol=1e-14)
+
+
+def test_field_tables_jit_matches_eager(symmetric_eq):
+    """jit of the field-table construction returns the eager values."""
+    eq = symmetric_eq
+    j = int(np.asarray(eq.runtime.setup.s_full).shape[0]) // 2
+    eager = boozer_input_tables(eq.state, eq.runtime, j)
+    jitted = jax.jit(lambda s: boozer_input_tables(s, eq.runtime, j))(eq.state)
+    for key in ("gmnc", "bsupumnc", "bsupvmnc", "bsubsmns"):
+        scale = float(np.max(np.abs(np.asarray(eager[key]))))
+        assert scale > 0.0, key
+        np.testing.assert_allclose(np.asarray(jitted[key]),
+                                   np.asarray(eager[key]), rtol=1e-9,
+                                   atol=1e-13 * scale, err_msg=key)
+
+
+def test_bsupvmnc_jvp_from_boundary_tangent_is_live(symmetric_eq):
+    """A boundary-coefficient tangent drives the traceable ``bsupvmnc``.
+
+    Downstream loss-fraction objectives differentiate the field tables in the
+    boundary dofs, so the forward tangent must be live: push the ``RBC(0,1)``
+    direction through the implicit-function-theorem tangent system
+    ``dz = -(dF/dz)^{-1} dF/dp t`` at the solved solovev state, then one
+    ``jax.jvp`` of the table construction.  Measured max ``|d(bsupvmnc)|``
+    = 4.8e-2 against a table scale of 5.1e-2 (2026-08-22, x64 CPU).
+    """
+    import dataclasses
+
+    import jax.numpy as jnp
+
+    from vmex.core import implicit as im
+
+    eq = symmetric_eq
+    inp = eq.inp
+    cfg = im.make_config(inp, ftol=1e-14, max_iterations=3000)
+    p0 = im.params_from_input(inp)
+    j = int(np.asarray(eq.runtime.setup.s_full).shape[0]) // 2
+
+    rt0 = im.runtime_from_params(p0, cfg)
+    mask = im._dof_mask(eq.state, rt0, cfg)
+    P = im._dof_projector(cfg, mask)
+    edge_mask = im._edge_mask(cfg)
+    frozen = jax.lax.stop_gradient(eq.state)
+    F = im.residual_fn(cfg, frozen, mask)
+    z0 = P(frozen)
+
+    zero = jax.tree.map(jnp.zeros_like, p0)
+    tangent = dataclasses.replace(
+        zero, rbc=zero.rbc.at[int(inp.ntor), 1].set(1.0))
+    b = jax.jvp(lambda prm: F(z0, prm), (p0,), (tangent,))[1]
+    dz, _ = im._adjoint_solve(
+        lambda t: jax.jvp(lambda zz: F(zz, p0), (z0,), (t,))[1],
+        jax.tree.map(jnp.negative, b), cfg)
+
+    def table(zz, prm):
+        rt = im.runtime_from_params(prm, cfg)
+        state = im._assemble(zz, rt, frozen, P, edge_mask)
+        return boozer_input_tables(state, rt, j)["bsupvmnc"]
+
+    _, dot = jax.jvp(table, (z0, p0), (P(dz), tangent))
+    dot = np.asarray(dot)
+    assert np.all(np.isfinite(dot))
+    assert float(np.max(np.abs(dot))) > 1e-3
 
 
 def test_refine_booz_grids_is_the_identity_at_oversample_one():

--- a/vmex/core/boozer_tables.py
+++ b/vmex/core/boozer_tables.py
@@ -48,6 +48,16 @@ def boozer_input_tables(state: SpectralState, rt: SolverRuntime, j: int) -> dict
     - ``bmnc``, ``bsubumnc``, ``bsubvmnc``: |B| and the covariant field
       components, native to the half mesh (``bcovar.f``), projected on the
       grid-representable ``cos(m*theta - n*zeta)`` modes;
+    - ``gmnc``, ``bsupumnc``, ``bsupvmnc``: ``sqrt(g)`` and the contravariant
+      field components, which ``wrout.f`` writes unfiltered on the full
+      Nyquist set;
+    - ``bsubsmns``: the covariant radial field ``B_s = B^u g_su + B^v g_sv``
+      from the ``bss.f`` metric cross terms, native to the half mesh.  For
+      stellarator-symmetric equilibria ``B_s`` is odd under the reflection
+      ``(theta, zeta) -> (-theta, -zeta)``, so its symmetric table is the
+      *sine* family — parity opposite to ``bmnc``/``bsubumnc``.  The wout
+      file stores the full-mesh average of consecutive half-mesh rows
+      (``wrout.f``); this table stays on half-mesh row ``j``;
     - ``rmnc``, ``zmns``: R/Z tables from the full-mesh rows ``j-1``/``j``
       with the VMEC odd-m ``sqrt(s)`` parity interpolation to the half mesh;
     - ``lmns``: the wout lambda sine table, reconstructed from the
@@ -58,12 +68,13 @@ def boozer_input_tables(state: SpectralState, rt: SolverRuntime, j: int) -> dict
       ``nfp`` factor, wout convention).
 
     Validation (tests/test_boozer_tables.py, and the sfincs_jax
-    flagship-example tests where this function originated): ``bmnc`` and the
-    parity-interpolated ``rmnc/zmns`` match the host wout engine to
-    ~1e-15..1e-10 relative (identical quadrature); ``bsubumnc/bsubvmnc`` and
-    ``lmns`` agree at the ~1e-3 half-mesh finite-difference level (looser at
-    very small ``ns``), which is the wout engine's own grid discrepancy, not
-    an error of this projection.
+    flagship-example tests where this function originated): ``bmnc``, the
+    parity-interpolated ``rmnc/zmns``, and the ``gmnc/bsupumnc/bsupvmnc/
+    bsubsmns`` families match the host wout engine to ~1e-15..1e-10 relative
+    (identical quadrature); ``bsubumnc/bsubvmnc`` and ``lmns`` agree at the
+    ~1e-3 half-mesh finite-difference level (looser at very small ``ns``),
+    which is the wout engine's own grid discrepancy, not an error of this
+    projection.
 
     Parameters
     ----------
@@ -177,6 +188,38 @@ def boozer_input_tables(state: SpectralState, rt: SolverRuntime, j: int) -> dict
     bsubvmnc, bsubvmns = (jnp.where(covariant_modes, a, 0.0)
                           for a in (bsubvmnc, bsubvmns))
 
+    # sqrt(g), B^u, B^v: half-mesh natives that wrout.f writes unfiltered on
+    # the full Nyquist set (no jxbforce band limit, unlike bsubu/bsubv).
+    sqrt_g = mirror(jnp.asarray(jacobian.sqrt_g)[j], "even")
+    bsupu = mirror(jnp.asarray(fields.bsupu)[j], "even")
+    bsupv = mirror(jnp.asarray(fields.bsupv)[j], "even")
+    gmnc, bsupumnc, bsupvmnc = (project(a, "cos") for a in (sqrt_g, bsupu, bsupv))
+    gmns, bsupumns, bsupvmns = (project(a, "sin") for a in (sqrt_g, bsupu, bsupv))
+
+    # B_s = B^u g_su + B^v g_sv on the half mesh (bss.f): rv12/zv12 average
+    # the toroidal derivatives to the half mesh, rs12/zs12 add the
+    # d(shalf)/ds odd-m chain-rule terms (dphids = 0.25).  B_s is odd under
+    # the stellarator reflection, so the mirror flips sign and the symmetric
+    # table is the sine family.
+    sqrt_s_half = jnp.sqrt(s_half_j)
+
+    def zeta_derivative_half(even, odd):
+        return 0.5 * (jnp.asarray(even)[j] + jnp.asarray(even)[j - 1]
+                      + sqrt_s_half * (jnp.asarray(odd)[j] + jnp.asarray(odd)[j - 1]))
+
+    rv12 = zeta_derivative_half(geometry.dR_dzeta_even, geometry.dR_dzeta_odd)
+    zv12 = zeta_derivative_half(geometry.dZ_dzeta_even, geometry.dZ_dzeta_odd)
+    dphids = 0.25
+    rs12 = jnp.asarray(jacobian.dR_ds)[j] + dphids * (
+        jnp.asarray(geometry.R_odd)[j] + jnp.asarray(geometry.R_odd)[j - 1]) / sqrt_s_half
+    zs12 = jnp.asarray(jacobian.dZ_ds)[j] + dphids * (
+        jnp.asarray(geometry.Z_odd)[j] + jnp.asarray(geometry.Z_odd)[j - 1]) / sqrt_s_half
+    g_su = rs12 * jnp.asarray(jacobian.ru12)[j] + zs12 * jnp.asarray(jacobian.zu12)[j]
+    g_sv = rs12 * rv12 + zs12 * zv12
+    bsubs = mirror(jnp.asarray(fields.bsupu)[j] * g_su
+                   + jnp.asarray(fields.bsupv)[j] * g_sv, "odd")
+    bsubsmns, bsubsmnc = project(bsubs, "sin"), project(bsubs, "cos")
+
     # R, Z: full-mesh rows j-1, j -> spectral -> VMEC parity interpolation
     def phys_row(even, odd, row):
         return jnp.asarray(even)[row] + sqrt_s[row] * jnp.asarray(odd)[row]
@@ -222,6 +265,10 @@ def boozer_input_tables(state: SpectralState, rt: SolverRuntime, j: int) -> dict
                            s=s, signgs=setup.signgs)
     return dict(xm=xm, xn=xn, rmnc=rmnc, zmns=zmns, lmns=lmns, bmnc=bmnc,
                 bsubumnc=bsubumnc, bsubvmnc=bsubvmnc,
+                gmnc=gmnc, bsupumnc=bsupumnc, bsupvmnc=bsupvmnc,
+                bsubsmns=bsubsmns,
                 rmns=rmns, zmnc=zmnc, lmnc=lmnc, bmns=bmns,
-                bsubumns=bsubumns, bsubvmns=bsubvmns, iota=iota,
+                bsubumns=bsubumns, bsubvmns=bsubvmns,
+                gmns=gmns, bsupumns=bsupumns, bsupvmns=bsupvmns,
+                bsubsmnc=bsubsmnc, iota=iota,
                 G=jnp.asarray(cur.bvco)[j], I=jnp.asarray(cur.buco)[j])


### PR DESCRIPTION
## What

`boozer_input_tables` gains eight wout-convention spectral tables at a half-mesh row, fully traceable: `gmnc`, `bsupumnc`, `bsupvmnc`, `bsubsmns`, and the LASYM partners `gmns`, `bsupumns`, `bsupvmns`, `bsubsmnc`. These are the coefficients a guiding-centre integrator consumes (Phase 21: ESSOS takes exactly this set), and until now the only code producing them was `nyquist.wout_field_tables` — host NumPy end to end, no gradient.

The real-space ingredients were already traceable (`fields.bsupu/bsupv`, `jacobian.sqrt_g`); `bsubsmns` is a row-level traceable transcription of `bsubs_half_mesh` (bss.f: `rv12/zv12` half-mesh averages, the `dphids = 0.25` odd-m chain terms, `B_s = B^u g_su + B^v g_sv`), mirrored with odd parity since B_s is reflection-odd. The table stays half-mesh native; the test compares through wrout.f's full-mesh-average convention, which is linear so no tolerance is lost.

## Measured

Against vmex's own wout rows, every shared mode, all interior rows, gate 1e-13·scale:

| deck | worst relative |
|---|---|
| solovev (symmetric, ns=11) | 1.1e-15 across all four tables |
| up_down LASYM finite-beta (ns=13) | 7.8e-15 across all eight tables |

`jax.jit` matches eager to ≤4.4e-16. A boundary tangent pushed through the implicit-function-theorem tangent system and then `jax.jvp` through the tables gives max |d(bsupvmnc)| = 4.785e-2 against a table scale of 5.06e-2 — finite, nonzero, and of order the table itself.

Independently re-verified in a separate session: `gmnc`/`bsupumnc`/`bsupvmnc` at 1.1e-15 by direct wout comparison; the branch's own convention-correct `bsubsmns` gate passes.

## Scope

No new file, no new API surface — consumers pull named keys and XLA dead-code-eliminates unused tables under jit. The differentiable loss-fraction objective itself waits on ESSOS#61 (external review) per the standing decoupling policy; this PR is the vmex-side prerequisite and depends on no ESSOS API.

## Local verification (GitHub Actions minutes exhausted)

`ruff check vmex tests` clean; `mypy vmex` clean (66 files); `tests/test_boozer_tables.py tests/test_omnigenity.py`: 19 passed, 4 skipped (pre-existing importorskip/full gates). `tests/manifest.json` untouched — the file is registered whole in `pr-physics-field`. Full local matrix queued behind the release-branch run currently in progress.