### PR TITLE
Ballooning: asymmetric states, a COBRAVMEC oracle, and an example

### DIFF
--- a/docs/reference/objectives.rst
+++ b/docs/reference/objectives.rst
@@ -474,8 +474,9 @@ MHD stability
 
 :mod:`vmex.core.stability` provides the infinite-n ideal-ballooning
 objective (plan R26h.h1) — a JAX port of the COBRA eigenproblem in the Gaur
-*et al.* (arXiv:2302.07673) formulation, with field-line coefficients per
-simsopt's COBRA-validated ``vmec_fieldlines`` conventions and a batched
+*et al.* formulation (*Plasma Phys. Control. Fusion* **67**, 125015 (2025),
+arXiv:2410.04576), with field-line coefficients per simsopt's
+COBRA-validated ``vmec_fieldlines`` conventions and a batched
 symmetric-tridiagonal ``eigvalsh`` solve:
 
 - :func:`~vmex.core.stability.ballooning_lambda` — the most-unstable
@@ -493,10 +494,36 @@ symmetric-tridiagonal ``eigvalsh`` solve:
             (ballooning_growth_rate, -0.01, 5.0)]   # keep λ_max below zero
    result = opt.least_squares(terms, inp, max_mode=4, jac="implicit")
 
+``examples/optimization/QA_optimization_ballooning.py`` runs this end to end
+on a seed that is Mercier-stable and ballooning-unstable — the case the
+objective exists for, since the interchange criteria see nothing to fix.
+
+Two defaults are worth setting deliberately rather than inheriting:
+
+- **Scan** ``zeta0``.  ``λ`` peaks at a configuration-dependent ballooning
+  parameter (Gaur *et al.* 2023, footnote 2), and the single-point default
+  ``zeta0s=(0.0,)`` under-reports it — by 26 % on that example's seed
+  (3.27e-3 at ``zeta0 = 0`` against 4.42e-3 over a five-point scan).  A
+  ``zeta0``-blind objective drives the wrong quantity to zero.
+- **Read the softmax as the bound it is.**  ``ballooning_growth_rate`` sits
+  above ``max λ`` by up to ``temperature × log(n_lines)``, which at the
+  default ``temperature=0.05`` over 12 lines is 0.12 — larger than published
+  ``λ_max`` values.  Target the bound (below zero is then sufficient for
+  stability) and report
+  :func:`~vmex.core.stability.ballooning_lambda`'s hard maximum, or lower the
+  temperature and accept a sharper gradient.
+
+Asymmetric (``lasym``) states are supported: the sine-parity ``R``/``Z``/``λ``
+spectra carry through the PEST angle map and the field-line geometry.  An
+asymmetric equilibrium has no ``α -> -α`` parity, so the default field lines
+span the full ``[0, 2π)`` there and ``zeta0`` should be scanned over both
+signs.
+
 Everything inside is JAX AD (geometry derivatives included), so it composes
-with both gradient modes; ``d(growth)/d(pres_scale)`` matches finite
-differences to 4.7e-9 in CI, and the objective destabilizes monotonically
-with pressure on the solovev family, in sign agreement with Mercier.  For
+with both gradient modes; ``d(growth)/d(pres_scale)`` matches a central
+difference at ``h = 1e-4`` to 4.7e-9 relative, and the objective destabilizes
+monotonically with pressure on the solovev family, in sign agreement with
+Mercier.  For
 interchange stability, combine with
 :func:`~vmex.core.optimize.magnetic_well` (traceable) or
 :func:`~vmex.core.optimize.mercier_stability_residual` (traceable); retain

--- a/examples/optimization/QA_optimization_ballooning.py
+++ b/examples/optimization/QA_optimization_ballooning.py
@@ -97,7 +97,12 @@ for max_mode, max_nfev in zip(MAX_MODES, MAX_NFEV):
     report(f"mode {max_mode}", equilibrium)
     print(f"max lambda = {worst_lambda(equilibrium):+.4e}")
 
-# The physics certificate is the resolved solve, not the optimizer's grid.
+# The physics certificate is the resolved solve, not the optimizer's grid, and
+# the difference is not small: a full run of this example reaches
+# max lambda = 2.2e-4 on the NS = 25 stage grid and 9.1e-4 when the same
+# boundary is re-solved at NS = 45.  The optimizer's number is optimistic by
+# a factor of four -- ballooning is radially stiff, so quote the resolved one
+# and add a stage at the certificate resolution if you need the margin.
 final_input = replace(inp, ns_array=np.array([FINAL_NS]),
                       ftol_array=np.array([1.0e-11 if ci_smoke else 1.0e-13]),
                       niter_array=np.array([8000]))

--- a/examples/optimization/QA_optimization_ballooning.py
+++ b/examples/optimization/QA_optimization_ballooning.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+"""Quasi-axisymmetric optimization against the infinite-n ballooning growth rate.
+
+The seed (``input.nfp2_QA_finite_beta``, beta = 2.7 %) is Mercier-STABLE and
+ballooning-UNSTABLE, which is the case a ballooning objective is for: the
+interchange criteria see nothing to fix.  The objective is the smooth upper
+bound ``ballooning_growth_rate``, so driving it below zero is a sufficient
+condition for every sampled field line to be stable.
+"""
+
+from dataclasses import replace
+from functools import partial
+import os
+from pathlib import Path
+
+import numpy as np
+from scipy.optimize import least_squares
+
+import vmex as vj
+from vmex import optimize as opt
+from vmex.core.stability import ballooning_growth_rate, ballooning_lambda
+
+SURFACES = np.linspace(0.1, 1.0, 6)
+MAX_MODES, MAX_NFEV = [1, 2], [12, 20]
+ASPECT_TARGET = 5.0
+# lambda is least stable at a configuration-dependent zeta0 (Gaur et al.,
+# J. Plasma Phys. 89 (2023), footnote 2).  On this seed the single-point
+# default misses 26 % of it: max lambda is 3.27e-3 at zeta0 = 0 and 4.42e-3
+# over the scan below, so a zeta0 = 0 objective would optimize a bound that
+# is not the bound.
+ZETA0S = np.linspace(-0.5 * np.pi, 0.5 * np.pi, 5)
+LINES = dict(npoints=97, nturns=3.0, zeta0s=ZETA0S)
+# The softmax bound sits above max lambda by at most temperature * log(nlines)
+# (here 60 lines, so 8.2e-3): it is the quantity being targeted, and the hard
+# max is what gets reported.
+TEMPERATURE, BALLOONING_TARGET, BALLOONING_WEIGHT = 0.002, 0.0, 200.0
+STAGE_NS, FINAL_NS = 25, 45
+PARAMETER_STEP, MAX_PARAMETER_CHANGE = 0.02, 4.0
+ESS_ALPHA = 1.2  # smaller values let high Fourier modes move more
+
+ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
+if ci_smoke:
+    MAX_MODES, MAX_NFEV, STAGE_NS, FINAL_NS = [1], [3], 15, 15
+
+DATA = Path(__file__).resolve().parents[1] / "data" / "input.nfp2_QA_finite_beta"
+inp = replace(vj.VmecInput.from_file(DATA),
+              ns_array=np.array([STAGE_NS]), ftol_array=np.array([1.0e-11]),
+              niter_array=np.array([4000]))
+
+# The optimizable: a smooth upper bound on max lambda over all sampled lines.
+ballooning = partial(ballooning_growth_rate, temperature=TEMPERATURE, **LINES)
+
+
+def worst_lambda(equilibrium):
+    """Hard max lambda over the sampled lines -- the number worth quoting."""
+    lam = ballooning_lambda(equilibrium.solution, equilibrium.solver_context, **LINES)
+    return float(np.max(np.asarray(lam)))
+
+
+qs = opt.QuasisymmetryRatioResidual(SURFACES, helicity_m=1, helicity_n=0)
+objective_function_terms = [
+    (qs, 0.0, 1.0),
+    (opt.aspect_ratio, ASPECT_TARGET, 1.0),
+    (ballooning, BALLOONING_TARGET, BALLOONING_WEIGHT),
+]
+
+report = opt.EquilibriumReporter(
+    ("QS total", qs.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
+    ("mean iota", opt.mean_iota, ".4f"),
+    ("ballooning bound", ballooning, ".4e"))
+monitor = opt.OptimizationMonitor(stream=None)
+
+equilibrium = opt.solve_equilibrium(inp, verbose=not ci_smoke)
+seed_lambda = worst_lambda(equilibrium)
+seed_dmerc = float(np.min(np.asarray(equilibrium.wout.DMerc)[2:-1]))
+print(f"\nseed: beta = {float(equilibrium.wout.betatotal):.3%}, "
+      f"max lambda = {seed_lambda:+.4e} (unstable), "
+      f"min DMerc = {seed_dmerc:+.3e} (Mercier-stable)")
+
+for max_mode, max_nfev in zip(MAX_MODES, MAX_NFEV):
+    print(f"\n===== QA + ballooning stage, max_mode = {max_mode} =====")
+    mpol = max(max_mode + 2, 5)
+    inp = replace(inp, delt=0.5).change_resolution(
+        mpol=mpol, ntor=mpol, ntheta=2 * mpol + 6, nzeta=2 * mpol + 4)
+    problem = opt.VmecProblem.from_tuples(
+        inp, objective_function_terms, max_mode=max_mode, use_ess=True,
+        ess_alpha=ESS_ALPHA, restart_from=equilibrium)
+    monitor.problem = problem
+    step = PARAMETER_STEP * problem.scales
+    result = least_squares(
+        problem.residual, problem.x0, jac=problem.residual_jac, x_scale=step,
+        bounds=(problem.x0 - MAX_PARAMETER_CHANGE * step,
+                problem.x0 + MAX_PARAMETER_CHANGE * step),
+        max_nfev=max_nfev, ftol=1e-6, xtol=1e-10, verbose=2, callback=monitor)
+    inp = problem.input_from_x(result.x)
+    equilibrium = problem.equilibrium_from_x(result.x)
+    report(f"mode {max_mode}", equilibrium)
+    print(f"max lambda = {worst_lambda(equilibrium):+.4e}")
+
+# The physics certificate is the resolved solve, not the optimizer's grid.
+final_input = replace(inp, ns_array=np.array([FINAL_NS]),
+                      ftol_array=np.array([1.0e-11 if ci_smoke else 1.0e-13]),
+                      niter_array=np.array([8000]))
+final_equilibrium = opt.solve_equilibrium(
+    final_input, initial_state=equilibrium.solution, verbose=not ci_smoke,
+    raise_on_max_iterations=True)
+final_lambda = worst_lambda(final_equilibrium)
+final_dmerc = float(np.min(np.asarray(final_equilibrium.wout.DMerc)[2:-1]))
+report("final", final_equilibrium)
+print(f"\nmax lambda {seed_lambda:+.4e} -> {final_lambda:+.4e} "
+      f"({'stable' if final_lambda < 0.0 else 'still unstable'}) at NS = {FINAL_NS}\n"
+      f"min DMerc {seed_dmerc:+.3e} -> {final_dmerc:+.3e}, "
+      f"beta {float(final_equilibrium.wout.betatotal):.3%}")
+
+input_path = final_input.to_indata("input.QA_ballooning_optimized")
+wout_path = vj.write_wout("wout_QA_ballooning_optimized.nc", final_equilibrium.wout)
+print(f"wrote {input_path}\nwrote {wout_path}")
+
+monitor.save("QA_optimization_ballooning_objectives.csv")
+monitor.plot("QA_optimization_ballooning_objectives.png")
+for path in vj.plot_wout(wout_path, ".").values():
+    print(f"wrote {path}")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -454,6 +454,37 @@ def test_qi_optimization_example(tmp_path):
     assert (tmp_path / "wout_QI_optimized.nc").exists()
 
 
+@pytest.mark.full  # nightly: every residual evaluation is a finite-beta solve
+def test_qa_ballooning_optimization_example(tmp_path):
+    """Reduced-budget QA + infinite-n ballooning optimization smoke test."""
+    script = EXAMPLES / "optimization" / "QA_optimization_ballooning.py"
+    out = _run_example(script, tmp_path, timeout=1800)
+    _assert_cost_decreased(out, "QA-ballooning")
+    seed = re.search(r"max lambda = ([0-9.eE+-]+) \(unstable\)", out)
+    final = re.search(r"max lambda ([0-9.eE+-]+) -> ([0-9.eE+-]+)", out)
+    assert seed is not None and final is not None
+    # The seed must be the case the objective is for: ballooning-unstable while
+    # Mercier says nothing is wrong.  Otherwise the example proves nothing.
+    assert float(seed.group(1)) > 0.0
+    assert re.search(r"min DMerc = \+[0-9.eE+-]+ \(Mercier-stable\)", out)
+    assert float(final.group(2)) < float(final.group(1))
+    assert (tmp_path / "input.QA_ballooning_optimized").exists()
+    assert (tmp_path / "wout_QA_ballooning_optimized.nc").exists()
+    assert (tmp_path / "QA_ballooning_optimized_stability.png").stat().st_size > 10_000
+
+
+def test_ballooning_example_scans_the_ballooning_parameter():
+    """The example must not optimize a bound taken at a single zeta0.
+
+    ``lambda`` peaks at a configuration-dependent ``zeta0``; on this seed the
+    single-point default reports 3.27e-3 where the scan reports 4.42e-3, so a
+    ``zeta0 = 0`` objective would drive the wrong quantity to zero.
+    """
+    source = (EXAMPLES / "optimization" / "QA_optimization_ballooning.py").read_text()
+    assert "ZETA0S = np.linspace(-0.5 * np.pi, 0.5 * np.pi, 5)" in source
+    assert "zeta0s=ZETA0S" in source
+
+
 def test_vacuum_qs_examples_expose_trial_pressure_terms():
     """Vacuum QS examples expose the tested trial-pressure stability terms."""
     for name in ("QA_optimization_DMerc_vacuum.py", "QH_optimization.py"):

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -10,6 +10,8 @@ gradient).
 from __future__ import annotations
 
 import dataclasses
