### PR TITLE
Fix two Gamma_c symmetry defects, jit it, and stop claiming its gradient converges

### DIFF
--- a/tests/test_gammac.py
+++ b/tests/test_gammac.py
@@ -137,20 +137,34 @@ def test_gamma_c_tracks_effective_ripple_on_a_ripple_ray(qa_eq):
 def test_boundary_gradient_liveness():
     """jax.grad through the implicit solve is finite, nonzero, FD-consistent.
 
-    li383 at ns=13, GammaC([0.5]). Measured for this commit: at the base
-    sampling (nalpha=7, 3 transits, 64 points/transit, 24 pitch) the
-    objective is 2.13e-3 and the reverse boundary gradient
-    d/d rbc[n=0, m=1] is -0.541 against central FD -0.427 (step 1e-4)
-    and -0.385 (step 2e-5): sign agreement, magnitude ratio 1.41. One
-    refinement step (13, 4, 96, 48) keeps the sign and moves the
-    magnitude to -0.119, while the Gamma_c value itself is
-    sampling-stable to 2 percent (anchor test) — the gradient of the
-    discretized objective is exact, but its magnitude at PR-lane
-    sampling carries superbanana-layer discretization scatter of up to
-    ~4.6x (convergence ladder in the PR record). The assertions encode
-    exactly that: finite nonzero gradients, FD consistency within a
-    factor 3 at fixed resolution, and sign stability under refinement;
-    optimize at one fixed resolution.
+    li383 at ns=13, GammaC([0.5]). What this test can honestly assert is
+    narrower than it once claimed. The gradient of the discretized objective
+    is exact — it agrees with a central difference of the same discretization
+    at fixed resolution — but it is **not a convergent quantity**. Measured
+    ladder of d/d rbc[n=0, m=1] over (nalpha, transits, points/transit,
+    pitch):
+
+        (7, 3, 64, 24)    -1.254
+        (7, 4, 96, 48)    +3.518
+        (9, 5, 128, 48)   -0.387
+        (13, 6, 192, 64)  -0.988
+        (17, 8, 256, 96)  +0.180
+
+    Three sign changes. Radial resolution does not help either: at fixed
+    sampling, ns = 13/25/49 gives -0.387, +0.175, -2.167. The same instability
+    is present before the symmetry fixes in this commit (-0.403, +0.582,
+    -0.554, -0.562, -0.111), so it is not a regression — an earlier revision
+    of this test asserted sign stability under one refinement step and was
+    passing on a lucky pair of configurations, not on a property.
+
+    The cause is structural: hard well detection and hard argmin selection
+    make the discretized Gamma_c piecewise in the boundary coefficients, with
+    breakpoints that move when the grid moves, so refinement changes which
+    function is being differentiated. Gamma_c is a value-level comparative
+    proxy; do not drive a boundary optimization with this gradient.
+
+    So: finite, nonzero, and FD-consistent at fixed resolution. No claim of
+    magnitude stability, and none of sign stability.
     """
     inp = VmecInput.from_file(DATA_DIR / "input.li383_low_res")
     params = im.params_from_input(inp, device=None)
@@ -180,8 +194,10 @@ def test_boundary_gradient_liveness():
     refined = float(np.asarray(jax.grad(
         lambda p: objective(p, 13, 4, 96, 48))(params).rbc)[index])
     assert np.isfinite(refined) and refined != 0.0
-    assert np.sign(refined) == np.sign(base)
-    assert 0.03 < abs(refined) < 1.5 and 0.03 < abs(base) < 1.5
+    # Deliberately no sign or magnitude-ratio assertion against `base`: the
+    # ladder in the docstring shows neither holds.  Only that both refinements
+    # produce a live number of a physically plausible order.
+    assert 1.0e-3 < abs(refined) < 1.0e2 and 1.0e-3 < abs(base) < 1.0e2
 
 
 def test_class_contract_and_validation():
@@ -232,3 +248,50 @@ def test_class_contract_and_validation():
             bmag=jnp.ones(8), radial_drift=0.0, radial_gradient=0.0,
             drift_correction=0.0, tangency=1.0, dl_dx=1.0, length=1.0,
             pitch=jnp.ones(3), pitch_weights=jnp.ones(3))
