### PR TITLE
Fix two independent LASYM defects: silent symmetrization in the bootstrap <J.B> lane, and the scalar-loop jxbforce filter

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -5,7 +5,8 @@ Zeff > 1; V2/V3 Zenodo QA/QH cross-check (<= 1% vs simsopt Redl curves,
 <= 10% RMS vs SFINCS interior, trapped-fraction parity; skips without the
 local dataset); differentiability of the double-where guards; traceable vs
 wout lane agreement; V4 ``<J.B>`` identity vs wout ``jdotb`` (<= 2% Zenodo,
-<= 1% solovev); V5 ``f_boot <= 1e-3`` on the published optima; V6 Picard
+<= 1% solovev and the LASYM up-down-asymmetric tokamak); V5
+``f_boot <= 1e-3`` on the published optima; V6 Picard
 convergence in <= 10 iterations; and the ``current_dofs`` driver with
 FD-checked AC/CURTOR Jacobian columns.
 
@@ -466,6 +467,20 @@ def eq():
     return equilibrium
 
 
+@pytest.fixture(scope="module")
+def lasym_eq():
+    """Up-down-asymmetric tokamak (LASYM = T, ntor = 0).
+
+    The deck exhausts NITER before FTOL — as its VMEC2000 golden does — but
+    the wout tables are what the wout lanes read, so convergence is not the
+    fixture's contract; carrying ``bmns``/``gmns`` is.
+    """
+    equilibrium = opt.solve_equilibrium(
+        VmecInput.from_file(DATA_DIR / "input.up_down_asymmetric_tokamak"))
+    assert bool(equilibrium.wout.lasym)
+    return equilibrium
+
+
 def test_state_lane_matches_wout_lane(eq):
     """redl_geometry_from_state agrees with redl_geometry_from_wout at
     discretization level (solver internal grid vs 64x65 wout synthesis)."""
@@ -585,9 +600,15 @@ def _interp_full(wout, surfaces, values):
                      np.asarray(values, dtype=float))
 
 
-def test_vmec_j_dot_B_state_lane_matches_wout_jdotb(eq):
-    """Traceable identity <J.B> vs the wout-engine jdotb (jxbforce.f) on the
-    solovev equilibrium: <= 1% (observed ~5e-5); wout-table identity ditto."""
+@pytest.mark.parametrize("fixture", ["eq", "lasym_eq"])
+def test_vmec_j_dot_B_state_lane_matches_wout_jdotb(request, fixture):
+    """Traceable identity <J.B> vs the wout-engine jdotb (jxbforce.f): <= 1%
+    (observed ~5e-5 solovev, ~9e-4 up_down); wout-table identity ditto.
+
+    The LASYM row is the regression gate on the ``geom=None`` synthesis: with
+    the sine families dropped the last assertion missed by 2.8e-3.
+    """
+    eq = request.getfixturevalue(fixture)
     surfaces = np.linspace(0.2, 0.9, 8)
     jv = np.asarray(bs.vmec_j_dot_B(eq.state, eq.runtime, surfaces=surfaces))
     jw = _interp_full(eq.wout, surfaces, eq.wout.jdotb)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -621,6 +621,18 @@ def test_vmec_j_dot_B_state_lane_matches_wout_jdotb(request, fixture):
     geom = bs.redl_geometry_from_wout(eq.wout, surfaces)
     jv_geom = np.asarray(bs.vmec_j_dot_B_from_wout(eq.wout, surfaces, geom=geom))
     np.testing.assert_allclose(jv_geom, jv_wout, rtol=1e-3)
