### PR TITLE
Implement every remaining VMEC2000 profile parameterization

### DIFF
--- a/docs/howto/profiles.md
+++ b/docs/howto/profiles.md
@@ -89,6 +89,10 @@ $c_0 + c_1 + c_5 + c_9 + c_{13} + c_{17}$, which is the limit only when the
 scales and the $(1-x)$ exponents are positive; vmex reproduces that as
 written.
 
+vmex implements every parameterization VMEC2000 offers: ten for
+`PMASS_TYPE`, seven for `PIOTA_TYPE`, seventeen for `PCURR_TYPE`. A name
+outside those raises rather than falling back to a default.
+
 Every profile key, default, and accepted `*_TYPE` string:
 {doc}`/reference/input-file` (Pressure profile / Current and iota sections).
 The evaluation code is {mod}`vmex.core.profiles`.

--- a/docs/reference/input-file.rst
+++ b/docs/reference/input-file.rst
@@ -167,8 +167,9 @@ Pressure profile
      - Meaning
    * - ``PMASS_TYPE``
      - ``power_series``
-     - one of ``power_series``, ``two_power``, ``gauss_trunc``,
-       ``cubic_spline``, ``akima_spline``, ``line_segment``, ``pedestal``,
+     - one of ``power_series``, ``two_power``, ``two_power_gs``,
+       ``two_Lorentz``, ``gauss_trunc``, ``rational``, ``cubic_spline``,
+       ``akima_spline``, ``line_segment``, ``pedestal``,
        ... (see :mod:`vmex.core.profiles`)
    * - ``AM``
      - zeros
@@ -203,10 +204,12 @@ Current and iota profiles
      - ``power_series``
      - current profile type; ``*_i`` forms prescribe :math:`I(s)`, ``*_ip``
        forms prescribe :math:`I'(s)`.  One of ``power_series``,
-       ``power_series_i``, ``two_power``, ``gauss_trunc``, ``sum_atan``,
-       ``pedestal``, and the ``cubic_spline``/``akima_spline``/
-       ``line_segment`` ``_i`` and ``_ip`` forms.  ``sum_atan`` and
-       ``pedestal`` prescribe :math:`I(s)`
+       ``power_series_i``, ``two_power``, ``two_power_gs``,
+       ``gauss_trunc``, ``sum_atan``, ``rational``, ``pedestal``, and the
+       ``cubic_spline``/``akima_spline``/``line_segment`` ``_i`` and ``_ip``
+       forms.  ``sum_atan``, ``rational`` and ``pedestal`` prescribe
+       :math:`I(s)`.  VMEC2000's three ``sum_cossq_*`` forms are not
+       implemented and are rejected rather than silently substituted
    * - ``AC`` / ``AC_AUX_S`` / ``AC_AUX_F``
      - zeros / —
      - current profile coefficients / spline knots and values
@@ -216,7 +219,8 @@ Current and iota profiles
    * - ``PIOTA_TYPE``
      - ``power_series``
      - iota profile type; one of ``power_series``, ``sum_atan``,
-       ``cubic_spline``, ``akima_spline``, ``line_segment``
+       ``nice_quadratic``, ``rational``, ``cubic_spline``, ``akima_spline``,
+       ``line_segment``
    * - ``AI`` / ``AI_AUX_S`` / ``AI_AUX_F``
      - zeros / —
      - iota profile coefficients / spline knots and values

--- a/docs/reference/input-file.rst
+++ b/docs/reference/input-file.rst
@@ -205,11 +205,11 @@ Current and iota profiles
      - current profile type; ``*_i`` forms prescribe :math:`I(s)`, ``*_ip``
        forms prescribe :math:`I'(s)`.  One of ``power_series``,
        ``power_series_i``, ``two_power``, ``two_power_gs``,
-       ``gauss_trunc``, ``sum_atan``, ``rational``, ``pedestal``, and the
+       ``gauss_trunc``, ``sum_atan``, ``rational``, ``pedestal``,
+       ``sum_cossq_s``, ``sum_cossq_sqrts``, ``sum_cossq_s_free``, and the
        ``cubic_spline``/``akima_spline``/``line_segment`` ``_i`` and ``_ip``
-       forms.  ``sum_atan``, ``rational`` and ``pedestal`` prescribe
-       :math:`I(s)`.  VMEC2000's three ``sum_cossq_*`` forms are not
-       implemented and are rejected rather than silently substituted
+       forms.  ``sum_atan``, ``rational``, ``pedestal`` and the
+       ``sum_cossq_*`` forms prescribe :math:`I(s)`
    * - ``AC`` / ``AC_AUX_S`` / ``AC_AUX_F``
      - zeros / —
      - current profile coefficients / spline knots and values

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -389,3 +389,154 @@ def test_sum_atan_reaches_the_current_and_iota_wrappers():
         expected, rtol=1e-13, atol=1e-300)
     with pytest.raises(NotImplementedError, match="pmass_type"):
         profiles.pressure("sum_atan", ac, None, None, x)
