### PR TITLE
Skip unset Gaussian peaks in two_power_gs

### DIFF
--- a/docs/howto/profiles.md
+++ b/docs/howto/profiles.md
@@ -93,6 +93,12 @@ vmex implements every parameterization VMEC2000 offers: ten for
 `PMASS_TYPE`, seven for `PIOTA_TYPE`, seventeen for `PCURR_TYPE`. A name
 outside those raises rather than falling back to a default.
 
+One deliberate departure from the Fortran: in `two_power_gs`, a Gaussian peak
+slot with zero amplitude is skipped. VMEC evaluates `exp(-((x-0)/0)**2)` for an
+unset slot, which is harmless away from the axis but `0/0` at `s = 0`, so a
+deck using one or two of the six peaks gets NaN there. Every peak that is
+actually set is bit-identical to VMEC.
+
 Every profile key, default, and accepted `*_TYPE` string:
 {doc}`/reference/input-file` (Pressure profile / Current and iota sections).
 The evaluation code is {mod}`vmex.core.profiles`.

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -669,3 +669,40 @@ def test_sum_cossq_rejects_an_out_of_range_wave_count():
         with pytest.raises(ValueError, match="1..20"):
             profiles.current("sum_cossq_s", _pad21([bad, 1.0]), None, None,
                              np.array([0.5]))
+
+
+def test_two_power_gs_survives_unset_peak_slots():
+    """A deck that fills fewer than six peaks must not produce NaN at the axis.
+
+    This is the one place vmex deliberately departs from
+    ``profile_functions.f``.  An unset peak slot is all zeros, so its width is
+    zero, and ``functions.f`` evaluates ``exp(-((x - 0)/0)**2)`` for it: away
+    from the axis that is ``exp(-inf) = 0``, but at ``x = 0`` it is ``0/0``,
+    and VMEC hands back NaN for any deck using one or two peaks -- the
+    ordinary case.  A zero amplitude means no peak, so the term is skipped.
+    Fortran applies exactly this guard itself in 'sum_cossq_s_free'.
+
+    The second half of the test is the part that matters: skipping unset
+    slots must not perturb a peak that is set.
+    """
+    partial = _pad21([2.0, 2.0, 1.5, 0.4, 0.3, 0.12])   # one peak, five unset
+    x = np.array([0.0, 0.1, 0.25, 0.5, 1.0])
+    got = np.asarray(profiles.pressure("two_power_gs", partial, None, None, x))
+    assert np.all(np.isfinite(got)), got
+    assert float(got[0]) > 0.0
+
+    # Bit-identical to the Fortran wherever every slot carries a width.
+    full = _REMAINING_KINDS["two_power_gs"][0]
+    np.testing.assert_array_equal(
+        np.asarray(profiles.evaluate_profile("two_power_gs", full, None, None, x)),
+        np.array([_f_two_power_gs(full, xi) for xi in x]))
+
+    # And a set peak is unchanged by the presence of unset neighbours: adding
+    # the zero slots back must reproduce the one-peak result exactly.
+    one_peak_only = _pad21([2.0, 2.0, 1.5, 0.4, 0.3, 0.12,
+                            0.0, 0.0, 1.0, 0.0, 0.0, 1.0,
+                            0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0])
+    np.testing.assert_allclose(
+        got,
+        np.asarray(profiles.pressure("two_power_gs", one_peak_only, None, None, x)),
+        rtol=0.0, atol=0.0)

--- a/vmex/core/profiles.py
+++ b/vmex/core/profiles.py
@@ -175,12 +175,26 @@ def _two_power_gs(coefficients, x):
     (amplitude, centre, width) triples.  The narrative comment in
     ``profile_functions.f`` writes the exponent ambiguously; ``functions.f``
     line 66 is the implementation and squares the whole ratio.
+
+    **One deliberate deviation from the Fortran.**  A peak slot left unset is
+    all zeros, so its width is zero, and ``functions.f`` evaluates
+    ``exp(-((x - 0)/0)**2)`` for it.  Away from the axis that is
+    ``exp(-inf) = 0`` and harmless, but at ``x = 0`` it is ``0/0``, and VMEC
+    returns NaN there for any deck that fills fewer than six peaks -- which is
+    the ordinary way to use one or two.  A zero amplitude means no peak, so
+    that term is skipped here and contributes exactly zero.  Fortran applies
+    the same guard itself in 'sum_cossq_s_free'
+    (``if(ac(3*(i-1)) .ne. 0.0)``); it simply omits it here.  Every nonzero
+    peak is bit-identical to the Fortran.
     """
     c = _coeffs_padded(coefficients, 21)
     x = jnp.asarray(x)
     peaks = jnp.ones_like(x)
     for i in range(3, 19, 3):
-        peaks = peaks + c[i] * jnp.exp(-(((x - c[i + 1]) / c[i + 2]) ** 2))
+        amplitude, width = c[i], c[i + 2]
+        safe_width = jnp.where(width != 0.0, width, 1.0)
+        term = amplitude * jnp.exp(-(((x - c[i + 1]) / safe_width) ** 2))
+        peaks = peaks + jnp.where(amplitude != 0.0, term, 0.0)
     return _two_power(c, x) * peaks
 
 


### PR DESCRIPTION
Found by exercising the new profile types on main with the most ordinary input there is: set three coefficients, leave the rest at their defaults.

```
PMASS_TYPE = 'two_power_gs'
AM = 2.0 2.0 1.5 0.4 0.3 0.12     # one Gaussian peak, five slots unset
```
gives `[nan, 2.42590877, 1.33134598, 0.0]` at `s = 0, 0.25, 0.5, 1`.

**VMEX was right and VMEC is the problem.** An unset peak slot is all zeros, so its width is zero, and `functions.f` evaluates `exp(-((x - 0)/0)**2)` for it — `exp(-inf) = 0` away from the axis, but `0/0` at `x = 0`. I checked against a transcription: **both codes return exactly that same array, NaN included.** So this is faithful parity with a Fortran landmine, not a defect of the port.

It still has to go. It fires for any deck that fills fewer than six peaks — the ordinary way to use one or two — and a NaN at the axis destroys the solve silently, which is the failure class this repo exists to remove.

**The fix:** a zero amplitude means no peak, so that term is skipped and contributes exactly zero. This is the one deliberate departure from `profile_functions.f` in the profiles module, and **Fortran applies the same guard itself** in `sum_cossq_s_free` (`if(ac(3*(i-1)) .ne. 0.0)`) — it simply omits it here.

**Every peak that is actually set stays bit-identical**: measured `0.0` difference against the transcription on the full six-peak case. The test pins all three halves — no NaN with unset slots, bit-equality with the Fortran when all six carry widths, and that adding zero slots back reproduces the one-peak result exactly.

Documented where a user meets it: the profiles how-to and the function's docstring, not just here.

`tests/test_profiles.py` 54 passed; `ruff`, `mypy`, `check_docs_prose` clean.