### PR TITLE
Release 0.7.0

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -81,6 +81,10 @@ jobs:
       - name: Install and solve outside the source tree
         env:
           ARTIFACT: ${{ matrix.artifact }}
+          # The tag, minus its leading v.  The validate job above has already
+          # checked it against pyproject, so this pins the *installed*
+          # artifact to the same version without a second source of truth.
+          EXPECTED_VERSION: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
           if [[ "$ARTIFACT" == "wheel" ]]; then
             package=(dist/*.whl)
@@ -100,7 +104,10 @@ jobs:
           from vmex import optimize
           from vmex.core.input import VmecInput
 
-          assert vmex.__version__ == "0.6.0"
+          import os
+
+          expected = os.environ["EXPECTED_VERSION"].lstrip("v")
+          assert vmex.__version__ == expected, (vmex.__version__, expected)
           path = Path(vmex.__file__).parent / "resources/input.nfp4_QH_warm_start"
           inp = replace(
               VmecInput.from_file(path),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vmex"
-version = "0.6.0"
+version = "0.7.0"
 description = "JAX implementation of VMEC2000 with differentiable fixed-boundary and branch-local free-boundary research paths."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump only. Cuts 0.7.0 on the merged content: #136-#150 and #158.

Headline is `sum_atan` (#158) and the refined-anchor implicit gradient fix (#148). Full notes go on the GitHub Release.

Verified: wheel and sdist build clean at 0.7.0; `vmex.__version__` reports 0.7.0, which is what the `publish-pypi` workflow validates against the tag.