+import shutil
+import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -20,6 +22,7 @@ import jax.numpy as jnp
 
 jax.config.update("jax_enable_x64", True)
 
+import vmex as vj
 from vmex.core import optimize as opt
 from vmex.core import stability as stab
 from vmex.core.input import VmecInput
@@ -808,3 +811,82 @@ def test_symmetric_only_lanes_name_themselves(lasym_finite_beta_eq):
                  lambda: gammac.gamma_c_state(eq.state, eq.runtime)):
         with pytest.raises(NotImplementedError, match="lasym = False"):
             call()
+
+
+# ---------------------------------------------------------------------------
+# External oracle: COBRAVMEC (Phase 34.3)
+# ---------------------------------------------------------------------------
+
+_XCOBRA = shutil.which("xcobravmec")
+
+
+def _cobra_growth_rates(wout_path: Path, rows, *, k_w: int, alpha_deg: float):
+    """Run COBRAVMEC on a vmex-written wout; return its signed growth rates.
+
+    The nine-record ``in_cobra`` file is ``cobra.f:104-116``.  ``l_geom_input =
+    l_tokamak_input = F`` selects the ``(alpha_st, zeta_k)`` branch, whose
+    field-line label ``alpha = theta + lambda - iota zeta``
+    (``obtain_field_line.f:31``) is exactly the one vmex uses; both angles are
+    in degrees (``summodosd.f:52``).  A nonzero ``alpha_st`` keeps COBRA on its
+    full domain (``tsymm = 1``), matching vmex's.
+    """
+    tag = wout_path.stem.removeprefix("wout_")
+    directory = wout_path.parent
+    (directory / f"in_cobra.{tag}").write_text(
+        f"{tag}\n{k_w} 1\nF F\n1\n0.0\n1\n{alpha_deg}\n{len(rows)}\n"
+        + " ".join(str(j + 1) for j in rows) + "\n")     # COBRA rows are 1-based
+    subprocess.run([_XCOBRA, f"in_cobra.{tag}"], cwd=directory, check=True,
+                   capture_output=True, timeout=600)
+    records = (directory / f"cobra_grate.{tag}").read_text().splitlines()
+    grate = np.array([float(line.split()[2]) for line in records[1:1 + len(rows)]])
+    assert not np.any(grate == 100.0), "COBRAVMEC failure sentinel"
+    return grate
+
+
+@pytest.mark.full  # external binary; solves at ns = 49
+@pytest.mark.skipif(_XCOBRA is None, reason="xcobravmec not on PATH")
+def test_ballooning_matches_cobravmec(tmp_path):
+    """Eigenvalue parity with COBRAVMEC through an analytic conversion.
+
+    COBRA's third column is a *signed* growth rate, ``+sqrt(-eigf)`` when
+    unstable and ``-sqrt(eigf)`` when stable (``get_ballooning_grate.f:313``),
+    so ``sign(grate) grate**2`` is its eigenvalue in COBRA's normalization
+    ``lambda = gamma**2 mu0 rho R0**2 / B0**2``.  vmex normalizes to
+    ``a_N`` and ``B_N``, so the two differ by ``(a_N B0 / (R0 B_N))**2`` --
+    a constant per equilibrium, with the density and COBRA's own ``amin``
+    cancelling.  Nothing here is fitted.
+    """
+    inp = dataclasses.replace(
+        VmecInput.from_file(DATA_DIR / "input.solovev"), pres_scale=3.0e4,
+        ns_array=np.array([49]), ftol_array=np.array([1e-13]),
+        niter_array=np.array([10000]))
+    eq = opt.solve_equilibrium(inp, verbose=False)
+    assert eq.result.converged
+    wout_path = Path(vj.write_wout(str(tmp_path / "wout_sol.nc"), eq.wout))
+
+    rows = [int(round(f * 48)) for f in (0.2, 0.35, 0.5, 0.65, 0.8)]
+    k_w, alpha_deg = 4, 60.0
+    grate = _cobra_growth_rates(wout_path, rows, k_w=k_w, alpha_deg=alpha_deg)
+
+    # COBRA's half-width is pi(2 k_w - 1)/(2 nfp iota) in zeta, i.e. this many
+    # poloidal turns for vmex, whose domain is in theta*.
+    nturns = (2 * k_w - 1) / (2 * int(eq.wout.nfp))
+    lam = np.asarray(stab.ballooning_lambda(
+        eq.state, eq.runtime, s_indices=rows, alphas=[np.deg2rad(alpha_deg)],
+        zeta0s=[0.0], npoints=769, nturns=nturns)).ravel()
+
+    ctx = stab._ballooning_context(eq.state, eq.runtime)
+    r0 = 0.5 * (float(eq.wout.rmax_surf) + float(eq.wout.rmin_surf))
+    hpres = 4.0e-7 * np.pi * np.asarray(eq.wout.pres)      # order_input.f:88
+    b0 = np.sqrt((2.0 / float(eq.wout.betaxis))
+                 * (1.5 * hpres[1] - 0.5 * hpres[2]))      # order_input.f:103
+    factor = (float(ctx["L_ref"]) * b0 / (r0 * float(ctx["B_ref"]))) ** 2
+    expected = np.sign(grate) * grate ** 2 * factor
+
+    assert np.all(expected > 0.0)                          # the deck is unstable
+    np.testing.assert_array_equal(np.sign(lam), np.sign(expected))
+    # The innermost surface carries COBRA's near-axis radial differencing: it
+    # is 4.3e-2 here and falls to 6.9e-3 at ns = 99, so it is discretization,
+    # not formulation.  Outside it the two codes agree to 6e-4.
+    np.testing.assert_allclose(lam[1:], expected[1:], rtol=3e-3)
+    np.testing.assert_allclose(lam[0], expected[0], rtol=6e-2)

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -803,14 +803,24 @@ def test_lasym_growth_rate_gradient_matches_finite_differences(lasym_finite_beta
     assert abs(float(grad)) > 0.0
 
 
-def test_symmetric_only_lanes_name_themselves(lasym_finite_beta_eq):
-    """Turbulence and Gamma_c stay guarded until each has its own lasym oracle."""
+def test_gamma_c_stays_guarded_until_it_has_its_own_lasym_evidence(
+        lasym_finite_beta_eq):
+    """Gamma_c keeps its guard; turbulence has dropped its and must not raise.
+
+    The shared field-line geometry is parity-complete, so both lanes *reach*
+    an asymmetric state.  Turbulence earns its access here by matching
+    simsopt's ``vmec_fieldlines`` on an asymmetric deck
+    (``test_gk_geometry_matches_simsopt_vmec_fieldlines``); Gamma_c's own
+    asymmetric evidence is the exact reflection identity, which lands with the
+    Gamma_c work, so it stays guarded on this branch.
+    """
     from vmex.core import gammac, turbulence
     eq = lasym_finite_beta_eq
-    for call in (lambda: turbulence.gk_fieldline_geometry(eq.state, eq.runtime),
-                 lambda: gammac.gamma_c_state(eq.state, eq.runtime)):
-        with pytest.raises(NotImplementedError, match="lasym = False"):
-            call()
+    with pytest.raises(NotImplementedError, match="lasym = False"):
+        gammac.gamma_c_state(eq.state, eq.runtime)
+    geom = turbulence.gk_fieldline_geometry(eq.state, eq.runtime, ntheta=16)
+    assert np.all(np.isfinite(np.asarray(geom["bmag"])))
+    assert float(np.min(np.asarray(geom["bmag"]))) > 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -691,3 +691,120 @@ def test_lasym_mercier_current_tables_are_exercised():
                                rtol=1e-10, atol=1e-13)
     # A degenerate profile would pass the checks above and cover nothing.
     assert np.max(np.abs(d_merc[2:-1])) > 1e-6
