### PR TITLE
Drop parity lane a back to -n 2; it was being killed, not failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,12 +167,10 @@ jobs:
     # jobs are the part no other job was running.  Measured on the runner at
     # -n 2: 30m00s, 27m40s, 26m54s, 21m22s, which put total CI wall clock at
     # 30 minutes against a ~14-minute budget before.  The four run in parallel
-    # with the nine physics jobs, so the fix is per-job width, not fewer tests:
-    # -n 4 on the same 4-vCPU runner, which the fast lane already uses.  If a
-    # lane runs out of memory instead of getting faster, go back to -n 2 and
-    # split pr-parity-c1 and pr-parity-c2 in the manifest -- test_optimize
-    # (~20 min of the c1 group) and test_gammac plus test_scaling (~12 min of
-    # c2) are what would need separating.
+    # with the nine physics jobs, so the fix is per-job width, not fewer tests.
+    # Measured at -n 4: c1 25m36s (from 27m40s), c2 15m07s (from 21m22s),
+    # misc 24m43s (from 26m54s) -- and lane a killed outright.  So the width
+    # is per-lane: a stays at -n 2, the rest keep the gain.
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -180,12 +178,23 @@ jobs:
         include:
           - lane: a
             selector: pr-parity-a1 pr-parity-a2 pr-parity-b
+            # -n 2, not 4: this lane carries the free-boundary modules
+            # (test_freeboundary_implicit alone has two ~8-minute tests), and
+            # four concurrent free-boundary solves exhaust the runner.  At -n 4
+            # it was killed mid-run at 73% with no test failure -- "The
+            # operation was canceled" at 32m10s, twice, on two different pull
+            # requests.  The other three lanes keep -n 4, which measurably
+            # helps them.
+            parallel: "-n 2"
           - lane: c1
             selector: pr-parity-c1 pr-parity-c3 pr-parity-d
+            parallel: "-n 4"
           - lane: c2
             selector: pr-parity-c2
+            parallel: "-n 4"
           - lane: misc
             selector: pr-examples pr-external pr-full-only pr-gradient pr-mirror-spline
+            parallel: "-n 4"
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -216,7 +225,7 @@ jobs:
           done
           # Lanes overlap, and a module selected twice would run twice.
           FILES="$(printf '%s\n' $FILES | sort -u | tr '\n' ' ')"
-          pytest -q -n 4 -m "not full and not weekly" \
+          pytest -q ${{ matrix.parallel }} -m "not full and not weekly" \
             $FILES --durations=20 --cov=vmex --cov-report=term
       - name: Stash coverage
         run: mv .coverage coverage.parity-${{ matrix.lane }}


### PR DESCRIPTION
**My own `-n 4` change in #153 broke the lane it should have left alone, and it is currently blocking every open PR.**

Lane `a` carries the free-boundary modules — `test_freeboundary_implicit` alone has two ~8-minute tests — and four concurrent free-boundary solves exhaust the runner. It dies **mid-run at 73% with no test failure**: `The operation was canceled` at **32m10s**, reproducibly, on both #152 and #155. That is not the 45-minute timeout; the runner went away.

The measurement says the width should be per-lane, not uniform:

| lane | `-n 2` | `-n 4` |
| --- | --- | --- |
| a | 30m00s | **killed** |
| c1 | 27m40s | 25m36s |
| c2 | 21m22s | **15m07s** |
| misc | 26m54s | 24m43s |

So `a` goes back to `-n 2` and the other three keep the gain, which is worth most on c2 (29%).

This is exactly the fallback the workflow comment recorded when I made the change — it is now the measured configuration rather than a note about what to do if the guess was wrong. The comment is updated to say so.

Blocks #151, #152, #155 and #156, all of which are otherwise green or nearly so.