### PR TITLE
Add the sum_atan profile parameterization

### DIFF
--- a/docs/howto/profiles.md
+++ b/docs/howto/profiles.md
@@ -72,6 +72,23 @@ spline profiles and shows they agree:
   mis-ordered knot silently shortens the profile — check the parsed
   {class}`~vmex.core.input.VmecInput` if a spline looks truncated.
 
+`sum_atan` is available for `PCURR_TYPE` and `PIOTA_TYPE` (VMEC2000 offers it
+for those two and not for pressure). It prescribes the profile itself, not its
+derivative:
+
+$$
+f(x) = c_0 + \frac{2}{\pi}\sum_{k=0}^{4} c_{1+4k}
+  \arctan\left(\frac{c_{2+4k}\, x^{c_{3+4k}}}{(1-x)^{c_{4+4k}}}\right)
+$$
+
+using `AC[0:21]` or `AI[0:21]`. Each group of four is an amplitude, a scale,
+and the two exponents, so one group already gives a tunable edge-localized
+step — the shape used for tokamak-like current profiles that rise sharply
+near the boundary. At `x >= 1` VMEC2000 substitutes the hardcoded sum
+$c_0 + c_1 + c_5 + c_9 + c_{13} + c_{17}$, which is the limit only when the
+scales and the $(1-x)$ exponents are positive; vmex reproduces that as
+written.
+
 Every profile key, default, and accepted `*_TYPE` string:
 {doc}`/reference/input-file` (Pressure profile / Current and iota sections).
 The evaluation code is {mod}`vmex.core.profiles`.

--- a/docs/reference/input-file.rst
+++ b/docs/reference/input-file.rst
@@ -202,7 +202,11 @@ Current and iota profiles
    * - ``PCURR_TYPE``
      - ``power_series``
      - current profile type; ``*_i`` forms prescribe :math:`I(s)`, ``*_ip``
-       forms prescribe :math:`I'(s)`
+       forms prescribe :math:`I'(s)`.  One of ``power_series``,
+       ``power_series_i``, ``two_power``, ``gauss_trunc``, ``sum_atan``,
+       ``pedestal``, and the ``cubic_spline``/``akima_spline``/
+       ``line_segment`` ``_i`` and ``_ip`` forms.  ``sum_atan`` and
+       ``pedestal`` prescribe :math:`I(s)`
    * - ``AC`` / ``AC_AUX_S`` / ``AC_AUX_F``
      - zeros / —
      - current profile coefficients / spline knots and values
@@ -211,7 +215,8 @@ Current and iota profiles
      - total toroidal current [A]
    * - ``PIOTA_TYPE``
      - ``power_series``
