### PR TITLE
Scrape what the optimization examples actually print

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -433,16 +433,24 @@ def test_qi_maxj_continuation_example(tmp_path):
     assert (tmp_path / "QI_maxJ_optimized_summary.png").stat().st_size > 10_000
 
 
-@pytest.mark.full  # nightly: QP-basin + QI stages + Boozer, subprocess cold-start heavy
+@pytest.mark.full  # nightly: QI mode ladder + Boozer, subprocess cold-start heavy
 def test_qi_optimization_example(tmp_path):
     pytest.importorskip("booz_xform_jax")
     script = EXAMPLES / "optimization" / "QI_optimization.py"
     out = _run_example(script, tmp_path)
     _assert_cost_decreased(out, "QI")
-    match = re.search(r"QI total: seed ([0-9.eE+-]+) -> final ([0-9.eE+-]+)", out)
-    assert match is not None
-    seed, final = float(match.group(1)), float(match.group(2))
-    assert np.isfinite(final) and final <= seed * 1.05
+    stage = re.search(r"\[QI mode \d+\] constructed QI = ([0-9.eE+-]+)", out)
+    final = re.search(r"\[final\] constructed QI = ([0-9.eE+-]+)", out)
+    assert stage is not None and final is not None
+    # the finer re-solve the example ends on must not undo the optimization
+    assert np.isfinite(float(final.group(1)))
+    assert float(final.group(1)) <= 1.05 * float(stage.group(1))
+    # the headline line carries the optimized total and its independent
+    # recomputation (equal grids under the CI budget, finer otherwise)
+    totals = re.search(r"QI total ([0-9.eE+-]+); independent fine-grid "
+                       r"validation ([0-9.eE+-]+)", out)
+    assert totals is not None
+    assert all(np.isfinite(float(value)) for value in totals.groups())
     assert (tmp_path / "wout_QI_optimized.nc").exists()
 
 
@@ -499,9 +507,10 @@ def test_bootstrap_optimization_examples(case, figure_of_merit, tmp_path):
 
 
 @pytest.mark.full  # nightly: optional optimizer interoperability, cold JAX compilation
+# each wout name carries the script's own METHOD constant
 @pytest.mark.parametrize(("script_name", "dependency", "output"), [
-    ("QA_optimization_scipy.py", None, "wout_QA_scipy_BFGS.nc"),
-    ("QI_optimization_scipy.py", None, "wout_QI_scipy_BFGS.nc"),
+    ("QA_optimization_scipy.py", None, "wout_QA_scipy_L-BFGS-B.nc"),
+    ("QI_optimization_scipy.py", None, "wout_QI_scipy_L-BFGS-B.nc"),
     ("QI_optimization_jaxopt.py", "jaxopt", "wout_QI_jaxopt_LBFGS.nc"),
     ("QI_optimization_optax.py", "optax", "wout_QI_optax_adam.nc"),
 ])


### PR DESCRIPTION
Three full-marked example assertions fail on main. All three are test bugs, not example regressions.

**`test_qi_optimization_example`** looked for `QI total: seed … -> final …`. Commit `109dcf00` removed the seed report; the example now prints `[QI mode 2] constructed QI = …`, `[final] constructed QI = …`, and `QI total 6.602e-01; independent fine-grid validation 6.602e-01`. `_assert_cost_decreased` passes throughout, so the optimization itself is healthy. The regex now reads the lines the example emits and keeps the non-regression check (final ≤ 1.05x the last stage).

**`test_scalar_optimizer_examples[QA_optimization_scipy.py]` and `[QI_optimization_scipy.py]`** — the earlier triage misattributed these to `assert "final cost" in out`, which passes. The real failure is the next line, `assert (tmp_path / output).exists()`: both scripts ship `METHOD = "L-BFGS-B"` and write `wout_Q{A,I}_scipy_L-BFGS-B.nc`, while the table asked for `…_BFGS.nc`. `METHOD` was already `L-BFGS-B` in `109dcf00`, the commit that added those rows, so **these two rows have never passed**. The jaxopt and optax rows were already correct.

Found by a `-m "full and not weekly"` sweep, a tier no scheduled workflow runs (Phase 32; the lanes are being wired in separately).

## Scope change

An earlier revision of this PR also marked the LASYM 3D DMerc gradient gate `xfail`. That is dropped: #148 fixes the underlying anchoring properly and tightens the shared gate from 2.0e-3 to 2.0e-5, so recording a known failure here would contradict it.

## Local verification

GitHub Actions is out of minutes. The three example tests: 3 passed in 352.64s. `ruff` clean.