### PR TITLE
Allow 'trace' as a how-to verb

### DIFF
--- a/tools/check_docs_prose.py
+++ b/tools/check_docs_prose.py
@@ -47,6 +47,7 @@ HOWTO_VERBS = {
     "run", "restart", "scan", "set", "scale", "optimize", "solve", "use",
     "diagnose", "plot", "troubleshoot", "build", "read", "write", "pick",
     "choose", "configure", "convert", "profile", "differentiate", "resume",
+    "trace",
 }
 
 TODO_RE = re.compile(r"\b(TODO|FIXME|XXX)\b")


### PR DESCRIPTION
`docs/howto/trace-alpha-particles.md` shipped with #138 and fails `tools/check_docs_prose.py`, which checks how-to titles against an allow-list of verbs. "Trace" is a legitimate verb; the gate's own error message says to extend the list. **main currently fails this gate.**

It escaped both hosted CI (Actions was already out of minutes when #138 landed) and my local matrix, whose quality job replicated ruff/mypy/build/sphinx but not `check_docs_prose.py` — the local runner has been corrected to match the workflow exactly.

Local verification: gate clean, ruff clean.