-     - iota profile type
+     - iota profile type; one of ``power_series``, ``sum_atan``,
+       ``cubic_spline``, ``akima_spline``, ``line_segment``
    * - ``AI`` / ``AI_AUX_S`` / ``AI_AUX_F``
      - zeros / —
      - iota profile coefficients / spline knots and values

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -281,3 +281,111 @@ def test_grad_through_two_power_current_coefficients():
         lambda c: jnp.sum(profiles.current("two_power", c, None, None, 0.5))
     )(ac)
     assert float(d[0]) == pytest.approx(0.5 - 0.5**3 / 3.0, rel=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# sum_atan (profile_functions.f pcurr/piota)
+# ---------------------------------------------------------------------------
+
+
+def _sum_atan_fortran(ac, x):
+    """``profile_functions.f`` lines 375-384, transcribed literally.
+
+    The reference is the Fortran itself rather than a simplification of it,
+    including the hardcoded ``x >= 1`` branch, so a divergence in either shows
+    up as a mismatch instead of being defined away.
+    """
+    a = np.zeros(21)
+    ac = np.asarray(ac, dtype=float)
+    a[: min(21, ac.size)] = ac[:21]
+    if x >= 1.0:
+        return a[0] + a[1] + a[5] + a[9] + a[13] + a[17]
+    return a[0] + (2.0 / np.pi) * (
+        a[1] * np.arctan(a[2] * x ** a[3] / (1 - x) ** a[4])
+        + a[5] * np.arctan(a[6] * x ** a[7] / (1 - x) ** a[8])
+        + a[9] * np.arctan(a[10] * x ** a[11] / (1 - x) ** a[12])
+        + a[13] * np.arctan(a[14] * x ** a[15] / (1 - x) ** a[16])
+        + a[17] * np.arctan(a[18] * x ** a[19] / (1 - x) ** a[20])
+    )
+
+
+#: (0) the HSX benchmark deck's own AC, (1) two groups with a negative
+#: amplitude, (2) all five groups with fractional exponents, (3) a short array
+#: that must pad, (4) a zero-exponent group, since ``0**0`` is 1 in Fortran.
+_SUM_ATAN_CASES = {
+    "hsx_deck": [0.0, 1.0, 1.00423652381532e01, 1.50747420899044e00, 1.0]
+    + [0.0] * 16,
+    "two_groups": [0.3, 0.8, 4.0, 2.0, 1.0, -0.25, 7.5, 1.25, 0.5] + [0.0] * 12,
+    "five_groups": [0.1, 0.5, 3.0, 1.0, 1.0, 0.2, 2.0, 1.5, 0.5, -0.1, 5.0,
+                    2.0, 1.5, 0.3, 1.0, 0.5, 1.0, -0.2, 8.0, 3.0, 2.0],
+    "short_array": [0.5, 2.0, 3.0],
+    "zero_exponent": [0.0, 1.0, 2.0, 0.0, 1.0] + [0.0] * 16,
+}
+
+
+@pytest.mark.parametrize("case", sorted(_SUM_ATAN_CASES))
+def test_sum_atan_matches_profile_functions_f(case):
+    """Values against the transcribed Fortran, endpoints included.
+
+    The grid deliberately includes ``x = 0`` and ``x = 1`` and the points just
+    inside them: those are the two places the expression is singular, and both
+    are real grid points for a VMEC profile.
+    """
+    ac = _SUM_ATAN_CASES[case]
+    x = np.concatenate([[0.0, 1e-12, 1e-6],
+                        np.linspace(0.001, 0.999, 40),
+                        [1.0 - 1e-9, 1.0]])
+    got = np.asarray(profiles.evaluate_profile("sum_atan", ac, None, None, x))
+    expected = np.array([_sum_atan_fortran(ac, xi) for xi in x])
+    assert np.all(np.isfinite(got))
+    scale = max(float(np.max(np.abs(expected))), 1e-300)
+    assert float(np.max(np.abs(got - expected))) / scale < 1e-13
+    # The hardcoded edge, exactly as Fortran writes it.
+    a = np.zeros(21)
+    a[: min(21, len(ac))] = np.asarray(ac, dtype=float)[:21]
+    assert float(got[-1]) == pytest.approx(
+        a[0] + a[1] + a[5] + a[9] + a[13] + a[17], rel=1e-14)
+
+
+def test_sum_atan_is_differentiable_at_both_endpoints():
+    """No NaN in the gradient at ``x = 0`` or ``x = 1``.
+
+    ``jnp.power`` with a non-integer exponent goes through ``exp(e log x)``,
+    so a naive ``x ** c`` puts ``log(0)`` on the tape and returns a NaN
+    derivative at the axis; the ``x >= 1`` branch of a ``jnp.where`` is
+    evaluated too, so an unguarded ``1/(1-x)`` poisons the other branch.  Both
+    are real grid points, so both matter.
+    """
+    ac = jnp.asarray(_SUM_ATAN_CASES["five_groups"])
+    for x in (0.0, 1e-14, 0.5, 1.0 - 1e-14, 1.0):
+        d = jax.grad(
+            lambda xx: profiles.evaluate_profile("sum_atan", ac, None, None, xx)
+        )(x)
+        assert np.isfinite(float(d)), f"d/dx at x={x}"
+    grad_c = jax.grad(
+        lambda c: jnp.sum(profiles.evaluate_profile(
+            "sum_atan", c, None, None, jnp.linspace(0.0, 1.0, 17)))
+    )(ac)
+    assert bool(jnp.all(jnp.isfinite(grad_c)))
+    assert float(jnp.max(jnp.abs(grad_c))) > 0.0
+
+
+def test_sum_atan_reaches_the_current_and_iota_wrappers():
+    """``sum_atan`` is selectable as ``pcurr_type`` and ``piota_type``.
+
+    VMEC2000 offers it for those two and not for ``pmass``
+    (``profile_functions.f`` has a ``CASE('sum_atan')`` in ``pcurr`` and
+    ``piota`` only), so the pressure wrapper must keep rejecting it.
+    """
+    ac = _SUM_ATAN_CASES["hsx_deck"]
+    x = np.linspace(0.0, 1.0, 9)
+    expected = np.array([_sum_atan_fortran(ac, xi) for xi in x])
+    # pcurr: sum_atan parameterizes I(s) itself, so no integration.
+    np.testing.assert_allclose(
+        np.asarray(profiles.current("sum_atan", ac, None, None, x)),
+        expected, rtol=1e-13, atol=1e-300)
+    np.testing.assert_allclose(
+        np.asarray(profiles.iota("sum_atan", ac, None, None, x)),
+        expected, rtol=1e-13, atol=1e-300)
+    with pytest.raises(NotImplementedError, match="pmass_type"):
+        profiles.pressure("sum_atan", ac, None, None, x)

--- a/tests/test_vmec2000_live.py
+++ b/tests/test_vmec2000_live.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import dataclasses
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -431,3 +432,87 @@ def test_live_vmec2000_exact_jvp_gmres_robustness(pytestconfig, tmp_path):
     np.testing.assert_allclose(actual.iotaf, reference.iotaf, atol=2e-14)
 
 
+
+
+#: The HSX benchmark deck's own AC (STELLOPT BENCHMARKS/DIAGNO_TEST/input.hsx):
+#: one arctangent group, the shape 'sum_atan' exists for.
+_SUM_ATAN_AC = np.array(
+    [0.0, 1.0, 1.00423652381532e01, 1.50747420899044e00, 1.0] + [0.0] * 16
+)
+
+
+def _sum_atan_current_input():
+    """li383 with its current profile replaced by ``pcurr_type='sum_atan'``."""
+    inp = VmecInput.from_file(DATA / "input.li383_low_res")
+    assert int(inp.ncurr) == 1, "the current profile only sets iota at NCURR = 1"
+    return dataclasses.replace(inp, pcurr_type="sum_atan", ac=_SUM_ATAN_AC)
+
+
+def _sum_atan_iota_input():
+    """The same deck with a prescribed ``piota_type='sum_atan'`` (NCURR = 0)."""
+    inp = VmecInput.from_file(DATA / "input.li383_low_res")
+    ai = np.array([0.3, 0.6, 5.0, 1.0, 1.0] + [0.0] * 16)
+    return dataclasses.replace(inp, ncurr=0, piota_type="sum_atan", ai=ai)
+
+
+@pytest.mark.parametrize(
+    "name, build, fields",
+    [
+        ("sum_atan_current", _sum_atan_current_input,
+         ("iotaf", "jcurv", "buco", "presf")),
+        ("sum_atan_iota", _sum_atan_iota_input, ("iotaf", "buco", "presf")),
+    ],
+)
+def test_live_vmec2000_sum_atan_parity(pytestconfig, tmp_path, name, build,
+                                       fields):
+    """``pcurr_type='sum_atan'`` against live VMEC2000, end to end.
+
+    The unit test in ``tests/test_profiles.py`` pins the formula against a
+    transcription of ``profile_functions.f``.  This one closes the loop
+    through the solver: with ``NCURR = 1`` the current profile sets ``iota``,
+    so a wrong ``I(s)`` moves ``iotaf`` and ``jcurv`` rather than staying
+    hidden in an unused array.
+
+    Both lanes VMEC2000 offers it for are covered: ``pcurr_type`` with
+    ``NCURR = 1``, where the current profile sets ``iota``, and ``piota_type``
+    with ``NCURR = 0``, where it is prescribed directly.  A wrong ``f(s)``
+    moves ``iotaf`` and ``jcurv`` in the first and ``iotaf`` in the second,
+    rather than staying hidden in an unused array.
+
+    Measured on li383_low_res: current lane ``iotaf`` 2.8e-14, ``jcurv``
+    1.2e-14, ``buco`` 2.2e-15, ``presf`` 1.9e-15, with
+    ``aspect``/``betatotal``/``volume_p``/``b0`` at 1e-15 or below; iota lane
+    ``iotaf`` 1.2e-16, ``buco`` 2.0e-14.  The bounds below are three orders
+    above that, so they gate a real divergence and not float64 noise.
+    """
+    vmec2000_dir = tmp_path / "vmec2000"
+    vmex_dir = tmp_path / "vmex"
+    vmec2000_dir.mkdir()
+    vmex_dir.mkdir()
+    inp = build()
+    for directory in (vmec2000_dir, vmex_dir):
+        inp.to_indata(directory / f"input.{name}")
+
+    _run([str(_executable(pytestconfig)), f"input.{name}"], cwd=vmec2000_dir)
+    _run(
+        [sys.executable, "-m", "vmex.core.cli", str(vmex_dir / f"input.{name}"),
+         "--outdir", str(vmex_dir), "--device", "cpu"],
+        cwd=ROOT,
+    )
+
+    reference = read_wout(vmec2000_dir / f"wout_{name}.nc")
+    actual = read_wout(vmex_dir / f"wout_{name}.nc")
+    assert int(actual.ier_flag) == int(reference.ier_flag) == 0
+    assert int(actual.ns) == int(reference.ns)
+    profile_type = (reference.pcurr_type if name.endswith("current")
+                    else reference.piota_type)
+    assert str(profile_type).strip().lower().startswith("sum_atan")
+    for field in fields:
+        limit = 1.0e-11
+        expected = np.asarray(getattr(reference, field), dtype=float)[1:-1]
+        got = np.asarray(getattr(actual, field), dtype=float)[1:-1]
+        scale = max(float(np.max(np.abs(expected))), np.finfo(float).tiny)
+        error = float(np.max(np.abs(got - expected))) / scale
+        assert error < limit, (field, error)
+    # A degenerate iota would satisfy the bounds above and prove nothing.
+    assert float(np.max(np.abs(np.asarray(actual.iotaf)))) > 0.1

--- a/vmex/core/profiles.py
+++ b/vmex/core/profiles.py
@@ -31,6 +31,9 @@ power_series         ``sum_i c[i] x**i``
 two_power            ``c[0] (1 - x**c[1])**c[2]``
 gauss_trunc          ``c[0]/(1-E) * (exp(-(x/c[1])**2) - E)``,
                      ``E = exp(-(1/c[1])**2)`` (normalized so f(0)=c[0])
+sum_atan             ``c[0] + (2/pi) sum_{k=0..4} c[1+4k]
+                     atan(c[2+4k] x**c[3+4k] / (1-x)**c[4+4k])`` -- iota and
+                     current only, and it parameterizes ``I``, not ``I'``
 pedestal             VMEC2000 ``pmass`` pedestal: degree-15 power series in
                      ``c[0:16]`` plus a tanh pedestal shaped by ``c[16:21]``
 cubic_spline         VMEC ``spline_cubic`` through (aux_s, aux_f) knots
@@ -57,6 +60,9 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 import numpy as np
+
+#: Denominator floor for 'sum_atan'; see :func:`_sum_atan`.
+_SUM_ATAN_FLOOR = 1.0e-300
 
 __all__ = [
     "MU0",
@@ -145,6 +151,56 @@ def _gauss_trunc(coefficients, x):
     x = jnp.asarray(x)
     edge = jnp.exp(-((1.0 / c[1]) ** 2))
     return c[0] / (1.0 - edge) * (jnp.exp(-((x / c[1]) ** 2)) - edge)
+
+
+def _pow_at_zero(x, exponent):
+    """``x ** exponent`` with the Fortran value, and no NaN gradient, at x = 0.
+
+    ``jnp.power`` with a non-integer exponent goes through ``exp(e log x)``,
+    so at ``x = 0`` both the value and its derivative come back NaN, where
+    Fortran gives ``0`` (``e > 0``), ``1`` (``e = 0``) or ``+inf``
+    (``e < 0``).  Evaluating at a stand-in and selecting afterwards keeps the
+    value exact for every ``x > 0`` and keeps ``log(0)`` out of the tape.
+    """
+    x = jnp.asarray(x)
+    positive = x > 0.0
+    powered = jnp.where(positive, x, 1.0) ** exponent
+    at_zero = jnp.where(exponent == 0.0, 1.0,
+                        jnp.where(exponent > 0.0, 0.0, jnp.inf))
+    return jnp.where(positive, powered, at_zero)
+
+
+def _sum_atan(coefficients, x):
+    """Sum of five arctangents (``profile_functions.f`` 'sum_atan').
+
+    ``f(x) = c0 + (2/pi) sum_k c[1+4k] atan(c[2+4k] x**c[3+4k] /
+    (1-x)**c[4+4k])`` over ``k = 0..4``, using ``c[0:21]``.
+
+    VMEC hardcodes the edge rather than taking the limit: at ``x >= 1`` it
+    returns ``c0 + c1 + c5 + c9 + c13 + c17``, which is that limit only when
+    every ``c[2+4k]`` and ``c[4+4k]`` is positive.  Reproduced as written,
+    because parity with ``pcurr``/``piota`` is the contract.
+
+    Only the denominator is guarded.  An untaken ``jnp.where`` branch is still
+    evaluated, so ``1 - x`` is floored away from zero to keep the ``x >= 1``
+    branch from putting a NaN into the gradient of the taken one; the floor is
+    far below any representable ``1 - x``, so interior values are exact and
+    the guarded expression still tends to ``atan(inf) = pi/2``.  ``x`` itself
+    is handled by :func:`_pow_at_zero` instead, because clamping it low would
+    move ``f(0)`` whenever an exponent ``c[3+4k]`` is fractional (at
+    ``eps = 1e-12`` and ``c = 0.5``, by 2e-7).
+    """
+    c = _coeffs_padded(coefficients, 21)
+    x = jnp.asarray(x)
+    interior = x < 1.0
+    one_minus = jnp.maximum(jnp.where(interior, 1.0 - x, 1.0), _SUM_ATAN_FLOOR)
+    total = jnp.zeros_like(x)
+    for k in range(5):
+        total = total + c[1 + 4 * k] * jnp.arctan(
+            c[2 + 4 * k] * _pow_at_zero(x, c[3 + 4 * k])
+            / one_minus ** c[4 + 4 * k])
+    edge = c[0] + c[1] + c[5] + c[9] + c[13] + c[17]
+    return jnp.where(interior, c[0] + (2.0 / jnp.pi) * total, edge)
 
 
 def _pedestal(coefficients, x):
@@ -490,6 +546,7 @@ _PARAMETERIZED = {
     "power_series": _power_series,
     "two_power": _two_power,
     "gauss_trunc": _gauss_trunc,
+    "sum_atan": _sum_atan,
     "pedestal": _pedestal,
     "power_series_ip": _pcurr_power_series_ip,
     "power_series_i": _pcurr_power_series_i,
@@ -591,7 +648,8 @@ def iota(piota_type: str, ai, ai_aux_s, ai_aux_f, s, *, bloat=1.0, lrfp=False):
     this port applies it uniformly (identical for the default ``bloat = 1``).
     """
     kind = str(piota_type).strip().lower()
-    if kind not in ("power_series", "cubic_spline", "akima_spline", "line_segment"):
+    if kind not in ("power_series", "sum_atan", "cubic_spline", "akima_spline",
+                    "line_segment"):
         raise NotImplementedError(f"piota_type={piota_type!r} not implemented")
     x = _bloated(s, bloat)
     value = evaluate_profile(kind, ai, ai_aux_s, ai_aux_f, x)
@@ -604,6 +662,7 @@ def iota(piota_type: str, ai, ai_aux_s, ai_aux_f, s, *, bloat=1.0, lrfp=False):
 _PCURR_KINDS = {
     "power_series": "power_series_ip",
     "power_series_i": "power_series_i",
+    "sum_atan": "sum_atan",
     "two_power": "two_power_ip",
     "gauss_trunc": "gauss_trunc_ip",
     "pedestal": "pedestal_i",


### PR DESCRIPTION
`sum_atan`, available for `PCURR_TYPE` and `PIOTA_TYPE` from this branch.

VMEC2000 offers it for those two and **not** for pressure — `profile_functions.f` has a `CASE('sum_atan')` at line 367 (`pcurr`) and line 601 (`piota`), and none in `pmass` — so vmex offers exactly those two and `pressure()` keeps rejecting it.

```
f(x) = c0 + (2/pi) * sum_{k=0..4} c[1+4k] * atan( c[2+4k] x^c[3+4k] / (1-x)^c[4+4k] )
```

over `AC[0:21]` / `AI[0:21]`. Each group of four is an amplitude, a scale and the two exponents. It parameterizes **the profile itself, not its derivative**, so the current lane returns `I(s)` directly with no quadrature — unlike `power_series`/`two_power`/`gauss_trunc`.

## Verified against VMEC2000 twice over

**Formula**, against a literal transcription of `profile_functions.f` lines 375-384 (including its hardcoded edge branch, so a divergence in either shows up rather than being defined away), on a grid containing `x = 0`, `x = 1` and the points just inside them:

| coefficient set | max relative |
| --- | --- |
| the HSX benchmark deck's own `AC` | 2.2e-16 |
| two groups, negative amplitude | 2.6e-16 |
| five groups, fractional exponents | 1.4e-16 |
| short array (pads to 21) | 0.0 |
| zero exponent (`0**0 = 1`) | — |

**End to end through the solver**, live `xvmec2000` on `li383_low_res`:

| lane | | |
| --- | --- | --- |
| `pcurr_type` (NCURR=1) | `iotaf` **2.8e-14**, `jcurv` 1.2e-14, `buco` 2.2e-15, `presf` 1.9e-15 | `aspect`/`betatotal`/`volume_p`/`b0` all ≤1e-15 |
| `piota_type` (NCURR=0) | `iotaf` **1.2e-16**, `buco` 2.0e-14 | |

Both lanes matter and both are tested: with `NCURR=1` the current profile *sets* `iota`, so a wrong `I(s)` moves `iotaf` and `jcurv` rather than sitting unused in an array.

## Two Fortran behaviours reproduced rather than tidied

- At `x >= 1` VMEC substitutes the hardcoded `c0 + c1 + c5 + c9 + c13 + c17`. That is the true limit **only** when every scale and every `(1-x)` exponent is positive. Parity with `pcurr`/`piota` is the contract, so vmex does the same and says so.
- `0**0 = 1`, which a zero x-exponent depends on.

## Numerics that only matter because vmex differentiates

`jnp.power` with a non-integer exponent goes through `exp(e log x)`, so a plain `x ** c` puts `log(0)` on the tape and returns NaN for **both** value and derivative at the axis — which is a real grid point. `_pow_at_zero` evaluates at a stand-in and selects the Fortran value afterwards (`0`, `1` or `+inf` by the sign of the exponent). Separately, an untaken `jnp.where` branch is still evaluated, so `1 - x` is floored far below any representable value to stop the `x >= 1` branch poisoning the gradient of the other one.

An earlier revision of this patch clamped `x` low as well. That moved `f(0)` by **2e-7** whenever an exponent was fractional — caught by the endpoint case in the unit test, which is why the grid includes `x = 0` explicitly.

`d/dx` is finite at `x = 0`, `1e-14`, `0.5`, `1 - 1e-14` and `1.0`; `d/dc` is finite and nonzero.

## Verification

`tests/test_profiles.py` + `tests/test_input_profiles.py` + `tests/test_test_manifest.py` — **185 passed**. The two live parity rows pass under `--run-vmec2000`. `INDATA` round-trip is exact (`pcurr_type` string and all 21 `AC` coefficients). `ruff`, `mypy` (68 files), `check_docs_prose` and `sphinx -W` clean.

Docs: `docs/reference/input-file.rst` now lists the accepted `PCURR_TYPE`/`PIOTA_TYPE` strings (it previously listed none for either), and `docs/howto/profiles.md` gains the formula and the edge-branch caveat.

No new files, no new bundled decks — the tests build their inputs from `input.li383_low_res` with `dataclasses.replace`.