+    # The two lanes are the same identity, so they must agree exactly, not
+    # merely within the gate above -- and at the axis too.  Every m != 0
+    # harmonic vanishes where the surface degenerates to a point;
+    # redl_geometry_from_wout zeroes them there and the geom=None lane did
+    # not, which put the two 4.0e-4 apart at s = 0 while they matched
+    # bit-for-bit everywhere else.
+    with_axis = np.concatenate([[0.0], surfaces])
+    axis_geom = bs.redl_geometry_from_wout(eq.wout, with_axis)
+    np.testing.assert_array_equal(
+        np.asarray(bs.vmec_j_dot_B_from_wout(eq.wout, with_axis)),
+        np.asarray(bs.vmec_j_dot_B_from_wout(eq.wout, with_axis,
+                                             geom=axis_geom)))
 
 
 @needs_zenodo

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -838,3 +838,71 @@ def test_least_squares_current_dofs_implicit():
         np.testing.assert_allclose(jac[:, col], fd,
                                    atol=1e-3 * max(np.max(np.abs(fd)), 1e-12),
                                    err_msg=f"implicit Jacobian column {col}")
+
+
+# ---------------------------------------------------------------------------
+# nyquist.filter_bsubuv_lasym, directly
+# ---------------------------------------------------------------------------
+
+
+def _filter_inputs(*, mpol, ntor, ntheta, nzeta, ns=7, seed=0):
+    """A trig table and a random covariant pair on its full theta grid."""
+    from vmex.core.fourier import Resolution, trig_tables
+
+    trig = trig_tables(Resolution(mpol=mpol, ntor=ntor, ntheta=ntheta,
+                                  nzeta=nzeta, nfp=3, ns=ns, lasym=True))
+    rng = np.random.default_rng(seed)
+    shape = (ns, int(trig.ntheta3), nzeta)
+    return (trig, rng.standard_normal(shape), rng.standard_normal(shape),
+            np.linspace(0.0, 1.0, ns))
+
+
+def test_filter_bsubuv_lasym_is_an_idempotent_projection():
+    """The scale contract the vectorized filter is written against.
+
+    ``filter_bsubuv_lasym`` had no direct test — its only coverage was
+    incidental, through the wout writer — so the property its docstring
+    claims was never actually gated.  One pass is a band-limited projection
+    returning the physical field, so a second pass must change nothing.
+    """
+    from vmex.core.nyquist import filter_bsubuv_lasym, nyquist_limits
+
+    trig, bsubu, bsubv, s = _filter_inputs(mpol=4, ntor=2, ntheta=16, nzeta=8)
+    mmax, nmax = 3, 2
+    assert min(nyquist_limits(trig)) > max(mmax, nmax)   # band inside Nyquist
+    once = filter_bsubuv_lasym(bsubu=bsubu, bsubv=bsubv, trig=trig,
+                               mmax_force=mmax, nmax_force=nmax, s=s)
+    twice = filter_bsubuv_lasym(bsubu=once[0], bsubv=once[1], trig=trig,
+                                mmax_force=mmax, nmax_force=nmax, s=s)
+    for first, second in zip(once, twice):
+        scale = max(float(np.max(np.abs(first))), 1e-300)
+        assert float(np.max(np.abs(second - first))) / scale < 1e-14
+    # A projection that returned its input unchanged would pass the above and
+    # test nothing.
+    assert float(np.max(np.abs(once[0] - bsubu))) > 1e-3
+
+
+def test_filter_bsubuv_lasym_halves_the_self_conjugate_nyquist_modes():
+    """The ``dnorm1`` half-weights, on a grid coarse enough to reach them.
+
+    ``mmax_force`` is ``mpol - 1`` and ``mnyq`` is ``ntheta2 - 1``, so the
+    self-conjugate half-weight only engages when the grid under-resolves the
+    retained modes.  ``VmecInput`` does not forbid that — ``MPOL = 8`` with
+    ``NTHETA = 10`` is accepted — so the branch is reachable from a deck and
+    is not dead code, which is what a first look at it suggests.
+
+    Idempotence is deliberately *not* asserted here: with the half-weights
+    engaged a second pass is not a no-op, and the docstring says so.  What is
+    asserted is that the filter runs, stays finite, and actually acts.
+    """
+    from vmex.core.nyquist import filter_bsubuv_lasym, nyquist_limits
+
+    trig, bsubu, bsubv, s = _filter_inputs(mpol=8, ntor=4, ntheta=10, nzeta=6)
+    mmax, nmax = 7, 4
+    mnyq, nnyq = nyquist_limits(trig)
+    assert mnyq <= mmax and nnyq <= nmax          # both half-weights engage
+    out_u, out_v = filter_bsubuv_lasym(bsubu=bsubu, bsubv=bsubv, trig=trig,
+                                       mmax_force=mmax, nmax_force=nmax, s=s)
+    assert out_u.shape == bsubu.shape and out_v.shape == bsubv.shape
+    assert np.all(np.isfinite(out_u)) and np.all(np.isfinite(out_v))
+    assert float(np.max(np.abs(out_u - bsubu))) > 1e-3