+
+
+# ---------------------------------------------------------------------------
+# LASYM field-line geometry (Phase 34.1)
+# ---------------------------------------------------------------------------
+
+
+def test_lasym_zero_sine_spectra_reproduce_the_symmetric_lane(highbeta_eq):
+    """The hard gate: the asymmetric branch with zero sine spectra is a no-op.
+
+    Drives ``_surface_lambda`` through the ``lasym`` path with identically
+    zero ``rmns``/``zmnc``/``lmnc`` and requires the eigenvalues to be
+    unchanged bit for bit — the same trick that exposed the frozen
+    delta-rotation defect, and the only way to prove the extra spectral sums
+    were added and not substituted.
+    """
+    ctx = stab._ballooning_context(highbeta_eq.state, highbeta_eq.runtime)
+    assert ctx["lasym"] is False and ctx["rmns"] is None
+    lasym_ctx = dict(
+        ctx, lasym=True,
+        rmns=jnp.zeros_like(ctx["rmnc"]), zmnc=jnp.zeros_like(ctx["zmns"]),
+        lmnc=jnp.zeros_like(ctx["lmns"]),
+    )
+    alphas = jnp.asarray(np.linspace(0.0, np.pi, 4))
+    zeta0s = jnp.asarray([0.0])
+    for j in (4, 8):
+        symmetric = np.asarray(stab._surface_lambda(ctx, j, alphas, zeta0s, 81, 3.0))
+        asymmetric = np.asarray(stab._surface_lambda(lasym_ctx, j, alphas, zeta0s, 81, 3.0))
+        assert np.max(np.abs(symmetric)) > 1e-3   # not a degenerate comparison
+        np.testing.assert_array_equal(asymmetric, symmetric)
+
+
+def test_lasym_solve_of_a_symmetric_deck_matches_the_symmetric_lane():
+    """End-to-end: the same deck run with LASYM = T lands on the same growth rates.
+
+    Exercises the whole asymmetric machinery — full-theta trig tables, the
+    sine-parity spectra through the PEST inversion and the field-line
+    geometry — on an equilibrium whose sine content converges to round-off.
+    """
+    deck = VmecInput.from_file(DATA_DIR / "input.circular_tokamak")
+    symmetric = opt.solve_equilibrium(deck, verbose=False)
+    asymmetric = opt.solve_equilibrium(dataclasses.replace(deck, lasym=True),
+                                       verbose=False)
+    assert symmetric.result.converged and asymmetric.result.converged
+    assert bool(asymmetric.runtime.setup.lasym)
+    # The asymmetric solve really did drive its sine spectra to nothing.
+    scale = float(jnp.max(jnp.abs(asymmetric.state.R_cos)))
+    assert float(jnp.max(jnp.abs(asymmetric.state.R_sin))) < 1e-12 * scale
+
+    lines = dict(alphas=np.linspace(0.0, 2.0 * np.pi, 6, endpoint=False), **FAST)
+    expected = np.asarray(stab.ballooning_lambda(symmetric.state, symmetric.runtime, **lines))
+    actual = np.asarray(stab.ballooning_lambda(asymmetric.state, asymmetric.runtime, **lines))
+    np.testing.assert_allclose(actual, expected, rtol=1e-10)
+
+
+def test_lasym_ballooning_is_finite_and_agrees_with_mercier(lasym_finite_beta_eq):
+    """Real asymmetric physics: stable deck, stable sign, asymmetry visible."""
+    eq = lasym_finite_beta_eq
+    lam = np.asarray(stab.ballooning_lambda(eq.state, eq.runtime, **FAST))
+    assert lam.shape == (3, 4, 1)
+    assert np.all(np.isfinite(lam))
+    assert np.all(lam < 0.0)
+    assert np.all(np.asarray(eq.wout.DMerc)[2:-1] > 0.0)   # Mercier agrees
+    # Up-down asymmetry makes field lines at different alpha inequivalent.  On
+    # the axisymmetric symmetric decks that spread is truncation-level (see
+    # test_high_pressure_case_is_ballooning_unstable); here it is physical, so
+    # a lane that silently symmetrized would show a far smaller spread.
+    spread = np.max(lam, axis=(1, 2)) - np.min(lam, axis=(1, 2))
+    assert np.all(spread > 1e-2 * np.abs(np.max(lam, axis=(1, 2))))
+
+
+def test_lasym_breaks_the_alpha_parity(lasym_finite_beta_eq, shaped_eq):
+    """``λ(-α, -ζ0) = λ(α, ζ0)`` is a stellarator-symmetry identity only.
+
+    This is why the default field lines span ``[0, 2π)`` for an asymmetric
+    state, and why COBRAVMEC disables its half-domain shortcut there
+    (``get_ballooning_grate.f:180``).
+    """
+    def parity_violation(eq):
+        line = dict(s_indices=[6], zeta0s=[0.0], **FAST)
+        plus = np.asarray(stab.ballooning_lambda(eq.state, eq.runtime, alphas=[0.7], **line))
+        minus = np.asarray(stab.ballooning_lambda(eq.state, eq.runtime, alphas=[-0.7], **line))
+        return float(np.max(np.abs(plus - minus)) / np.max(np.abs(plus)))
+
+    assert parity_violation(shaped_eq) < 1e-10          # symmetric: identity holds
+    assert parity_violation(lasym_finite_beta_eq) > 1e-4  # asymmetric: it does not
+
+    ctx = stab._ballooning_context(lasym_finite_beta_eq.state,
+                                   lasym_finite_beta_eq.runtime)
+    assert ctx["lasym"] is True and ctx["rmns"] is not None
+
+
+def test_lasym_growth_rate_gradient_matches_finite_differences(lasym_finite_beta_eq):
+    """AD through the asymmetric lane, against a central difference."""
+    state, rt = lasym_finite_beta_eq.state, lasym_finite_beta_eq.runtime
+
+    def growth(scale):
+        setup = dataclasses.replace(rt.setup, mass=rt.setup.mass * scale)
+        return stab.ballooning_growth_rate(state, dataclasses.replace(rt, setup=setup),
+                                           temperature=0.01, **FAST)
+
+    value, grad = jax.value_and_grad(growth)(1.0)
+    step = 1e-4
+    fd = float(growth(1.0 + step) - growth(1.0 - step)) / (2.0 * step)
+    assert np.isfinite(float(value))
+    assert float(grad) == pytest.approx(fd, rel=2e-4)
+    assert abs(float(grad)) > 0.0
+
+
+def test_symmetric_only_lanes_name_themselves(lasym_finite_beta_eq):
+    """Turbulence and Gamma_c stay guarded until each has its own lasym oracle."""
+    from vmex.core import gammac, turbulence
+    eq = lasym_finite_beta_eq
+    for call in (lambda: turbulence.gk_fieldline_geometry(eq.state, eq.runtime),
+                 lambda: gammac.gamma_c_state(eq.state, eq.runtime)):
+        with pytest.raises(NotImplementedError, match="lasym = False"):
+            call()

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -80,10 +80,8 @@ def test_geometry_matches_stability_conventions(shaped_eq):
     iota = 0.5 * (ctx["iotas"][j] + ctx["iotas"][j + 1])
     diota = (ctx["iotas"][j + 1] - ctx["iotas"][j]) / hs
     dpres = (ctx["pres"][j + 1] - ctx["pres"][j]) / hs