+
+
+def test_gamma_c_respects_the_stellarator_reflection():
+    """The exact identity that caught two defects.
+
+    Gamma_c is even under the stellarator reflection and the sine-parity
+    spectra are odd, so on a stellarator-symmetric equilibrium
+    ``d(Gamma_c)/d(sine)`` must be *identically* zero.  Run on a symmetric
+    deck solved with ``LASYM = T``, so the sine coefficients are real degrees
+    of freedom whose converged content is round-off — which makes the identity
+    exact rather than approximate.
+
+    It was violated at 55 % of the physical gradient.  Two causes:
+
+    * the trace window ran ``x in [0, L]`` instead of centred on the
+      field-line label, so the sampled ``(alpha, x)`` set was not closed under
+      ``(alpha, x) -> (-alpha, -x)``.  Centring alone took it to 13 %, and
+      makes the per-line estimator mirror-invariant to 1.8e-14;
+    * ``b_min``/``b_max`` are ``jnp.min``/``jnp.max`` over the |B| of a
+      reflection-closed line set, so the extrema sit at mirror-image *pairs*
+      and the cotangent went entirely to one member of each pair.  Holding the
+      pitch grid fixed under differentiation took the violation to 6.6e-11 and
+      moved the physical gradient by 1.8e-4.
+
+    Measured here: ratio 5.8e-11 against a physical ``d/dR_cos`` of 2.6e+03.
+    """
+    inp = dataclasses.replace(
+        VmecInput.from_file(DATA_DIR / "input.li383_low_res"), lasym=True)
+    eq = opt.solve_equilibrium(inp)
+    assert eq.result.converged and bool(eq.runtime.setup.lasym)
+    state, rt = eq.state, eq.runtime
+    # The identity is only exact where the sine content is: check that first.
+    cos_scale = float(jnp.max(jnp.abs(state.R_cos)))
+    assert float(jnp.max(jnp.abs(state.R_sin))) < 1.0e-12 * cos_scale
+
+    def total(spectral):
+        return gammac.gamma_c_state(
+            spectral, rt, surfaces=(0.5,), nalpha=6, num_transit=3,
+            points_per_transit=32, num_pitch=12,
+            quadrature_order=16)["gamma_c"][0]
+
+    gradient = jax.grad(total)(state)
+    physical = float(jnp.max(jnp.abs(gradient.R_cos)))
+    spurious = float(jnp.max(jnp.abs(gradient.R_sin)))
+    assert physical > 1.0        # the comparison is not against zero
+    assert spurious / physical < 1.0e-8
+

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -803,24 +803,27 @@ def test_lasym_growth_rate_gradient_matches_finite_differences(lasym_finite_beta
     assert abs(float(grad)) > 0.0
 
 
-def test_gamma_c_stays_guarded_until_it_has_its_own_lasym_evidence(
-        lasym_finite_beta_eq):
-    """Gamma_c keeps its guard; turbulence has dropped its and must not raise.
+def test_every_field_line_lane_reaches_an_asymmetric_state(lasym_finite_beta_eq):
+    """Ballooning, turbulence and Gamma_c all run on a lasym equilibrium.
 
-    The shared field-line geometry is parity-complete, so both lanes *reach*
-    an asymmetric state.  Turbulence earns its access here by matching
-    simsopt's ``vmec_fieldlines`` on an asymmetric deck
-    (``test_gk_geometry_matches_simsopt_vmec_fieldlines``); Gamma_c's own
-    asymmetric evidence is the exact reflection identity, which lands with the
-    Gamma_c work, so it stays guarded on this branch.
+    All three share one parity-complete field-line geometry, and each now has
+    its own asymmetric evidence rather than a guard: ballooning through the
+    zero-sine and LASYM-of-a-symmetric-deck gates above, turbulence against
+    simsopt's ``vmec_fieldlines`` on an asymmetric deck, and Gamma_c through
+    the exact reflection identity.  Nothing here should raise, and nothing
+    should come back non-finite.
     """
     from vmex.core import gammac, turbulence
     eq = lasym_finite_beta_eq
-    with pytest.raises(NotImplementedError, match="lasym = False"):
-        gammac.gamma_c_state(eq.state, eq.runtime)
+    lam = np.asarray(stab.ballooning_lambda(eq.state, eq.runtime, **FAST))
+    assert np.all(np.isfinite(lam))
     geom = turbulence.gk_fieldline_geometry(eq.state, eq.runtime, ntheta=16)
     assert np.all(np.isfinite(np.asarray(geom["bmag"])))
     assert float(np.min(np.asarray(geom["bmag"]))) > 0.0
+    out = gammac.gamma_c_state(eq.state, eq.runtime, surfaces=(0.5,), nalpha=4,
+                               num_transit=2, points_per_transit=32,
+                               num_pitch=8, quadrature_order=16)
+    assert np.all(np.isfinite(np.asarray(out["gamma_c"])))
 
 
 # ---------------------------------------------------------------------------

--- a/vmex/core/gammac.py
+++ b/vmex/core/gammac.py
@@ -70,6 +70,7 @@ field-line parameterization.
 
 from __future__ import annotations
 
+import functools
 from typing import Any, Iterable, Sequence
 
 import numpy as np
@@ -80,7 +81,8 @@ import jax.numpy as jnp
 from .bounce import bounce_action
 from .solver import SolverRuntime, SpectralState
 from .stability import (
-    _ballooning_context, _parabola, _require_symmetric, _theta_vmec_from_pest,
+    _ballooning_context, _pest_lambda, _surface_closures, _surface_tables,
+    _theta_vmec_from_pest,
 )
 
 Array = Any
@@ -177,13 +179,14 @@ def gamma_c_from_fieldlines(
     return out
 
 
-def _make_gamma_point_fn(m: Array, xn: Array, rtab: Array, ztab: Array,
-                         ltab: Array, iota: Array, diota: Array, phipf_j: Array):
+def _make_gamma_point_fn(m: Array, xn: Array, tabs: dict, iota: Array,
+                         diota: Array, phipf_j: Array):
     """Point-evaluation closure for one flux surface (Nemov drift set).
 
-    The spectral machinery of
-    :func:`vmex.core.turbulence._make_gk_point_fn`, returning at
-    ``q = (t, theta, phi)`` (evaluated at ``t = s - s_j = 0``) the tuple
+    Built on :func:`vmex.core.stability._surface_closures`, so the sine-parity
+    spectra of an asymmetric state are carried without a second
+    implementation.  Returns at ``q = (t, theta, phi)`` (evaluated at
+    ``t = s - s_j = 0``) the tuple
 
     ``(|B|, B^phi, B x grad|B| . grad s, d|B|/ds|PEST, dB^phi/ds|PEST,
     (grad s x b) . grad phi, |grad s|, ||e_theta|| / (1 + lambda_theta))``
@@ -192,36 +195,8 @@ def _make_gamma_point_fn(m: Array, xn: Array, rtab: Array, ztab: Array,
     ``dtheta/ds = -lambda_s / (1 + lambda_theta)`` and the last entry is
     ``||e_alpha||`` at fixed ``(rho, phi)``.
     """
-
-    def coeffs(tab: Array, t: Array) -> Array:
-        return tab[0] + t * tab[1] + (t * t) * tab[2]
-
-    def lam_fn(q: Array) -> Array:
-        t, th, ph = q[0], q[1], q[2]
-        return coeffs(ltab, t) @ jnp.sin(th * m - ph * xn)
-
-    def pos_fn(q: Array) -> Array:
-        t, th, ph = q[0], q[1], q[2]
-        ang = th * m - ph * xn
-        R = coeffs(rtab, t) @ jnp.cos(ang)
-        Z = coeffs(ztab, t) @ jnp.sin(ang)
-        return jnp.array([R * jnp.cos(ph), R * jnp.sin(ph), Z])
-
-    def b_vector(q: Array) -> Array:
-        J = jax.jacfwd(pos_fn)(q)                     # columns: e_s, e_th, e_ph
-        sqrt_g = jnp.linalg.det(J)
-        lam_g = jax.grad(lam_fn)(q)
-        iota_t = iota + diota * q[0]
-        return phipf_j * ((iota_t - lam_g[2]) * J[:, 1]
-                          + (1.0 + lam_g[1]) * J[:, 2]) / sqrt_g
-
-    def modb_fn(q: Array) -> Array:
-        return jnp.linalg.norm(b_vector(q))
-
-    def bsupphi_fn(q: Array) -> Array:
-        J = jax.jacfwd(pos_fn)(q)
-        lam_g = jax.grad(lam_fn)(q)
-        return phipf_j * (1.0 + lam_g[1]) / jnp.linalg.det(J)
+    pos_fn, lam_fn, b_vector, modb_fn, bsupphi_fn = _surface_closures(
+        m, xn, tabs, iota, diota, phipf_j)
 
     def point(q: Array):
         J = jax.jacfwd(pos_fn)(q)
@@ -264,6 +239,127 @@ def _surface_rows(surfaces, ns: int) -> tuple[int, ...]:
     return rows
 
 
+#: Per-surface outputs of :func:`_gamma_c_rows`.  Everything else the bounce
+#: kernel builds stays inside the jit and is eliminated as dead code.
+_ROW_FIELDS = ("gamma_c", "excluded_fraction", "overflow_fraction",
+               "line_length", "pitch")
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=("rows", "nalpha", "num_transit", "points_per_transit",
+                     "num_pitch", "quadrature_order", "max_wells"))
+def _gamma_c_rows(
+    state: SpectralState,
+    rt: SolverRuntime,
+    zeta0: Array,
+    *,
+    rows: tuple[int, ...],
+    nalpha: int,
+    num_transit: int,
+    points_per_transit: int,
+    num_pitch: int,
+    quadrature_order: int,
+    max_wells: int,
+) -> dict[str, Array]:
+    """``Gamma_c`` of the full-mesh rows ``rows``, as one XLA executable.
+
+    Module-level rather than a ``jax.jit`` at the call site, so every boundary
+    iterate of an optimization stage reuses one compilation instead of
+    re-tracing the spectral field-line machinery.  Measured on a three-surface
+    nfp = 2 case: 0.96 s eager against 0.03 s here, values bit-identical.
+    Everything that sets an array shape is static.
+    """
+
+    ctx = _ballooning_context(state, rt)
+    dtype = ctx["s"].dtype
+    alpha = jnp.asarray(
+        2.0 * np.pi * np.arange(int(nalpha)) / int(nalpha), dtype=dtype)
+    length = 2.0 * np.pi * int(num_transit)
+    # Centred on the field-line label, not [0, L].  The stellarator
+    # reflection maps (alpha, x) -> (-alpha, -x) and the alpha set is closed
+    # under negation, so a window symmetric in x makes the estimator exactly
+    # invariant under it -- and Gamma_c is even while the sine-parity spectra
+    # are odd, so d(Gamma_c)/d(sine) then vanishes on a symmetric state as it
+    # must.  A one-sided window does not: measured, it left a spurious
+    # symmetry-breaking gradient at 55% of the physical one.
+    x = jnp.linspace(
+        -0.5 * length, 0.5 * length,
+        int(points_per_transit) * int(num_transit) + 1, dtype=dtype)
+    # Open midpoint rule, uniform in the reflecting level 1/lambda rather
+    # than lambda (the Unalmis et al. pitch-sampling guidance); the open
+    # ends avoid the incomputable bounce integral at the global maximum.
+    level_nodes = jnp.asarray(
+        (np.arange(int(num_pitch)) + 0.5) / int(num_pitch), dtype=dtype)
+    zeta0_c = jnp.asarray(zeta0, dtype=dtype)
+    hs, psi_edge = ctx["hs"], ctx["psi_edge"]
+
+    results = []
+    iotas = []
+    for j in rows:
+        iota = 0.5 * (ctx["iotas"][j] + ctx["iotas"][j + 1])
+        diota = (ctx["iotas"][j + 1] - ctx["iotas"][j]) / hs
+        iotas.append(iota)
+        tabs = _surface_tables(ctx, j)
+        point = _make_gamma_point_fn(
+            ctx["m"], ctx["xn"], tabs, iota, diota, ctx["phipf"][j])
+        lmns0, lmnc0 = _pest_lambda(tabs)
+
+        def line(a, point=point, lmns0=lmns0, lmnc0=lmnc0, iota=iota):
+            theta_star = a + x
+            phi = zeta0_c + x / iota
+            theta_v = _theta_vmec_from_pest(
+                theta_star, phi, lmns0, ctx["m"], ctx["xn"], lmnc0)
+            q = jnp.stack([jnp.zeros_like(theta_v), theta_v, phi], axis=-1)
+            return jax.vmap(point)(q)
+
+        (modB, b_sup_phi, bxgb_gs, modb_s_pest, bsupphi_s_pest,
+         gs_cross_b_gphi, grad_s_norm, e_alpha_norm) = jax.vmap(line)(alpha)
+
+        two_rho = 2.0 * jnp.sqrt(ctx["s"][j])
+        modb_r = two_rho * modb_s_pest                # d|B|/drho at fixed PEST angles
+        correction = (
+            two_rho * diota * psi_edge * gs_cross_b_gphi
+            - 2.0 * modb_r + modB * (two_rho * bsupphi_s_pest) / b_sup_phi)
+        dl_dx = modB / jnp.abs(iota * b_sup_phi)
+        # The pitch nodes are a quadrature grid, not an observable, and the
+        # |B| extrema over a reflection-closed set of lines are attained at
+        # mirror-image PAIRS of points.  Differentiating through jnp.min/max
+        # sends the whole cotangent to one member of each pair, which breaks a
+        # symmetry Gamma_c has exactly: on a stellarator-symmetric state
+        # d(Gamma_c)/d(sine spectra) must vanish, and it came out at 17% of
+        # the physical gradient.  Worse, that term does not converge -- over
+        # num_pitch = 12/24/48/96 the violation ran 1.7e-1, 1.8e-1, 6.0e-3,
+        # 1.6e-1, so it is an erratic subgradient with no limit, not a
+        # discretization term.  Holding the grid fixed under differentiation
+        # restores the identity to 1e-10 and moves the physical gradient by
+        # 2e-4.
+        b_min = jax.lax.stop_gradient(jnp.min(modB))
+        b_max = jax.lax.stop_gradient(jnp.max(modB))
+        level = b_min + (b_max - b_min) * level_nodes
+        results.append(gamma_c_from_fieldlines(
+            bmag=modB,
+            radial_drift=psi_edge * bxgb_gs / modB**3,
+            radial_gradient=modb_r / modB,
+            drift_correction=correction / modB,
+            tangency=grad_s_norm / two_rho * e_alpha_norm,
+            dl_dx=dl_dx, length=length, pitch=1.0 / level,
+            pitch_weights=(b_max - b_min) / int(num_pitch) / level**2,
+            max_wells=max_wells, quadrature_order=quadrature_order))
+
+    stacked: dict[str, Array] = {
+        name: jnp.stack([out[name] for out in results]) for name in _ROW_FIELDS
+    }
+    # The field-line map phi = x / iota is meaningless through iota ~ 0;
+    # poison the result instead of returning a plausible number.
+    iota_row = jnp.stack(iotas)
+    stacked["gamma_c"] = jnp.where(
+        jnp.abs(iota_row) > 1.0e-6, stacked["gamma_c"], jnp.nan)
+    stacked["s"] = ctx["s"][jnp.asarray(rows)]
+    stacked["iota"] = iota_row
+    return stacked
+
+
 def gamma_c_state(
     state: SpectralState,
     rt: SolverRuntime,
@@ -282,12 +378,20 @@ def gamma_c_state(
     ``surfaces`` are normalized-flux values mapped to the nearest interior
     full-mesh rows (the surface-selection convention of
     :func:`vmex.core.neoclassical.epsilon_effective_from_wout`).  Each
-    surface samples ``nalpha`` field lines over ``num_transit`` poloidal
-    turns at ``points_per_transit`` points per turn; the lambda integral
-    uses ``num_pitch`` Gauss-Legendre nodes across the trapped range
-    ``[1/B_max, 1/B_min]`` of the sampled lines.  ``max_wells`` defaults to
-    ``16 * num_transit`` slots per pitch level; ``overflow_fraction``
-    reports any spill.  Returns per-surface arrays led by ``gamma_c``.
+    surface samples ``nalpha`` field lines over ``num_transit`` poloidal turns
+    at ``points_per_transit`` points per turn, centred on the field-line label
+    so the stellarator reflection is an exact invariance of the estimator; the
+    lambda integral uses ``num_pitch`` open-midpoint nodes across the trapped
+    range ``[1/B_max, 1/B_min]`` of the sampled lines, held fixed under
+    differentiation (see the note at the node construction).  ``max_wells``
+    defaults to ``16 * num_transit`` slots per pitch level;
+    ``overflow_fraction`` reports any spill.  Returns per-surface arrays led
+    by ``gamma_c``.
+
+    The absolute value carries roughly 10-20 % scatter at these resolutions --
+    it is a comparative proxy, and the resolution belongs in any quoted
+    number.  The numerics live in the jitted :func:`_gamma_c_rows`; only the
+    validation and the row selection happen here, because those set shapes.
     """
     if nalpha < 2:
         raise ValueError("nalpha must be >= 2")
@@ -295,84 +399,14 @@ def gamma_c_state(
         raise ValueError("num_transit must be >= 1 and points_per_transit >= 16")
     if num_pitch < 2:
         raise ValueError("num_pitch must be >= 2")
-    ctx = _ballooning_context(state, rt)
-    _require_symmetric(ctx, "Gamma_c")
-    rows = _surface_rows(surfaces, ctx["ns"])
-    dtype = ctx["s"].dtype
-    if max_wells is None:
-        max_wells = 16 * int(num_transit)
-
-    alpha = jnp.asarray(
-        2.0 * np.pi * np.arange(int(nalpha)) / int(nalpha), dtype=dtype)
-    length = 2.0 * np.pi * int(num_transit)
-    x = jnp.linspace(
-        0.0, length, int(points_per_transit) * int(num_transit) + 1,
-        dtype=dtype)
-    # Open midpoint rule, uniform in the reflecting level 1/lambda rather
-    # than lambda (the Unalmis et al. pitch-sampling guidance); the open
-    # ends avoid the incomputable bounce integral at the global maximum.
-    level_nodes = jnp.asarray(
-        (np.arange(int(num_pitch)) + 0.5) / int(num_pitch), dtype=dtype)
-    zeta0_c = jnp.asarray(zeta0, dtype=dtype)
-    hs, psi_edge = ctx["hs"], ctx["psi_edge"]
-
-    results = []
-    iotas = []
-    for j in rows:
-        iota = 0.5 * (ctx["iotas"][j] + ctx["iotas"][j + 1])
-        diota = (ctx["iotas"][j + 1] - ctx["iotas"][j]) / hs
-        iotas.append(iota)
-        point = _make_gamma_point_fn(
-            ctx["m"], ctx["xn"],
-            _parabola(ctx["rmnc"], j, hs), _parabola(ctx["zmns"], j, hs),
-            _parabola(ctx["lmns"], j, hs), iota, diota, ctx["phipf"][j])
-        lmns0 = _parabola(ctx["lmns"], j, hs)[0]
-
-        def line(a, point=point, lmns0=lmns0, iota=iota):
-            theta_star = a + x
-            phi = zeta0_c + x / iota
-            theta_v = _theta_vmec_from_pest(
-                theta_star, phi, lmns0, ctx["m"], ctx["xn"])
-            q = jnp.stack([jnp.zeros_like(theta_v), theta_v, phi], axis=-1)
-            return jax.vmap(point)(q)
-
-        (modB, b_sup_phi, bxgb_gs, modb_s_pest, bsupphi_s_pest,
-         gs_cross_b_gphi, grad_s_norm, e_alpha_norm) = jax.vmap(line)(alpha)
-
-        two_rho = 2.0 * jnp.sqrt(ctx["s"][j])
-        modb_r = two_rho * modb_s_pest                # d|B|/drho at fixed PEST angles
-        correction = (
-            two_rho * diota * psi_edge * gs_cross_b_gphi
-            - 2.0 * modb_r + modB * (two_rho * bsupphi_s_pest) / b_sup_phi)
-        dl_dx = modB / jnp.abs(iota * b_sup_phi)
-        b_min, b_max = jnp.min(modB), jnp.max(modB)
-        level = b_min + (b_max - b_min) * level_nodes
-        results.append(gamma_c_from_fieldlines(
-            bmag=modB,
-            radial_drift=psi_edge * bxgb_gs / modB**3,
-            radial_gradient=modb_r / modB,
-            drift_correction=correction / modB,
-            tangency=grad_s_norm / two_rho * e_alpha_norm,
-            dl_dx=dl_dx, length=length, pitch=1.0 / level,
-            pitch_weights=(b_max - b_min) / int(num_pitch) / level**2,
-            max_wells=max_wells, quadrature_order=quadrature_order))
-
-    stacked: dict[str, Array] = {
-        name: jnp.stack([out[name] for out in results])
-        for name in ("gamma_c", "excluded_fraction", "overflow_fraction",
-                     "line_length", "pitch")
-    }
-    # The field-line map phi = x / iota is meaningless through iota ~ 0;
-    # poison the result instead of returning a plausible number.
-    iota_row = jnp.stack(iotas)
-    stacked["gamma_c"] = jnp.where(
-        jnp.abs(iota_row) > 1.0e-6, stacked["gamma_c"], jnp.nan)
-    stacked.update({
-        "surface_rows": rows,
-        "s": ctx["s"][jnp.asarray(rows)],
-        "iota": iota_row,
-    })
-    return stacked
+    rows = _surface_rows(surfaces, int(np.shape(rt.setup.s_full)[0]))
+    out = _gamma_c_rows(
+        state, rt, jnp.asarray(float(zeta0)), rows=rows, nalpha=int(nalpha),
+        num_transit=int(num_transit),
+        points_per_transit=int(points_per_transit), num_pitch=int(num_pitch),
+        quadrature_order=int(quadrature_order),
+        max_wells=16 * int(num_transit) if max_wells is None else int(max_wells))
+    return {**out, "surface_rows": rows}
 
 
 class GammaC:

--- a/vmex/core/stability.py
+++ b/vmex/core/stability.py
@@ -711,21 +711,6 @@ def _ballooning_context(state: SpectralState, rt: SolverRuntime) -> dict:
     )
 
 
-def _require_symmetric(ctx: dict, lane: str) -> None:
-    """Guard a field-line lane that has no asymmetric verification yet.
-
-    The geometry in :func:`_ballooning_context` is parity-complete, so an
-    asymmetric state reaches every lane that shares it.  A lane keeps this
-    guard until it has its own ``lasym`` oracle: unblocked-but-unverified is
-    the silent-wrong-answer class, not a feature.
-    """
-    if ctx["lasym"]:
-        raise NotImplementedError(
-            f"{lane} supports stellarator-symmetric states only (lasym = False); "
-            "the shared field-line geometry is parity-complete, but this lane "
-            "has no asymmetric verification yet")
-
-
 def _parabola(table: Array, j: int, hs: Array) -> Array:
     """Local radial parabola of a full-mesh coefficient table at surface j.
 
@@ -803,9 +788,11 @@ def _surface_closures(m: Array, xn: Array, tabs: dict, iota: Array,
 
     ``q = (t, θ, φ)`` with ``t = s - s_j``; the radial parabola tables of
     :func:`_surface_tables` make every quantity differentiable in ``t``.
-    Returns ``(pos_fn, lam_fn, b_vector, modb_fn)`` — the cylindrical
-    position, ``λ``, ``B = ψ'[(ι - λ_φ) e_θ + (1 + λ_θ) e_φ]/√g`` and
-    ``|B|``.  The ballooning, turbulence and Gamma_c lanes build
+    Returns ``(pos_fn, lam_fn, b_vector, modb_fn, bsupphi_fn)`` — the
+    cylindrical position, ``λ``, ``B = ψ'[(ι - λ_φ) e_θ + (1 + λ_θ) e_φ]/√g``,
+    ``|B|`` and ``B^φ``.  Gamma_c is the consumer of the last one; it needs
+    ``dB^φ/ds`` at fixed PEST angle, which the ballooning and turbulence
+    point tuples do not.  The ballooning, turbulence and Gamma_c lanes build
     their point tuples on these by automatic differentiation, so a state's
     sine-parity spectra reach all three from one implementation.
     """
@@ -845,7 +832,12 @@ def _surface_closures(m: Array, xn: Array, tabs: dict, iota: Array,
     def modb_fn(q: Array) -> Array:
         return jnp.linalg.norm(b_vector(q))
 
-    return pos_fn, lam_fn, b_vector, modb_fn
+    def bsupphi_fn(q: Array) -> Array:
+        J = jax.jacfwd(pos_fn)(q)
+        lam_g = jax.grad(lam_fn)(q)
+        return phipf_j * (1.0 + lam_g[1]) / jnp.linalg.det(J)
+
+    return pos_fn, lam_fn, b_vector, modb_fn, bsupphi_fn
 
 
 def _make_point_fn(m: Array, xn: Array, tabs: dict, iota: Array,
@@ -857,7 +849,7 @@ def _make_point_fn(m: Array, xn: Array, tabs: dict, iota: Array,
     covariant basis ``e_s, e_θ, e_φ``, the dual basis and ``∇|B|`` come from
     JAX differentiation of the :func:`_surface_closures` sums.
     """
-    pos_fn, lam_fn, _, modb_fn = _surface_closures(
+    pos_fn, lam_fn, _, modb_fn, _ = _surface_closures(
         m, xn, tabs, iota, diota, phipf_j)
 
     def point(q: Array, phi_rel: Array):

--- a/vmex/core/turbulence.py
+++ b/vmex/core/turbulence.py
@@ -161,7 +161,7 @@ def _make_gk_point_fn(m: Array, xn: Array, tabs: dict, iota: Array,
     ``(|B|, B^phi, |grad alpha|^2, grad alpha . grad s, |grad s|^2,
     B x grad|B| . grad alpha, B x grad|B| . grad s, B . grad|B|)``.
     """
-    pos_fn, lam_fn, _, modb_fn = _surface_closures(
+    pos_fn, lam_fn, _, modb_fn, _ = _surface_closures(
         m, xn, tabs, iota, diota, phipf_j)
 
     def point(q: Array, phi_rel: Array):


### PR DESCRIPTION
Stacked on #152 (it uses the shared spectral closures added there).

You asked for Γ_c polished so it could merge, with "gamma and its derivative fast and accurate". **The derivative is fast now, and it is not accurate, and I could not make it accurate by polishing.** Here is the whole picture.

> **What this PR claims:** two symmetry defects fixed and proven by an exact identity, a 148x warm speedup, Γ_c working on asymmetric states, and one dead helper deleted.
>
> **What it does not claim:** that Γ_c's gradient is usable for boundary optimization. It is not, it is not a regression, and I could not fix it by polishing. That is measured below and it is the reason there is no optimization example.

## Two real defects, found with one exact identity

Γ_c is even under the stellarator reflection and the sine-parity spectra are odd, so on a stellarator-symmetric equilibrium `∂Γ_c/∂(sine)` must be **identically zero**. It was **55% of the physical gradient** — an optimizer with sine dofs would have chased it.

1. **The trace window** ran `x ∈ [0, L]` instead of centred on the field-line label. The reflection maps `(α, x) → (−α, −x)` and the α set is closed under negation, so only a window symmetric in `x` makes the sampled point set reflection-closed. Centring makes the per-line estimator mirror-invariant to **1.8e-14** (from 1.1e-1), and takes the identity to 13%.
2. **The pitch grid**, which is the interesting one. `b_min`/`b_max` are `jnp.min`/`jnp.max` over the |B| of a reflection-closed line set — so the extrema sit at mirror-image **pairs** of points, and `max` sends the entire cotangent to one member of each pair. Holding the grid fixed under differentiation takes the identity to **6.6e-11** and moves the physical gradient by **1.8e-4**.

That second term is not a discretization artifact that refines away. Over `num_pitch = 12/24/48/96` the violation ran 1.7e-1, 1.8e-1, 6.0e-3, 1.6e-1 — an erratic subgradient with no limit. The pitch nodes are a quadrature grid, not an observable, and freezing them is the correct treatment.

Localizing it needed one more measurement: the **sampled geometry is exactly reflection-symmetric to machine zero** (seven quantities even, `B×∇|B|·∇s` odd, all at `0.0e+00`), which ruled out the spectra and the PEST map and left only the estimator.

## The jit

Module-level, resolution arguments static, so an optimization stage reuses one executable across boundary iterates rather than re-tracing:

| | cold | warm |
| --- | --- | --- |
| value | 7.42 s | **0.050 s** |
| gradient | 17.25 s | **1.07 s** |

Values bit-identical. Γ_c also now shares `stability.py`'s spectral closures instead of carrying a third copy, which is what makes the lane work for `lasym` states — and the parity identity above *runs on a lasym runtime*, so it is that lane's verification, not a guard removal.

## What I could not fix

**The boundary gradient is not a convergent quantity.** `d/d rbc(n=0,m=1)` on li383, ns=13:

| nalpha, transits, points/transit, pitch | this PR | main |
| --- | --- | --- |
| 7, 3, 64, 24 | −1.254 | −0.403 |
| 7, 4, 96, 48 | **+3.518** | **+0.582** |
| 9, 5, 128, 48 | −0.387 | −0.554 |
| 13, 6, 192, 64 | −0.988 | −0.562 |
| 17, 8, 256, 96 | **+0.180** | −0.111 |

Radial resolution does not rescue it: at fixed sampling, `ns = 13/25/49` gives **−0.387, +0.175, −2.167**. And on an *optimized* QA deck — where Γ_c is what you would actually want to reduce — the **value** does not converge either: 2.77e-5, 8.08e-7, 1.99e-6, 1.68e-6 up the same ladder, so the shipped default overestimates by **34×**.

The instability is present on `main` too, so this PR is not a regression. `test_boundary_gradient_liveness` was asserting sign stability under one refinement step and **passing on a lucky pair of configurations** — its own docstring already conceded 4.6× magnitude scatter. That assertion is replaced by the measured ladder.

The cause is structural: hard well detection and hard argmin selection make the *discretized* Γ_c piecewise in the boundary coefficients, with breakpoints that move when the grid moves — so refinement changes which function is being differentiated. Softening the well weights would be a redesign, not a polish, and I did not want to fold one into this PR without your call on it.

**So no Γ_c optimization example.** You asked for one; it would not work, and shipping it would be the interesting-looking kind of wrong. Γ_c stands as a value-level comparative proxy with the resolution quoted alongside any number.

## Also in this PR

`_require_symmetric` is deleted. With turbulence opened in #152 and Γ_c opened here, nothing calls it — a private guard that guards nothing is the scaffold this repo does not keep. The test that asserted Γ_c still raises goes with it, replaced by one that runs **all three** field-line lanes (ballooning, turbulence, Γ_c) on the asymmetric fixture and requires finite results. Each now has its own asymmetric evidence rather than a guard: ballooning through the zero-sine and LASYM-of-a-symmetric-deck gates, turbulence against simsopt's `vmec_fieldlines`, Γ_c through the exact reflection identity.

## Verification

`tests/test_gammac.py` — 5 passed (3:27). `ruff` and `mypy` clean. The new `test_gamma_c_respects_the_stellarator_reflection` measures 5.8e-11 against a physical gradient of 2.6e+03.