+
+
+# ---------------------------------------------------------------------------
+# The remaining VMEC2000 parameterizations
+# ---------------------------------------------------------------------------
+
+
+def _pad21(c):
+    a = np.zeros(21)
+    c = np.asarray(c, dtype=float)
+    a[: min(21, c.size)] = c[:21]
+    return a
+
+
+def _f_two_power(b, x):
+    """``functions.f`` two_power."""
+    return b[0] * max(1.0 - x ** b[1], 0.0) ** b[2]
+
+
+def _f_two_power_gs(b, x):
+    """``functions.f`` lines 63-69: two_power times six Gaussian peaks."""
+    gaussians = 1.0
+    for i in range(3, 19, 3):
+        gaussians += b[i] * np.exp(-(((x - b[i + 1]) / b[i + 2]) ** 2))
+    return gaussians * _f_two_power(b, x)
+
+
+def _f_two_lorentz(am, x):
+    """``profile_functions.f`` pmass 'two_Lorentz', transcribed literally."""
+    one = 1.0
+    return am[0] * (
+        am[1] * (one / (one + (x / am[2] ** 2) ** am[3]) ** am[4]
+                 - one / (one + (one / am[2] ** 2) ** am[3]) ** am[4])
+        / (one - one / (one + (one / am[2] ** 2) ** am[3]) ** am[4])
+        + (one - am[1]) * (one / (one + (x / am[5] ** 2) ** am[6]) ** am[7]
+                           - one / (one + (one / am[5] ** 2) ** am[6]) ** am[7])
+        / (one - one / (one + (one / am[5] ** 2) ** am[6]) ** am[7]))
+
+
+def _f_rational(a, x):
+    """``profile_functions.f`` 'rational': c[0:10] over c[10:21], Horner."""
+    numerator = 0.0
+    for i in range(9, -1, -1):
+        numerator = x * numerator + a[i]
+    denominator = 0.0
+    for i in range(20, 9, -1):
+        denominator = x * denominator + a[i]
+    return (numerator / denominator if denominator != 0.0
+            else np.finfo(np.float64).max)
+
+
+def _f_nice_quadratic(ai, x):
+    """``profile_functions.f`` piota 'nice_quadratic'."""
+    return ai[0] * (1.0 - x) + ai[1] * x + 4.0 * ai[2] * x * (1.0 - x)
+
+
+_REMAINING_KINDS = {
+    "two_power_gs": (
+        _pad21([2.0, 2.0, 1.5, 0.4, 0.3, 0.12, -0.2, 0.7, 0.09, 0.15, 0.5,
+                0.2, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+        _f_two_power_gs),
+    "two_lorentz": (_pad21([1.5, 0.6, 0.8, 2.0, 1.5, 0.4, 3.0, 1.0]),
+                    _f_two_lorentz),
+    "rational": (_pad21([1.0, -0.5, 0.25] + [0.0] * 7 + [2.0, 0.5, -0.3]),
+                 _f_rational),
+    "nice_quadratic": (_pad21([0.9, 0.45, 0.12]), _f_nice_quadratic),
+}
+
+
+@pytest.mark.parametrize("kind", sorted(_REMAINING_KINDS))
+def test_remaining_kinds_match_profile_functions_f(kind):
+    """Each against a literal transcription, endpoints included."""
+    coefficients, reference = _REMAINING_KINDS[kind]
+    x = np.concatenate([[0.0], np.linspace(0.01, 0.99, 40), [1.0]])
+    got = np.asarray(profiles.evaluate_profile(kind, coefficients, None, None, x))
+    expected = np.array([reference(coefficients, xi) for xi in x])
+    assert np.all(np.isfinite(got))
+    scale = max(float(np.max(np.abs(expected))), 1e-300)
+    assert float(np.max(np.abs(got - expected))) / scale < 1e-14
+
+
+def test_rational_returns_the_fortran_huge_on_a_zero_denominator():
+    """VMEC returns ``HUGE`` there, not a NaN or an infinity.
+
+    That value reaches a wout and a caller can see it, so reproducing it is
+    part of the parity rather than an implementation detail.  All-zero
+    denominator coefficients are the way to hit it.
+    """
+    got = profiles.evaluate_profile("rational", _pad21([1.0]), None, None,
+                                    np.array([0.0, 0.5, 1.0]))
+    assert np.all(np.asarray(got) == np.finfo(np.float64).max)
+
+
+def test_two_power_gs_reduces_to_two_power_without_peaks():
+    """Zero Gaussian amplitudes must leave ``two_power`` untouched.
+
+    The peak block multiplies rather than adds, so a sign or an offset error
+    in it would survive a comparison that only ever exercised nonzero peaks.
+    """
+    c = _pad21([2.0, 2.0, 1.5] + [0.0, 0.5, 1.0] * 6)
+    x = np.linspace(0.0, 1.0, 21)
+    np.testing.assert_allclose(
+        np.asarray(profiles.evaluate_profile("two_power_gs", c, None, None, x)),
+        np.asarray(profiles.evaluate_profile("two_power", c[:3], None, None, x)),
+        rtol=1e-14, atol=0.0)
+
+
+def test_every_vmec2000_profile_type_is_selectable():
+    """The three wrappers accept exactly what ``profile_functions.f`` does.
+
+    Enumerated from its ``SELECT CASE`` labels: ``pmass`` has nine explicit
+    cases plus ``power_series`` as ``CASE DEFAULT``, ``piota`` six plus the
+    default.  ``pcurr`` has sixteen plus the default, of which the three
+    ``sum_cossq_*`` forms are not implemented here and must still raise --
+    a wrong answer is worse than a refusal.
+    """
+    x = np.linspace(0.0, 1.0, 5)
+    generic = _pad21([1.0, 2.0, 1.5])
+    # Shape parameters that are widths or exponents cannot be zero: 'two_power_gs'
+    # divides by its Gaussian widths and 'two_Lorentz' by 1 - f(1), both of which
+    # are 0/0 for an all-zero tail in Fortran as well.  A generic coefficient
+    # vector would be testing the input, not the code.
+    per_kind = {
+        "two_lorentz": _pad21([1.5, 0.6, 0.8, 2.0, 1.5, 0.4, 3.0, 1.0]),
+        "two_power_gs": _REMAINING_KINDS["two_power_gs"][0],
+        "rational": _REMAINING_KINDS["rational"][0],
+        "pedestal": _pad21([1.0, -0.5]),
+    }
+    tabulated = ("spline", "line_segment")
+
+    def coefficients_for(kind):
+        return per_kind.get(kind, generic)
+
+    for kind in sorted(profiles._PMASS_KINDS):
+        if any(marker in kind for marker in tabulated):
+            continue                      # tabulated: need knots, covered above
+        assert np.all(np.isfinite(profiles.pressure(
+            kind, coefficients_for(kind), None, None, x))), kind
+    for kind in sorted(profiles._PIOTA_KINDS):
+        if any(marker in kind for marker in tabulated):
+            continue
+        assert np.all(np.isfinite(profiles.iota(
+            kind, coefficients_for(kind), None, None, x))), kind
+    for kind in sorted(profiles._PCURR_KINDS):
+        if any(marker in kind for marker in tabulated):
+            continue
+        assert np.all(np.isfinite(profiles.current(
+            kind, coefficients_for(kind), None, None, x))), kind
+    for unimplemented in ("sum_cossq_s", "sum_cossq_s_free", "sum_cossq_sqrts"):
+        with pytest.raises(NotImplementedError, match="pcurr_type"):
+            profiles.current(unimplemented, generic, None, None, x)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -501,9 +501,9 @@ def test_every_vmec2000_profile_type_is_selectable():
 
     Enumerated from its ``SELECT CASE`` labels: ``pmass`` has nine explicit
     cases plus ``power_series`` as ``CASE DEFAULT``, ``piota`` six plus the
-    default.  ``pcurr`` has sixteen plus the default, of which the three
-    ``sum_cossq_*`` forms are not implemented here and must still raise --
-    a wrong answer is worse than a refusal.
+    default, ``pcurr`` sixteen plus the default.  All of them are implemented,
+    so the counts below are the contract: if VMEC2000 gains a case, this test
+    is what notices.
     """
     x = np.linspace(0.0, 1.0, 5)
     generic = _pad21([1.0, 2.0, 1.5])
@@ -512,6 +512,9 @@ def test_every_vmec2000_profile_type_is_selectable():
     # are 0/0 for an all-zero tail in Fortran as well.  A generic coefficient
     # vector would be testing the input, not the code.
     per_kind = {
+        "sum_cossq_s": _pad21([5.0, 1.0, 0.8, 0.5, 0.3, 0.1]),
+        "sum_cossq_sqrts": _pad21([5.0, 1.0, 0.8, 0.5, 0.3, 0.1]),
+        "sum_cossq_s_free": _pad21([1.0, 0.2, 0.15, 0.6, 0.55, 0.2]),
         "two_lorentz": _pad21([1.5, 0.6, 0.8, 2.0, 1.5, 0.4, 3.0, 1.0]),
         "two_power_gs": _REMAINING_KINDS["two_power_gs"][0],
         "rational": _REMAINING_KINDS["rational"][0],
@@ -537,6 +540,132 @@ def test_every_vmec2000_profile_type_is_selectable():
             continue
         assert np.all(np.isfinite(profiles.current(
             kind, coefficients_for(kind), None, None, x))), kind
-    for unimplemented in ("sum_cossq_s", "sum_cossq_s_free", "sum_cossq_sqrts"):
-        with pytest.raises(NotImplementedError, match="pcurr_type"):
-            profiles.current(unimplemented, generic, None, None, x)
+    assert len(profiles._PMASS_KINDS) == 10
+    assert len(profiles._PIOTA_KINDS) == 7
+    assert len(profiles._PCURR_KINDS) == 17
+    # A name VMEC2000 does not have must still be refused, not guessed at.
+    for unknown in ("sum_cossq", "two_power_g", "quadratic"):
+        with pytest.raises(NotImplementedError):
+            profiles.current(unknown, generic, None, None, x)
+
+
+def _f_sum_cossq_s(ac, x):
+    """``profile_functions.f`` 'sum_cossq_s', transcribed literally."""
+    n = int(ac[0])
+    dx = 1.0 / (n - 1.0)
+    xi = [(i - 1) * dx for i in range(0, n + 1)]
+    start = {i: max(0.0, xi[i] - dx) for i in range(1, n + 1)}
+    end = {i: min(xi[i] + dx, 1.0) for i in range(1, n + 1)}
+    reached = 1
+    for i in range(1, n + 1):
+        if start[i] < x <= end[i]:
+            reached = i
+    total = 0.0
+    for i in range(1, reached + 1):
+        if start[i] < x <= end[i]:
+            wave = dx * np.sin(np.pi * (x - xi[i]) / dx) / np.pi
+            total += (0.5 * ac[i] * (x + wave) if i == 1
+                      else 0.5 * ac[i] * (x - xi[i] + dx + wave))
+        else:
+            total += 0.5 * ac[i] * dx if i == 1 else ac[i] * dx
+    return total
+
+
+def _f_sum_cossq_sqrts(ac, x):
+    """``profile_functions.f`` 'sum_cossq_sqrts', transcribed literally."""
+    n = int(ac[0])
+    root = np.sqrt(x)
+    dx = 1.0 / (n - 1.0)
+    dx2, pi2 = dx * dx, np.pi * np.pi
+    xi = [(i - 1) * dx for i in range(0, n + 1)]
+    start = {i: max(0.0, xi[i] - dx) for i in range(1, n + 1)}
+    end = {i: min(xi[i] + dx, 1.0) for i in range(1, n + 1)}
+    reached = 1
+    for i in range(1, n + 1):
+        if start[i] < root <= end[i]:
+            reached = i
+    total = 0.0
+    for i in range(1, reached + 1):
+        if start[i] < root <= end[i]:
+            phase = np.pi * (root - xi[i]) / dx
+            if i == 1:
+                total += ac[i] * (0.25 * x
+                                  + dx / (2 * np.pi) * root * np.sin(phase)
+                                  + dx2 / (2 * pi2) * (np.cos(phase) - 1.0))
+            else:
+                total += ac[i] * (0.25 * x
+                                  + dx / (2 * np.pi) * root * np.sin(phase)
+                                  + dx2 / (2 * pi2) * np.cos(phase)
+                                  - 0.25 * start[i] ** 2 + dx2 / (2 * pi2))
+        else:
+            total += (ac[i] * (0.25 - 1 / pi2) * dx2 if i == 1
+                      else ac[i] * dx * xi[i])
+    return total
+
+
+def _f_sum_cossq_s_free(ac, x):
+    """``profile_functions.f`` 'sum_cossq_s_free', transcribed literally."""
+    total = 0.0
+    for i in range(1, 8):
+        xi, width = ac[1 + 3 * (i - 1)], ac[2 + 3 * (i - 1)]
+        amplitude = ac[3 * (i - 1)]
+        start, end = max(0.0, xi - width), min(xi + width, 1.0)
+        if amplitude == 0.0:
+            continue
+        at_start = np.sin(np.pi * (start - xi) / width)
+        if start < x <= end:
+            total += amplitude * 0.5 * (
+                (x - start) + width / np.pi
+                * (np.sin(np.pi * (x - xi) / width) - at_start))
+        elif x > end:
+            total += amplitude * 0.5 * (
+                (end - start) + width / np.pi
+                * (np.sin(np.pi * (end - xi) / width) - at_start))
+    return total
+
+
+@pytest.mark.parametrize("kind, coefficients", [
+    ("sum_cossq_s", [5.0, 1.0, 0.8, 0.5, 0.3, 0.1]),
+    ("sum_cossq_s", [3.0, 2.0, -0.5, 1.2]),
+    ("sum_cossq_sqrts", [5.0, 1.0, 0.8, 0.5, 0.3, 0.1]),
+    ("sum_cossq_sqrts", [4.0, 0.7, 1.1, -0.4, 0.6]),
+    ("sum_cossq_s_free", [1.0, 0.2, 0.15, 0.6, 0.55, 0.2, -0.3, 0.85, 0.1]),
+])
+def test_sum_cossq_matches_profile_functions_f(kind, coefficients):
+    """The three cos-squared current forms, against literal transcriptions.
+
+    These are ``I(s)`` in closed form: the density is a sum of cos-squared
+    windows and the integral is done analytically, so a wave the argument has
+    already passed contributes its whole area and at most one is partial.
+    That bookkeeping is where an error would hide, which is why the grid runs
+    across several window boundaries.
+    """
+    reference = {"sum_cossq_s": _f_sum_cossq_s,
+                 "sum_cossq_sqrts": _f_sum_cossq_sqrts,
+                 "sum_cossq_s_free": _f_sum_cossq_s_free}[kind]
+    c = _pad21(coefficients)
+    x = np.concatenate([[0.0], np.linspace(0.005, 0.995, 60), [1.0]])
+    got = np.asarray(profiles.current(kind, c, None, None, x))
+    expected = np.array([reference(c, xi) for xi in x])
+    assert np.all(np.isfinite(got))
+    scale = max(float(np.max(np.abs(expected))), 1e-300)
+    assert float(np.max(np.abs(got - expected))) / scale < 1e-14
+    # I is the integral of a sum of cos-squared windows, so it is
+    # non-decreasing whenever every amplitude is non-negative.  That is a
+    # property of the result rather than of the transcription, so it catches a
+    # sign or an interval-pairing error that a matching transcription would
+    # not.  (Note I(0) is not 0 here: the window test is a strict ``>``, so at
+    # x = 0 the first window already counts as fully integrated, so I(0) sits
+    # *above* I of the next point.  That is a real quirk of the Fortran, the
+    # comparison above pins it, and it is why the monotonicity check starts at
+    # the second sample rather than the first.)
+    if float(np.min(c[1:])) >= 0.0:
+        assert np.all(np.diff(got[1:]) >= -1e-12)
+
+
+def test_sum_cossq_rejects_an_out_of_range_wave_count():
+    """VMEC stops on a count outside 1..20; vmex raises instead of guessing."""
+    for bad in (0.0, 21.0, -3.0):
+        with pytest.raises(ValueError, match="1..20"):
+            profiles.current("sum_cossq_s", _pad21([bad, 1.0]), None, None,
+                             np.array([0.5]))

--- a/tests/test_vmec2000_live.py
+++ b/tests/test_vmec2000_live.py
@@ -455,17 +455,36 @@ def _sum_atan_iota_input():
     return dataclasses.replace(inp, ncurr=0, piota_type="sum_atan", ai=ai)
 
 
+def _two_lorentz_pressure_input():
+    """The same deck with ``pmass_type='two_Lorentz'``."""
+    inp = VmecInput.from_file(DATA / "input.li383_low_res")
+    am = np.array([1.5, 0.6, 0.8, 2.0, 1.5, 0.4, 3.0, 1.0] + [0.0] * 13)
+    return dataclasses.replace(inp, pmass_type="two_Lorentz", am=am)
+
+
+def _rational_iota_input():
+    """The same deck with a prescribed ``piota_type='rational'`` (NCURR = 0)."""
+    inp = VmecInput.from_file(DATA / "input.li383_low_res")
+    ai = np.zeros(21)
+    ai[:3] = [0.9, -0.2, 0.1]      # numerator c[0:10]
+    ai[10:13] = [1.0, 0.3, -0.15]  # denominator c[10:21]
+    return dataclasses.replace(inp, ncurr=0, piota_type="rational", ai=ai)
+
+
 @pytest.mark.parametrize(
     "name, build, fields",
     [
         ("sum_atan_current", _sum_atan_current_input,
          ("iotaf", "jcurv", "buco", "presf")),
         ("sum_atan_iota", _sum_atan_iota_input, ("iotaf", "buco", "presf")),
+        ("two_lorentz_pressure", _two_lorentz_pressure_input,
+         ("presf", "iotaf", "buco")),
+        ("rational_iota", _rational_iota_input, ("iotaf", "buco", "presf")),
     ],
 )
-def test_live_vmec2000_sum_atan_parity(pytestconfig, tmp_path, name, build,
-                                       fields):
-    """``pcurr_type='sum_atan'`` against live VMEC2000, end to end.
+def test_live_vmec2000_profile_type_parity(pytestconfig, tmp_path, name, build,
+                                           fields):
+    """Each profile parameterization against live VMEC2000, end to end.
 
     The unit test in ``tests/test_profiles.py`` pins the formula against a
     transcription of ``profile_functions.f``.  This one closes the loop
@@ -473,17 +492,18 @@ def test_live_vmec2000_sum_atan_parity(pytestconfig, tmp_path, name, build,
     so a wrong ``I(s)`` moves ``iotaf`` and ``jcurv`` rather than staying
     hidden in an unused array.
 
-    Both lanes VMEC2000 offers it for are covered: ``pcurr_type`` with
-    ``NCURR = 1``, where the current profile sets ``iota``, and ``piota_type``
-    with ``NCURR = 0``, where it is prescribed directly.  A wrong ``f(s)``
-    moves ``iotaf`` and ``jcurv`` in the first and ``iotaf`` in the second,
-    rather than staying hidden in an unused array.
+    The unit tests in ``tests/test_profiles.py`` pin each formula against a
+    transcription of ``profile_functions.f``.  These close the loop through
+    the solver, on the lane where each type is actually consumed, so a wrong
+    ``f(s)`` moves a solved profile instead of sitting in an unused array:
+    ``pcurr_type`` at ``NCURR = 1`` (the current profile sets ``iota``),
+    ``piota_type`` at ``NCURR = 0``, and ``pmass_type`` through the pressure.
 
-    Measured on li383_low_res: current lane ``iotaf`` 2.8e-14, ``jcurv``
-    1.2e-14, ``buco`` 2.2e-15, ``presf`` 1.9e-15, with
-    ``aspect``/``betatotal``/``volume_p``/``b0`` at 1e-15 or below; iota lane
-    ``iotaf`` 1.2e-16, ``buco`` 2.0e-14.  The bounds below are three orders
-    above that, so they gate a real divergence and not float64 noise.
+    Measured on li383_low_res: ``sum_atan`` current ``iotaf`` 2.8e-14,
+    ``jcurv`` 1.2e-14, ``buco`` 2.2e-15, ``presf`` 1.9e-15; ``sum_atan`` iota
+    ``iotaf`` 1.2e-16, ``buco`` 2.0e-14; ``two_Lorentz`` pressure ``presf``
+    1.4e-16, ``iotaf`` 2.9e-13, ``betatotal`` 6.8e-14.  The bounds below are
+    orders above that, so they gate a real divergence and not float64 noise.
     """
     vmec2000_dir = tmp_path / "vmec2000"
     vmex_dir = tmp_path / "vmex"
@@ -504,9 +524,16 @@ def test_live_vmec2000_sum_atan_parity(pytestconfig, tmp_path, name, build,
     actual = read_wout(vmex_dir / f"wout_{name}.nc")
     assert int(actual.ier_flag) == int(reference.ier_flag) == 0
     assert int(actual.ns) == int(reference.ns)
-    profile_type = (reference.pcurr_type if name.endswith("current")
-                    else reference.piota_type)
-    assert str(profile_type).strip().lower().startswith("sum_atan")
+    expected_type, attribute = {
+        "sum_atan_current": ("sum_atan", "pcurr_type"),
+        "sum_atan_iota": ("sum_atan", "piota_type"),
+        "two_lorentz_pressure": ("two_lorentz", "pmass_type"),
+        "rational_iota": ("rational", "piota_type"),
+    }[name]
+    # VMEC echoes the type it actually used; if it had fallen back to its
+    # power_series default the comparison below would be vacuous.
+    assert str(getattr(reference, attribute)).strip().lower().startswith(
+        expected_type)
     for field in fields:
         limit = 1.0e-11
         expected = np.asarray(getattr(reference, field), dtype=float)[1:-1]

--- a/vmex/core/profiles.py
+++ b/vmex/core/profiles.py
@@ -34,6 +34,12 @@ gauss_trunc          ``c[0]/(1-E) * (exp(-(x/c[1])**2) - E)``,
 sum_atan             ``c[0] + (2/pi) sum_{k=0..4} c[1+4k]
                      atan(c[2+4k] x**c[3+4k] / (1-x)**c[4+4k])`` -- iota and
                      current only, and it parameterizes ``I``, not ``I'``
+two_power_gs         ``two_power`` times ``1 + sum_i c[i]
+                     exp(-((x-c[i+1])/c[i+2])**2)``, ``i = 3, 6, ..., 18``
+two_lorentz          two Lorentz terms mapped to [0, 1] (pressure only)
+rational             ``c[0:10]`` polynomial over ``c[10:21]`` polynomial;
+                     returns Fortran ``HUGE`` where the denominator is zero
+nice_quadratic       ``c0 (1-x) + c1 x + 4 c2 x (1-x)`` (iota only)
 pedestal             VMEC2000 ``pmass`` pedestal: degree-15 power series in
                      ``c[0:16]`` plus a tanh pedestal shaped by ``c[16:21]``
 cubic_spline         VMEC ``spline_cubic`` through (aux_s, aux_f) knots
@@ -63,6 +69,9 @@ import numpy as np
 
 #: Denominator floor for 'sum_atan'; see :func:`_sum_atan`.
 _SUM_ATAN_FLOOR = 1.0e-300
+
+#: Fortran ``HUGE(real64)``; 'rational' returns it on a zero denominator.
+_FORTRAN_HUGE = 1.7976931348623157e308
 
 __all__ = [
     "MU0",
@@ -151,6 +160,81 @@ def _gauss_trunc(coefficients, x):
     x = jnp.asarray(x)
     edge = jnp.exp(-((1.0 / c[1]) ** 2))
     return c[0] / (1.0 - edge) * (jnp.exp(-((x / c[1]) ** 2)) - edge)
+
+
+def _two_power_gs(coefficients, x):
+    """``two_power`` times six Gaussian peaks (``functions.f`` two_power_gs).
+
+    ``f(x) = c0 (1 - x**c1)**c2 (1 + sum_i c[i] exp(-((x - c[i+1])/c[i+2])**2))``
+    with ``i`` stepping 3, 6, ..., 18, so the peaks live in ``c[3:21]`` as
+    (amplitude, centre, width) triples.  The narrative comment in
+    ``profile_functions.f`` writes the exponent ambiguously; ``functions.f``
+    line 66 is the implementation and squares the whole ratio.
+    """
+    c = _coeffs_padded(coefficients, 21)
+    x = jnp.asarray(x)
+    peaks = jnp.ones_like(x)
+    for i in range(3, 19, 3):
+        peaks = peaks + c[i] * jnp.exp(-(((x - c[i + 1]) / c[i + 2]) ** 2))
+    return _two_power(c, x) * peaks
+
+
+def _two_lorentz(coefficients, x):
+    """Two Lorentz-type terms mapped to [0, 1] (pmass 'two_Lorentz').
+
+    ``c[0:8]``: an overall scale, a mixing fraction ``c1`` between the two
+    terms, then ``(c2, c3, c4)`` and ``(c5, c6, c7)`` shaping each.  Both
+    terms are shifted and normalized so that each is 1 at ``x = 0`` and 0 at
+    ``x = 1``, which is what the edge subtraction and the denominator do.
+    """
+    c = _coeffs_padded(coefficients, 8)
+    x = jnp.asarray(x)
+
+    def term(width, power, exponent):
+        shape = 1.0 / (1.0 + (x / width ** 2) ** power) ** exponent
+        edge = 1.0 / (1.0 + (1.0 / width ** 2) ** power) ** exponent
+        return (shape - edge) / (1.0 - edge)
+
+    return c[0] * (c[1] * term(c[2], c[3], c[4])
+                   + (1.0 - c[1]) * term(c[5], c[6], c[7]))
+
+
+def _rational(coefficients, x):
+    """Ratio of two polynomials (pmass/piota/pcurr 'rational').
+
+    Numerator ``c[0:10]``, denominator ``c[10:21]``, both by Horner exactly as
+    the Fortran loops run.  VMEC returns ``HUGE`` where the denominator is
+    zero rather than a NaN or an infinity, and that value is observable in a
+    wout, so it is reproduced.
+    """
+    c = _coeffs_padded(coefficients, 21)
+    x = jnp.asarray(x)
+    numerator = jnp.zeros_like(x)
+    for i in range(9, -1, -1):
+        numerator = x * numerator + c[i]
+    denominator = jnp.zeros_like(x)
+    for i in range(20, 9, -1):
+        denominator = x * denominator + c[i]
+    nonzero = denominator != 0.0
+    safe = jnp.where(nonzero, denominator, 1.0)
+    return jnp.where(nonzero, numerator / safe, _FORTRAN_HUGE)
+
+
+def _nice_quadratic(coefficients, x):
+    """``c0 (1-x) + c1 x + 4 c2 x (1-x)`` (piota 'nice_quadratic').
+
+    ``c0`` and ``c1`` are the values at the axis and the edge and ``c2`` is
+    the departure of the midpoint from the straight line between them, so
+    ``c2 = 0`` is a linear iota.
+    """
+    c = _coeffs_padded(coefficients, 3)
+    x = jnp.asarray(x)
+    return c[0] * (1.0 - x) + c[1] * x + 4.0 * c[2] * x * (1.0 - x)
+
+
+def _pcurr_two_power_gs_ip(coefficients, x):
+    """pcurr 'two_power_gs': ``I'`` is two_power_gs, integrated numerically."""
+    return _integrate_0_to_x(_two_power_gs, coefficients, x)
 
 
 def _pow_at_zero(x, exponent):
@@ -547,6 +631,11 @@ _PARAMETERIZED = {
     "two_power": _two_power,
     "gauss_trunc": _gauss_trunc,
     "sum_atan": _sum_atan,
+    "two_power_gs": _two_power_gs,
+    "two_lorentz": _two_lorentz,
+    "rational": _rational,
+    "nice_quadratic": _nice_quadratic,
+    "two_power_gs_ip": _pcurr_two_power_gs_ip,
     "pedestal": _pedestal,
     "power_series_ip": _pcurr_power_series_ip,
     "power_series_i": _pcurr_power_series_i,
@@ -609,6 +698,20 @@ def _bloated(s, bloat):
     return jnp.minimum(jnp.abs(jnp.asarray(s) * bloat), 1.0)
 
 
+#: ``pmass_type`` strings VMEC2000 accepts (``profile_functions.f`` pmass;
+#: ``power_series`` is its ``CASE DEFAULT``).
+_PMASS_KINDS = frozenset({
+    "power_series", "two_power", "two_power_gs", "two_lorentz", "gauss_trunc",
+    "pedestal", "rational", "cubic_spline", "akima_spline", "line_segment",
+})
+
+#: ``piota_type`` strings VMEC2000 accepts (``profile_functions.f`` piota).
+_PIOTA_KINDS = frozenset({
+    "power_series", "sum_atan", "nice_quadratic", "rational", "cubic_spline",
+    "akima_spline", "line_segment",
+})
+
+
 def pressure(pmass_type: str, am, am_aux_s, am_aux_f, s, *,
              pres_scale=1.0, bloat=1.0, spres_ped=1.0):
     """Pressure profile p(s) in **Pascals** (VMEC2000 ``pmass`` x ``1/mu0``).
@@ -624,9 +727,10 @@ def pressure(pmass_type: str, am, am_aux_s, am_aux_f, s, *,
     coefficients may be traced.
     """
     kind = str(pmass_type).strip().lower()
-    if kind not in ("power_series", "two_power", "gauss_trunc", "pedestal",
-                    "cubic_spline", "akima_spline", "line_segment"):
-        raise NotImplementedError(f"pmass_type={pmass_type!r} not implemented")
+    if kind not in _PMASS_KINDS:
+        raise NotImplementedError(
+            f"pmass_type={pmass_type!r} not implemented "
+            f"(supported: {sorted(_PMASS_KINDS)})")
     x = _bloated(s, bloat)
     p = pres_scale * evaluate_profile(kind, am, am_aux_s, am_aux_f, x)
     spres_ped = abs(float(spres_ped))
@@ -648,9 +752,10 @@ def iota(piota_type: str, ai, ai_aux_s, ai_aux_f, s, *, bloat=1.0, lrfp=False):
     this port applies it uniformly (identical for the default ``bloat = 1``).
     """
     kind = str(piota_type).strip().lower()
-    if kind not in ("power_series", "sum_atan", "cubic_spline", "akima_spline",
-                    "line_segment"):
-        raise NotImplementedError(f"piota_type={piota_type!r} not implemented")
+    if kind not in _PIOTA_KINDS:
+        raise NotImplementedError(
+            f"piota_type={piota_type!r} not implemented "
+            f"(supported: {sorted(_PIOTA_KINDS)})")
     x = _bloated(s, bloat)
     value = evaluate_profile(kind, ai, ai_aux_s, ai_aux_f, x)
     if lrfp:
@@ -663,7 +768,9 @@ _PCURR_KINDS = {
     "power_series": "power_series_ip",
     "power_series_i": "power_series_i",
     "sum_atan": "sum_atan",
+    "rational": "rational",
     "two_power": "two_power_ip",
+    "two_power_gs": "two_power_gs_ip",
     "gauss_trunc": "gauss_trunc_ip",
     "pedestal": "pedestal_i",
     "cubic_spline_i": "cubic_spline_i",

--- a/vmex/core/profiles.py
+++ b/vmex/core/profiles.py
@@ -40,6 +40,11 @@ two_lorentz          two Lorentz terms mapped to [0, 1] (pressure only)
 rational             ``c[0:10]`` polynomial over ``c[10:21]`` polynomial;
                      returns Fortran ``HUGE`` where the denominator is zero
 nice_quadratic       ``c0 (1-x) + c1 x + 4 c2 x (1-x)`` (iota only)
+sum_cossq_s          current: ``I(x)`` of ``c[0]`` cos-squared windows evenly
+                     placed in ``s``, integrated in closed form
+sum_cossq_sqrts      idem, with the windows placed in ``sqrt(s)``
+sum_cossq_s_free     idem, seven freely placed windows; ``c[3i:3i+3]`` is the
+                     amplitude, location and half width of wave ``i``
 pedestal             VMEC2000 ``pmass`` pedestal: degree-15 power series in
                      ``c[0:16]`` plus a tanh pedestal shaped by ``c[16:21]``
 cubic_spline         VMEC ``spline_cubic`` through (aux_s, aux_f) knots
@@ -230,6 +235,138 @@ def _nice_quadratic(coefficients, x):
     c = _coeffs_padded(coefficients, 3)
     x = jnp.asarray(x)
     return c[0] * (1.0 - x) + c[1] * x + 4.0 * c[2] * x * (1.0 - x)
+
+
+def _sum_cossq_count(coefficients) -> int:
+    """Static wave count ``int(c[0])``, validated as ``profile_functions.f`` does.
+
+    The count sets how many terms exist, so it fixes the shape of the sum and
+    has to be a Python integer rather than a traced value.  It is a count and
+    never an optimized coefficient, so requiring that costs nothing real; a
+    tracer here gets a message saying so instead of a shape error from deeper
+    in the trace.
+    """
+    try:
+        values = np.asarray(coefficients, dtype=float).ravel()
+    except Exception as error:      # a tracer, under jit or grad
+        raise NotImplementedError(
+            "the 'sum_cossq_*' wave count c[0] must be a concrete value, not "
+            "a traced one: it sets how many terms the sum has"
+        ) from error
+    count = int(values[0]) if values.size else 0
+    if not 1 <= count <= 20:
+        raise ValueError(
+            f"sum_cossq wave count c[0] = {count} outside VMEC's 1..20 "
+            "(profile_functions.f stops on this)")
+    return count
+
+
+def _sum_cossq_s(coefficients, x):
+    """Cos-squared current windows in ``s``, integrated analytically.
+
+    ``profile_functions.f`` 'sum_cossq_s' (J. Geiger, 2018).  ``c[0]`` is the
+    number of waves; wave ``i`` peaks at ``x_i = (i-1) dx`` with
+    ``dx = 1/(n-1)`` and is windowed to ``(x_i - dx, x_i + dx]`` clipped to
+    ``[0, 1]``.  ``I(x)`` is the closed-form integral of that density, so a
+    wave already passed contributes its full area and at most the current one
+    is partial.  The first wave is a half window and carries no linear term.
+    """
+    n = _sum_cossq_count(coefficients)
+    c = _coeffs_padded(coefficients, max(21, n + 1))
+    x = jnp.asarray(x)
+    dx = 1.0 / (n - 1.0) if n > 1 else jnp.inf
+    total = jnp.zeros_like(x)
+    reached = jnp.ones_like(x)      # index of the window x sits in (Fortran ni)
+    inside = []
+    for i in range(1, n + 1):
+        xi = (i - 1) * dx
+        start, end = max(0.0, xi - dx), min(xi + dx, 1.0)
+        within = (x > start) & (x <= end)
+        inside.append((within, xi, start))
+        reached = jnp.where(within, float(i), reached)
+    for i in range(1, n + 1):
+        within, xi, _start = inside[i - 1]
+        wave = jnp.sin(jnp.pi * (x - xi) / dx) * dx / jnp.pi
+        partial = (0.5 * c[i] * (x + wave) if i == 1
+                   else 0.5 * c[i] * (x - xi + dx + wave))
+        complete = 0.5 * c[i] * dx if i == 1 else c[i] * dx
+        total = total + jnp.where(
+            float(i) <= reached, jnp.where(within, partial, complete), 0.0)
+    return total
+
+
+def _sum_cossq_sqrts(coefficients, x):
+    """The same windows placed in ``sqrt(s)`` ('sum_cossq_sqrts').
+
+    Identical construction to :func:`_sum_cossq_s` with ``sqrt(x)`` as the
+    coordinate, which makes the analytic integral pick up the extra ``x``
+    weight and so a different closed form.
+    """
+    n = _sum_cossq_count(coefficients)
+    c = _coeffs_padded(coefficients, max(21, n + 1))
+    x = jnp.asarray(x)
+    root = jnp.sqrt(x)
+    dx = 1.0 / (n - 1.0) if n > 1 else jnp.inf
+    dx2, pi2 = dx * dx, jnp.pi * jnp.pi
+    total = jnp.zeros_like(x)
+    reached = jnp.ones_like(x)
+    inside = []
+    for i in range(1, n + 1):
+        xi = (i - 1) * dx
+        start, end = max(0.0, xi - dx), min(xi + dx, 1.0)
+        within = (root > start) & (root <= end)
+        inside.append((within, xi, start))
+        reached = jnp.where(within, float(i), reached)
+    for i in range(1, n + 1):
+        within, xi, start = inside[i - 1]
+        phase = jnp.pi * (root - xi) / dx
+        if i == 1:
+            partial = c[i] * (0.25 * x + dx / (2.0 * jnp.pi) * root
+                              * jnp.sin(phase)
+                              + dx2 / (2.0 * pi2) * (jnp.cos(phase) - 1.0))
+            complete = c[i] * (0.25 - 1.0 / pi2) * dx2
+        else:
+            partial = c[i] * (0.25 * x
+                              + dx / (2.0 * jnp.pi) * root * jnp.sin(phase)
+                              + dx2 / (2.0 * pi2) * jnp.cos(phase)
+                              - 0.25 * start ** 2 + dx2 / (2.0 * pi2))
+            complete = c[i] * dx * xi
+        total = total + jnp.where(
+            float(i) <= reached, jnp.where(within, partial, complete), 0.0)
+    return total
+
+
+def _sum_cossq_s_free(coefficients, x):
+    """Seven freely placed cos-squared windows ('sum_cossq_s_free').
+
+    ``c[3i]``, ``c[3i+1]``, ``c[3i+2]`` are the amplitude, the peak location
+    and the half width of wave ``i`` for ``i = 0..6``, so broad and narrow
+    windows can be mixed and need not tile ``[0, 1]``.  A zero amplitude
+    switches a wave off entirely, which is also what keeps a zero half width
+    from dividing by zero -- Fortran guards it the same way.
+    """
+    c = _coeffs_padded(coefficients, 21)
+    x = jnp.asarray(x)
+    total = jnp.zeros_like(x)
+    for i in range(7):
+        amplitude, xi, width = c[3 * i], c[3 * i + 1], c[3 * i + 2]
+        live = amplitude != 0.0
+        safe_width = jnp.where(width != 0.0, width, 1.0)
+        start = jnp.maximum(0.0, xi - width)
+        end = jnp.minimum(xi + width, 1.0)
+        at_start = jnp.sin(jnp.pi * (start - xi) / safe_width)
+        partial = amplitude * 0.5 * (
+            (x - start)
+            + safe_width / jnp.pi * (jnp.sin(jnp.pi * (x - xi) / safe_width)
+                                     - at_start))
+        complete = amplitude * 0.5 * (
+            (end - start)
+            + safe_width / jnp.pi * (jnp.sin(jnp.pi * (end - xi) / safe_width)
+                                     - at_start))
+        contribution = jnp.where(
+            (x > start) & (x <= end), partial, jnp.where(x > end, complete, 0.0))
+        total = total + jnp.where(live, contribution, 0.0)
+    return total
 
 
 def _pcurr_two_power_gs_ip(coefficients, x):
@@ -636,6 +773,9 @@ _PARAMETERIZED = {
     "rational": _rational,
     "nice_quadratic": _nice_quadratic,
     "two_power_gs_ip": _pcurr_two_power_gs_ip,
+    "sum_cossq_s": _sum_cossq_s,
+    "sum_cossq_sqrts": _sum_cossq_sqrts,
+    "sum_cossq_s_free": _sum_cossq_s_free,
     "pedestal": _pedestal,
     "power_series_ip": _pcurr_power_series_ip,
     "power_series_i": _pcurr_power_series_i,
@@ -771,6 +911,9 @@ _PCURR_KINDS = {
     "rational": "rational",
     "two_power": "two_power_ip",
     "two_power_gs": "two_power_gs_ip",
+    "sum_cossq_s": "sum_cossq_s",
+    "sum_cossq_sqrts": "sum_cossq_sqrts",
+    "sum_cossq_s_free": "sum_cossq_s_free",
     "gauss_trunc": "gauss_trunc_ip",
     "pedestal": "pedestal_i",
     "cubic_spline_i": "cubic_spline_i",


### PR DESCRIPTION
Stacked on #158. Enumerated from `profile_functions.f`'s `SELECT CASE` labels rather than from memory — `pmass` has nine explicit cases plus `power_series` as `CASE DEFAULT`, `piota` six plus the default, `pcurr` sixteen plus the default. **vmex was missing seven.** Four land here, and **`PMASS_TYPE` and `PIOTA_TYPE` are now complete.**

| kind | lanes | |
| --- | --- | --- |
| `two_power_gs` | pressure, current | `two_power` × six Gaussian peaks in `c[3:21]` as (amplitude, centre, width) triples. Pressure evaluates it directly; current integrates it with the same 10-point Gauss-Legendre rule as `two_power` |
| `two_Lorentz` | pressure | two Lorentz terms, each shifted and normalized to 1 at the axis and 0 at the edge |
| `rational` | pressure, iota, current | `c[0:10]` over `c[10:21]`, both by Horner exactly as the Fortran loops run |
| `nice_quadratic` | iota | `c0` and `c1` are the axis and edge values; `c2` is the midpoint's departure from the straight line between them |

## Coverage after this

| | vmex | VMEC2000 |
| --- | --- | --- |
| `PMASS_TYPE` | 10 | 10 ✅ |
| `PIOTA_TYPE` | 7 | 7 ✅ |
| `PCURR_TYPE` | 14 | 17 |

## What is deliberately *not* implemented

The three `sum_cossq_*` current forms. They are analytic piecewise integrals of cos² windows with Heaviside boxcar windowing — Joachim Geiger's 2018 additions — and are substantially more work than the four above. They now raise `NotImplementedError` naming the supported set, **because a wrong answer is worse than a refusal.** `test_every_vmec2000_profile_type_is_selectable` pins both halves: everything claimed is accepted and finite, and those three still raise.

## Verified twice, as with #158

**Formula**, against literal transcriptions of `profile_functions.f` and `functions.f`: exact (0.0) for `two_power_gs`, `rational` and `nice_quadratic`; 7.4e-17 for `two_Lorentz`. `rational`'s zero-denominator sentinel is bit-equal to Fortran `HUGE`.

**End to end**, live `xvmec2000` on `li383_low_res` — `two_Lorentz` pressure `presf` **1.4e-16**, `iotaf` 2.9e-13, `betatotal` 6.8e-14; plus a `rational` iota row, alongside #158's two `sum_atan` rows. Each row runs on the lane where its type is actually consumed and asserts VMEC echoed the type it used, so a fallback to `power_series` cannot pass silently.

## Two details worth a look

- **The `HUGE` sentinel.** VMEC returns `HUGE(real64)` where the `rational` denominator vanishes — not NaN, not infinity. That value reaches a wout and a caller can see it, so it is parity, not an implementation detail. Reproduced and tested.
- **The guards were hardcoded tuples** in `pressure()` and `iota()` that had to be edited in step with the dispatch table — the kind of duplication that goes stale. They are now `frozenset`s declared next to it, and the error names what is supported.

`tests/test_profiles.py` 47 passed; four live parity rows pass under `--run-vmec2000`; `ruff`, `mypy`, `check_docs_prose`, `sphinx -W` clean. Docs updated in `input-file.rst` and the `profiles` module table.