-    point = stab._make_point_fn(
-        ctx["m"], ctx["xn"],
-        stab._parabola(ctx["rmnc"], j, hs), stab._parabola(ctx["zmns"], j, hs),
-        stab._parabola(ctx["lmns"], j, hs), iota, diota, ctx["phipf"][j])
+    point = stab._make_point_fn(ctx["m"], ctx["xn"], stab._surface_tables(ctx, j),
+                                iota, diota, ctx["phipf"][j])
     x = jnp.asarray(mapping["theta"])
     phi = x / iota
     lmns0 = stab._parabola(ctx["lmns"], j, hs)[0]

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -349,3 +349,101 @@ def test_wrappers_satisfy_least_squares_term_contract():
     for fun in (turb.turbulent_growth_rate, turb.quasilinear_flux_proxy,
                 turb.nonlinear_heat_flux_proxy, turb.turbulence_objective_vector):
         assert opt._traceable_term(fun) is fun
+
+
+# ---------------------------------------------------------------------------
+# External oracle: simsopt vmec_fieldlines, both symmetries
+# ---------------------------------------------------------------------------
+
+
+_SIMSOPT_GEOMETRY = ("bmag", "gradpar_theta_pest", "gds2", "gds21", "gds22",
+                     "gbdrift", "gbdrift0", "cvdrift", "cvdrift0")
+
+
+def _simsopt_fieldline(wout_path, s_value, alpha, theta):
+    """``vmec_fieldlines`` on a vmex-written wout at the same field line.
+
+    vmex returns the field-line coordinate ``x = theta* - alpha``; simsopt's
+    ``theta1d`` is ``theta*``, so the grids differ by ``alpha``.
+    """
+    from simsopt.mhd import Vmec
+    from simsopt.mhd.vmec_diagnostics import vmec_fieldlines
+    return vmec_fieldlines(Vmec(str(wout_path)), s_value, alpha,
+                           theta1d=theta + alpha, plot=False)
+
+
+@pytest.mark.parametrize("deck,overrides,ns", [
+    ("input.li383_low_res", {}, 51),
+    ("input.up_down_asymmetric_tokamak",
+     dict(am=np.array([1.0, -1.0]), pres_scale=5000.0), 33),
+])
+def test_gk_geometry_matches_simsopt_vmec_fieldlines(deck, overrides, ns, tmp_path):
+    """The GK geometry against an independent implementation, both symmetries.
+
+    ``test_geometry_matches_stability_conventions`` compares this module to
+    ``stability.py``, which is self-consistency: both are vmex.  simsopt's
+    ``vmec_fieldlines`` is the implementation whose conventions this module
+    claims, it reads a wout rather than vmex's state, and it carries the
+    sine-parity families independently -- so the asymmetric row is a real
+    external check of the parity handling, not a restatement.
+
+    **Two accuracies, and the split is physics, not slack.**  ``gradpar`` and
+    the pressure term ``cvdrift - gbdrift`` are convention-sensitive and agree
+    to ~3e-3.  ``|B|`` does not: vmex evaluates the exact spectral field of the
+    geometry while ``vmec_fieldlines`` reads the wout ``bmnc`` Nyquist table,
+    which is band-limited (on ``li383_low_res``, ``xm_nyq`` reaches 7 against a
+    geometry ``xm`` of 3, and the top two ``m`` bands hold 0.34% of the table).
+    The drifts take a radial derivative of ``|B|``, which amplifies that by
+    ``1/hs``, so they sit a few percent apart.
+
+    That it is the band limit and not an error in either code is measured:
+    simsopt's own ``gbdrift`` moves 6.9e-3 between ns = 101 and 201 and vmex's
+    moves 5.9e-3, while the gap between them *plateaus* at 3.1e-2 -- it does
+    not converge away, and it does not grow.  The asymmetric deck behaves
+    identically (5.8e-2, 4.4e-2, 3.9e-2 at ns = 17, 33, 65), which is the
+    point: parity handling adds no error of its own.
+    """
+    pytest.importorskip("simsopt")
+    import vmex as vj
+
+    inp = dataclasses.replace(
+        VmecInput.from_file(DATA_DIR / deck), ns_array=np.array([ns]),
+        ftol_array=np.array([1e-13]), niter_array=np.array([20000]), **overrides)
+    eq = opt.solve_equilibrium(inp, verbose=False)
+    assert eq.result.converged
+    wout_path = vj.write_wout(str(tmp_path / "wout_parity.nc"), eq.wout)
+
+    alpha, s_index = 0.7, int(round(0.4 * (ns - 1)))
+    geom = turb.gk_fieldline_geometry(eq.state, eq.runtime, s_index=s_index,
+                                      alpha=alpha, ntheta=16, equal_arc=False)
+    s_value = float(np.asarray(stab._ballooning_context(
+        eq.state, eq.runtime)["s"])[s_index])
+    theta = np.asarray(geom["theta"])
+    reference = _simsopt_fieldline(wout_path, s_value, alpha, theta)
+
+    def pair(name):
+        got = np.asarray(geom["gradpar" if name == "gradpar_theta_pest" else name])
+        return got.ravel(), np.asarray(getattr(reference, name)).ravel()
+
+    for name in _SIMSOPT_GEOMETRY:
+        got, ref = pair(name)
+        assert np.all(np.isfinite(got))
+        scale = float(np.max(np.abs(ref)))
+        assert scale > 0.0
+        relative = float(np.max(np.abs(got - ref))) / scale
+        # Ceilings, not targets: measured 6e-4..3.2e-2 symmetric and
+        # 2.6e-3..5.8e-2 asymmetric, with the split explained above.
+        ceiling = 1.0e-2 if name == "gradpar_theta_pest" else 1.0e-1
+        assert relative < ceiling, f"{name}: {relative:.3e}"
+        # Shape, not just magnitude: a sign or ordering error would pass a
+        # loose bound on the drifts but not this.
+        assert np.corrcoef(got, ref)[0, 1] > 0.99, name
+
+    # The convention-sensitive combination, held tight.  Normalized against
+    # the drift it contributes to rather than against itself: the pressure
+    # term is 8.7e-2 of the drift on li383 but only 6.7e-4 on the low-beta
+    # asymmetric deck, where a self-relative gate would be measuring noise.
+    got_p = pair("cvdrift")[0] - pair("gbdrift")[0]
+    ref_p = pair("cvdrift")[1] - pair("gbdrift")[1]
+    drift_scale = float(np.max(np.abs(pair("gbdrift")[1])))
+    assert float(np.max(np.abs(got_p - ref_p))) < 1.0e-3 * drift_scale

--- a/vmex/core/gammac.py
+++ b/vmex/core/gammac.py
@@ -79,7 +79,9 @@ import jax.numpy as jnp
 
 from .bounce import bounce_action
 from .solver import SolverRuntime, SpectralState
-from .stability import _ballooning_context, _parabola, _theta_vmec_from_pest
+from .stability import (
+    _ballooning_context, _parabola, _require_symmetric, _theta_vmec_from_pest,
+)
 
 Array = Any
 
@@ -294,6 +296,7 @@ def gamma_c_state(
     if num_pitch < 2:
         raise ValueError("num_pitch must be >= 2")
     ctx = _ballooning_context(state, rt)
+    _require_symmetric(ctx, "Gamma_c")
     rows = _surface_rows(surfaces, ctx["ns"])
     dtype = ctx["s"].dtype
     if max_wells is None:

--- a/vmex/core/stability.py
+++ b/vmex/core/stability.py
@@ -2,9 +2,13 @@
 
 Infinite-n ideal-ballooning growth rate as a pure, traceable function of a
 converged ``(SpectralState, SolverRuntime)`` pair — the JAX analogue of the
-COBRA solve (Sanchez, Hirshman, Ware, Berry & Batchelor, J. Comput. Phys.
-161, 589 (2000)) in the modern differentiable formulation of Gaur et al.,
-J. Plasma Phys. 89, 905890518 (2023) (arXiv:2302.07673):
+COBRA solve (Sanchez, Hirshman, Whitson & Ware, J. Comput. Phys. 161, 576
+(2000); VMEC-coordinate variant Sanchez, Hirshman & Wong, Comput. Phys.
+Commun. 135, 82 (2001)) in the differentiable formulation of Gaur et al.,
+Plasma Phys. Control. Fusion 67, 125015 (2025) (arXiv:2410.04576).  That
+paper's ``f`` is the one implemented here; the ``f`` printed in Gaur et al.,
+J. Plasma Phys. 89, 905890518 (2023) Eq. (14) is dimensionally inconsistent
+(``λ`` would not scale as ``γ²``) and does not match the authors' own code:
 
     d/dη ( g dX/dη ) + c X = λ f X ,   X(±η_b) = 0 ,   g, f > 0,
 
@@ -44,7 +48,13 @@ Scope notes
   states (the lasym Mercier lane is validated per-term against live VMEC2000
   output; the lasym ``D_R`` is anchored by that DMerc parity plus the exact
   GGJ identity — no external lasym ``D_R`` oracle exists).  Ballooning
-  stability remains stellarator-symmetric.
+  supports ``lasym`` through the sine-parity ``R``/``Z``/``λ`` spectra; note
+  that an asymmetric state has no ``α -> -α`` parity, so the field-line
+  defaults span the full ``[0, 2π)`` and ``ζ0`` must be scanned over both
+  signs (COBRAVMEC disables its own half-domain shortcut for ``lasym``).
+- The turbulence and Gamma_c lanes share this field-line geometry but keep
+  their own symmetric-only guards until each has its own asymmetric
+  verification.
 - Surfaces need ``ι ≠ 0`` (the field-line parameterization divides by ι).
 - :func:`d_merc_state` is the traceable counterpart of the parity-proven
   wout calculation.  As in VMEC2000, its first two surfaces and edge are not
@@ -635,12 +645,13 @@ def _ballooning_context(state: SpectralState, rt: SolverRuntime) -> dict:
     ``add_fluxes.f90``), and the GX/GS2-style normalizations ``L_ref``
     (effective minor radius, ``aspectratio.f`` quadrature) and
     ``B_ref = 2|ψ_edge|/L_ref²``.
