### PR TITLE
Run the manifest primary lanes that no CI job was invoking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,65 @@ jobs:
           path: coverage.physics-${{ matrix.lane }}
           retention-days: 3
 
+  parity:
+    name: Manifest parity lane (${{ matrix.lane }})
+    runs-on: ubuntu-latest
+    # The primary-lane partition is the whole pull-request suite; these four
+    # jobs are the part no other job was running.  Durations come from the
+    # runner, not a guess -- rebalance the grouping from the reported times.
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: a
+            selector: pr-parity-a1 pr-parity-a2 pr-parity-b
+          - lane: c1
+            selector: pr-parity-c1 pr-parity-c3 pr-parity-d
+          - lane: c2
+            selector: pr-parity-c2
+          - lane: misc
+            selector: pr-examples pr-external pr-full-only pr-gradient pr-mirror-spline
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          python -m pip install ".[coils,turbulence,freeb]" pytest pytest-cov pytest-xdist
+      - name: Add XLA compile headroom
+        run: |
+          sudo fallocate -l 12G /mnt/vmex-swap
+          sudo chmod 600 /mnt/vmex-swap
+          sudo mkswap /mnt/vmex-swap
+          sudo swapon /mnt/vmex-swap
+      - name: Fetch the golden digests
+        run: python tools/fetch_assets.py --bundle golden-v1
+      - name: Run the manifest lanes
+        env:
+          JAX_ENABLE_X64: "1"
+        run: |
+          FILES=""
+          for LANE in ${{ matrix.selector }}; do
+            FILES="$FILES $(python tools/test_manifest.py select "$LANE")"
+          done
+          # Lanes overlap, and a module selected twice would run twice.
+          FILES="$(printf '%s\n' $FILES | sort -u | tr '\n' ' ')"
+          pytest -q -n 2 -m "not full and not weekly" \
+            $FILES --durations=20 --cov=vmex --cov-report=term
+      - name: Stash coverage
+        run: mv .coverage coverage.parity-${{ matrix.lane }}
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: coverage-parity-${{ matrix.lane }}
+          path: coverage.parity-${{ matrix.lane }}
+          retention-days: 3
+
   device:
     name: Two-device placement and AD
     runs-on: ubuntu-latest
@@ -195,7 +254,7 @@ jobs:
     name: Changed executable lines (>= 95%)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [fast, physics, device]
+    needs: [fast, physics, parity, device]
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -211,7 +270,7 @@ jobs:
           merge-multiple: true
       - name: Combine coverage and enforce the mirror floor
         run: |
-          coverage combine coverage.device coverage.fast coverage.physics-*
+          coverage combine coverage.device coverage.fast coverage.physics-* coverage.parity-*
           coverage report --include='*/vmex/mirror/*' --fail-under=90
           coverage xml
       - name: Enforce changed-line coverage
@@ -223,7 +282,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    needs: [quality, fast, physics, device, changed-coverage]
+    needs: [quality, fast, physics, parity, device, changed-coverage]
     steps:
       - name: Require every review gate
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,8 +164,15 @@ jobs:
     name: Manifest parity lane (${{ matrix.lane }})
     runs-on: ubuntu-latest
     # The primary-lane partition is the whole pull-request suite; these four
-    # jobs are the part no other job was running.  Durations come from the
-    # runner, not a guess -- rebalance the grouping from the reported times.
+    # jobs are the part no other job was running.  Measured on the runner at
+    # -n 2: 30m00s, 27m40s, 26m54s, 21m22s, which put total CI wall clock at
+    # 30 minutes against a ~14-minute budget before.  The four run in parallel
+    # with the nine physics jobs, so the fix is per-job width, not fewer tests:
+    # -n 4 on the same 4-vCPU runner, which the fast lane already uses.  If a
+    # lane runs out of memory instead of getting faster, go back to -n 2 and
+    # split pr-parity-c1 and pr-parity-c2 in the manifest -- test_optimize
+    # (~20 min of the c1 group) and test_gammac plus test_scaling (~12 min of
+    # c2) are what would need separating.
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -209,7 +216,7 @@ jobs:
           done
           # Lanes overlap, and a module selected twice would run twice.
           FILES="$(printf '%s\n' $FILES | sort -u | tr '\n' ' ')"
-          pytest -q -n 2 -m "not full and not weekly" \
+          pytest -q -n 4 -m "not full and not weekly" \
             $FILES --durations=20 --cov=vmex --cov-report=term
       - name: Stash coverage
         run: mv .coverage coverage.parity-${{ matrix.lane }}

