### PR TITLE
Alpha-particle tracing: trace_alphas and vmex --trace on released ESSOS (Phase 21.2b/21.3)

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -33,6 +33,7 @@ parallel-ensembles
 :maxdepth: 1
 
 plot-diagnostics
+trace-alpha-particles
 use-wout-downstream
 troubleshoot
 ```

--- a/docs/howto/trace-alpha-particles.md
+++ b/docs/howto/trace-alpha-particles.md
@@ -1,0 +1,59 @@
+# Trace alpha particles
+
+`vmex --trace` follows an ensemble of fusion-born alpha particles
+(guiding-centre model, ESSOS tracer) through a converged equilibrium and
+reports the exact loss fraction; the same trace is one call away in Python
+via {func}`~vmex.core.tracing.trace_alphas`. Requires ESSOS
+(`pip install essos`).
+
+## From the CLI
+
+```console
+vmex --trace wout_case.nc                  # trace, print, four figures
+vmex input.case --trace                    # solve first, then trace
+vmex --trace wout_case.nc --outdir figs/ \
+     --trace-particles 400 --trace-tmax 1e-3 --trace-s 0.3
+```
+
+The console output gives the loss fraction, the lost / axis-termination /
+solver-failure counts, and the tracing wall time. Four figures are written
+next to the input (or into `--outdir`): `*_trace_trajectories.png` (sampled
+orbits in 3-D over a translucent LCFS), `*_trace_vparallel.png`
+(normalized parallel velocity), `*_trace_loss_fraction.png` (cumulative
+loss fraction against time), and `*_trace_energy_error.png` (relative
+energy error of the integrator).
+
+Particles start on one flux surface `s` (uniform in poloidal angle, one
+field period in toroidal angle, uniform pitch), at the fusion-alpha birth
+energy of 3.52 MeV. An orbit counts as lost when it reaches `s >= 0.99`.
+Loss fractions are physically meaningful at reactor scale — run
+`vmex --scale wout_case.nc` first to put the equilibrium at ARIES-CS field
+and size.
+
+## From Python
+
+```python
+import vmex as vj
+
+result = vj.trace_alphas("wout_case.nc", nparticles=400, tmax=1e-3)
+print(result.loss_fraction, result.particles_lost)
+vj.plot_tracing("wout_case.nc", result, outdir="figs")
+```
+
+`trace_alphas` accepts a path or an in-memory
+{class}`~vmex.core.wout.WoutData` (written through a temporary wout file —
+the route released ESSOS reads) and returns an
+{class}`~vmex.core.tracing.AlphaTracingResult` with the loss-fraction time
+series, per-particle loss times, trajectories in flux and Cartesian
+coordinates, energies, and the counts.
+
+## Scope
+
+This is the exact loss-fraction *diagnostic*; it is parity with the rest of
+the ecosystem — DESC v0.17 also ships particle tracing
+(`desc.particles.trace_particles`). The differentiable alpha-loss
+*objective* (a smooth surrogate a boundary optimization can descend) is a
+separate feature that waits on the ESSOS array-based field constructor
+(uwplasma/ESSOS#61) and vmex's traceable field tables. The exact loss
+fraction is piecewise constant in the boundary — use it to certify, not to
+optimize.

--- a/docs/reference/api/basic.rst
+++ b/docs/reference/api/basic.rst
@@ -47,3 +47,9 @@ Optional neoclassical diagnostics
 
 .. automodule:: vmex.core.neoclassical
    :members:
+
+Optional alpha-particle tracing
+-------------------------------
+
+.. automodule:: vmex.core.tracing
+   :members:

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -16,6 +16,7 @@ Usage
    vmex --plot mout_*.nc       — straight-axis mirror diagnostics
    vmex --booz wout_*.nc       — run booz_xform_jax, write boozmn_*.nc
    vmex --plot boozmn_*.nc     — Boozer contour/spectrum plots
+   vmex --trace wout_*.nc      — trace alpha particles (ESSOS), plot losses
    vmex --scale PATH [B R]     — dimensionally scale an input or WOUT
    vmex --doctor               — installation and JAX backend diagnostics
    vmex --test                 — run and plot the bundled quick-start case
@@ -53,6 +54,21 @@ Options
    * - ``--booz-surfaces S``
      - Boozer surfaces: comma/space-separated normalized ``s`` values, or
        ``all`` (default).
+   * - ``--trace``
+     - Trace fusion alpha particles through the equilibrium with ESSOS
+       (guiding centre, exact loss fraction): print the loss fraction and
+       the lost/axis-termination/failure counts, and write the four tracing
+       figures (3-D orbits, ``v_par/v``, loss fraction vs time, energy
+       error). Works on a ``wout_*.nc`` input or after solving an input
+       file (requires ESSOS, ``pip install essos``). See
+       :doc:`/howto/trace-alpha-particles`.
+   * - ``--trace-tmax X`` / ``--trace-timestep X``
+     - Tracing horizon / integrator step in seconds (defaults ``3e-4`` /
+       ``5e-7``).
+   * - ``--trace-particles N`` / ``--trace-times N``
+     - Ensemble size / saved samples per orbit (defaults 200 / 200).
+   * - ``--trace-s X`` / ``--trace-seed N``
+     - Launch surface ``s`` (default 0.25) and sampling seed (default 42).
    * - ``--outdir DIR``
      - Directory for wout/boozmn/figure output (default: alongside the
        input).

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -93,6 +93,7 @@
     ["tests/test_stability.py", "diagnostics", "oracle", "slow", "cpu-gpu", "golden", "external", ["pr-parity-c2", "full-core-n-s"]],
     ["tests/test_step_control.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "pr-fast", "full-core-n-s"]],
     ["tests/test_stress_high_force.py", "equilibrium", "integration", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "full-core-n-s"]],
+    ["tests/test_tracing.py", "diagnostics", "integration", "medium", "cpu", "none", "analytic", ["pr-parity-c2", "optional", "full-core-t-z"]],
     ["tests/test_turbulence.py", "diagnostics", "oracle", "slow", "cpu-gpu", "reference-nc", "external", ["pr-parity-c2", "optional", "full-core-t-z"]],
     ["tests/test_vacuum_analytic_recurrence.py", "free-boundary", "oracle", "slow", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "full-core-t-z"]],
     ["tests/test_validation_guards.py", "diagnostics", "unit", "fast", "cpu", "none", "none", ["pr-parity-c2", "full-core-t-z"]],

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,125 @@
+"""Alpha-particle tracing through released ESSOS (``vmex.core.tracing``).
+
+Small and honest: 8 particles over ``tmax = 1e-5`` s on the solovev quick
+case.  Gates: the trace runs on the released ESSOS surface, the counts are
+mutually consistent, the loss fraction is a fraction, the in-memory
+equilibrium route (temporary-wout hop) reproduces the file route, and
+``vmex --trace`` writes the four tracing figures end to end.  Skips cleanly
+without ESSOS.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+netCDF4 = pytest.importorskip("netCDF4")
+jax = pytest.importorskip("jax")
+pytest.importorskip("essos")
+
+jax.config.update("jax_enable_x64", True)
+
+from vmex.core import cli
+from vmex.core.tracing import trace_alphas
+from vmex.core.wout import read_wout
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "examples" / "data"
+SOLOVEV_DECK = DATA_DIR / "input.solovev"
+
+TRACE_KWARGS = dict(
+    tmax=1e-5, nparticles=8, s=0.25, seed=1, timestep=5e-7, times_to_trace=12,
+)
+
+
+@pytest.fixture(autouse=True)
+def _enable_jit():
+    """Tracing needs JIT (the repo conftest disables it for unit tests)."""
+    jax.config.update("jax_disable_jit", False)
+    yield
+
+
+@pytest.fixture(scope="module")
+def solovev_wout(tmp_path_factory) -> Path:
+    """One quiet CLI solve of the solovev deck, shared by the tests below."""
+    jax.config.update("jax_disable_jit", False)
+    outdir = tmp_path_factory.mktemp("trace_wout")
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        rc = cli.main([str(SOLOVEV_DECK), "--outdir", str(outdir), "--quiet"])
+    assert rc == 0, buffer.getvalue()
+    return outdir / "wout_solovev.nc"
+
+
+@pytest.fixture(scope="module")
+def traced(solovev_wout):
+    jax.config.update("jax_disable_jit", False)
+    return trace_alphas(solovev_wout, **TRACE_KWARGS)
+
+
+def test_counts_are_consistent(traced):
+    n = traced.nparticles
+    assert n == 8
+    lost = int(np.sum(traced.lost_times >= 0.0))
+    confined = int(np.sum(traced.lost_times < 0.0))
+    assert lost == traced.particles_lost
+    assert traced.particles_lost + confined == n
+    # Failed orbits (non-finite without a recorded loss) are a subset of the
+    # not-lost population, so lost + (confined - failed) + failed = n.
+    assert 0 <= traced.particles_failed <= confined
+    assert 0 <= traced.particles_unresolved <= n
+
+
+def test_loss_fraction_is_a_fraction(traced):
+    assert 0.0 <= traced.loss_fraction <= 1.0
+    assert traced.loss_fraction == pytest.approx(
+        traced.particles_lost / traced.nparticles)
+    assert traced.loss_fraction == pytest.approx(float(traced.loss_fractions[-1]))
+    assert np.all(np.diff(traced.loss_fractions) >= 0.0)  # cumulative
+
+
+def test_shapes_times_and_birth_energy(traced):
+    assert traced.trajectories.shape == (8, 12, 4)
+    assert traced.trajectories_xyz.shape == (8, 12, 3)
+    assert traced.times.shape == (12,)
+    assert traced.loss_fractions.shape == (12,)
+    assert traced.lost_times.shape == (8,)
+    assert traced.energies.shape == (8, 12)
+    assert traced.times[0] == 0.0
+    assert traced.times[-1] == pytest.approx(TRACE_KWARGS["tmax"])
+    # E(t=0) is the fusion-alpha birth energy by construction of mu.
+    np.testing.assert_allclose(
+        traced.energies[:, 0], traced.particle_energy, rtol=1e-12)
+    assert traced.particle_energy > 0.0
+    assert traced.total_speed > 0.0
+    assert traced.wall_time_s > 0.0
+
+
+def test_in_memory_equilibrium_matches_the_file_route(traced, solovev_wout):
+    result = trace_alphas(read_wout(solovev_wout), **TRACE_KWARGS)
+    assert result.particles_lost == traced.particles_lost
+    assert result.loss_fraction == pytest.approx(traced.loss_fraction)
+    np.testing.assert_allclose(result.trajectories, traced.trajectories)
+
+
+def test_cli_trace_writes_summary_and_figures(solovev_wout, tmp_path):
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        rc = cli.main([
+            str(solovev_wout), "--trace", "--outdir", str(tmp_path),
+            "--trace-particles", "8", "--trace-tmax", "1e-5",
+            "--trace-times", "12", "--trace-seed", "1",
+        ])
+    stdout = buffer.getvalue()
+    assert rc == 0, stdout
+    assert "Loss fraction:" in stdout
+    assert "Axis terminations:" in stdout
+    assert "Solver failures:" in stdout
+    for suffix in (
+        "trace_trajectories", "trace_vparallel",
+        "trace_loss_fraction", "trace_energy_error",
+    ):
+        assert (tmp_path / f"solovev_{suffix}.png").exists(), suffix

--- a/vmex/__init__.py
+++ b/vmex/__init__.py
@@ -19,6 +19,9 @@ Public API (lazily imported; ``import vmex as vj``):
 - :func:`~vmex.core.boozer.run_booz_xform` — Boozer transform (booz_xform_jax)
 - :func:`~vmex.core.neoclassical.epsilon_effective_from_wout` — optional
   NEO_JAX effective-ripple profile
+- :func:`~vmex.core.tracing.trace_alphas` /
+  :func:`~vmex.core.plotting.plot_tracing` — optional ESSOS alpha-particle
+  tracing (exact loss fraction; also ``vmex --trace``)
 - :func:`~vmex.core.mgrid.read_mgrid` / :func:`~vmex.core.mgrid.write_mgrid`
   / :func:`~vmex.core.mgrid.tabulate_cartesian_field`
   / :class:`~vmex.core.mgrid.MgridField` (mgrid or tabulated direct field)
@@ -149,6 +152,10 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
         ".core.neoclassical", "epsilon_effective_from_boozer"),
     "epsilon_effective_from_wout": (
         ".core.neoclassical", "epsilon_effective_from_wout"),
+    # alpha-particle tracing (ESSOS)
+    "AlphaTracingResult": (".core.tracing", "AlphaTracingResult"),
+    "trace_alphas": (".core.tracing", "trace_alphas"),
+    "plot_tracing": (".core.plotting", "plot_tracing"),
     # optimizer-neutral problem callables
     "Evaluation": (".core.problem", "Evaluation"),
     "FunctionProblem": (".core.problem", "FunctionProblem"),

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -10,7 +10,8 @@ The solve path is the clean-room core end to end:
 :func:`vmex.core.multigrid.solve_multigrid` (fixed boundary) or
 :func:`vmex.core.multigrid.solve_free_boundary_multigrid` (free boundary) ->
 :func:`vmex.core.wout.wout_from_state` -> :func:`vmex.core.wout.write_wout`,
-plus the core plotting (``--plot``) and Boozer (``--booz``) drivers.
+plus the core plotting (``--plot``), Boozer (``--booz``) and alpha-particle
+tracing (``--trace``, ESSOS) drivers.
 
 Zero-crash policy: every failure maps to a typed
 :class:`vmex.core.errors.VmecError`; the CLI prints the VMEC2000
@@ -149,6 +150,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  vmex --plot mout_*.nc  — straight-axis mirror diagnostics\n"
             "  vmex --booz wout_*.nc  — run booz_xform_jax, write boozmn_*.nc\n"
             "  vmex --plot boozmn_*.nc— Boozer contour/spectrum plots\n"
+            "  vmex --trace wout_*.nc — trace alpha particles (ESSOS), plot losses\n"
             "  vmex --scale input.X [B R] — scale an input or WOUT\n"
             "  vmex --doctor          — installation and JAX backend diagnostics\n"
             "  vmex --test            — run and plot the bundled quick-start case\n"
@@ -211,6 +213,40 @@ def build_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
         help="Boozer surfaces: comma/space-separated normalized s values, or 'all' (default).",
+    )
+    p.add_argument(
+        "--trace",
+        action="store_true",
+        help=(
+            "Trace fusion alpha particles through the equilibrium with ESSOS "
+            "(guiding centre): print the loss fraction and counts, and write "
+            "the orbit/loss/energy figures. Works on a wout_*.nc input or "
+            "after solving an input file (requires ESSOS)."
+        ),
+    )
+    p.add_argument(
+        "--trace-tmax", type=float, default=3e-4,
+        help="Tracing horizon in seconds (default: 3e-4).",
+    )
+    p.add_argument(
+        "--trace-particles", type=int, default=200,
+        help="Number of alpha particles (default: 200).",
+    )
+    p.add_argument(
+        "--trace-s", type=float, default=0.25,
+        help="Launch surface s = psi/psi_b (default: 0.25).",
+    )
+    p.add_argument(
+        "--trace-seed", type=int, default=42,
+        help="Sampling seed for angles and pitch (default: 42).",
+    )
+    p.add_argument(
+        "--trace-timestep", type=float, default=5e-7,
+        help="Integrator timestep in seconds (default: 5e-7).",
+    )
+    p.add_argument(
+        "--trace-times", type=int, default=200,
+        help="Number of saved samples per orbit (default: 200).",
     )
     p.add_argument("--outdir", type=str, default=None, help="Directory for wout/boozmn/figure output (default: alongside the input).")
     p.add_argument("--quiet", action="store_true", help="Silence the VMEC-style stdout.")
@@ -727,6 +763,8 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
             wout_path, args, plot_dir,
             plot=args.plot is not None, emit=emit, quiet=bool(args.quiet),
         )
+    if bool(args.trace):
+        _run_trace(wout_path, args, plot_dir, emit=emit, quiet=bool(args.quiet))
     if not bool(result.converged):  # NITER exhaustion: wout kept, distinct code
         return int(result.ier_flag) or 1
     return 0
@@ -790,6 +828,49 @@ def _run_booz(wout_path: Path, args, outdir: Path, *, plot: bool, emit, quiet: b
     if plot:
         _plot_boozmn_file(boozmn_path, outdir, emit=emit, quiet=quiet)
     return boozmn_path
+
+
+def _run_trace(wout_path: Path, args, outdir: Path, *, emit, quiet: bool) -> None:
+    """Alpha-particle tracing driver for ``--trace`` (requires ESSOS)."""
+    from .plotting import plot_tracing
+    from .tracing import trace_alphas
+
+    if not quiet:
+        emit(
+            f" Tracing {int(args.trace_particles)} alpha particles from "
+            f"s={float(args.trace_s):g} (ESSOS GuidingCenter, "
+            f"tmax={float(args.trace_tmax):.3g} s)"
+        )
+    try:
+        result = trace_alphas(
+            wout_path,
+            tmax=float(args.trace_tmax),
+            nparticles=int(args.trace_particles),
+            s=float(args.trace_s),
+            seed=int(args.trace_seed),
+            timestep=float(args.trace_timestep),
+            times_to_trace=int(args.trace_times),
+        )
+    except ImportError as exc:
+        raise VmecInputError(
+            WERROR_MESSAGES[INPUT_ERROR_FLAG],
+            hint="--trace requires essos (pip install essos)",
+        ) from exc
+    except ValueError as exc:  # e.g. lasym equilibria (released-ESSOS limit)
+        raise VmecInputError(
+            WERROR_MESSAGES[INPUT_ERROR_FLAG], hint=str(exc)
+        ) from exc
+    if not quiet:
+        emit(f" ESSOS tracing took {result.wall_time_s:.2f} s")
+        emit(
+            f" Loss fraction: {100.0 * result.loss_fraction:.2f}% "
+            f"({result.particles_lost} of {result.nparticles} particles lost)"
+        )
+        emit(f" Axis terminations: {result.particles_unresolved}")
+        emit(f" Solver failures: {result.particles_failed}")
+    for key, path in plot_tracing(wout_path, result, outdir).items():
+        if not quiet:
+            emit(f"   Saved {key}: {path}")
 
 
 # ---------------------------------------------------------------------------
@@ -1015,11 +1096,13 @@ def _dispatch(args, parser: argparse.ArgumentParser, *, emit) -> int:
     quiet = bool(args.quiet)
 
     if bool(args.scale):
-        if plot_requested or bool(args.booz) or bool(args.test):
-            parser.error("--scale cannot be combined with --plot, --booz, or --test")
+        if plot_requested or bool(args.booz) or bool(args.trace) or bool(args.test):
+            parser.error("--scale cannot be combined with --plot, --booz, --trace, or --test")
         return _scale_file(args, input_path, outdir, emit=emit)
 
     if _is_boozmn_path(input_path):
+        if bool(args.trace):
+            parser.error("particle tracing requires toroidal wout_*.nc inputs")
         if not plot_requested:
             parser.error("boozmn_*.nc inputs are plot-only; use --plot boozmn_*.nc")
         _plot_boozmn_file(input_path, plot_outdir, emit=emit, quiet=quiet)
@@ -1030,16 +1113,20 @@ def _dispatch(args, parser: argparse.ArgumentParser, *, emit) -> int:
             parser.error("mout_*.nc inputs are plot-only; use --plot mout_*.nc")
         if bool(args.booz):
             parser.error("Boozer transforms require toroidal wout_*.nc inputs")
+        if bool(args.trace):
+            parser.error("particle tracing requires toroidal wout_*.nc inputs")
         _plot_mout_file(input_path, plot_outdir, emit=emit, quiet=quiet)
         return 0
 
     if _is_wout_path(input_path):
-        if not plot_requested and not bool(args.booz):
-            parser.error("wout_*.nc inputs require --plot and/or --booz")
+        if not plot_requested and not bool(args.booz) and not bool(args.trace):
+            parser.error("wout_*.nc inputs require --plot, --booz, and/or --trace")
         if plot_requested:
             _plot_wout_file(input_path, plot_outdir, emit=emit, quiet=quiet)
         if bool(args.booz):
             _run_booz(input_path, args, plot_outdir, plot=plot_requested, emit=emit, quiet=quiet)
+        if bool(args.trace):
+            _run_trace(input_path, args, plot_outdir, emit=emit, quiet=quiet)
         return 0
 
     return _solve_input_file(args, input_path, outdir, emit=emit)

--- a/vmex/core/plotting.py
+++ b/vmex/core/plotting.py
@@ -31,6 +31,8 @@ Public API
 ----------
 ``plot_wout(path_or_WoutData, outdir, which=(...)) -> dict[str, Path]``
 ``plot_boozmn(path, outdir) -> dict[str, Path]``
+``plot_tracing(wout, result, outdir) -> dict[str, Path]`` — the four
+alpha-tracing figures for a :class:`~vmex.core.tracing.AlphaTracingResult`
 plus the per-figure helpers each of those dispatches to.
 """
 
@@ -58,6 +60,7 @@ __all__ = [
     "plot_boozmn_spectrum",
     "plot_boozmn_mode_profiles",
     "boozer_modB_on_surface",
+    "plot_tracing",
 ]
 
 _DPI = 200            # publication resolution for every saved PNG
@@ -1738,3 +1741,160 @@ def plot_boozmn(
         fn, filename = plotters[key]
         results[key] = fn(bx, outdir / filename)
     return results
+
+
+# ==========================================================================
+# Alpha-particle tracing figures (vmex --trace; see vmex.core.tracing)
+# ==========================================================================
+
+def _trace_indices(nparticles: int, n_trajectories: int) -> np.ndarray:
+    """Evenly spaced particle indices — deterministic figure content."""
+    count = max(1, min(int(n_trajectories), int(nparticles)))
+    return np.unique(np.linspace(0, nparticles - 1, count).astype(int))
+
+
+def _finite_or_nan(values: np.ndarray) -> np.ndarray:
+    """Replace non-finite samples (post-loss event fill) with NaN gaps."""
+    return np.where(np.isfinite(values), values, np.nan)
+
+
+def plot_trace_trajectories(
+    wout, result, out_path: str | Path, *, n_trajectories: int = 4,
+) -> Path:
+    """Sampled guiding-centre orbits in 3-D over a translucent LCFS."""
+    plt = _import_matplotlib()
+    wout, _ = _as_wout(wout)
+    with _rc_context():
+        fig = plt.figure(figsize=(6.4, 5.6), frameon=False)
+        ax = fig.add_subplot(111, projection="3d")
+        theta = np.linspace(0.0, 2.0 * np.pi, 60)
+        phi = np.linspace(0.0, 2.0 * np.pi, 180)
+        R, Z = surface_rz(wout, s_index=int(wout.ns) - 1, theta=theta, phi=phi)
+        phi2d = np.meshgrid(phi, theta)[0]
+        X, Y = R * np.cos(phi2d), R * np.sin(phi2d)
+        ax.plot_surface(
+            X, Y, Z, color="0.6", alpha=0.2, rstride=2, cstride=2,
+            linewidth=0.0, antialiased=False, shade=False,
+        )
+        for i in _trace_indices(result.nparticles, n_trajectories):
+            xyz = result.trajectories_xyz[i]
+            finite = np.isfinite(xyz).all(axis=1)
+            ax.plot(
+                xyz[finite, 0], xyz[finite, 1], xyz[finite, 2],
+                lw=1.2, label=f"particle {i + 1}",
+            )
+        scale = 0.7 * max(np.abs(X).max(), np.abs(Y).max())
+        ax.auto_scale_xyz([-scale, scale], [-scale, scale], [-scale, scale])
+        ax.set_box_aspect([1, 1, 1]); ax.set_axis_off()
+        ax.legend(loc="upper right")
+        out_path = Path(out_path)
+        fig.savefig(out_path, dpi=_DPI, bbox_inches="tight", pad_inches=0.05)
+        plt.close(fig)
+    return out_path
+
+
+def plot_trace_vparallel(
+    result, out_path: str | Path, *, n_trajectories: int = 4,
+) -> Path:
+    """Normalized parallel velocity ``v_par/v`` of the sampled orbits."""
+    plt = _import_matplotlib()
+    with _rc_context():
+        fig, ax = plt.subplots(figsize=(6.4, 4.2), layout="constrained")
+        for i in _trace_indices(result.nparticles, n_trajectories):
+            vpar = result.trajectories[i, :, 3] / result.total_speed
+            ax.plot(result.times, _finite_or_nan(vpar), label=f"particle {i + 1}")
+        ax.set_ylim(-1.0, 1.0)
+        ax.set_xlabel("time [s]")
+        ax.set_ylabel(r"$v_{\parallel}/v$")
+        ax.legend()
+        out_path = Path(out_path)
+        fig.savefig(out_path, dpi=_DPI)
+        plt.close(fig)
+    return out_path
+
+
+def plot_trace_loss_fraction(result, out_path: str | Path) -> Path:
+    """Cumulative loss fraction against time."""
+    plt = _import_matplotlib()
+    with _rc_context():
+        fig, ax = plt.subplots(figsize=(6.4, 4.2), layout="constrained")
+        ax.plot(result.times, result.loss_fractions, "-")
+        ax.set_ylim(0.0, 1.0)
+        ax.set_xlabel("time [s]")
+        ax.set_ylabel("loss fraction")
+        ax.set_title(
+            f"final loss fraction {100.0 * result.loss_fraction:.2f}% "
+            f"({result.particles_lost} of {result.nparticles})"
+        )
+        out_path = Path(out_path)
+        fig.savefig(out_path, dpi=_DPI)
+        plt.close(fig)
+    return out_path
+
+
+def plot_trace_energy_error(
+    result, out_path: str | Path, *, n_trajectories: int = 4,
+) -> Path:
+    """Relative energy error of the sampled orbits (integrator quality)."""
+    plt = _import_matplotlib()
+    with _rc_context():
+        fig, ax = plt.subplots(figsize=(6.4, 4.2), layout="constrained")
+        # Skip the first samples, exact by construction of mu (t = 0).
+        times = result.times[2:]
+        indices = _trace_indices(result.nparticles, n_trajectories)
+        errors = np.abs(
+            result.energies[indices, 2:] / result.particle_energy - 1.0)
+        for i, error in zip(indices, errors):
+            ax.plot(times, _finite_or_nan(error), label=f"particle {i + 1}")
+        # Promptly lost ensembles can leave no positive finite error samples;
+        # a log axis cannot autoscale on that, so keep linear axes then.
+        if np.any(np.isfinite(errors) & (errors > 0.0)):
+            ax.set_xscale("log"); ax.set_yscale("log")
+        ax.set_xlabel("time [s]")
+        ax.set_ylabel("relative energy error")
+        ax.legend()
+        out_path = Path(out_path)
+        fig.savefig(out_path, dpi=_DPI)
+        plt.close(fig)
+    return out_path
+
+
+def plot_tracing(
+    wout, result, outdir: str | Path, *,
+    name: str | None = None, n_trajectories: int = 4,
+) -> dict[str, Path]:
+    """Write the four alpha-tracing figures for one tracing result.
+
+    Parameters
+    ----------
+    wout:
+        The traced equilibrium — path to ``wout_*.nc`` or a
+        :class:`~vmex.core.wout.WoutData` (LCFS backdrop of the 3-D figure).
+    result:
+        An :class:`~vmex.core.tracing.AlphaTracingResult` from
+        :func:`~vmex.core.tracing.trace_alphas`.
+    outdir, name:
+        Output directory (created if missing) and basename prefix
+        (default: case name from the wout path).
+    n_trajectories:
+        Number of evenly sampled orbits in the per-particle figures.
+
+    Returns a mapping from figure key (``trajectories``, ``vparallel``,
+    ``loss_fraction``, ``energy_error``) to the written PNG path.
+    """
+    data, default_name = _as_wout(wout)
+    label = name or default_name
+    outdir = _ensure_outdir(outdir)
+    return {
+        "trajectories": plot_trace_trajectories(
+            data, result, outdir / f"{label}_trace_trajectories.png",
+            n_trajectories=n_trajectories),
+        "vparallel": plot_trace_vparallel(
+            result, outdir / f"{label}_trace_vparallel.png",
+            n_trajectories=n_trajectories),
+        "loss_fraction": plot_trace_loss_fraction(
+            result, outdir / f"{label}_trace_loss_fraction.png"),
+        "energy_error": plot_trace_energy_error(
+            result, outdir / f"{label}_trace_energy_error.png",
+            n_trajectories=n_trajectories),
+    }

--- a/vmex/core/plotting.py
+++ b/vmex/core/plotting.py
@@ -1865,20 +1865,12 @@ def plot_tracing(
 ) -> dict[str, Path]:
     """Write the four alpha-tracing figures for one tracing result.
 
-    Parameters
-    ----------
-    wout:
-        The traced equilibrium — path to ``wout_*.nc`` or a
-        :class:`~vmex.core.wout.WoutData` (LCFS backdrop of the 3-D figure).
-    result:
-        An :class:`~vmex.core.tracing.AlphaTracingResult` from
-        :func:`~vmex.core.tracing.trace_alphas`.
-    outdir, name:
-        Output directory (created if missing) and basename prefix
-        (default: case name from the wout path).
-    n_trajectories:
-        Number of evenly sampled orbits in the per-particle figures.
-
+    ``wout`` is the traced equilibrium — a ``wout_*.nc`` path or a
+    :class:`~vmex.core.wout.WoutData` — used as the LCFS backdrop of the 3-D
+    figure; ``result`` is an :class:`~vmex.core.tracing.AlphaTracingResult`
+    from :func:`~vmex.core.tracing.trace_alphas`.  Figures land in ``outdir``
+    (created if missing) under ``name`` (default: the wout case name), with
+    ``n_trajectories`` evenly sampled orbits in the per-particle panels.
     Returns a mapping from figure key (``trajectories``, ``vparallel``,
     ``loss_fraction``, ``energy_error``) to the written PNG path.
     """

--- a/vmex/core/tracing.py
+++ b/vmex/core/tracing.py
@@ -1,0 +1,212 @@
+"""Alpha-particle guiding-centre tracing through released ESSOS.
+
+- :func:`trace_alphas` — trace fusion-born alpha particles launched from one
+  flux surface of an equilibrium and return the exact loss-fraction
+  diagnostics as an :class:`AlphaTracingResult`.
+
+The tracer is ESSOS (``essos.dynamics.Tracing`` over ``essos.fields.Vmec``),
+imported inside the call so vmex imports without ESSOS installed.  Only the
+released ESSOS surface is used — ``Vmec(wout_filename)``, ``Particles``,
+``Tracing`` and its ``loss_fractions``/``lost_times``/``trajectories``
+outputs.  Consequences of that restriction:
+
+- ``essos.fields.Vmec`` reads a wout *file*, so an in-memory equilibrium
+  (:class:`~vmex.core.wout.WoutData`) takes a temporary-wout hop through
+  :func:`~vmex.core.wout.write_wout`.  The file write severs any gradient;
+  the differentiable loss-fraction objective is a separate feature gated on
+  the ESSOS array constructor (uwplasma/ESSOS#61) and is not provided here.
+- The particle energy along each orbit is reconstructed locally from
+  ``0.5*m*v_par^2 + mu*|B|`` (released ESSOS exposes it inconsistently
+  across versions: an eager array in 0.16, a method on the development line).
+- Released ESSOS keeps no solver-failure ledger, so ``particles_failed``
+  counts trajectories with non-finite samples that ESSOS did not attribute
+  to a boundary loss; axis terminations are reported when the installed
+  ESSOS tracks them and are zero otherwise (0.16 has no axis event).
+
+Particles are sampled uniformly on the surface ``s``: ``theta`` over
+``[0, 2*pi)``, ``phi`` over one field period ``[0, 2*pi/nfp)``, and pitch
+``v_par/v`` over ``[-1, 1)``, from ``jax.random.PRNGKey(seed)``.  A particle
+counts as lost when its orbit reaches ``s >= 0.99`` (the ESSOS
+``loss_fraction`` criterion).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _essos_imports():
+    try:
+        from essos import constants, dynamics, fields
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "alpha-particle tracing requires ESSOS (`pip install essos`)"
+        ) from exc
+    return constants, dynamics, fields
+
+
+@dataclasses.dataclass(frozen=True)
+class AlphaTracingResult:
+    """Exact alpha-loss diagnostics from one :func:`trace_alphas` call.
+
+    ``trajectories`` holds the guiding-centre coordinates
+    ``(s, theta, phi, v_par)`` at each saved time; lost orbits keep the
+    non-finite post-event samples ESSOS writes after the boundary crossing.
+    ``lost_times`` is ``-1`` for particles that were never lost.
+    """
+
+    nparticles: int
+    loss_fraction: float
+    particles_lost: int
+    particles_unresolved: int
+    particles_failed: int
+    wall_time_s: float
+    particle_energy: float
+    total_speed: float
+    times: np.ndarray = dataclasses.field(repr=False)
+    loss_fractions: np.ndarray = dataclasses.field(repr=False)
+    lost_times: np.ndarray = dataclasses.field(repr=False)
+    trajectories: np.ndarray = dataclasses.field(repr=False)
+    trajectories_xyz: np.ndarray = dataclasses.field(repr=False)
+    energies: np.ndarray = dataclasses.field(repr=False)
+
+
+def trace_alphas(
+    source: Any,
+    *,
+    tmax: float = 3e-4,
+    nparticles: int = 200,
+    s: float = 0.25,
+    seed: int = 42,
+    timestep: float = 5e-7,
+    times_to_trace: int = 200,
+    model: str = "GuidingCenter",
+) -> AlphaTracingResult:
+    """Trace fusion alphas from surface ``s`` of a wout file or equilibrium.
+
+    Parameters
+    ----------
+    source:
+        Path to a ``wout_*.nc`` file, or an in-memory
+        :class:`~vmex.core.wout.WoutData` (written to a temporary wout —
+        the released-ESSOS route into ``essos.fields.Vmec``).
+    tmax, timestep, times_to_trace:
+        Integration horizon [s], integrator step [s], and number of saved
+        samples (uniform in time, including ``t = 0``).
+    nparticles, s, seed:
+        Ensemble size, launch surface, and sampling seed (see module notes).
+    model:
+        ESSOS tracing model (``"GuidingCenter"`` by default).
+    """
+    essos = _essos_imports()
+
+    if hasattr(source, "rmnc") and hasattr(source, "xm"):  # WoutData
+        if bool(source.lasym):
+            raise ValueError(
+                "released ESSOS traces stellarator-symmetric fields only; "
+                "the lasym partner tables would be silently dropped"
+            )
+        from .wout import write_wout
+
+        with tempfile.TemporaryDirectory(prefix="vmex_trace_") as tmp:
+            wout_path = Path(tmp) / "wout_equilibrium.nc"
+            write_wout(wout_path, source)
+            return _trace_wout_file(
+                wout_path, essos, tmax=tmax, nparticles=nparticles,
+                s=s, seed=seed, timestep=timestep,
+                times_to_trace=times_to_trace, model=model,
+            )
+
+    wout_path = Path(source)
+    import netCDF4
+
+    with netCDF4.Dataset(str(wout_path)) as ds:
+        if bool(int(ds.variables["lasym__logical__"][()])):
+            raise ValueError(
+                "released ESSOS traces stellarator-symmetric fields only; "
+                f"{wout_path.name} is an lasym equilibrium"
+            )
+    return _trace_wout_file(
+        wout_path, essos, tmax=tmax, nparticles=nparticles, s=s,
+        seed=seed, timestep=timestep, times_to_trace=times_to_trace,
+        model=model,
+    )
+
+
+def _trace_wout_file(
+    wout_path: Path, essos, *, tmax: float, nparticles: int,
+    s: float, seed: int, timestep: float, times_to_trace: int, model: str,
+) -> AlphaTracingResult:
+    constants, dynamics, fields = essos
+    import jax
+    import jax.numpy as jnp
+
+    vmec = fields.Vmec(str(wout_path))
+
+    theta_key, phi_key, pitch_key = jax.random.split(
+        jax.random.PRNGKey(int(seed)), 3)
+    theta = jax.random.uniform(
+        theta_key, (nparticles,), minval=0.0, maxval=2.0 * jnp.pi)
+    phi = jax.random.uniform(
+        phi_key, (nparticles,), minval=0.0, maxval=2.0 * jnp.pi / int(vmec.nfp))
+    pitch = jax.random.uniform(
+        pitch_key, (nparticles,), minval=-1.0, maxval=1.0)
+    particles = dynamics.Particles(
+        initial_xyz=jnp.stack(
+            [jnp.full((nparticles,), float(s)), theta, phi], axis=1),
+        initial_vparallel_over_v=pitch,
+        mass=constants.ALPHA_PARTICLE_MASS,
+        charge=constants.ALPHA_PARTICLE_CHARGE,
+        energy=constants.FUSION_ALPHA_PARTICLE_ENERGY,
+    )
+
+    start = time.perf_counter()
+    tracing = dynamics.Tracing(
+        field=vmec, particles=particles, maxtime=float(tmax),
+        timestep=float(timestep), times_to_trace=int(times_to_trace),
+        model=model,
+    )
+    wall_time_s = time.perf_counter() - start
+
+    trajectories = np.asarray(tracing.trajectories, dtype=float)
+    lost_times = np.asarray(tracing.lost_times, dtype=float)
+    loss_fractions = np.asarray(tracing.loss_fractions, dtype=float)
+
+    # Energy along each orbit from the guiding-centre invariant
+    # E = 0.5*m*v_par^2 + mu*|B|, with mu fixed by the first sample.
+    mass = float(particles.mass)
+    particle_energy = float(particles.energy)
+    absB = np.asarray(
+        jax.vmap(vmec.AbsB)(
+            jnp.asarray(trajectories[:, :, :3].reshape(-1, 3))),
+        dtype=float,
+    ).reshape(nparticles, -1)
+    vpar = trajectories[:, :, 3]
+    mu = (particle_energy - 0.5 * mass * vpar[:, 0] ** 2) / absB[:, 0]
+    energies = 0.5 * mass * vpar**2 + mu[:, None] * absB
+
+    lost_mask = lost_times >= 0.0
+    finite_mask = np.isfinite(trajectories).all(axis=(1, 2))
+    return AlphaTracingResult(
+        nparticles=int(nparticles),
+        loss_fraction=float(loss_fractions[-1]),
+        particles_lost=int(round(float(tracing.total_particles_lost))),
+        particles_unresolved=int(
+            getattr(tracing, "total_particles_unresolved", 0) or 0),
+        particles_failed=int(np.sum(~finite_mask & ~lost_mask)),
+        wall_time_s=float(wall_time_s),
+        particle_energy=particle_energy,
+        total_speed=float(particles.total_speed),
+        times=np.asarray(tracing.times, dtype=float),
+        loss_fractions=loss_fractions,
+        lost_times=lost_times,
+        trajectories=trajectories,
+        trajectories_xyz=np.asarray(tracing.trajectories_xyz, dtype=float),
+        energies=energies,
+    )


### PR DESCRIPTION
Phase 21.2b/21.3 of the plan: `vmex/core/tracing.py` (`trace_alphas`) and `vmex --trace`, built on **released ESSOS only**.

## What's in

- **`vmex.core.tracing.trace_alphas(source, *, tmax=3e-4, nparticles=200, s=0.25, seed=42, timestep=5e-7, times_to_trace=200, model="GuidingCenter")`** — traces fusion-born alphas from one flux surface and returns a frozen `AlphaTracingResult`: `loss_fraction`, `loss_fractions` time series, `lost_times`, flux/Cartesian `trajectories`, per-orbit energies, lost/unresolved/failed counts, and the tracing wall time. `source` is a wout path or a solved in-memory `WoutData`; the in-memory route writes a temporary wout through the existing writer, because released `essos.fields.Vmec` reads files only (documented; the file hop severs any gradient, none is claimed). ESSOS is imported inside the call, so `import vmex` works without ESSOS.
- **`vmex --trace wout_*.nc`** (also after solving an input file), dispatched like `--plot`/`--booz`: prints loss fraction, counts and timing; writes the four figures of the #122 reference script — 3-D orbits over a translucent LCFS, `v_par/v`, loss fraction vs time, relative energy error — via `plotting.plot_tracing`, reusing the house rc/saving conventions. Tracing knobs exposed as `--trace-tmax/--trace-particles/--trace-s/--trace-seed/--trace-timestep/--trace-times` with the Phase 21 defaults. No hardcoded wout paths; no `XLA_FLAGS` device-count mutation (device sharding is ESSOS's own runtime policy).
- Tests (`tests/test_tracing.py`, 8 particles, `tmax=1e-5`, solovev quick deck): count identities (lost from `lost_times` == reported lost; lost + confined == nparticles; failed disjoint from lost), loss fraction in [0, 1] and equal to `lost/n`, shapes/birth-energy checks, in-memory route reproduces the file route bit-for-bit, and CLI end-to-end writes the four PNGs. `pytest.importorskip("essos")` keeps the module a clean skip without ESSOS. Registered in `tests/manifest.json` (one record line, `diagnostics`/`integration`/`medium`, lanes `pr-parity-c2, optional, full-core-t-z` — off `pr-fast`).
- Docs: `docs/howto/trace-alpha-particles.md` (+ howto toctree), CLI reference rows, `vmex.core.tracing` API entry, lazy exports `trace_alphas`/`AlphaTracingResult`/`plot_tracing`. The howto states plainly that DESC v0.17 also ships particle tracing (`desc.particles.trace_particles`) — this feature is parity; the differentiable objective is the differentiator and comes separately.

## Released-ESSOS surface used (and verified)

Verified against **both** the PyPI release (`essos==0.16` wheel, inspected) and the installed development checkout (`0.17.dev247+g8631a66f9`): `essos.fields.Vmec(wout_filename)`, `essos.dynamics.Particles`, `essos.dynamics.Tracing(field, particles, maxtime, timestep, times_to_trace, model)`, and the outputs `loss_fractions`, `total_particles_lost`, `lost_times`, `trajectories`, `trajectories_xyz`, `times`, plus `Vmec.AbsB`/`nfp` and the alpha constants. Where the two lines disagree, vmex sides with what both provide:

- orbit energies are reconstructed locally from `0.5*m*v_par^2 + mu*|B|` (0.16 exposes `energy` as an eager array, the dev line as a method — neither is relied on);
- `particles_unresolved` reads `total_particles_unresolved` when the installed ESSOS tracks axis events and is 0 otherwise (0.16 has no axis event — genuinely zero there);
- `particles_failed` is counted in vmex (non-finite trajectory samples not attributed to a boundary loss) — released ESSOS keeps no failure ledger;
- `lasym` equilibria are rejected with a clear error (released `Vmec` reads only the symmetric tables and would silently drop the partners).

## Out of scope (waits on ESSOS #61 + vmex #137)

The differentiable `alpha_loss_fraction` optimizable (21.2/21.4/21.5's gradient gates): needs `Vmec.from_arrays` and `soft_loss_fraction` from uwplasma/ESSOS#61 (open, awaiting an independent reviewer) and the traceable field tables (`feat/traceable-field-tables` / #137). Nothing in this PR calls or feature-detects that API.

**#122 superseded.** This PR turns `examples/optimization/trace_particles.py` (the #122 script, never merged) into the feature Phase 21 asked for — same sampling, same tracer, same four figures, minus the hardcoded wout path and the import-time `XLA_FLAGS` mutation the plan bans. #122 can be closed when this merges.

## Local verification (Actions is out of minutes)

- `ruff check .` — clean; `mypy vmex` — clean (67 files).
- `pytest tests/test_tracing.py` — 5 passed, **14.3 s cold-cache** (12.6 s warm).
- `pytest tests/test_test_manifest.py tests/test_docs_nav.py` — 8 passed, 3 skipped (built-HTML checks), 4.6 s; manifest ownership gate collects the new module.
- `pytest tests/test_cli.py tests/test_package_api.py -n 2` — 35 passed, 2 failed: `test_bundled_test_smoke` and `test_python_dash_m_version[argv0]` **fail identically on unmodified `main` (274e7ac2) in this environment** — a stale `vmex 0.5.0` in site-packages shadows the subprocess `python -m vmex` calls. Pre-existing, unrelated.
- `pytest tests/test_plot_summary.py tests/test_plotting_boozer.py -n 2` — 32 passed, 2:03.
- Sanity trace on the solovev quick case (8 alphas, 1e-5 s): 7 lost, 1 axis termination, 0 failures, loss fraction 0.875 — prompt loss of 3.5 MeV alphas in a table-top tokamak, as expected.