--- a/vmex/core/bootstrap.py
+++ b/vmex/core/bootstrap.py
@@ -738,9 +738,16 @@ def vmec_j_dot_B_from_wout(wout, surfaces, *, geom: RedlGeometry | None = None,
         xn = _as_1d(np.asarray(wout.xn_nyq, dtype=float))
         mn = int(xm.shape[0])
 
+        # Every m != 0 harmonic vanishes at the magnetic axis, where the
+        # surface degenerates to a point.  redl_geometry_from_wout zeroes them
+        # there; without the same treatment the two lanes disagreed by 4.0e-4
+        # at s = 0 while matching bit-for-bit everywhere else.
+        axis_modes = (np.asarray(surfaces) == 0.0)[:, None] & (xm != 0.0)[None, :]
+
         def half(name):
-            return _interp_half_grid(_mode_matrix(wout, name, ns=ns, mn=mn)[1:],
-                                     surfaces, s_half)
+            values = _interp_half_grid(
+                _mode_matrix(wout, name, ns=ns, mn=mn)[1:], surfaces, s_half)
+            return jnp.where(axis_modes, 0.0, values)
 
         theta1d = jnp.linspace(0.0, 2.0 * jnp.pi, int(ntheta), endpoint=False)
         phi1d = jnp.linspace(0.0, 2.0 * jnp.pi / int(wout.nfp), int(nphi),

--- a/vmex/core/bootstrap.py
+++ b/vmex/core/bootstrap.py
@@ -710,8 +710,9 @@ def vmec_j_dot_B_from_wout(wout, surfaces, *, geom: RedlGeometry | None = None,
     """The section-6.2 identity evaluated from wout tables (parity lane).
 
     Same formula as :func:`vmec_j_dot_B` with ``buco``/``pres``/``phi`` read
-    from the wout dataset and ``<B^2>`` synthesized from ``bmnc``/``gmnc`` at
-    the requested ``surfaces``; pass ``geom`` (a :class:`RedlGeometry` from
+    from the wout dataset and ``<B^2>`` synthesized from ``bmnc``/``gmnc``
+    (plus the ``bmns``/``gmns`` partners when ``lasym``) at the requested
+    ``surfaces``; pass ``geom`` (a :class:`RedlGeometry` from
     :func:`redl_geometry_from_wout` at the *same* surfaces) to reuse its
     ``fsa_B2`` instead.  This is the validation lane — the wout ``jdotb``
     itself (jxbforce.f) is what :class:`RedlBootstrapMismatch` consumes.
@@ -736,18 +737,27 @@ def vmec_j_dot_B_from_wout(wout, surfaces, *, geom: RedlGeometry | None = None,
         xm = _as_1d(np.asarray(wout.xm_nyq, dtype=float))
         xn = _as_1d(np.asarray(wout.xn_nyq, dtype=float))
         mn = int(xm.shape[0])
-        bmnc = _interp_half_grid(_mode_matrix(wout, "bmnc", ns=ns, mn=mn)[1:],
-                                 surfaces, s_half)
-        gmnc = _interp_half_grid(_mode_matrix(wout, "gmnc", ns=ns, mn=mn)[1:],
-                                 surfaces, s_half)
+
+        def half(name):
+            return _interp_half_grid(_mode_matrix(wout, name, ns=ns, mn=mn)[1:],
+                                     surfaces, s_half)
+
         theta1d = jnp.linspace(0.0, 2.0 * jnp.pi, int(ntheta), endpoint=False)
         phi1d = jnp.linspace(0.0, 2.0 * jnp.pi / int(wout.nfp), int(nphi),
                              endpoint=False)
         angle = (theta1d[:, None, None] * xm[None, None, :]
                  - phi1d[None, :, None] * xn[None, None, :])
         cosangle = jnp.cos(angle)
-        modB = jnp.einsum("sm,tpm->stp", bmnc, cosangle)
-        sqrtg = jnp.abs(jnp.einsum("sm,tpm->stp", gmnc, cosangle))
+        modB = jnp.einsum("sm,tpm->stp", half("bmnc"), cosangle)
+        sqrtg = jnp.einsum("sm,tpm->stp", half("gmnc"), cosangle)
+        if bool(getattr(wout, "lasym", False)):
+            # On a LASYM wout the sine families carry the up-down-asymmetric
+            # half of |B| and sqrt(g); dropping them symmetrizes <B^2> (same
+            # synthesis as :func:`redl_geometry_from_wout`).
+            sinangle = jnp.sin(angle)
+            modB += jnp.einsum("sm,tpm->stp", half("bmns"), sinangle)
+            sqrtg += jnp.einsum("sm,tpm->stp", half("gmns"), sinangle)
+        sqrtg = jnp.abs(sqrtg)
         fsa_B2 = (jnp.mean(modB * modB * sqrtg, axis=(1, 2))
                   / jnp.mean(sqrtg, axis=(1, 2)))
 

--- a/vmex/core/nyquist.py
+++ b/vmex/core/nyquist.py
@@ -292,8 +292,13 @@ def filter_bsubuv_lasym(
     sums are cancellation-limited near the edge).  Returns full-grid
     ``(ns, ntheta3, nzeta)`` arrays.
 
-    Scale contract: one pass is an idempotent band-limited projection
-    returning the *physical* field.  The lasym analysis tables carry the
+    Scale contract: one pass is a band-limited projection returning the
+    *physical* field, and it is idempotent (measured 3.8e-16) whenever the
+    force band lies strictly inside the grid Nyquist -- which is the case for
+    any deck whose ``NTHETA`` resolves its ``MPOL``.  A deliberately coarse
+    grid (``MPOL = 8`` with ``NTHETA = 10``, say) puts ``mnyq`` inside the
+    band, the self-conjugate half-weights below engage, and a second pass is
+    then not a no-op.  The lasym analysis tables carry the
     full-interval ``1/(nzeta*ntheta1)`` and the per-mode ``dnorm1`` below
     doubles it, giving the ``1/(nzeta*(ntheta2-1))`` weight the reduced-grid
     parity sum needs.

--- a/vmex/core/nyquist.py
+++ b/vmex/core/nyquist.py
@@ -284,11 +284,13 @@ def filter_bsubuv_lasym(
 ) -> tuple[np.ndarray, np.ndarray]:
     """jxbforce.f low-pass filter of ``bsubu/bsubv`` for ``lasym = True``.
 
-    Mirrors the Fortran surface loop: ``fsym_fft`` parity split to the reduced
-    grid, the band-limited transform/inverse for both parities, and the
-    ``fext_fft`` extension back to the full theta grid.  Long-double
-    accumulation (the sums are cancellation-limited near the edge).
-    Returns full-grid ``(ns, ntheta3, nzeta)`` arrays.
+    Mirrors the Fortran surface loop — ``fsym_fft`` parity split to the
+    reduced grid, the band-limited transform/inverse for both parities, and
+    the ``fext_fft`` extension back to the full theta grid — contracted with
+    ``np.einsum`` over all surfaces at once, as in
+    :func:`filter_bsubuv_symmetric`.  Long-double accumulation is kept (the
+    sums are cancellation-limited near the edge).  Returns full-grid
+    ``(ns, ntheta3, nzeta)`` arrays.
 
     Scale contract: one pass is an idempotent band-limited projection
     returning the *physical* field.  The lasym analysis tables carry the
@@ -313,86 +315,50 @@ def filter_bsubuv_lasym(
     sinmu = np.asarray(trig.sinmu, dtype=acc)[:nt2, : mmax + 1]
     cosnv = np.asarray(trig.cosnv, dtype=acc)[:, : nmax + 1]
     sinnv = np.asarray(trig.sinnv, dtype=acc)[:, : nmax + 1]
+
+    # fixaray.f half-interval analysis norm: the tables carry
+    # 1/(nzeta*ntheta1); the reduced-grid parity analysis needs
+    # 1/(nzeta*(ntheta2-1)) = 2/(nzeta*ntheta1).  Every factor is a power of
+    # two, so folding it out of the mode sums is exact.
+    dnorm1 = np.full((mmax + 1, nmax + 1), 2.0, dtype=acc)
     mnyq, nnyq = nyquist_limits(trig)
+    if mnyq > 0 and mnyq <= mmax:
+        dnorm1[mnyq, :] *= 0.5
+    if nnyq > 0 and nnyq <= nmax:
+        dnorm1[:, nnyq] *= 0.5
 
-    bsubu_out = np.zeros((ns, nt3, nzeta), dtype=acc)
-    bsubv_out = np.zeros((ns, nt3, nzeta), dtype=acc)
+    # fsym_fft/fext_fft reflection: theta -> ntheta1 - theta, zeta -> -zeta
+    # (index 0 maps to itself on both circles).
+    theta_r = np.concatenate([[0], nt1 - np.arange(1, nt2)])
+    zeta_r = np.concatenate([[0], nzeta - np.arange(1, nzeta)])
+    ext_r = nt1 - np.arange(nt2, nt3)
 
-    for js in range(ns):
-        bu = bsubu[js, :nt3, :].T  # Fortran (zeta, theta) ordering
-        bv = bsubv[js, :nt3, :].T
-        bu_ch = np.stack([bu, bu], axis=-1)  # (nzeta, nt3, parity)
-        bv_ch = np.stack([bv, bv], axis=-1)
+    def _filter_field(f: np.ndarray) -> np.ndarray:
+        # (ns, ntheta, nzeta) -> Fortran (ns, nzeta, ntheta) ordering.
+        g = np.swapaxes(f[:, :nt3, :], 1, 2)
+        mirror = g[:, zeta_r[:, None], theta_r[None, :]]
+        f_s = 0.5 * (g[:, :, :nt2] + mirror)
+        f_a = 0.5 * (g[:, :, :nt2] - mirror)
+        # Band-limited analysis of both reflection parities.  jxbforce.f
+        # carries even/odd m in separate 1/shalf channels; with the default
+        # parity split (odd = shalf * even) the division cancels exactly, so
+        # both channels see the same field and one pass suffices (same
+        # argument as :func:`filter_bsubuv_symmetric`).
+        c1 = np.einsum("skj,jm,kn->smn", f_s, cosmui, cosnv, optimize=True) * dnorm1
+        c2 = np.einsum("skj,jm,kn->smn", f_s, sinmui, sinnv, optimize=True) * dnorm1
+        c3 = np.einsum("skj,jm,kn->smn", f_a, sinmui, cosnv, optimize=True) * dnorm1
+        c4 = np.einsum("skj,jm,kn->smn", f_a, cosmui, sinnv, optimize=True) * dnorm1
+        sym = (np.einsum("smn,jm,kn->skj", c1, cosmu, cosnv, optimize=True)
+               + np.einsum("smn,jm,kn->skj", c2, sinmu, sinnv, optimize=True))
+        asym = (np.einsum("smn,jm,kn->skj", c3, sinmu, cosnv, optimize=True)
+                + np.einsum("smn,jm,kn->skj", c4, cosmu, sinnv, optimize=True))
+        out = np.empty((ns, nzeta, nt3), dtype=acc)
+        out[:, :, :nt2] = sym + asym
+        if nt3 > nt2:  # fext_fft: theta > pi from the reflected parities
+            out[:, :, nt2:] = (sym - asym)[:, zeta_r[:, None], ext_r[None, :]]
+        return np.asarray(np.swapaxes(out, 1, 2), dtype=float)
 
-        bu_s = np.zeros((nzeta, nt2, 2), dtype=acc)
-        bu_a = np.zeros((nzeta, nt2, 2), dtype=acc)
-        bv_s = np.zeros((nzeta, nt2, 2), dtype=acc)
-        bv_a = np.zeros((nzeta, nt2, 2), dtype=acc)
-        for i in range(nt2):
-            ir = 0 if i == 0 else (nt1 - i)
-            for kz in range(nzeta):
-                kzr = 0 if kz == 0 else (nzeta - kz)
-                bu_a[kz, i, :] = 0.5 * (bu_ch[kz, i, :] - bu_ch[kzr, ir, :])
-                bu_s[kz, i, :] = 0.5 * (bu_ch[kz, i, :] + bu_ch[kzr, ir, :])
-                bv_a[kz, i, :] = 0.5 * (bv_ch[kz, i, :] - bv_ch[kzr, ir, :])
-                bv_s[kz, i, :] = 0.5 * (bv_ch[kz, i, :] + bv_ch[kzr, ir, :])
-
-        bsubua = np.zeros((nzeta, nt2, 2), dtype=acc)
-        bsubva = np.zeros((nzeta, nt2, 2), dtype=acc)
-        for m in range(mmax + 1):
-            mparity = m & 1
-            for n in range(nmax + 1):
-                # fixaray.f half-interval analysis norm: the tables carry
-                # 1/(nzeta*ntheta1); the reduced-grid parity analysis needs
-                # 1/(nzeta*(ntheta2-1)) = 2/(nzeta*ntheta1).
-                dnorm1 = acc(2.0)
-                if mnyq > 0 and m == mnyq:
-                    dnorm1 *= 0.5
-                if nnyq > 0 and n == nnyq and n != 0:
-                    dnorm1 *= 0.5
-
-                bsubumn1 = bsubumn2 = bsubvmn1 = bsubvmn2 = acc(0.0)
-                bsubumn3 = bsubumn4 = bsubvmn3 = bsubvmn4 = acc(0.0)
-                for k in range(nzeta):
-                    for j in range(nt2):
-                        tsini1 = sinmui[j, m] * cosnv[k, n] * dnorm1
-                        tsini2 = cosmui[j, m] * sinnv[k, n] * dnorm1
-                        tcosi1 = cosmui[j, m] * cosnv[k, n] * dnorm1
-                        tcosi2 = sinmui[j, m] * sinnv[k, n] * dnorm1
-                        bsubumn1 += tcosi1 * bu_s[k, j, mparity]
-                        bsubumn2 += tcosi2 * bu_s[k, j, mparity]
-                        bsubvmn1 += tcosi1 * bv_s[k, j, mparity]
-                        bsubvmn2 += tcosi2 * bv_s[k, j, mparity]
-                        bsubumn3 += tsini1 * bu_a[k, j, mparity]
-                        bsubumn4 += tsini2 * bu_a[k, j, mparity]
-                        bsubvmn3 += tsini1 * bv_a[k, j, mparity]
-                        bsubvmn4 += tsini2 * bv_a[k, j, mparity]
-
-                for k in range(nzeta):
-                    for j in range(nt2):
-                        tcos1 = cosmu[j, m] * cosnv[k, n]
-                        tcos2 = sinmu[j, m] * sinnv[k, n]
-                        bsubua[k, j, 0] += tcos1 * bsubumn1 + tcos2 * bsubumn2
-                        bsubva[k, j, 0] += tcos1 * bsubvmn1 + tcos2 * bsubvmn2
-                        tsin1 = sinmu[j, m] * cosnv[k, n]
-                        tsin2 = cosmu[j, m] * sinnv[k, n]
-                        bsubua[k, j, 1] += tsin1 * bsubumn3 + tsin2 * bsubumn4
-                        bsubva[k, j, 1] += tsin1 * bsubvmn3 + tsin2 * bsubvmn4
-
-        bu_full = np.zeros((nzeta, nt3), dtype=acc)
-        bv_full = np.zeros((nzeta, nt3), dtype=acc)
-        bu_full[:, :nt2] = bsubua[:, :, 0] + bsubua[:, :, 1]
-        bv_full[:, :nt2] = bsubva[:, :, 0] + bsubva[:, :, 1]
-        for i in range(nt2, nt3):
-            ir = nt1 - i
-            for kz in range(nzeta):
-                kzr = 0 if kz == 0 else (nzeta - kz)
-                bu_full[kz, i] = bsubua[kzr, ir, 0] - bsubua[kzr, ir, 1]
-                bv_full[kz, i] = bsubva[kzr, ir, 0] - bsubva[kzr, ir, 1]
-        bsubu_out[js] = bu_full.T
-        bsubv_out[js] = bv_full.T
-
-    return np.asarray(bsubu_out, dtype=float), np.asarray(bsubv_out, dtype=float)
+    return _filter_field(bsubu), _filter_field(bsubv)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two independent LASYM defects, one commit each. They share nothing but the
symmetry mode: the first is a silent wrong answer in a public bootstrap API,
the second a 200x-2400x cost in the wout writer.

## FIX 1 — `bootstrap.vmec_j_dot_B_from_wout` silently symmetrized LASYM wouts

`vmec_j_dot_B_from_wout` builds `<B^2>` itself when `geom` is not supplied
(its default). That synthesis read `bmnc`/`gmnc` only — the cosine families —
with no `bmns`/`gmns` and no guard, so on a LASYM wout it returned the
symmetrized answer without saying so. It is public API
(`bootstrap.__all__`), and `redl_geometry_from_wout` sixty lines above
already had the case right.

**Reproduction** — `examples/data/input.up_down_asymmetric_tokamak`
(LASYM = T, ntor = 0, ns = 17), `<J.B>` at s = 0.2, 0.35, 0.5, 0.65, 0.8,
default path against the `geom=` lane it is asserted to match:

| s | `geom=` lane | `geom=None` (before) | rel |
|---|---|---|---|
| 0.20 | -6336715.354 | -6340171.826 | 5.45e-4 |
| 0.35 | -4968726.521 | -4974146.622 | 1.09e-3 |
| 0.50 | -3679646.002 | -3685959.880 | 1.72e-3 |
| 0.65 | -2517122.467 | -2523051.150 | 2.36e-3 |
| 0.80 | -1543787.885 | -1548083.651 | 2.78e-3 |

The repo asserts these two lanes agree at `rtol=1e-3`
(`tests/test_bootstrap.py`), but that test only ever ran on symmetric
solovev, where the omission is invisible.

**Change** — the `geom=None` synthesis now adds the `bmns`/`gmns` partners
on the sine angle, exactly as `redl_geometry_from_wout` does.

**After** — the two lanes agree bit-for-bit on the LASYM deck: relative
difference `[0, 0, 0, 0, 0]`, max 0.0.

**The symmetric path was not also wrong.** Same five surfaces on solovev,
before and after the change, `geom=` lane and `geom=None`, all four vectors
identical to the last digit:
`[-17920.04375251, -17809.696918, -17702.64336158, -17598.57690667,
-17498.88018143]`. The `lasym` branch is skipped for symmetric decks and the
surviving expression is unchanged op for op.

The agreement test is now parametrized over the LASYM deck alongside solovev,
so both symmetry modes carry the gate.

## FIX 2 — `nyquist.filter_bsubuv_lasym` was a five-deep Python scalar loop

The lasym filter looped over surface x m x n x zeta x theta in Python while
its stellarator-symmetric twin sixty lines above contracts the same
transforms with `np.einsum`. It runs up to three times per wout write and on
every LASYM deck with `ntor > 0` — every 3-D asymmetric deck here.

**Change** — the same transforms (`fsym_fft` reflection split, band-limited
analysis/synthesis of both parities, `fext_fft` extension) contracted with
`np.einsum` over all surfaces at once. The per-mode `dnorm1` weight moves
out of the mode sums; every factor in it is a power of two, so that step is
exact.

**Before / after** (min over trials — the machine is shared; nfp = 5,
ns = 17, ntheta = 2*mpol+6, Nyquist-extended trig, band limits
mmax_force = mpol-1):

| box | mpol | loop | einsum | speedup | symmetric twin |
|---|---|---|---|---|---|
| ntor=4, nzeta=12 | 4 | 95.0 ms | 0.450 ms | **211x** | 0.174 ms |
| ntor=4, nzeta=12 | 8 | 271.7 ms | 0.516 ms | **527x** | 0.197 ms |
| ntor=4, nzeta=12 | 12 | 543.1 ms | 0.631 ms | **860x** | 0.211 ms |
| ntor=mpol-1 | 4 | 64.2 ms | 0.414 ms | **155x** | 0.165 ms |
| ntor=mpol-1 | 8 | 643.6 ms | 0.681 ms | **945x** | 0.209 ms |
| ntor=mpol-1 | 12 | 2882.6 ms | 1.204 ms | **2393x** | 0.234 ms |

The gap to the symmetric twin closes from 388x-12312x to 2.5x-5.1x; what is
left is the `longdouble` dtype keeping numpy off BLAS, plus eight
contractions against the twin's six.

In situ, on the arguments the wout writer actually passes (captured from a
real solve): 376x-538x on `cth_like_free_bdy_lasym_small`, 8.6x-12.3x on
`up_down_asymmetric_tokamak` (small, and ntor = 0 collapses the n loop).

**Bit-parity.** Against a frozen copy of the loop, on the captured
wout-writer arguments of both decks (3 calls each, all agreeing):

| deck | field | scale | max abs diff | rel to scale |
|---|---|---|---|---|
| `cth_like_free_bdy_lasym_small` (nfp=5, ntor=4, ns=15, 16x20) | bsubu | 2.688e-02 | 2.78e-17 | 1.03e-15 |
| | bsubv | 5.869e-01 | 8.88e-16 | 1.51e-15 |
| `up_down_asymmetric_tokamak` (ntor=0, ns=17, 16x1) | bsubu | 3.863e-01 | 8.33e-17 | 2.16e-16 |
| | bsubv | 3.207e+01 | 1.42e-14 | 4.43e-16 |

1-7 ulp of the field scale, i.e. summation-order round-off. Random-input
sweeps across mpol/ntor/nzeta edge shapes (including mpol = 1 and ntor = 0)
stay in 1.9e-16 - 9.0e-16 scale-relative. `tests/test_wout_golden.py` passes
unchanged, including its `up_down_asymmetric_tokamak` case, which is the gate
that matters.

**Precision decision: extended precision kept, not dropped.** The
accumulation stays `np.longdouble` end to end, dtype for dtype with the loop.
It was worth checking what that costs, because `longdouble` keeps numpy off
BLAS: a float64 clone of the identical contractions runs **1.07x** faster on
the cth deck and **1.01x** on up_down, and lands the same 1-2 ulp from the
loop. There was nothing to buy, so nothing was traded.

Worth recording: on this host (macOS arm64) `np.longdouble` has float64
machine parameters — itemsize 8, eps 2.22e-16 — so the extended accumulation
only actually engages where long double is wider, e.g. x86-64 at 80 bits.
Keeping the dtype leaves that platform behavior unchanged too.

## Local verification

GitHub Actions is out of minutes; everything below ran on this machine with
`python3` (MacPorts 3.11), `pytest -n 2`.

- `tests/test_bootstrap.py` (both parametrized rows), `tests/test_wout_golden.py`,
  `tests/test_stability.py`, `tests/test_test_manifest.py` — **62 passed,
  10 skipped** in 7:23
- `tests/test_lasym_free_case.py`, `tests/test_lasym_free_convergence.py`,
  `tests/test_boozer_tables.py`, `tests/test_postprocess_currents.py`,
  `tests/test_geometry_fields.py` — **40 passed, 1 skipped** in 1:46
- `ruff check vmex tests examples benchmarks tools` — clean
- `mypy vmex` — clean (68 source files)

No `tests/test_nyquist*.py` exists; the lasym filter's gate is the golden wout
parity above.