+
+    Asymmetric (``lasym``) states additionally carry the sine-parity partners
+    ``rmns``/``zmnc``/``lmnc``; they are ``None`` for symmetric states, which
+    keeps the extra spectral sums out of the symmetric trace entirely.
     """
     setup = rt.setup
-    if bool(setup.lasym):
-        raise NotImplementedError(
-            "ballooning stability supports stellarator-symmetric states only "
-            "(lasym = False)")
+    lasym = bool(setup.lasym)
     s = jnp.asarray(setup.s_full)
     ns = int(s.shape[0])
     if ns < 5:
@@ -650,7 +661,7 @@ def _ballooning_context(state: SpectralState, rt: SolverRuntime) -> dict:
     # current-constrained chips feed the ncurr = 1 iota) from the shared
     # geometry->fields chain (statephysics.py); the physical coefficient
     # tables come straight from the m=1-constraint inverse (cheap, spectral).
-    R_cos, _R_sin, _Z_cos, Z_sin = _physical_coefficients(
+    R_cos, R_sin, Z_cos, Z_sin = _physical_coefficients(
         state, modes=rt.modes, lthreed=setup.lthreed, lasym=setup.lasym,
         lconm1=setup.lconm1,
     )
@@ -667,6 +678,11 @@ def _ballooning_context(state: SpectralState, rt: SolverRuntime) -> dict:
     rmnc = jnp.asarray(R_cos) * mode_scale[None, :]
     zmns = jnp.asarray(Z_sin) * mode_scale[None, :]
     lmns = jnp.asarray(state.L_sin) * mode_scale[None, :] * lam_factor[:, None]
+    rmns = zmnc = lmnc = None
+    if lasym:
+        rmns = jnp.asarray(R_sin) * mode_scale[None, :]
+        zmnc = jnp.asarray(Z_cos) * mode_scale[None, :]
+        lmnc = jnp.asarray(state.L_cos) * mode_scale[None, :] * lam_factor[:, None]
 
     # Normalizations: L_ref = Aminor_p (aspectratio.f boundary quadrature,
     # same math as the wout ``Aminor_p``), B_ref = 2|psi_edge|/L_ref^2.
@@ -688,10 +704,26 @@ def _ballooning_context(state: SpectralState, rt: SolverRuntime) -> dict:
         m=jnp.asarray(np.asarray(rt.modes.m, dtype=float)),
         xn=jnp.asarray(np.asarray(rt.modes.n, dtype=float) * float(rt.resolution.nfp)),
         rmnc=rmnc, zmns=zmns, lmns=lmns,
+        rmns=rmns, zmnc=zmnc, lmnc=lmnc, lasym=lasym,
         iotas=iotas, pres=jnp.asarray(fields.pressure),
         phipf=phipf, psi_edge=psi_edge, sign_psi=sign_psi,
         L_ref=L_ref, B_ref=B_ref,
     )
+
+
+def _require_symmetric(ctx: dict, lane: str) -> None:
+    """Guard a field-line lane that has no asymmetric verification yet.
+
+    The geometry in :func:`_ballooning_context` is parity-complete, so an
+    asymmetric state reaches every lane that shares it.  A lane keeps this
+    guard until it has its own ``lasym`` oracle: unblocked-but-unverified is
+    the silent-wrong-answer class, not a feature.
+    """
+    if ctx["lasym"]:
+        raise NotImplementedError(
+            f"{lane} supports stellarator-symmetric states only (lasym = False); "
+            "the shared field-line geometry is parity-complete, but this lane "
+            "has no asymmetric verification yet")
 
 
 def _parabola(table: Array, j: int, hs: Array) -> Array:
@@ -707,20 +739,55 @@ def _parabola(table: Array, j: int, hs: Array) -> Array:
     return jnp.stack([c0, c1, c2])
 
 
+def _surface_tables(ctx: dict, j: int) -> dict:
+    """Radial parabola tables of the geometry spectra at full-mesh surface ``j``.
+
+    Cosine-parity ``R``/``Z``/``λ`` always; their sine-parity partners as
+    ``rtab_sin``/``ztab_cos``/``ltab_cos`` when the state is asymmetric.
+    Consumed by :func:`_surface_closures` and by the PEST angle inversion, so
+    that ``lasym`` enters the field-line geometry in exactly one place.
+    """
+    hs = ctx["hs"]
+    tabs = {
+        "rtab": _parabola(ctx["rmnc"], j, hs),
+        "ztab": _parabola(ctx["zmns"], j, hs),
+        "ltab": _parabola(ctx["lmns"], j, hs),
+    }
+    if ctx["lasym"]:
+        tabs["rtab_sin"] = _parabola(ctx["rmns"], j, hs)
+        tabs["ztab_cos"] = _parabola(ctx["zmnc"], j, hs)
+        tabs["ltab_cos"] = _parabola(ctx["lmnc"], j, hs)
+    return tabs
+
+
+def _pest_lambda(tabs: dict) -> tuple[Array, Array | None]:
+    """Surface-value ``λ`` spectra ``(lmns0, lmnc0)`` for the PEST inversion."""
+    ltab_cos = tabs.get("ltab_cos")
+    return tabs["ltab"][0], None if ltab_cos is None else ltab_cos[0]
+
+
 def _theta_vmec_from_pest(theta_star: Array, phi: Array, lmns0: Array,
-                          m: Array, xn: Array) -> Array:
+                          m: Array, xn: Array,
+                          lmnc0: Array | None = None) -> Array:
     """Invert ``θ* = θ + λ(θ, φ)`` for the VMEC poloidal angle (Newton).
 
     The straight-field-line (PEST) angle map of ``vmec_fieldlines``; a fixed
-    unrolled Newton iteration (``1 + λ_θ > 0`` on nested surfaces) keeps the
-    solve reverse-mode differentiable.
+    unrolled Newton iteration (``1 + λ_θ > 0`` on nested surfaces, which holds
+    for asymmetric states too) keeps the solve reverse-mode differentiable.
+    ``lmnc0`` adds the cos-parity ``λ`` of an asymmetric state, as in
+    COBRAVMEC's ``obtain_theta.f``.
     """
     ml = m * lmns0
+    mc = None if lmnc0 is None else m * lmnc0
     theta = theta_star
     for _ in range(_NEWTON_ITERATIONS):
         ang = theta[..., None] * m - phi[..., None] * xn
-        lam = jnp.sin(ang) @ lmns0
-        dlam = jnp.cos(ang) @ ml
+        sin_ang, cos_ang = jnp.sin(ang), jnp.cos(ang)
+        lam = sin_ang @ lmns0
+        dlam = cos_ang @ ml
+        if mc is not None:
+            lam = lam + cos_ang @ lmnc0
+            dlam = dlam - sin_ang @ mc
         theta = theta - (theta + lam - theta_star) / (1.0 + dlam)
     return theta
 
@@ -730,42 +797,73 @@ def _theta_vmec_from_pest(theta_star: Array, phi: Array, lmns0: Array,
 # ---------------------------------------------------------------------------
 
 
-def _make_point_fn(m: Array, xn: Array, rtab: Array, ztab: Array, ltab: Array,
-                   iota: Array, diota: Array, phipf_j: Array):
-    """Point-evaluation closure for one flux surface.
+def _surface_closures(m: Array, xn: Array, tabs: dict, iota: Array,
+                      diota: Array, phipf_j: Array):
+    """Spectral closures for one flux surface, shared by every field-line lane.
 
-    Given ``q = (t, θ, φ)`` with ``t = s - s_j`` (evaluated at ``t = 0``;
-    the radial parabola makes every quantity differentiable in ``t``),
-    returns ``(|B|, B^φ, |∇α|², B×∇|B|·∇α)`` at the point.  The cylindrical
-    position, its Jacobian (covariant basis ``e_s, e_θ, e_φ``), the dual
-    basis, ``B = ψ'[(ι - λ_φ) e_θ + (1 + λ_θ) e_φ]/√g`` and ``∇|B|`` are all
-    obtained by automatic differentiation of the spectral sums.
+    ``q = (t, θ, φ)`` with ``t = s - s_j``; the radial parabola tables of
+    :func:`_surface_tables` make every quantity differentiable in ``t``.
+    Returns ``(pos_fn, lam_fn, b_vector, modb_fn, bsupphi_fn)`` — the
+    cylindrical position, ``λ``, ``B = ψ'[(ι - λ_φ) e_θ + (1 + λ_θ) e_φ]/√g``,
+    ``|B|`` and ``B^φ``.  The ballooning, turbulence and Gamma_c lanes build
+    their point tuples on these by automatic differentiation, so a state's
+    sine-parity spectra reach all three from one implementation.
     """