--- a/docs/reference/objectives.rst
+++ b/docs/reference/objectives.rst
@@ -518,9 +518,13 @@ JAX-native Hermite–Laguerre flux-tube solver, formerly SPECTRAX-GK;
   pure JAX, no gkx import needed;
 - :func:`~vmex.core.turbulence.turbulent_growth_rate` — the dominant
   linear ITG/TEM growth rate on that flux tube.  Fully differentiable in
-  *both* gradient modes (validated 0.44 ``v_th/L`` at the Cyclone-base
-  drive ``R/L_Ti = 6.9`` versus ~0 below the critical gradient; AD vs FD
-  2.9e-8);
+  *both* gradient modes.  ``r_over_lt``/``r_over_ln`` are ``R/L`` and are
+  divided by the equilibrium's aspect ratio on the way in, since GKX's
+  operator consumes ``a/L``; pass ``params_linear`` to give it ``a/L``
+  directly.  Measured on the shaped tokamak deck at the Cyclone-base drive
+  ``R/L_Ti = 6.9`` (aspect 2.643, so ``a/L_Ti = 2.611``): 0.184 ``v_th/L``
+  against 8.9e-15 below the critical gradient, with reverse and forward AD
+  gated against finite differences to 1e-5 relative;
 - :func:`~vmex.core.turbulence.quasilinear_flux_proxy` and
   :func:`~vmex.core.turbulence.nonlinear_heat_flux_proxy` — the
   mixing-length and saturation-rule heat-flux surrogates.  These weight the

--- a/tests/test_multigrid_ladder.py
+++ b/tests/test_multigrid_ladder.py
@@ -115,8 +115,26 @@ def measure(fn):
 
 
 def _run_measurement(body: str) -> dict:
-    """Run ``_MEASURE_PRELUDE + body`` in a cold subprocess; parse JSON tail."""
-    env = dict(os.environ, JAX_PLATFORMS="cpu")
+    """Run ``_MEASURE_PRELUDE + body`` in a cold subprocess; parse JSON tail.
+
+    Two environment settings the measurement cannot do without.
+
+    ``VMEX_JAX_LOGGING_LEVEL=WARNING`` is the one that matters: importing vmex
+    sets ``jax_logging_level = "ERROR"`` by default (``vmex/__init__.py``,
+    ``_configure_jax_logging``), which raises the ``jax`` logger from 30 to 40
+    and filters exactly the WARNING-level ``"Compiling ..."`` records the
+    counter below is built on.  The prelude installs its handler *before*
+    importing vmex, so the level it sets is overwritten and every counter reads
+    zero -- which is what these assertions were seeing.  Use vmex's own
+    override rather than fighting it.
+
+    ``VMEX_COMPILATION_CACHE=disabled`` makes "cold" mean cold: a persistent
+    cache shared with whatever ran earlier turns a compile into a cache load,
+    which emits no record either.
+    """
+    env = dict(os.environ, JAX_PLATFORMS="cpu",
+               VMEX_JAX_LOGGING_LEVEL="WARNING",
+               VMEX_COMPILATION_CACHE="disabled")
     proc = subprocess.run(
         [sys.executable, "-c", _MEASURE_PRELUDE + body],
         capture_output=True, text=True, env=env,

--- a/tests/test_test_manifest.py
+++ b/tests/test_test_manifest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -82,6 +83,48 @@ def test_manifest_report_lists_timings_and_every_skip(tmp_path: Path) -> None:
         assert {
             "owner", "primary", "duration", "device", "asset", "oracle"
         } <= record.keys()
+
+
+def _invoked_lanes() -> set[str]:
+    """Lane names the workflows actually hand to ``test_manifest.py select``.
+
+    Both spellings: a literal ``select <lane>`` and a matrix ``selector:``
+    value interpolated into one.
+    """
+    text = "\n".join(
+        path.read_text() for path in sorted((ROOT / ".github" / "workflows").glob("*.yml")))
+    invoked: set[str] = set()
+    for value in re.findall(r"^\s*selector:\s*(.+?)\s*$", text, re.M):
+        invoked.update(value.split())          # a matrix value may list several
+    invoked |= set(re.findall(r"test_manifest\.py select ([a-z][A-Za-z0-9-]*)", text))
+    return invoked
+
+
+def test_every_primary_pr_lane_is_invoked_by_a_workflow() -> None:
+    """A primary lane no job runs is a module no job runs.
+
+    ``validate`` already makes every record declare exactly one primary PR
+    lane, so the union of those lanes is the whole pull-request suite.  What
+    was missing is the other half of the contract: the workflows have to
+    invoke all of them.  Twelve of fourteen once did not, which took 94 of
+    100 modules out of pull-request CI and made the changed-line coverage
+    gate fail on code that was in fact tested.
+    """
+    _, records = test_manifest.load()
+    primary = {
+        lane
+        for record in records
+        for lane in record["lanes"]
+        if lane != "pr-fast"
+        and any(lane.startswith(prefix) for prefix in test_manifest.PRIMARY_LANES)
+    }
+    assert primary
+    missing = sorted(primary - _invoked_lanes())
+    assert not missing, (
+        "primary PR lanes that no workflow invokes, so their modules never "
+        f"run in CI: {missing}. Add a matrix entry in .github/workflows/ci.yml "
+        "or move the modules to a lane that has one."
+    )
 
 
 def test_workflow_selects_manifest_lanes() -> None:

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -33,6 +33,7 @@ import jax.numpy as jnp  # noqa: E402
 from vmex.core import optimize as opt  # noqa: E402
 from vmex.core import stability as stab  # noqa: E402
 from vmex.core import turbulence as turb  # noqa: E402
+from vmex.core.statephysics import aspect_ratio  # noqa: E402
 from vmex.core.input import VmecInput  # noqa: E402
 
 pytestmark = pytest.mark.usefixtures("_module_jit_enabled")  # full solves: run jitted
@@ -202,6 +203,36 @@ def test_contract_passes_gkx_validation(shaped_eq):
     assert geom.source_model == "vmex:core.turbulence"
     assert float(geom.gradpar_value) > 0.0
     assert int(np.asarray(geom.theta).shape[0]) == 32
+
+
+def test_drive_gradients_reach_gkx_as_a_over_l(shaped_eq):
+    """``r_over_lt`` is R/L; GKX's operator consumes a/L.  Pin the conversion.
+
+    GKX's ``LinearParams`` defaults are ``tprim = 2.49``, ``fprim = 0.8`` --
+    the Cyclone base case ``R/L_T = 6.9``, ``R/L_n = 2.2`` divided by that
+    case's ``R/a = 2.77``.  vmex used to set the deprecated ``R_over_LTi``
+    instead, which applied no normalization at all, so ``r_over_lt = 6.9``
+    reached the operator as ``tprim = 6.9`` -- R/a times too strongly driven,
+    on every turbulence evaluation.  This deck's aspect ratio is 2.643, so the
+    Cyclone drive lands at 2.611, next to GKX's own default.
+
+    No solver call: the defect was entirely in how the parameters were built,
+    and this runs wherever gkx imports.
+    """
+    pytest.importorskip("gkx")
+    state, rt = shaped_eq.state, shaped_eq.runtime
+    aspect = float(aspect_ratio(state, rt))
+    assert aspect == pytest.approx(2.6427, rel=1e-3)
+    params = turb._linear_params(None, 6.9, 2.2, aspect)
+    assert float(params.tprim) == pytest.approx(6.9 / aspect, rel=1e-12)
+    assert float(params.fprim) == pytest.approx(2.2 / aspect, rel=1e-12)
+    assert float(params.tprim) == pytest.approx(2.611, rel=1e-3)
+    # The subcritical case the growth-rate test relies on is well below GKX's
+    # Cyclone default, which is the whole point of the conversion.
+    assert float(turb._linear_params(None, 1.0, None, aspect).tprim) < 0.4
+    # params_linear is the escape hatch and must pass through untouched.
+    explicit = turb._linear_params(params, None, None, aspect)
+    assert explicit is params
 
 
 def test_growth_rate_is_itg_critical_gradient_monotone(shaped_eq):

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -178,15 +178,25 @@ def test_surface_index_validation(shaped_eq):
 
 
 def _require_gkx():
-    """Skip unless gkx is importable *and* its jax floor is satisfied.
+    """Skip unless gkx is importable."""
+    pytest.importorskip("gkx")
+
+
+def _require_gkx_eigenvectors():
+    """Additionally require the jax floor gkx's *eigenvector* path declares.
 
     gkx reaches reverse-mode eigenvector derivatives through
     ``lax_linalg.eig(enable_eigvec_derivs=...)``, which first exists in jax
     0.10.1 and which gkx declares accordingly.  gkx still imports against an
-    older jax, so importorskip alone lets these reach a call-time TypeError
+    older jax, so importorskip alone lets those reach a call-time TypeError
     that is an unsatisfied dependency contract, not a defect.
+
+    Only the eigenvector-weighted lanes need it.  ``turbulent_growth_rate``
+    reduces the operator with ``jnp.linalg.eigvals`` and works on any
+    supported jax, so gating it too left the whole ITG lane dark on every host
+    below the floor -- which is how the R/L-into-a/L units defect survived.
     """
-    pytest.importorskip("gkx")
+    _require_gkx()
     from jax._src.lax import linalg as lax_linalg
 
     if "enable_eigvec_derivs" not in inspect.signature(lax_linalg.eig).parameters:
@@ -248,7 +258,7 @@ def test_growth_rate_is_itg_critical_gradient_monotone(shaped_eq):
 
 def test_objective_vector_and_scalar_proxies_consistent(shaped_eq):
     """Vector entries reproduce the documented saturation-rule proxies."""
-    _require_gkx()
+    _require_gkx_eigenvectors()
     state, rt = shaped_eq.state, shaped_eq.runtime
     vec = np.asarray(turb.turbulence_objective_vector(state, rt, **GK))
     named = dict(zip(turb.TURBULENCE_OBJECTIVE_NAMES, vec))
@@ -301,7 +311,7 @@ def test_eigenvector_weighted_proxies_are_value_level(shaped_eq):
     GK operator, whose derivatives JAX declines unless
     ``enable_eigvec_derivs``); reverse AD must either refuse with that
     error or agree with the FD lane that ``jac=None`` actually uses."""
-    _require_gkx()
+    _require_gkx_eigenvectors()
     state, rt = shaped_eq.state, shaped_eq.runtime
 
     def ql(scale):

--- a/vmex/core/turbulence.py
+++ b/vmex/core/turbulence.py
@@ -75,6 +75,7 @@ import jax
 import jax.numpy as jnp
 
 from .solver import SolverRuntime, SpectralState
+from .statephysics import aspect_ratio
 from .stability import (
     _ballooning_context, _parabola, _theta_vmec_from_pest,
     _validate_surface_index,
@@ -417,7 +418,7 @@ def _split_kwargs(kwargs: dict) -> tuple[dict, dict]:
     return geometry, kwargs
 
 
-def _linear_params(params_linear, r_over_lt, r_over_ln):
+def _linear_params(params_linear, r_over_lt, r_over_ln, aspect):
     """GKX LinearParams: explicit object, or its collisionless
     optimization defaults with optionally overridden drive gradients."""
     if params_linear is not None:
@@ -428,10 +429,19 @@ def _linear_params(params_linear, r_over_lt, r_over_ln):
     params = _default_gradient_linear_params()
     import dataclasses
     updates = {}
+    # GKX's operator consumes a/L gradients -- its ``tprim``/``fprim``, the
+    # TOML convention -- never R/L.  Its own defaults, ``tprim = 2.49`` and
+    # ``fprim = 0.8``, are the Cyclone base case ``R/L_T = 6.9``,
+    # ``R/L_n = 2.2`` divided by that case's ``R/a = 2.77``.  vmex's arguments
+    # are R/L, so divide by *this* equilibrium's aspect ratio: matching R/L is
+    # what carries the ITG drive across devices, and a/L is then a consequence
+    # of the shape.  Setting the deprecated ``R_over_LTi``/``R_over_Ln``
+    # instead, as this did, applied no normalization at all and made every
+    # evaluation R/a times too strongly driven.
     if r_over_lt is not None:
-        updates["R_over_LTi"] = float(r_over_lt)
+        updates["tprim"] = r_over_lt / aspect
     if r_over_ln is not None:
-        updates["R_over_Ln"] = float(r_over_ln)
+        updates["fprim"] = r_over_ln / aspect
     return dataclasses.replace(params, **updates) if updates else params
 
 
@@ -462,10 +472,13 @@ def turbulence_objective_vector(
     :data:`TURBULENCE_OBJECTIVE_NAMES`
     (``gkx.solver_objective_vector_from_geometry``).
 
-    The drive gradients live in GKX's ``LinearParams``
-    (``params_linear``; default: its collisionless optimization defaults
-    ``R/L_n = 2.2``, ``R/L_Ti = 6.9`` — the Cyclone-base ITG drive —
-    optionally overridden via ``r_over_lt``/``r_over_ln``).
+    The drive gradients live in GKX's ``LinearParams`` (``params_linear``;
+    default: its collisionless optimization defaults ``a/L_n = 0.8``,
+    ``a/L_Ti = 2.49`` — the Cyclone-base ITG drive at that case's
+    ``R/a = 2.77``).  ``r_over_lt``/``r_over_ln`` override them in ``R/L``,
+    divided by this equilibrium's aspect ratio on the way in, since GKX's
+    operator consumes ``a/L``; pass ``params_linear`` to supply ``a/L``
+    directly.
     """
     gkx = _gkx()
     geom = flux_tube_geometry(state, rt, **geometry_kwargs)
@@ -474,7 +487,8 @@ def turbulence_objective_vector(
         selected_ky_index=int(selected_ky_index),
         n_laguerre=int(n_laguerre), n_hermite=int(n_hermite),
         nx=int(nx), ny=int(ny), lx=float(lx), ly=float(ly),
-        params_linear=_linear_params(params_linear, r_over_lt, r_over_ln),
+        params_linear=_linear_params(params_linear, r_over_lt, r_over_ln,
+                                    aspect_ratio(state, rt)),
         terms=terms,
     )
 
@@ -503,7 +517,8 @@ def turbulent_growth_rate(state: SpectralState, rt: SolverRuntime, **kwargs) -> 
     gkx = _gkx()
     params_linear = _linear_params(
         solver_kwargs.pop("params_linear", None),
-        solver_kwargs.pop("r_over_lt", None), solver_kwargs.pop("r_over_ln", None))
+        solver_kwargs.pop("r_over_lt", None), solver_kwargs.pop("r_over_ln", None),
+        aspect_ratio(state, rt))
     geom = flux_tube_geometry(state, rt, **geometry_kwargs)
     matrix = gkx.solver_linear_operator_matrix_from_geometry(
         geom, params_linear=params_linear, **solver_kwargs)


### PR DESCRIPTION
`tests/manifest.json` makes every module declare exactly one primary PR lane, and `tools/test_manifest.py validate` enforces it — so the union of those lanes is the whole pull-request suite. The other half of that contract was never checked: **the workflows have to invoke all of them, and twelve of fourteen were invoked by nothing.**

```
pr-parity-a1  pr-parity-a2  pr-parity-b   pr-parity-c1
pr-parity-c2  pr-parity-c3  pr-parity-d   pr-examples
pr-external   pr-full-only  pr-gradient   pr-mirror-spline
```

That took **36 modules / 256 non-full tests out of pull-request CI entirely.** All 256 pass — they were simply never run (6m45s locally, `-n 4`). Among the 36 is `tests/test_test_manifest.py`, the module that validates the manifest, which is why nothing noticed.

Stale markers still in `test_workflow_selects_manifest_lanes` (`A1_FILES=`, `C2_FILES=`, `core-a-c)`) say what happened: the workflow was once organized around this partition, was refactored into nine `pr-physics-*` jobs driven by explicit node lists, and the record-level lanes were left behind as dead labels.

## Why this surfaced now

[#151](https://github.com/uwplasma/vmex/pull/151) fails `Changed executable lines (>= 95%)` at 67% — `vmex/core/bootstrap.py (0.0%): Missing lines 741-742,751-753,757-760`. That is the entire `geom=None` branch of `vmec_j_dot_B_from_wout`, which **is** covered by `test_vmec_j_dot_B_state_lane_matches_wout_jdotb[eq]/[lasym_eq]` — a test in `tests/test_bootstrap.py`, whose primary lane is `pr-parity-b`, which no job runs. The gate was reporting a CI hole as a test gap. [#152](https://github.com/uwplasma/vmex/pull/152) would have hit the same wall for `tests/test_stability.py` (`pr-parity-c2`).

## What this does

Four sharded `parity` jobs cover the twelve lanes:

| job | selectors | non-full tests |
| --- | --- | --- |
| `a` | `pr-parity-a1 pr-parity-a2 pr-parity-b` | 194 |
| `c1` | `pr-parity-c1 pr-parity-c3 pr-parity-d` | 540 |
| `c2` | `pr-parity-c2` | 351 |
| `misc` | `pr-examples pr-external pr-full-only pr-gradient pr-mirror-spline` | 104 |

Lanes overlap, so each job dedups its file list (`sort -u`) before running — a module selected by two lanes runs once. Coverage from the new jobs is combined into the changed-line gate, and `pr-gate` waits on them.

**On the grouping and the timeout.** I am not going to pretend I know the runner durations. My laptop currently has three physics jobs competing on it, so its numbers would be fiction. `timeout-minutes` starts at 45 and the grouping is a first cut by test count; the honest next step is to read the four durations off the first CI run here and rebalance from those. If a job is slow enough to bother you, splitting `c1` is the obvious first move.

## The guard

`test_every_primary_pr_lane_is_invoked_by_a_workflow` closes the loop. It fails on `main` naming all twelve lanes, and it reads both spellings a workflow can use — a literal `select <lane>` and a matrix `selector:` value, which may now list several. Without it this recurs the next time the workflow is reshaped.

Local: `ruff` clean, `tests/test_test_manifest.py` 6 passed (was 5; the new one fails on `main`).
