### PR TITLE
Expect the stability panel in the bundled smoke figures

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -237,7 +237,9 @@ def test_bundled_test_smoke(tmp_path):
     wout = read_wout(tmp_path / "wout_nfp4_QH_warm_start.nc")
     assert int(wout.ns) == 35
     figures = sorted(p.name for p in (tmp_path / "figures").glob("*.png"))
-    assert len(figures) == 5, figures
+    # boundary3d, modB, profiles, stability, summary, surfaces
+    assert len(figures) == 6, figures
+    assert any("stability" in f for f in figures), figures
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`vmex --test` writes six figures since #118 added the stability panel to `plot_wout`; `test_bundled_test_smoke` (full lane) still asserted five, so the full lane fails on current main. Pin six and require the stability panel by name.

Found while verifying #138 locally; reproduced on unmodified main. Local verification: the test passes (35 s), ruff clean. Not caught by the PR matrices because the test carries the `full` mark.