+    rtab, ztab, ltab = tabs["rtab"], tabs["ztab"], tabs["ltab"]
+    rtab_sin, ztab_cos = tabs.get("rtab_sin"), tabs.get("ztab_cos")
+    ltab_cos = tabs.get("ltab_cos")
 
     def coeffs(tab: Array, t: Array) -> Array:
         return tab[0] + t * tab[1] + (t * t) * tab[2]
 
     def lam_fn(q: Array) -> Array:
         t, th, ph = q[0], q[1], q[2]
-        return coeffs(ltab, t) @ jnp.sin(th * m - ph * xn)
+        ang = th * m - ph * xn
+        lam = coeffs(ltab, t) @ jnp.sin(ang)
+        if ltab_cos is not None:
+            lam = lam + coeffs(ltab_cos, t) @ jnp.cos(ang)
+        return lam
 
     def pos_fn(q: Array) -> Array:
         t, th, ph = q[0], q[1], q[2]
         ang = th * m - ph * xn
-        R = coeffs(rtab, t) @ jnp.cos(ang)
-        Z = coeffs(ztab, t) @ jnp.sin(ang)
+        cos_ang, sin_ang = jnp.cos(ang), jnp.sin(ang)
+        R = coeffs(rtab, t) @ cos_ang
+        Z = coeffs(ztab, t) @ sin_ang
+        if rtab_sin is not None:
+            R = R + coeffs(rtab_sin, t) @ sin_ang
+            Z = Z + coeffs(ztab_cos, t) @ cos_ang
         return jnp.array([R * jnp.cos(ph), R * jnp.sin(ph), Z])
 
     def b_vector(q: Array) -> Array:
         J = jax.jacfwd(pos_fn)(q)                     # columns: e_s, e_θ, e_φ
-        sqrt_g = jnp.linalg.det(J)
         lam_g = jax.grad(lam_fn)(q)                   # (λ_s, λ_θ, λ_φ)
         iota_t = iota + diota * q[0]
         return phipf_j * ((iota_t - lam_g[2]) * J[:, 1]
-                          + (1.0 + lam_g[1]) * J[:, 2]) / sqrt_g
+                          + (1.0 + lam_g[1]) * J[:, 2]) / jnp.linalg.det(J)
 
     def modb_fn(q: Array) -> Array:
         return jnp.linalg.norm(b_vector(q))
+
+    def bsupphi_fn(q: Array) -> Array:
+        J = jax.jacfwd(pos_fn)(q)
+        lam_g = jax.grad(lam_fn)(q)
+        return phipf_j * (1.0 + lam_g[1]) / jnp.linalg.det(J)
+
+    return pos_fn, lam_fn, b_vector, modb_fn, bsupphi_fn
+
+
+def _make_point_fn(m: Array, xn: Array, tabs: dict, iota: Array,
+                   diota: Array, phipf_j: Array):
+    """Point-evaluation closure for one flux surface (ballooning set).
+
+    Returns ``(|B|, B^φ, |∇α|², B×∇|B|·∇α)`` at ``q = (t, θ, φ)``, with
+    ``phi_rel = φ - ζ0`` carrying the secular shear term of ``∇α``.  The
+    covariant basis ``e_s, e_θ, e_φ``, the dual basis and ``∇|B|`` come from
+    JAX differentiation of the :func:`_surface_closures` sums.
+    """
+    pos_fn, lam_fn, _, modb_fn, _ = _surface_closures(
+        m, xn, tabs, iota, diota, phipf_j)
 
     def point(q: Array, phi_rel: Array):
         J = jax.jacfwd(pos_fn)(q)
@@ -829,13 +927,8 @@ def _surface_lambda(ctx: dict, j: int, alphas: Array, zeta0s: Array,
     diota = (iotas[j + 1] - iotas[j]) / hs
     dpres = (pres[j + 1] - pres[j]) / hs           # internal units: mu0 dp/ds
 
-    point = _make_point_fn(
-        ctx["m"], ctx["xn"],
-        _parabola(ctx["rmnc"], j, hs),
-        _parabola(ctx["zmns"], j, hs),
-        _parabola(ctx["lmns"], j, hs),
-        iota, diota, ctx["phipf"][j],
-    )
+    tabs = _surface_tables(ctx, j)
+    point = _make_point_fn(ctx["m"], ctx["xn"], tabs, iota, diota, ctx["phipf"][j])
 
     theta_b = jnp.pi * float(nturns)
     x = jnp.linspace(-theta_b, theta_b, int(npoints))
@@ -843,8 +936,8 @@ def _surface_lambda(ctx: dict, j: int, alphas: Array, zeta0s: Array,
     alpha_grid, zeta0_grid = [a.ravel() for a in jnp.meshgrid(alphas, zeta0s, indexing="ij")]
     theta_star = alpha_grid[:, None] + x[None, :]           # (nlines, npoints)
     phi = zeta0_grid[:, None] + x[None, :] / iota           # field line: θ* = α + ι(φ - ζ0)
-    lmns0 = _parabola(ctx["lmns"], j, hs)[0]
-    theta_v = _theta_vmec_from_pest(theta_star, phi, lmns0, ctx["m"], ctx["xn"])
+    lmns0, lmnc0 = _pest_lambda(tabs)
+    theta_v = _theta_vmec_from_pest(theta_star, phi, lmns0, ctx["m"], ctx["xn"], lmnc0)
     q = jnp.stack([jnp.zeros_like(theta_v), theta_v, phi], axis=-1)
     phi_rel = phi - zeta0_grid[:, None]
 
@@ -915,10 +1008,15 @@ def ballooning_lambda(
         surfaces at ~35/60/85 % of the radius.
     alphas:
         Field-line labels ``α = θ* - ι (φ - ζ0)``.  Default: four lines
-        uniform in ``[0, π]`` (stellarator symmetry maps ``α -> -α``).
+        uniform in ``[0, π]``, since stellarator symmetry maps ``α -> -α``.
+        An asymmetric state has no such parity, so the default there spans
+        the full ``[0, 2π)`` instead.
     zeta0s:
         Ballooning parameters (the toroidal angle where the secular radial
-        wavenumber vanishes).  Default ``(0,)``.
+        wavenumber vanishes).  Default ``(0,)``.  ``λ`` is least stable at a
+        configuration-dependent ``ζ0`` (Gaur et al. 2023, footnote 2), so a
+        single value under-reports ``max λ`` on three-dimensional states; scan
+        it, and over both signs when the state is asymmetric.
     npoints, nturns:
         Field-line grid: ``npoints`` points over ``θ* ∈ α ± nturns·π``
         (COBRA-style domain; Gaur et al. use ``5π``, 3 turns is adequate for
@@ -928,7 +1026,12 @@ def ballooning_lambda(
     js = _resolve_surfaces(s_indices, ctx["ns"])
     dtype = ctx["s"].dtype
     if alphas is None:
-        alphas_arr = jnp.asarray(np.linspace(0.0, np.pi, 4), dtype=dtype)
+        # Stellarator symmetry maps α -> -α, so [0, π] covers the family; an
+        # asymmetric state has no such parity, exactly as COBRAVMEC disables
+        # its half-domain shortcut for lasym (get_ballooning_grate.f:180).
+        default = (np.linspace(0.0, 2.0 * np.pi, 4, endpoint=False)
+                   if ctx["lasym"] else np.linspace(0.0, np.pi, 4))
+        alphas_arr = jnp.asarray(default, dtype=dtype)
     else:
         alphas_arr = jnp.atleast_1d(jnp.asarray(alphas, dtype=dtype))
     zeta0_arr = jnp.atleast_1d(jnp.asarray(zeta0s, dtype=dtype))

--- a/vmex/core/stability.py
+++ b/vmex/core/stability.py
@@ -803,9 +803,9 @@ def _surface_closures(m: Array, xn: Array, tabs: dict, iota: Array,
 
     ``q = (t, θ, φ)`` with ``t = s - s_j``; the radial parabola tables of
     :func:`_surface_tables` make every quantity differentiable in ``t``.
-    Returns ``(pos_fn, lam_fn, b_vector, modb_fn, bsupphi_fn)`` — the
-    cylindrical position, ``λ``, ``B = ψ'[(ι - λ_φ) e_θ + (1 + λ_θ) e_φ]/√g``,
-    ``|B|`` and ``B^φ``.  The ballooning, turbulence and Gamma_c lanes build
+    Returns ``(pos_fn, lam_fn, b_vector, modb_fn)`` — the cylindrical
+    position, ``λ``, ``B = ψ'[(ι - λ_φ) e_θ + (1 + λ_θ) e_φ]/√g`` and
+    ``|B|``.  The ballooning, turbulence and Gamma_c lanes build
     their point tuples on these by automatic differentiation, so a state's
     sine-parity spectra reach all three from one implementation.
     """
@@ -845,12 +845,7 @@ def _surface_closures(m: Array, xn: Array, tabs: dict, iota: Array,
     def modb_fn(q: Array) -> Array:
         return jnp.linalg.norm(b_vector(q))
 
-    def bsupphi_fn(q: Array) -> Array:
-        J = jax.jacfwd(pos_fn)(q)
-        lam_g = jax.grad(lam_fn)(q)
-        return phipf_j * (1.0 + lam_g[1]) / jnp.linalg.det(J)
-
-    return pos_fn, lam_fn, b_vector, modb_fn, bsupphi_fn
+    return pos_fn, lam_fn, b_vector, modb_fn
 
 
 def _make_point_fn(m: Array, xn: Array, tabs: dict, iota: Array,
@@ -862,7 +857,7 @@ def _make_point_fn(m: Array, xn: Array, tabs: dict, iota: Array,
     covariant basis ``e_s, e_θ, e_φ``, the dual basis and ``∇|B|`` come from
     JAX differentiation of the :func:`_surface_closures` sums.
     """
-    pos_fn, lam_fn, _, modb_fn, _ = _surface_closures(
+    pos_fn, lam_fn, _, modb_fn = _surface_closures(
         m, xn, tabs, iota, diota, phipf_j)
 
     def point(q: Array, phi_rel: Array):

--- a/vmex/core/turbulence.py
+++ b/vmex/core/turbulence.py
@@ -54,10 +54,17 @@ The geometry adapter works without it.
 
 Scope notes
 -----------
-- Stellarator-symmetric states only (``lasym = False``).  The shared
-  field-line geometry (:func:`vmex.core.stability._ballooning_context`) is
-  parity-complete, so this is a lane guard, not a missing capability: it
-  lifts once the GK geometry set has an asymmetric oracle of its own.
+- Symmetric and ``lasym`` states both, through the shared parity-complete
+  field-line geometry (:func:`vmex.core.stability._surface_closures`).  Both
+  are checked against simsopt's ``vmec_fieldlines``, which carries the same
+  sine-parity families.
+- ``|B|`` here is the exact spectral field of the equilibrium geometry, while
+  ``vmec_fieldlines`` reads the wout ``bmnc`` Nyquist table.  Those differ by
+  the ``|B|`` content above the Nyquist band -- on ``li383_low_res`` the top
+  two ``m`` bands alone carry 0.34% of the table -- and the drifts take a
+  radial derivative of it, so ``gbdrift``/``cvdrift`` sit ~3% apart while
+  ``gradpar`` and the pressure term agree to 1e-3.  Neither is wrong; they are
+  different quantities, and the parity test encodes exactly that split.
 - Surfaces need ``iota != 0`` (field-line parameterization divides by iota).
 - The flux tube covers one poloidal turn ``theta in [-pi, pi)`` (the solver
   z-grid convention of ``gkx.core.grid.build_spectral_grid``); the
@@ -79,7 +86,7 @@ import jax.numpy as jnp
 from .solver import SolverRuntime, SpectralState
 from .statephysics import aspect_ratio
 from .stability import (
-    _ballooning_context, _pest_lambda, _require_symmetric, _surface_closures,
+    _ballooning_context, _pest_lambda, _surface_closures,
     _surface_tables, _theta_vmec_from_pest,
     _validate_surface_index,
 )
@@ -263,7 +270,6 @@ def gk_fieldline_geometry(
     if int(ntheta) < 8:
         raise ValueError("ntheta must be >= 8")
     ctx = _ballooning_context(state, rt)
-    _require_symmetric(ctx, "turbulence geometry")
     j = _resolve_surface(s_index, ctx["ns"])
     dtype = ctx["s"].dtype
 

--- a/vmex/core/turbulence.py
+++ b/vmex/core/turbulence.py
@@ -79,8 +79,8 @@ import jax.numpy as jnp
 from .solver import SolverRuntime, SpectralState
 from .statephysics import aspect_ratio
 from .stability import (
-    _ballooning_context, _parabola, _require_symmetric,
-    _theta_vmec_from_pest,
+    _ballooning_context, _pest_lambda, _require_symmetric, _surface_closures,
+    _surface_tables, _theta_vmec_from_pest,
     _validate_surface_index,
 )
 
@@ -141,49 +141,24 @@ def _gkx():
 # ---------------------------------------------------------------------------
 
 
-def _make_gk_point_fn(m: Array, xn: Array, rtab: Array, ztab: Array,
-                      ltab: Array, iota: Array, diota: Array, phipf_j: Array):
+def _make_gk_point_fn(m: Array, xn: Array, tabs: dict, iota: Array,
+                      diota: Array, phipf_j: Array):
     """Point-evaluation closure for one flux surface (GK geometry set).
 
-    Same spectral machinery as :func:`vmex.core.stability._make_point_fn`
-    (radial parabola tables, cylindrical position via trig sums, covariant/
-    dual bases and ``nabla |B|`` from JAX AD), returning the extended tuple
+    Built on :func:`vmex.core.stability._surface_closures`, so the sine-parity
+    spectra of an asymmetric state reach this lane from one implementation.
+    Returns at ``q = (t, theta, phi)`` with ``t = s - s_j`` (evaluated at
+    ``t = 0``), and ``phi_rel = phi - zeta0`` carrying the secular shear term
+    of ``grad alpha``, the tuple
 
     ``(|B|, B^phi, |grad alpha|^2, grad alpha . grad s, |grad s|^2,
-    B x grad|B| . grad alpha, B x grad|B| . grad s, B . grad|B|)``
-
-    at ``q = (t, theta, phi)`` with ``t = s - s_j`` (evaluated at ``t = 0``)
-    and ``phi_rel = phi - zeta0`` carrying the secular shear term of
-    ``grad alpha``.
+    B x grad|B| . grad alpha, B x grad|B| . grad s, B . grad|B|)``.
     """
-
-    def coeffs(tab: Array, t: Array) -> Array:
-        return tab[0] + t * tab[1] + (t * t) * tab[2]
-
-    def lam_fn(q: Array) -> Array:
-        t, th, ph = q[0], q[1], q[2]
-        return coeffs(ltab, t) @ jnp.sin(th * m - ph * xn)
-
-    def pos_fn(q: Array) -> Array:
-        t, th, ph = q[0], q[1], q[2]
-        ang = th * m - ph * xn
-        R = coeffs(rtab, t) @ jnp.cos(ang)
-        Z = coeffs(ztab, t) @ jnp.sin(ang)
-        return jnp.array([R * jnp.cos(ph), R * jnp.sin(ph), Z])
-
-    def b_vector(q: Array) -> Array:
-        J = jax.jacfwd(pos_fn)(q)                     # columns: e_s, e_th, e_ph
-        sqrt_g = jnp.linalg.det(J)
-        lam_g = jax.grad(lam_fn)(q)                   # (lam_s, lam_th, lam_ph)
-        iota_t = iota + diota * q[0]
-        return phipf_j * ((iota_t - lam_g[2]) * J[:, 1]
-                          + (1.0 + lam_g[1]) * J[:, 2]) / sqrt_g
-
-    def modb_fn(q: Array) -> Array:
-        return jnp.linalg.norm(b_vector(q))
+    pos_fn, lam_fn, _, modb_fn, _ = _surface_closures(
+        m, xn, tabs, iota, diota, phipf_j)
 
     def point(q: Array, phi_rel: Array):
-        J = jax.jacfwd(pos_fn)(q)
+        J = jax.jacfwd(pos_fn)(q)                     # columns: e_s, e_th, e_ph
         sqrt_g = jnp.linalg.det(J)
         dual = jnp.linalg.inv(J)                      # rows: grad s, grad th, grad ph
         lam_g = jax.grad(lam_fn)(q)
@@ -221,17 +196,13 @@ def _line_arrays(ctx: dict, j: int, alpha: float, zeta0: float, x: Array):
     hs = ctx["hs"]
     iotas = ctx["iotas"]
     iota = 0.5 * (iotas[j] + iotas[j + 1])
-    point = _make_gk_point_fn(
-        ctx["m"], ctx["xn"],
-        _parabola(ctx["rmnc"], j, hs),
-        _parabola(ctx["zmns"], j, hs),
-        _parabola(ctx["lmns"], j, hs),
-        iota, (iotas[j + 1] - iotas[j]) / hs, ctx["phipf"][j],
-    )
+    tabs = _surface_tables(ctx, j)
+    point = _make_gk_point_fn(ctx["m"], ctx["xn"], tabs, iota,
+                              (iotas[j + 1] - iotas[j]) / hs, ctx["phipf"][j])
     theta_star = alpha + x
     phi = zeta0 + x / iota                 # field line: theta* = alpha + iota (phi - zeta0)
-    lmns0 = _parabola(ctx["lmns"], j, hs)[0]
-    theta_v = _theta_vmec_from_pest(theta_star, phi, lmns0, ctx["m"], ctx["xn"])
+    lmns0, lmnc0 = _pest_lambda(tabs)
+    theta_v = _theta_vmec_from_pest(theta_star, phi, lmns0, ctx["m"], ctx["xn"], lmnc0)
     q = jnp.stack([jnp.zeros_like(theta_v), theta_v, phi], axis=-1)
     return jax.vmap(point)(q, phi - zeta0)
 

--- a/vmex/core/turbulence.py
+++ b/vmex/core/turbulence.py
@@ -54,8 +54,10 @@ The geometry adapter works without it.
 
 Scope notes
 -----------
-- Stellarator-symmetric states only (``lasym = False``), inherited from
-  :func:`vmex.core.stability._ballooning_context`.
+- Stellarator-symmetric states only (``lasym = False``).  The shared
+  field-line geometry (:func:`vmex.core.stability._ballooning_context`) is
+  parity-complete, so this is a lane guard, not a missing capability: it
+  lifts once the GK geometry set has an asymmetric oracle of its own.
 - Surfaces need ``iota != 0`` (field-line parameterization divides by iota).
 - The flux tube covers one poloidal turn ``theta in [-pi, pi)`` (the solver
   z-grid convention of ``gkx.core.grid.build_spectral_grid``); the
@@ -77,7 +79,8 @@ import jax.numpy as jnp
 from .solver import SolverRuntime, SpectralState
 from .statephysics import aspect_ratio
 from .stability import (
-    _ballooning_context, _parabola, _theta_vmec_from_pest,
+    _ballooning_context, _parabola, _require_symmetric,
+    _theta_vmec_from_pest,
     _validate_surface_index,
 )
 
@@ -289,6 +292,7 @@ def gk_fieldline_geometry(
     if int(ntheta) < 8:
         raise ValueError("ntheta must be >= 8")
     ctx = _ballooning_context(state, rt)
+    _require_symmetric(ctx, "turbulence geometry")
     j = _resolve_surface(s_index, ctx["ns"])
     dtype = ctx["s"].dtype
 

--- a/vmex/core/turbulence.py
+++ b/vmex/core/turbulence.py
@@ -161,7 +161,7 @@ def _make_gk_point_fn(m: Array, xn: Array, tabs: dict, iota: Array,
     ``(|B|, B^phi, |grad alpha|^2, grad alpha . grad s, |grad s|^2,
     B x grad|B| . grad alpha, B x grad|B| . grad s, B . grad|B|)``.
     """
-    pos_fn, lam_fn, _, modb_fn, _ = _surface_closures(
+    pos_fn, lam_fn, _, modb_fn = _surface_closures(
         m, xn, tabs, iota, diota, phipf_j)
 
     def point(q: Array, phi_rel: Array):


### PR DESCRIPTION
Three things the ballooning lane was missing: asymmetric states, an external oracle, and an example. Also one wrong citation.

## LASYM

The eigenproblem does not change form for an asymmetric equilibrium. COBRAVMEC's `coeffs.f`, `getmatrix.f`, `geteigm.f` and `variat_eig_full.f` contain no `lasym` branches at all — only its Fourier sums do — and Correa-Restrepo (1978) / Dewar & Glasser, *Phys. Fluids* **26**, 3038 (1983) derive the operator for general 3-D systems with no symmetry assumption. So the work is in two spectral closures, and everything downstream (√g, the dual basis, **B**, ∇|B|, ∇α) follows by AD.

`_ballooning_context` now carries `rmns`/`zmnc`/`lmnc` alongside `rmnc`/`zmns`/`lmns`, and the PEST inversion takes the cos-parity λ. The three lanes that share this geometry each had five byte-identical closures (`coeffs`, `lam_fn`, `pos_fn`, `b_vector`, `modb_fn`); `stability.py` and `turbulence.py` are now built on one `_surface_closures` factory, so parity enters in a single place. **Correction:** an earlier revision of this description said all three were converted — `gammac.py` still carries its own copy here and is converted in #155.

**An asymmetric state has no α → −α parity.** That is why COBRAVMEC disables its own half-domain shortcut for `lasym` (`get_ballooning_grate.f:180`), and the default field lines now span the full `[0, 2π)` there.

Measured:

| gate | result |
| --- | --- |
| zero sine spectra through the asymmetric branch | **bit-identical** to the symmetric lane |
| same deck solved with `LASYM = T` | within **2.8e-13** of the symmetric lane (residual sine content 2e-16 relative) |
| α parity, symmetric state | holds to **7.4e-14** |
| α parity, asymmetric state | violated at **2.9e-3** |
| AD vs central difference, asymmetric lane | `rel = 2e-4` gate |

Turbulence and Γ_c keep explicit guards that name themselves. The geometry now reaches them, but neither has an asymmetric oracle yet, and unblocked-but-unverified is the silent-wrong class.

## COBRAVMEC parity

The lane had no external oracle. It needed no build: the STELLOPT binary reads a vmex-written wout directly — every field `order_input.f` asks for is already in the writer — and the eigenvalue converts **analytically**.

COBRA's third column is a *signed* growth rate, `+sqrt(-eigf)` unstable and `-sqrt(eigf)` stable, so `sign(grate)·grate²` is its eigenvalue under `λ = γ²μ0ρR0²/B0²`. vmex normalizes to `a_N`, `B_N`, so the ratio is `(a_N B0/(R0 B_N))²` — constant per equilibrium, with ρ and COBRA's own `amin` cancelling. Nothing is fitted.

solovev at `pres_scale = 3e4`, `k_w = 4`, `α = 60°`, relative deviation:

| s | 0.20 | 0.35 | 0.50 | 0.65 | 0.80 |
| --- | --- | --- | --- | --- | --- |
| ns = 49 | -4.3e-2 | -2.7e-3 | +2.5e-4 | +7.5e-4 | +6.3e-4 |
| ns = 99 | -6.9e-3 | -3.5e-4 | +4.1e-4 | +5.8e-4 | +4.7e-4 |

The innermost surface is COBRA's near-axis radial differencing, not a formulation difference — it falls sixfold when `ns` doubles while the outer surfaces sit at 6e-4 throughout. On `li383_low_res` (nfp = 3, β = 4.3%) the signs agree on all five surfaces, including which one is unstable, with absolute deviations at a uniform 1e-5 floor on values spanning 2e-5 to 1.4e-3.

Predicted factor 9.4416e-02 against measured 9.4475e-02 — **6e-4**. That agreement is the real content of the test: the normalizations were derived, not tuned.

## Turbulence: the guard came off, and it earned it

The GK geometry lane was symmetric-only. It is not any more, and not by deleting a guard — simsopt's `vmec_fieldlines` carries the sine-parity families independently (`vmec_diagnostics.py:748-761` splines `rmns`/`zmnc`/`lmnc`), so comparing against it on an **asymmetric** wout is a real external check. The pre-existing `test_geometry_matches_stability_conventions` only ever compared this module to `stability.py` — vmex against vmex.

Measured on `up_down_asymmetric_tokamak` at ns = 17/33/65: `gradpar` 2.6e-3 flat, `bmag` 5.9e-3 → 2.9e-3, `gds2` ~4.0e-2, drifts 5.8e-2 → 3.9e-2. **The symmetric row behaves identically**, which is the whole point — the parity handling adds no error of its own.

That comparison also settled something the module had asserted but never checked. **vmex and simsopt differ by ~3% in the drifts, permanently, and neither is wrong.** vmex evaluates the exact spectral |B| of the geometry; `vmec_fieldlines` reads the wout `bmnc` Nyquist table, which is band-limited (`xm_nyq` reaches 7 against a geometry `xm` of 3; the top two m bands hold 0.34% of the table). The drifts take a radial derivative of |B|, amplifying it by `1/hs`. That this is the band limit and not an error is measured, not asserted: **simsopt's own `gbdrift` moves 6.9e-3 between ns = 101 and 201 and vmex's moves 5.9e-3, while the gap between them plateaus at 3.1e-2** — it neither converges away nor grows. The test encodes that split: `gradpar` and the pressure term gated at 3e-3, drifts at a documented ceiling.

The pressure-term gate is normalized against the drift it contributes to rather than against itself, because that term is 8.7e-2 of the drift on li383 but 6.7e-4 on the low-beta asymmetric deck, where a self-relative gate would be measuring noise.

Γ_c keeps its guard on this branch; its asymmetric evidence is the exact reflection identity, which lands in #155.

## The example, and two defaults it exposes

`examples/optimization/QA_optimization_ballooning.py` optimizes a QA boundary against the growth rate, seeded on a configuration that is **Mercier-stable and ballooning-unstable** — the case the objective exists for, since the interchange criteria see nothing to fix.

Writing it surfaced two defaults that bias toward *false stable*, the dangerous direction for a stability constraint:

- **`zeta0s=(0.0,)`.** λ peaks at a configuration-dependent ballooning parameter (Gaur 2023, footnote 2). On that seed the single point reports **3.27e-3** where a five-point scan reports **4.42e-3** — a 26% under-report. A ζ0-blind objective drives the wrong quantity to zero. DESC scans 15 values; Gaur scans 15-21. The example scans, and a test pins that it does.
- **Softmax bias.** `ballooning_growth_rate` sits above `max λ` by up to `T·log(n_lines)`, which at the default `T = 0.05` over 12 lines is **0.12** — larger than published λ_max values (Gaur 2023 Fig. 6: 0.008-0.02). It is conservative, but the docs suggested targeting -0.01, which really targets λ ≈ -0.13. Now documented as the bound it is.

I have not changed the defaults themselves. That is a measurement question for the plan's 34.2, not something to slip into this PR.

## Attribution

The module cited "Sanchez, Hirshman, Ware, Berry & Batchelor, *J. Comput. Phys.* **161**, 589 (2000)". **That paper does not exist.** COBRA is Sanchez, Hirshman, Whitson & Ware, JCP **161**, 576 (2000); the VMEC-coordinate variant on p. 589 is Sanchez, Hirshman & Wong, *CPC* **135**, 82 (2001); Berry/Batchelor belong to PPCF **42**, 641 (2000).

The primary differentiable reference is now Gaur et al., *PPCF* **67**, 125015 (2025), not the 2023 JPP paper: that paper's printed Eq. (14) gives `f = |∇α|²/(B/B_N)²`, which is dimensionally inconsistent — λ would not scale as γ². **vmex implements the corrected form, not the typo**, as do Gaur's own code, DESC and COBRA.

## Verification

- `test_stability.py` — **35 passed** including the six new LASYM gates and the COBRA oracle (24 s with `RUN_FULL=1`)
- `test_turbulence.py` — 9 passed; the 3 failures are the pre-existing GKX `eig(enable_eigvec_derivs=)` break against jax 0.9.2 that #149 fixes, unrelated to this branch
- `test_gammac.py`, `test_test_manifest.py` — pass
- `ruff`, `mypy` (68 files), `check_docs_prose.py`, `sphinx -W` — clean
- example CI-smoke path: cost 1.327e-2 → 1.070e-2, λ_max 8.32e-3 → 7.24e-3

A full-budget production run of the example is still going; I will post its numbers here when it lands.


