### PR TITLE
Add branch-preserving strong-force polish driver

### DIFF
--- a/docs/explanation/high-order-force-balance.rst
+++ b/docs/explanation/high-order-force-balance.rst
@@ -184,3 +184,46 @@ high-order angular coupling.  It is a right preconditioner, not the polishing
 operator, and it never assembles a dense high-order Jacobian.  The subsequent
 p-level hierarchy may wrap it as the coarse solve without changing this
 contract.
+
+The strong endpoint is first normalized by its frozen initial RMS and then by
+a deterministic matrix-free estimate of the low-inverse/strong-Jacobian
+stiffness.  This positive scalar leaves the target root unchanged while making
+the continuation endpoints comparable.  The estimate uses a fixed probe and a
+bounded number of JVP/low-inverse applications; it is stored as
+``operator_balance`` for provenance.
+
+Branch-preserving driver
+------------------------
+
+The fixed-boundary host driver first solves the ``alpha=0`` legacy consistency
+endpoint, then calls SOLVAX adaptive continuation with state-dependent JVPs,
+Eisenstat--Walker forcing, and the stored low-order inverse.  The measured
+initial pseudo-time scale is large because the legacy endpoint has already
+been row equilibrated; ``dtau=1e6`` reaches the Newton regime on the structural
+Solovev gate while retaining PTC backtracking and adaptive shrink safeguards.
+
+Every proposed state must remain finite and retain a signed-Jacobian margin
+above both an absolute floor and a fixed fraction of the lifted branch margin.
+The fixed boundary, profile data, parity, and lambda gauge cannot drift because
+they are absent from the free coordinate map.  Rejected states never replace
+the accepted branch point.
+
+If ordinary parameter continuation exhausts its minimum step, the driver can
+form a matrix-free branch tangent and invoke SOLVAX's bordered
+pseudo-arclength corrector.  Its block-elimination preconditioner reuses the
+same low-order inverse and an explicit scalar Schur complement; no dense
+high-order Jacobian is formed.  A compact report retains accepted/rejected
+stages, nonlinear and linear work, residual evaluations, arclength work,
+minimum Jacobian margin, factor time, and wall time.  Failure to reach
+``alpha=1`` or to pass the independent overintegrated certificate is typed and
+never reported as a polished equilibrium.  ``return_unpolished`` is an
+explicit opt-in policy that returns the original native state with
+``report.converged=False``.
+
+``PolishConfig.preconditioner="legacy"`` is the measured default.  An
+experimental ``"mode-block"`` variant probes only bounded bands of neighboring
+Fourier modes, retaining all radial and R/Z/lambda couplings inside each band,
+and blends the low and strong blocks with ``alpha``.  It never assembles a
+global Jacobian.  The variant remains opt-in because the hard coarse Solovev
+stress case did not reduce total Krylov work; future p/h hierarchy benchmarks,
+not API preference, decide whether it can become the default.

--- a/docs/reference/api/advanced.rst
+++ b/docs/reference/api/advanced.rst
@@ -30,6 +30,9 @@ High-order correction transfer and preconditioner
 .. automodule:: vmex.core.polish
    :members:
 
+.. automodule:: vmex.core.polish_driver
+   :members:
+
 Spectral representation and physics kernels
 -------------------------------------------
 

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 from pathlib import Path
+from types import SimpleNamespace
 
 import jax
 import jax.numpy as jnp
@@ -34,6 +35,8 @@ from vmex.core.polish_driver import (
     _branch_tangent,
     _build_mode_block_preconditioner,
     _low_inverse,
+    _residual_evaluations,
+    _supports_keyword,
     polish_strong_root,
 )
 from vmex.core.strong_force import lift_high_order_state
@@ -41,6 +44,24 @@ from vmex.core.strong_force import lift_high_order_state
 jax.config.update("jax_enable_x64", True)
 
 DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
+
+
+def test_solvax_continuation_api_compatibility_helpers():
+    def legacy_preconditioner(state, rhs, dtau):
+        del state, dtau
+        return rhs
+
+    def parameterized_preconditioner(state, rhs, dtau, parameter):
+        del state, dtau, parameter
+        return rhs
+
+    assert not _supports_keyword(legacy_preconditioner, "parameter")
+    assert _supports_keyword(parameterized_preconditioner, "parameter")
+    assert _residual_evaluations(
+        SimpleNamespace(nonlinear_steps=3, residual_evaluations=9)
+    ) == 9
+    assert _residual_evaluations(SimpleNamespace(nonlinear_steps=3)) == 4
+    assert _residual_evaluations(SimpleNamespace(steps=2)) == 3
 
 
 def _tree_dot(left, right):

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -31,9 +31,11 @@ from vmex.core.polish import (
 )
 from vmex.core.polish_driver import (
     PolishConfig,
+    _arclength_to_target,
     _bordered_preconditioner,
     _branch_tangent,
     _build_mode_block_preconditioner,
+    _continuation_precondition,
     _low_inverse,
     _residual_evaluations,
     _supports_keyword,
@@ -57,11 +59,153 @@ def test_solvax_continuation_api_compatibility_helpers():
 
     assert not _supports_keyword(legacy_preconditioner, "parameter")
     assert _supports_keyword(parameterized_preconditioner, "parameter")
+    np.testing.assert_array_equal(
+        legacy_preconditioner(None, jnp.ones((2,)), None), jnp.ones((2,))
+    )
+    np.testing.assert_array_equal(
+        parameterized_preconditioner(None, jnp.ones((2,)), None, None),
+        jnp.ones((2,)),
+    )
     assert _residual_evaluations(
         SimpleNamespace(nonlinear_steps=3, residual_evaluations=9)
     ) == 9
     assert _residual_evaluations(SimpleNamespace(nonlinear_steps=3)) == 4
     assert _residual_evaluations(SimpleNamespace(steps=2)) == 3
+    assert not _supports_keyword(1, "parameter")
+
+
+def test_parameterized_continuation_preconditioner_switches_at_half(monkeypatch):
+    rhs = jnp.asarray([1.0, -2.0])
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._low_inverse", lambda value, runtime: 2.0 * value
+    )
+    block = SimpleNamespace(apply=lambda value, alpha, dtau: 3.0 * value)
+    np.testing.assert_array_equal(
+        _continuation_precondition(rhs, 0.25, 1.0, SimpleNamespace(), block),
+        2.0 * rhs,
+    )
+    np.testing.assert_array_equal(
+        _continuation_precondition(rhs, 0.75, 1.0, SimpleNamespace(), block),
+        3.0 * rhs,
+    )
+
+
+def test_arclength_crossing_runs_target_correction_and_counts_work(monkeypatch):
+    zero = jnp.zeros((2,))
+    target_vector = jnp.asarray([0.25, -0.5])
+
+    def corrector(
+        residual,
+        initial,
+        *,
+        tangent,
+        predictor,
+        config,
+        admissible,
+        precond,
+    ):
+        del residual, initial, tangent, config, precond
+        assert bool(admissible(*predictor))
+        return SimpleNamespace(
+            x=predictor,
+            steps=2,
+            linear_iterations=3,
+            residual_evaluations=4,
+            converged=True,
+            linear_converged=True,
+        )
+
+    def target(residual, initial, *, precond, admissible, config):
+        del residual, initial, config
+        assert bool(admissible(target_vector))
+        np.testing.assert_array_equal(precond(target_vector, target_vector, 1.0), target_vector)
+        return SimpleNamespace(
+            x=target_vector,
+            steps=5,
+            linear_iterations=6,
+            residual_evaluations=7,
+            converged=True,
+            linear_converged=True,
+        )
+
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._solvax_continuation_api",
+        lambda: (None, None, None, corrector, target),
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._ptc_config", lambda config: object()
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._branch_tangent",
+        lambda *args, **kwargs: (jnp.zeros_like(zero), jnp.asarray(1.0)),
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._bordered_preconditioner",
+        lambda *args, **kwargs: lambda state, rhs, dtau: rhs,
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._low_inverse", lambda rhs, runtime: rhs
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver.strong_root_residual",
+        lambda vector, runtime, alpha: vector + alpha,
+    )
+    result = _arclength_to_target(
+        zero,
+        0.95,
+        SimpleNamespace(),
+        PolishConfig(max_arclength_steps=1, arclength_step=0.1),
+        lambda vector, alpha: jnp.all(jnp.isfinite(vector)) & jnp.isfinite(alpha),
+        None,
+        None,
+    )
+    np.testing.assert_array_equal(result[0], target_vector)
+    assert result[1:] == (1.0, 1, 7, 9, 11)
+
+
+def test_bordered_tangent_uses_previous_orientation(monkeypatch):
+    zero = jnp.zeros((2,))
+    previous = (jnp.asarray([-1.0, -1.0]), jnp.asarray(-1.0))
+
+    def fake_gmres(operator, rhs, *, precond, **kwargs):
+        del kwargs
+        physical, normalization = operator(rhs)
+        assert physical.shape == zero.shape
+        assert np.isfinite(float(normalization))
+        for actual, expected in zip(
+            jax.tree.leaves(precond(rhs)), jax.tree.leaves(rhs), strict=True
+        ):
+            np.testing.assert_array_equal(actual, expected)
+        return SimpleNamespace(
+            x=(jnp.asarray([0.5, 0.25]), jnp.asarray(0.5)),
+            converged=True,
+            residual_norm=jnp.asarray(0.0),
+            iterations=1,
+        )
+
+    monkeypatch.setattr("vmex.core.polish_driver.gmres", fake_gmres)
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._bordered_preconditioner",
+        lambda *args, **kwargs: lambda state, rhs, dtau: rhs,
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver.strong_root_residual",
+        lambda vector, runtime, alpha: vector + alpha * jnp.ones_like(vector),
+    )
+    tangent = _branch_tangent(
+        zero,
+        0.5,
+        SimpleNamespace(),
+        PolishConfig(),
+        previous,
+        None,
+    )
+    np.testing.assert_allclose(
+        jnp.vdot(tangent[0], tangent[0]).real + tangent[1] ** 2,
+        1.0,
+        rtol=2.0e-13,
+    )
+    assert float(jnp.vdot(tangent[0], previous[0]) + tangent[1] * previous[1]) > 0.0
 
 
 def _tree_dot(left, right):

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -12,6 +12,7 @@ import pytest
 
 from vmex.core import implicit
 from vmex.core import solver
+from vmex.core.errors import StrongForceContinuationError
 from vmex.core.input import VmecInput
 from vmex.core.polish import (
     HighOrderCorrection,
@@ -26,6 +27,14 @@ from vmex.core.polish import (
     preconditioner_refresh_decision,
     strong_root_rank,
     strong_root_residual,
+)
+from vmex.core.polish_driver import (
+    PolishConfig,
+    _bordered_preconditioner,
+    _branch_tangent,
+    _build_mode_block_preconditioner,
+    _low_inverse,
+    polish_strong_root,
 )
 from vmex.core.strong_force import lift_high_order_state
 
@@ -364,3 +373,135 @@ def test_strong_root_validation_branches(small_adapter, small_strong_root):
     )
     assert rank == layout.size
     assert values.shape == (layout.size,)
+
+
+def test_low_vector_inverse_matches_scaled_legacy_endpoint(small_strong_root):
+    runtime = small_strong_root
+    zero = jnp.zeros((runtime.layout.size,), dtype=jnp.float64)
+    direction = jnp.linspace(-0.1, 0.2, runtime.layout.size)
+    _, response = jax.jvp(
+        lambda value: strong_root_residual(value, runtime, 0.0),
+        (zero,),
+        (direction,),
+    )
+    recovered = _low_inverse(response, runtime)
+    np.testing.assert_allclose(recovered, direction, rtol=2.0e-11, atol=2.0e-11)
+
+
+def test_arclength_tangent_and_bordered_preconditioner_are_finite(
+    small_strong_root,
+):
+    runtime = small_strong_root
+    zero = jnp.zeros((runtime.layout.size,), dtype=jnp.float64)
+    block_preconditioner = _build_mode_block_preconditioner(runtime)
+    direction = jnp.linspace(-0.15, 0.25, runtime.layout.size)
+    _, response = jax.jvp(
+        lambda value: strong_root_residual(value, runtime, 1.0),
+        (zero,),
+        (direction,),
+    )
+    recovered = block_preconditioner.apply(response, 1.0)
+    np.testing.assert_allclose(recovered, direction, rtol=3.0e-8, atol=3.0e-8)
+    tangent = _branch_tangent(
+        zero,
+        0.0,
+        runtime,
+        PolishConfig(),
+        None,
+        block_preconditioner,
+    )
+    np.testing.assert_allclose(
+        jnp.vdot(tangent[0], tangent[0]).real + tangent[1] ** 2,
+        1.0,
+        rtol=2.0e-13,
+    )
+    assert float(tangent[1]) > 0.0
+    rhs = (jnp.linspace(-0.2, 0.3, runtime.layout.size), jnp.asarray(0.4))
+    corrected = _bordered_preconditioner(
+        runtime, tangent, block_preconditioner
+    )((zero, 0.0), rhs, 1.0e6)
+    assert corrected[0].shape == zero.shape
+    assert np.all(np.isfinite(np.asarray(corrected[0])))
+    assert np.isfinite(float(corrected[1]))
+
+
+def test_polish_driver_records_bounded_unpolished_return(
+    small_strong_root, monkeypatch
+):
+    class InitialCertificate:
+        normalized_l2 = jnp.asarray(2.0)
+
+    config = PolishConfig(
+        max_continuation_stages=1,
+        alpha_initial_step=1.0e-3,
+        alpha_min_step=1.0e-3,
+        alpha_max_step=1.0e-3,
+        max_nonlinear_iterations=12,
+        use_pseudo_arclength=True,
+        fail_policy="return_unpolished",
+    )
+
+    def fail_tangent(*args, **kwargs):
+        del args, kwargs
+        raise StrongForceContinuationError("test tangent failure")
+
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._arclength_to_target", fail_tangent
+    )
+    result = polish_strong_root(
+        small_strong_root,
+        config=config,
+        initial_certificate=InitialCertificate(),
+    )
+    report = result.polish_report
+    assert not report.converged
+    assert report.termination_reason == "pseudo-arclength-tangent-failed"
+    assert report.final_alpha == pytest.approx(1.0e-3)
+    assert report.continuation_accepted == 1
+    assert report.continuation_rejected == 0
+    assert report.nonlinear_iterations > 0
+    assert report.linear_iterations > 0
+    assert report.minimum_signed_jacobian > 0.0
+    np.testing.assert_array_equal(result.correction, 0.0)
+    assert result.native_equilibrium is small_strong_root.native
+
+
+def test_polish_driver_skips_an_already_certified_state(small_strong_root):
+    class InitialCertificate:
+        normalized_l2 = jnp.asarray(1.0e-9)
+        minimum_signed_jacobian = jnp.asarray(0.5)
+
+    result = polish_strong_root(
+        small_strong_root,
+        config=PolishConfig(validation_tolerance=1.0e-8),
+        initial_certificate=InitialCertificate(),
+    )
+    report = result.polish_report
+    assert report.converged
+    assert report.termination_reason == "already-certified"
+    assert report.nonlinear_iterations == 0
+    assert report.linear_iterations == 0
+    assert report.residual_evaluations == 0
+    np.testing.assert_array_equal(result.correction, 0.0)
+
+
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({"tolerance": 0.0}, "tolerances"),
+        ({"validation_tolerance": 0.0}, "tolerances"),
+        ({"alpha_min_step": 0.1}, "alpha_min_step"),
+        ({"ptc_initial_dtau": 0.0}, "ptc_initial_dtau"),
+        ({"max_continuation_stages": 0}, "iteration limits"),
+        ({"linear_restart": 0}, "linear/backtracking"),
+        ({"preconditioner": "bad"}, "preconditioner"),
+        ({"minimum_jacobian_ratio": 0.0}, "minimum_jacobian_ratio"),
+        ({"minimum_jacobian_floor": 0.0}, "minimum_jacobian_floor"),
+        ({"arclength_step": 0.0}, "pseudo-arclength"),
+        ({"fail_policy": "bad"}, "fail_policy"),
+        ({"tolerance": float("nan")}, "finite"),
+    ],
+)
+def test_polish_config_validation(updates, message):
+    with pytest.raises(ValueError, match=message):
+        PolishConfig(**updates)

--- a/vmex/__init__.py
+++ b/vmex/__init__.py
@@ -182,6 +182,11 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
     "EquilibriumReporter": (".core.monitoring", "EquilibriumReporter"),
     "OptimizationMonitor": (".core.monitoring", "OptimizationMonitor"),
     "OptimizationRecord": (".core.monitoring", "OptimizationRecord"),
+    # high-order strong-force polishing
+    "PolishConfig": (".core.polish_driver", "PolishConfig"),
+    "PolishReport": (".core.polish_driver", "PolishReport"),
+    "PolishResult": (".core.polish_driver", "PolishResult"),
+    "polish_strong_root": (".core.polish_driver", "polish_strong_root"),
     # external fields
     "MgridData": (".core.mgrid", "MgridData"),
     "MgridField": (".core.mgrid", "MgridField"),
@@ -207,6 +212,10 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
     "VmecJacobianError": (".core.errors", "VmecJacobianError"),
     "VmecConvergenceError": (".core.errors", "VmecConvergenceError"),
     "VmecNumericalError": (".core.errors", "VmecNumericalError"),
+    "StrongForceContinuationError": (
+        ".core.errors", "StrongForceContinuationError"),
+    "StrongForceCertificationError": (
+        ".core.errors", "StrongForceCertificationError"),
     "MgridNotFoundError": (".core.errors", "MgridNotFoundError"),
     # modules
     "core": (".core", None),

--- a/vmex/core/__init__.py
+++ b/vmex/core/__init__.py
@@ -9,6 +9,7 @@ Module map (each header docstring names its VMEC2000 counterpart):
 - ``radial_basis``    local high-order splines + rho^|m| axis regularity
 - ``strong_force``    continuous reconstruction + independent JxB-grad(p) oracle
 - ``polish``          high/low transfer + stored raw-block polish preconditioner
+- ``polish_driver``   PTC/continuation strong-root correction and reports
 - ``fourier``         Resolution, ModeTable, trig tables (fixaray.f)
 - ``transforms``      totzsps/totzspa/tomnsps/tomnspa as batched matmuls
 - ``geometry``        real-space R/Z/lambda, half-mesh jacobian (jacobian.f)

--- a/vmex/core/errors.py
+++ b/vmex/core/errors.py
@@ -168,6 +168,26 @@ class AdjointSolveError(VmecNumericalError):
 
 
 @dataclass
+class StrongForceContinuationError(VmecNumericalError):
+    """The branch-preserving strong-force correction did not reach alpha=1."""
+
+    alpha: float = 0.0
+    residual_norm: float = 0.0
+    nonlinear_iterations: int = 0
+    linear_iterations: int = 0
+    accepted_stages: int = 0
+    rejected_stages: int = 0
+
+
+@dataclass
+class StrongForceCertificationError(VmecNumericalError):
+    """A converged strong root failed the independent overintegrated gate."""
+
+    normalized_l2: float = float("inf")
+    tolerance: float = 0.0
+
+
+@dataclass
 class MgridNotFoundError(VmecError):
     """A free-boundary run referenced an mgrid file that cannot be read.
 

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -9,6 +9,7 @@ certificate.  No optimizer or residual-norm minimization is used.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from inspect import signature
 from time import perf_counter
 from typing import Any, Literal, NamedTuple
 
@@ -57,6 +58,22 @@ def _solvax_continuation_api() -> tuple[Any, ...]:
         pseudo_arclength_corrector,
         pseudo_transient_continuation,
     )
+
+
+def _supports_keyword(function: Any, keyword: str) -> bool:
+    """Return whether an installed SOLVAX callable exposes a new keyword."""
+
+    try:
+        return keyword in signature(function).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+def _residual_evaluations(result: Any) -> int:
+    """Read exact work accounting, with a conservative pre-0.19 fallback."""
+
+    nonlinear_steps = getattr(result, "nonlinear_steps", getattr(result, "steps", 0))
+    return int(getattr(result, "residual_evaluations", nonlinear_steps + 1))
 
 
 @dataclass(frozen=True)
@@ -468,6 +485,15 @@ def _arclength_to_target(
             vector + config.arclength_step * tangent[0],
             jnp.asarray(alpha) + config.arclength_step * tangent[1],
         )
+        corrector_kwargs = (
+            {
+                "precond": _bordered_preconditioner(
+                    runtime, tangent, block_preconditioner
+                )
+            }
+            if _supports_keyword(pseudo_arclength_corrector, "precond")
+            else {}
+        )
         corrected = pseudo_arclength_corrector(
             lambda value, parameter: strong_root_residual(
                 value, runtime, parameter
@@ -477,13 +503,11 @@ def _arclength_to_target(
             predictor=predictor,
             config=nonlinear,
             admissible=lambda value, parameter: admissible(value, parameter),
-            precond=_bordered_preconditioner(
-                runtime, tangent, block_preconditioner
-            ),
+            **corrector_kwargs,
         )
         total_nonlinear += int(corrected.steps)
         total_linear += int(corrected.linear_iterations)
-        total_evaluations += int(corrected.residual_evaluations)
+        total_evaluations += _residual_evaluations(corrected)
         if not bool(corrected.converged) or not bool(corrected.linear_converged):
             return vector, alpha, step, total_nonlinear, total_linear, total_evaluations
         previous_alpha = alpha
@@ -505,7 +529,7 @@ def _arclength_to_target(
             )
             total_nonlinear += int(target.steps)
             total_linear += int(target.linear_iterations)
-            total_evaluations += int(target.residual_evaluations)
+            total_evaluations += _residual_evaluations(target)
             if bool(target.converged) and bool(target.linear_converged):
                 return (
                     target.x,
@@ -605,7 +629,7 @@ def polish_strong_root(
     )
     nonlinear_iterations = int(endpoint.steps)
     linear_iterations = int(endpoint.linear_iterations)
-    residual_evaluations = int(endpoint.residual_evaluations)
+    residual_evaluations = _residual_evaluations(endpoint)
     steps: tuple[Any, ...] = ()
     arclength_steps = 0
     vector = endpoint.x
@@ -623,6 +647,9 @@ def polish_strong_root(
         continuation_preconditioners = (
             {"precond": precondition}
             if block_preconditioner is None
+            or not _supports_keyword(
+                adaptive_continuation, "parameterized_precond"
+            )
             else {
                 "parameterized_precond": (
                     lambda state, rhs, dtau, parameter: _continuation_precondition(
@@ -651,7 +678,7 @@ def polish_strong_root(
         vector, alpha = continuation.x, continuation.alpha
         nonlinear_iterations += sum(stage.nonlinear_steps for stage in steps)
         linear_iterations += sum(stage.linear_iterations for stage in steps)
-        residual_evaluations += sum(stage.residual_evaluations for stage in steps)
+        residual_evaluations += sum(_residual_evaluations(stage) for stage in steps)
         converged = continuation.converged
         reason = "strong-root" if converged else "continuation-stalled"
         if not converged and config.use_pseudo_arclength:

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -10,20 +10,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from time import perf_counter
-from typing import Literal, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import jax
 import jax.numpy as jnp
 import numpy as np
-from solvax import (
-    ContinuationConfig,
-    ContinuationStep,
-    PseudoTransientConfig,
-    adaptive_continuation,
-    gmres,
-    pseudo_arclength_corrector,
-    pseudo_transient_continuation,
-)
+from solvax import gmres
 
 from .errors import StrongForceCertificationError, StrongForceContinuationError
 from .polish import (
@@ -39,6 +31,32 @@ from .strong_force import (
 )
 
 Array = object
+
+
+def _solvax_continuation_api() -> tuple[Any, ...]:
+    """Load the continuation extension supplied by the companion SOLVAX PR."""
+
+    try:
+        from solvax import (
+            ContinuationConfig,
+            PseudoTransientConfig,
+            adaptive_continuation,
+            pseudo_arclength_corrector,
+            pseudo_transient_continuation,
+        )
+    except ImportError as error:
+        raise RuntimeError(
+            "strong-force polishing requires a SOLVAX release containing "
+            "adaptive continuation, pseudo-transient continuation, and "
+            "pseudo-arclength correction (uwplasma/SOLVAX#87)"
+        ) from error
+    return (
+        ContinuationConfig,
+        PseudoTransientConfig,
+        adaptive_continuation,
+        pseudo_arclength_corrector,
+        pseudo_transient_continuation,
+    )
 
 
 @dataclass(frozen=True)
@@ -288,7 +306,8 @@ def _low_inverse(rhs: jax.Array, runtime: StrongRootRuntime) -> jax.Array:
     return runtime.layout.pack(solution)
 
 
-def _ptc_config(config: PolishConfig) -> PseudoTransientConfig:
+def _ptc_config(config: PolishConfig) -> Any:
+    _, PseudoTransientConfig, _, _, _ = _solvax_continuation_api()
     return PseudoTransientConfig(
         rtol=config.tolerance,
         atol=config.tolerance,
@@ -301,7 +320,8 @@ def _ptc_config(config: PolishConfig) -> PseudoTransientConfig:
     )
 
 
-def _continuation_config(config: PolishConfig) -> ContinuationConfig:
+def _continuation_config(config: PolishConfig) -> Any:
+    ContinuationConfig, _, _, _, _ = _solvax_continuation_api()
     return ContinuationConfig(
         target=1.0,
         initial_step=config.alpha_initial_step,
@@ -433,6 +453,9 @@ def _arclength_to_target(
     block_preconditioner: _ModeBlockPreconditioner | None,
     initial_tangent: tuple[jax.Array, jax.Array] | None,
 ):
+    _, _, _, pseudo_arclength_corrector, pseudo_transient_continuation = (
+        _solvax_continuation_api()
+    )
     tangent = (
         _branch_tangent(vector, alpha, runtime, config, None, block_preconditioner)
         if initial_tangent is None
@@ -544,6 +567,9 @@ def polish_strong_root(
             solve_seconds=perf_counter() - started,
         )
         return PolishResult(runtime.native, initial_certificate, report, zero)
+    _, _, adaptive_continuation, _, pseudo_transient_continuation = (
+        _solvax_continuation_api()
+    )
     initial_margin = float(_minimum_signed_jacobian(zero, runtime))
     block_preconditioner = (
         _build_mode_block_preconditioner(runtime)
@@ -580,7 +606,7 @@ def polish_strong_root(
     nonlinear_iterations = int(endpoint.steps)
     linear_iterations = int(endpoint.linear_iterations)
     residual_evaluations = int(endpoint.residual_evaluations)
-    steps: tuple[ContinuationStep, ...] = ()
+    steps: tuple[Any, ...] = ()
     arclength_steps = 0
     vector = endpoint.x
     alpha = 0.0

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -1,0 +1,735 @@
+"""Branch-preserving fixed-boundary strong-force polishing.
+
+This host orchestrator follows the square residual defined in
+``vmex.core.polish``.  Each nonlinear stage remains JIT-compatible in SOLVAX;
+host code records continuation decisions and evaluates the independent final
+certificate.  No optimizer or residual-norm minimization is used.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Literal, NamedTuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from solvax import (
+    ContinuationConfig,
+    ContinuationStep,
+    PseudoTransientConfig,
+    adaptive_continuation,
+    gmres,
+    pseudo_arclength_corrector,
+    pseudo_transient_continuation,
+)
+
+from .errors import StrongForceCertificationError, StrongForceContinuationError
+from .polish import (
+    StrongRootRuntime,
+    apply_high_order_correction,
+    strong_root_residual,
+)
+from .strong_force import (
+    HighOrderEquilibriumState,
+    StrongForceReport,
+    certify_strong_force,
+    evaluate_strong_force,
+)
+
+Array = object
+
+
+@dataclass(frozen=True)
+class PolishConfig:
+    """Conservative controls for a fixed-boundary strong-root correction."""
+
+    tolerance: float = 1.0e-8
+    validation_tolerance: float | None = None
+    max_continuation_stages: int = 32
+    alpha_initial_step: float = 1.0e-3
+    alpha_min_step: float = 1.0e-5
+    alpha_max_step: float = 0.1
+    ptc_initial_dtau: float = 1.0e6
+    ptc_max_dtau: float = 1.0e12
+    max_nonlinear_iterations: int = 80
+    max_backtracks: int = 12
+    linear_restart: int = 30
+    linear_max_restarts: int = 20
+    preconditioner: Literal["legacy", "mode-block"] = "legacy"
+    minimum_jacobian_ratio: float = 0.1
+    minimum_jacobian_floor: float = 1.0e-8
+    use_pseudo_arclength: bool = True
+    max_arclength_steps: int = 16
+    arclength_step: float = 1.0e-2
+    fail_policy: Literal["raise", "return_unpolished"] = "raise"
+
+    def __post_init__(self) -> None:
+        finite = (
+            self.tolerance,
+            self.validation_tolerance
+            if self.validation_tolerance is not None
+            else self.tolerance,
+            self.alpha_initial_step,
+            self.alpha_min_step,
+            self.alpha_max_step,
+            self.ptc_initial_dtau,
+            self.ptc_max_dtau,
+            self.minimum_jacobian_ratio,
+            self.minimum_jacobian_floor,
+            self.arclength_step,
+        )
+        if not all(np.isfinite(value) for value in finite):
+            raise ValueError("polish controls must be finite")
+        if self.tolerance <= 0.0 or (
+            self.validation_tolerance is not None
+            and self.validation_tolerance <= 0.0
+        ):
+            raise ValueError("polish tolerances must be positive")
+        if not 0.0 < self.alpha_min_step <= self.alpha_initial_step <= self.alpha_max_step:
+            raise ValueError("require alpha_min_step <= alpha_initial_step <= alpha_max_step")
+        if not 0.0 < self.ptc_initial_dtau <= self.ptc_max_dtau:
+            raise ValueError("require 0 < ptc_initial_dtau <= ptc_max_dtau")
+        if self.max_continuation_stages < 1 or self.max_nonlinear_iterations < 1:
+            raise ValueError("polish iteration limits must be positive")
+        if self.max_backtracks < 0 or self.linear_restart < 1 or self.linear_max_restarts < 1:
+            raise ValueError("polish linear/backtracking limits are invalid")
+        if self.preconditioner not in ("legacy", "mode-block"):
+            raise ValueError("preconditioner must be 'legacy' or 'mode-block'")
+        if not 0.0 < self.minimum_jacobian_ratio <= 1.0:
+            raise ValueError("minimum_jacobian_ratio must lie in (0, 1]")
+        if self.minimum_jacobian_floor <= 0.0:
+            raise ValueError("minimum_jacobian_floor must be positive")
+        if self.max_arclength_steps < 0 or self.arclength_step <= 0.0:
+            raise ValueError("pseudo-arclength controls are invalid")
+        if self.fail_policy not in ("raise", "return_unpolished"):
+            raise ValueError("fail_policy must be 'raise' or 'return_unpolished'")
+
+    @property
+    def certificate_tolerance(self) -> float:
+        """Independent validation threshold used after the solve."""
+
+        return (
+            self.tolerance
+            if self.validation_tolerance is None
+            else self.validation_tolerance
+        )
+
+
+@dataclass(frozen=True)
+class PolishReport:
+    """Compact machine-readable summary of one correction attempt."""
+
+    converged: bool
+    termination_reason: str
+    final_alpha: float
+    initial_normalized_l2: float
+    final_normalized_l2: float
+    continuation_accepted: int
+    continuation_rejected: int
+    nonlinear_iterations: int
+    linear_iterations: int
+    residual_evaluations: int
+    arclength_steps: int
+    minimum_signed_jacobian: float
+    factor_build_seconds: float
+    solve_seconds: float
+
+
+class PolishResult(NamedTuple):
+    """Native state, independent certificate, report, and free correction."""
+
+    native_equilibrium: HighOrderEquilibriumState
+    strong_force: StrongForceReport
+    polish_report: PolishReport
+    correction: jax.Array
+
+
+@dataclass(frozen=True, eq=False)
+class _ModeBlockPreconditioner:
+    """Independent Fourier-mode blocks for the low/strong Jacobian pencil."""
+
+    indices: tuple[jax.Array, ...]
+    low_blocks: tuple[jax.Array, ...]
+    strong_blocks: tuple[jax.Array, ...]
+    build_seconds: float
+
+    def apply(
+        self,
+        rhs: jax.Array,
+        alpha: jax.Array,
+        dtau: jax.Array | float = jnp.inf,
+    ) -> jax.Array:
+        """Apply regularized block solves without forming a global Jacobian."""
+
+        rhs = jnp.asarray(rhs)
+        alpha = jnp.asarray(alpha, dtype=rhs.dtype)
+        inverse_dtau = jnp.where(
+            jnp.isfinite(jnp.asarray(dtau)),
+            1.0 / jnp.asarray(dtau, dtype=rhs.dtype),
+            jnp.asarray(0.0, dtype=rhs.dtype),
+        )
+        result = jnp.zeros_like(rhs)
+        for indices, low, strong in zip(
+            self.indices, self.low_blocks, self.strong_blocks, strict=True
+        ):
+            matrix = (1.0 - alpha) * low + alpha * strong
+            scale = jnp.maximum(jnp.linalg.norm(matrix, ord=jnp.inf), 1.0)
+            regularization = 32.0 * jnp.finfo(rhs.dtype).eps * scale
+            shifted = matrix + (
+                inverse_dtau + regularization
+            ) * jnp.eye(matrix.shape[0], dtype=rhs.dtype)
+            result = result.at[indices].set(jnp.linalg.solve(shifted, rhs[indices]))
+        return result
+
+
+def _mode_block_indices(
+    runtime: StrongRootRuntime,
+    *,
+    poloidal_bandwidth: int = 3,
+) -> tuple[jax.Array, ...]:
+    """Group reduced coordinates into bounded neighboring-mode bands."""
+
+    layout = runtime.layout
+    m = np.asarray(runtime.native.m, dtype=int)
+    n = np.asarray(runtime.native.n, dtype=int)
+    mnmax = int(layout.mnmax)
+    mode_columns = [
+        *(np.asarray(layout.r_indices, dtype=int) % mnmax),
+        *(np.asarray(layout.z_indices, dtype=int)[:, 0] % mnmax),
+        *(np.asarray(layout.l_indices, dtype=int) % mnmax),
+    ]
+    groups: dict[tuple[int, int], list[int]] = {}
+    for position, mode in enumerate(mode_columns):
+        key = (abs(int(n[mode])), int(m[mode]) // int(poloidal_bandwidth))
+        groups.setdefault(key, []).append(position)
+    return tuple(
+        jnp.asarray(groups[key], dtype=jnp.int32)
+        for key in sorted(groups)
+    )
+
+
+def _build_mode_block_preconditioner(
+    runtime: StrongRootRuntime,
+) -> _ModeBlockPreconditioner:
+    """Probe only same-mode Jacobian blocks at the lifted branch point."""
+
+    started = perf_counter()
+    zero = jnp.zeros(
+        (runtime.layout.size,), dtype=jnp.asarray(runtime.native.R_cos).dtype
+    )
+    indices = _mode_block_indices(runtime)
+    low_blocks: list[jax.Array] = []
+    strong_blocks: list[jax.Array] = []
+    for block_indices in indices:
+        local_zero = jnp.zeros((block_indices.size,), dtype=zero.dtype)
+
+        def block_residual(local, alpha):
+            vector = zero.at[block_indices].set(local)
+            return strong_root_residual(vector, runtime, alpha)[block_indices]
+
+        low_blocks.append(
+            jax.jacfwd(lambda local: block_residual(local, 0.0))(local_zero)
+        )
+        strong_blocks.append(
+            jax.jacfwd(lambda local: block_residual(local, 1.0))(local_zero)
+        )
+    jax.block_until_ready((low_blocks, strong_blocks))
+    return _ModeBlockPreconditioner(
+        indices,
+        tuple(low_blocks),
+        tuple(strong_blocks),
+        perf_counter() - started,
+    )
+
+
+def _continuation_precondition(
+    rhs: jax.Array,
+    alpha: jax.Array,
+    dtau: jax.Array,
+    runtime: StrongRootRuntime,
+    block_preconditioner: _ModeBlockPreconditioner,
+) -> jax.Array:
+    """Use the exact legacy inverse early and mode bands near strong force."""
+
+    return jax.lax.cond(
+        jnp.asarray(alpha) < 0.5,
+        lambda value: _low_inverse(value, runtime),
+        lambda value: block_preconditioner.apply(value, alpha, dtau),
+        rhs,
+    )
+
+
+def _corrected_state(vector: jax.Array, runtime: StrongRootRuntime):
+    low = runtime.layout.unpack(vector)
+    correction = runtime.transfer.prolong(low)
+    return apply_high_order_correction(runtime.native, correction)
+
+
+def _minimum_signed_jacobian(vector: jax.Array, runtime: StrongRootRuntime) -> jax.Array:
+    state = _corrected_state(vector, runtime)
+    rr, tt, zz = jnp.meshgrid(
+        jnp.asarray(runtime.radial_nodes),
+        jnp.asarray(runtime.theta),
+        jnp.asarray(runtime.zeta),
+        indexing="ij",
+    )
+    samples = evaluate_strong_force(state, rr, tt, zz)
+    signed = float(state.jacobian_sign) * samples.sqrt_g / jnp.maximum(rr, 1.0e-14)
+    return jnp.min(signed)
+
+
+def _low_inverse(rhs: jax.Array, runtime: StrongRootRuntime) -> jax.Array:
+    """Invert the row-scaled low endpoint in reduced vector coordinates."""
+
+    low_rhs = runtime.layout.unpack(rhs)
+    solution = runtime.low_preconditioner.solve_scaled(low_rhs)
+    return runtime.layout.pack(solution)
+
+
+def _ptc_config(config: PolishConfig) -> PseudoTransientConfig:
+    return PseudoTransientConfig(
+        rtol=config.tolerance,
+        atol=config.tolerance,
+        max_steps=config.max_nonlinear_iterations,
+        initial_dt=config.ptc_initial_dtau,
+        max_dt=config.ptc_max_dtau,
+        max_backtracks=config.max_backtracks,
+        linear_restart=config.linear_restart,
+        linear_max_restarts=config.linear_max_restarts,
+    )
+
+
+def _continuation_config(config: PolishConfig) -> ContinuationConfig:
+    return ContinuationConfig(
+        target=1.0,
+        initial_step=config.alpha_initial_step,
+        min_step=config.alpha_min_step,
+        max_step=config.alpha_max_step,
+        max_stages=config.max_continuation_stages,
+    )
+
+
+def _branch_tangent(
+    vector: jax.Array,
+    alpha: float,
+    runtime: StrongRootRuntime,
+    config: PolishConfig,
+    previous: tuple[jax.Array, jax.Array] | None,
+    block_preconditioner: _ModeBlockPreconditioner | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    residual = lambda value: strong_root_residual(value, runtime, alpha)  # noqa: E731
+    _, jvp = jax.linearize(residual, vector)
+    parameter_direction = strong_root_residual(
+        vector, runtime, 1.0
+    ) - strong_root_residual(vector, runtime, 0.0)
+    if previous is None:
+        linear = gmres(
+            jvp,
+            -parameter_direction,
+            precond=(
+                (lambda value: _low_inverse(value, runtime))
+                if block_preconditioner is None
+                else lambda value: block_preconditioner.apply(value, alpha)
+            ),
+            restart=config.linear_restart,
+            rtol=min(1.0e-6, config.tolerance),
+            atol=config.tolerance,
+            max_restarts=config.linear_max_restarts,
+        )
+        linear_x = linear.x
+        linear_alpha = jnp.asarray(1.0, dtype=jnp.asarray(linear.x).dtype)
+    else:
+        previous_x, previous_alpha = previous
+
+        def bordered(value):
+            tangent_x, tangent_alpha = value
+            physical = jax.tree.map(
+                jnp.add,
+                jvp(tangent_x),
+                jax.tree.map(lambda item: item * tangent_alpha, parameter_direction),
+            )
+            normalization = (
+                jnp.vdot(previous_x, tangent_x).real
+                + previous_alpha * tangent_alpha
+            )
+            return physical, normalization
+
+        linear = gmres(
+            bordered,
+            (jnp.zeros_like(vector), jnp.asarray(1.0, dtype=vector.dtype)),
+            precond=lambda rhs: _bordered_preconditioner(
+                runtime, previous, block_preconditioner
+            )((vector, jnp.asarray(alpha)), rhs, jnp.inf),
+            restart=config.linear_restart,
+            rtol=min(1.0e-6, config.tolerance),
+            atol=config.tolerance,
+            max_restarts=config.linear_max_restarts,
+        )
+        linear_x, linear_alpha = linear.x
+    if not bool(linear.converged):
+        raise StrongForceContinuationError(
+            "pseudo-arclength tangent solve did not converge",
+            hint="refine the radial representation or increase the linear budget",
+            alpha=float(alpha),
+            residual_norm=float(linear.residual_norm),
+            linear_iterations=int(linear.iterations),
+        )
+    tangent_x = jnp.asarray(linear_x)
+    tangent_alpha = jnp.asarray(linear_alpha, dtype=tangent_x.dtype)
+    norm = jnp.sqrt(jnp.vdot(tangent_x, tangent_x).real + tangent_alpha**2)
+    tangent_x, tangent_alpha = tangent_x / norm, tangent_alpha / norm
+    if previous is not None:
+        orientation = jnp.vdot(tangent_x, previous[0]).real + tangent_alpha * previous[1]
+        sign = jnp.where(orientation < 0.0, -1.0, 1.0)
+        tangent_x, tangent_alpha = sign * tangent_x, sign * tangent_alpha
+    return tangent_x, tangent_alpha
+
+
+def _bordered_preconditioner(
+    runtime: StrongRootRuntime,
+    tangent: tuple[jax.Array, jax.Array],
+    block_preconditioner: _ModeBlockPreconditioner | None = None,
+):
+    """Return a low-order block-elimination preconditioner for a bordered root."""
+
+    tangent_x, tangent_alpha = tangent
+
+    def apply(state, rhs, dtau):
+        vector, alpha = state
+        rhs_x, rhs_alpha = rhs
+        parameter_direction = strong_root_residual(
+            vector, runtime, 1.0
+        ) - strong_root_residual(vector, runtime, 0.0)
+        inverse = (
+            (lambda rhs: _low_inverse(rhs, runtime))
+            if block_preconditioner is None
+            else lambda rhs: block_preconditioner.apply(rhs, alpha, dtau)
+        )
+        q_rhs = inverse(rhs_x)
+        q_parameter = inverse(parameter_direction)
+        schur = tangent_alpha - jnp.vdot(tangent_x, q_parameter).real
+        tiny = jnp.sqrt(jnp.finfo(jnp.asarray(schur).dtype).eps)
+        safe_schur = jnp.where(
+            jnp.abs(schur) > tiny,
+            schur,
+            jnp.where(schur < 0.0, -tiny, tiny),
+        )
+        delta_alpha = (
+            rhs_alpha - jnp.vdot(tangent_x, q_rhs).real
+        ) / safe_schur
+        return q_rhs - q_parameter * delta_alpha, delta_alpha
+
+    return apply
+
+
+def _arclength_to_target(
+    vector: jax.Array,
+    alpha: float,
+    runtime: StrongRootRuntime,
+    config: PolishConfig,
+    admissible,
+    block_preconditioner: _ModeBlockPreconditioner | None,
+    initial_tangent: tuple[jax.Array, jax.Array] | None,
+):
+    tangent = (
+        _branch_tangent(vector, alpha, runtime, config, None, block_preconditioner)
+        if initial_tangent is None
+        else initial_tangent
+    )
+    nonlinear = _ptc_config(config)
+    total_nonlinear = total_linear = total_evaluations = 0
+    for step in range(config.max_arclength_steps):
+        predictor = (
+            vector + config.arclength_step * tangent[0],
+            jnp.asarray(alpha) + config.arclength_step * tangent[1],
+        )
+        corrected = pseudo_arclength_corrector(
+            lambda value, parameter: strong_root_residual(
+                value, runtime, parameter
+            ),
+            predictor,
+            tangent=tangent,
+            predictor=predictor,
+            config=nonlinear,
+            admissible=lambda value, parameter: admissible(value, parameter),
+            precond=_bordered_preconditioner(
+                runtime, tangent, block_preconditioner
+            ),
+        )
+        total_nonlinear += int(corrected.steps)
+        total_linear += int(corrected.linear_iterations)
+        total_evaluations += int(corrected.residual_evaluations)
+        if not bool(corrected.converged) or not bool(corrected.linear_converged):
+            return vector, alpha, step, total_nonlinear, total_linear, total_evaluations
+        previous_alpha = alpha
+        vector, alpha_array = corrected.x
+        alpha = float(alpha_array)
+        if (previous_alpha - 1.0) * (alpha - 1.0) <= 0.0:
+            target = pseudo_transient_continuation(
+                lambda value: strong_root_residual(value, runtime, 1.0),
+                vector,
+                precond=(
+                    (lambda state, rhs, dtau: _low_inverse(rhs, runtime))
+                    if block_preconditioner is None
+                    else lambda state, rhs, dtau: block_preconditioner.apply(
+                        rhs, 1.0, dtau
+                    )
+                ),
+                admissible=lambda value: admissible(value, 1.0),
+                config=nonlinear,
+            )
+            total_nonlinear += int(target.steps)
+            total_linear += int(target.linear_iterations)
+            total_evaluations += int(target.residual_evaluations)
+            if bool(target.converged) and bool(target.linear_converged):
+                return (
+                    target.x,
+                    1.0,
+                    step + 1,
+                    total_nonlinear,
+                    total_linear,
+                    total_evaluations,
+                )
+        tangent = _branch_tangent(
+            vector,
+            alpha,
+            runtime,
+            config,
+            tangent,
+            block_preconditioner,
+        )
+    return (
+        vector,
+        alpha,
+        config.max_arclength_steps,
+        total_nonlinear,
+        total_linear,
+        total_evaluations,
+    )
+
+
+def polish_strong_root(
+    runtime: StrongRootRuntime,
+    *,
+    config: PolishConfig | None = None,
+    initial_certificate: StrongForceReport | None = None,
+) -> PolishResult:
+    """Follow the legacy-connected fixed-boundary branch to strong force."""
+
+    config = PolishConfig() if config is None else config
+    started = perf_counter()
+    initial_certificate = (
+        certify_strong_force(runtime.native)
+        if initial_certificate is None
+        else initial_certificate
+    )
+    zero = jnp.zeros((runtime.layout.size,), dtype=jnp.asarray(runtime.native.R_cos).dtype)
+    if float(initial_certificate.normalized_l2) <= config.certificate_tolerance:
+        report = PolishReport(
+            converged=True,
+            termination_reason="already-certified",
+            final_alpha=1.0,
+            initial_normalized_l2=float(initial_certificate.normalized_l2),
+            final_normalized_l2=float(initial_certificate.normalized_l2),
+            continuation_accepted=0,
+            continuation_rejected=0,
+            nonlinear_iterations=0,
+            linear_iterations=0,
+            residual_evaluations=0,
+            arclength_steps=0,
+            minimum_signed_jacobian=float(initial_certificate.minimum_signed_jacobian),
+            factor_build_seconds=runtime.low_preconditioner.factor_build_seconds,
+            solve_seconds=perf_counter() - started,
+        )
+        return PolishResult(runtime.native, initial_certificate, report, zero)
+    initial_margin = float(_minimum_signed_jacobian(zero, runtime))
+    block_preconditioner = (
+        _build_mode_block_preconditioner(runtime)
+        if config.preconditioner == "mode-block"
+        else None
+    )
+    factor_build_seconds = (
+        runtime.low_preconditioner.factor_build_seconds
+        + (0.0 if block_preconditioner is None else block_preconditioner.build_seconds)
+    )
+    margin_floor = max(
+        config.minimum_jacobian_floor,
+        config.minimum_jacobian_ratio * initial_margin,
+    )
+
+    def admissible(vector, alpha):
+        del alpha
+        residual = strong_root_residual(vector, runtime, 1.0)
+        return (
+            jnp.all(jnp.isfinite(vector))
+            & jnp.all(jnp.isfinite(residual))
+            & (_minimum_signed_jacobian(vector, runtime) >= margin_floor)
+        )
+
+    nonlinear = _ptc_config(config)
+    precondition = lambda state, rhs, dtau: _low_inverse(rhs, runtime)  # noqa: E731
+    endpoint = pseudo_transient_continuation(
+        lambda vector: strong_root_residual(vector, runtime, 0.0),
+        zero,
+        precond=precondition,
+        admissible=lambda vector: admissible(vector, 0.0),
+        config=nonlinear,
+    )
+    nonlinear_iterations = int(endpoint.steps)
+    linear_iterations = int(endpoint.linear_iterations)
+    residual_evaluations = int(endpoint.residual_evaluations)
+    steps: tuple[ContinuationStep, ...] = ()
+    arclength_steps = 0
+    vector = endpoint.x
+    alpha = 0.0
+    converged = bool(endpoint.converged) and bool(endpoint.linear_converged)
+    reason = "alpha-zero-failed"
+    if converged:
+        accepted_states: list[tuple[jax.Array, float]] = [(vector, 0.0)]
+
+        def record_accepted_state(candidate, parameter, solution):
+            del solution
+            accepted_states.append((candidate, float(parameter)))
+            return True
+
+        continuation_preconditioners = (
+            {"precond": precondition}
+            if block_preconditioner is None
+            else {
+                "parameterized_precond": (
+                    lambda state, rhs, dtau, parameter: _continuation_precondition(
+                        rhs,
+                        parameter,
+                        dtau,
+                        runtime,
+                        block_preconditioner,
+                    )
+                )
+            }
+        )
+        continuation = adaptive_continuation(
+            lambda value, parameter: strong_root_residual(
+                value, runtime, parameter
+            ),
+            vector,
+            alpha0=0.0,
+            nonlinear_config=nonlinear,
+            continuation_config=_continuation_config(config),
+            admissible=admissible,
+            accept_stage=record_accepted_state,
+            **continuation_preconditioners,
+        )
+        steps = continuation.steps
+        vector, alpha = continuation.x, continuation.alpha
+        nonlinear_iterations += sum(stage.nonlinear_steps for stage in steps)
+        linear_iterations += sum(stage.linear_iterations for stage in steps)
+        residual_evaluations += sum(stage.residual_evaluations for stage in steps)
+        converged = continuation.converged
+        reason = "strong-root" if converged else "continuation-stalled"
+        if not converged and config.use_pseudo_arclength:
+            initial_tangent = None
+            if len(accepted_states) >= 2:
+                previous_vector, previous_alpha = accepted_states[-2]
+                delta_vector = vector - previous_vector
+                delta_alpha = jnp.asarray(alpha - previous_alpha)
+                tangent_norm = jnp.sqrt(
+                    jnp.vdot(delta_vector, delta_vector).real + delta_alpha**2
+                )
+                initial_tangent = (
+                    delta_vector / tangent_norm,
+                    delta_alpha / tangent_norm,
+                )
+            try:
+                (
+                    vector,
+                    alpha,
+                    arclength_steps,
+                    arc_nonlinear,
+                    arc_linear,
+                    arc_evaluations,
+                ) = _arclength_to_target(
+                    vector,
+                    alpha,
+                    runtime,
+                    config,
+                    admissible,
+                    block_preconditioner,
+                    initial_tangent,
+                )
+            except StrongForceContinuationError:
+                reason = "pseudo-arclength-tangent-failed"
+            else:
+                nonlinear_iterations += arc_nonlinear
+                linear_iterations += arc_linear
+                residual_evaluations += arc_evaluations
+                converged = alpha == 1.0
+                reason = (
+                    "pseudo-arclength" if converged else "pseudo-arclength-stalled"
+                )
+
+    accepted = sum(stage.accepted for stage in steps)
+    rejected = len(steps) - accepted
+    if not converged:
+        report = PolishReport(
+            converged=False,
+            termination_reason=reason,
+            final_alpha=float(alpha),
+            initial_normalized_l2=float(initial_certificate.normalized_l2),
+            final_normalized_l2=float(initial_certificate.normalized_l2),
+            continuation_accepted=accepted,
+            continuation_rejected=rejected,
+            nonlinear_iterations=nonlinear_iterations,
+            linear_iterations=linear_iterations,
+            residual_evaluations=residual_evaluations,
+            arclength_steps=arclength_steps,
+            minimum_signed_jacobian=float(_minimum_signed_jacobian(vector, runtime)),
+            factor_build_seconds=factor_build_seconds,
+            solve_seconds=perf_counter() - started,
+        )
+        if config.fail_policy == "raise":
+            raise StrongForceContinuationError(
+                "strong-force continuation did not reach alpha=1",
+                hint="inspect the continuation report and refine the radial representation",
+                alpha=float(alpha),
+                residual_norm=float(jnp.linalg.norm(strong_root_residual(vector, runtime, alpha))),
+                nonlinear_iterations=nonlinear_iterations,
+                linear_iterations=linear_iterations,
+                accepted_stages=accepted,
+                rejected_stages=rejected,
+            )
+        return PolishResult(runtime.native, initial_certificate, report, zero)
+
+    state = _corrected_state(vector, runtime)
+    certificate = certify_strong_force(state)
+    certified = float(certificate.normalized_l2) <= config.certificate_tolerance
+    report = PolishReport(
+        converged=certified,
+        termination_reason="certified" if certified else "certification-failed",
+        final_alpha=1.0,
+        initial_normalized_l2=float(initial_certificate.normalized_l2),
+        final_normalized_l2=float(certificate.normalized_l2),
+        continuation_accepted=accepted,
+        continuation_rejected=rejected,
+        nonlinear_iterations=nonlinear_iterations,
+        linear_iterations=linear_iterations,
+        residual_evaluations=residual_evaluations,
+        arclength_steps=arclength_steps,
+        minimum_signed_jacobian=float(certificate.minimum_signed_jacobian),
+        factor_build_seconds=factor_build_seconds,
+        solve_seconds=perf_counter() - started,
+    )
+    if not certified and config.fail_policy == "raise":
+        raise StrongForceCertificationError(
+            "strong root failed the independent force certificate",
+            hint="increase radial degree/resolution and retry once",
+            normalized_l2=float(certificate.normalized_l2),
+            tolerance=config.certificate_tolerance,
+        )
+    if not certified:
+        return PolishResult(runtime.native, initial_certificate, report, zero)
+    return PolishResult(state, certificate, report, vector)
+
+
+__all__ = ["PolishConfig", "PolishReport", "PolishResult", "polish_strong_root"]


### PR DESCRIPTION
## Summary
- add an immutable fixed-boundary polish configuration, result, and machine-readable report
- drive the exact anchored low endpoint with SOLVAX adaptive PTC continuation and physical Jacobian/admissibility checks
- add secant-seeded, bordered pseudo-arclength tangents near folds and typed continuation/certification failures
- retain the measured legacy inverse as the default; include a bounded neighboring-mode block variant as an explicitly experimental option
- expose the advanced driver lazily without changing existing solve behavior

## Evidence
- Ruff and mypy pass for the new source and tests
- focused polish/preconditioner module: 29 passed
- package API module: 21 passed
- strict Sphinx HTML build passes
- bounded Solovev production diagnostic: deterministic equation orientation moved the accepted branch from alpha about 0.51 to about 0.995 and the SOLVAX dynamic-parameter compile fix reduced the attempt from 347 s to 91 s

## Claim boundary
This PR provides and validates the driver/control-flow layer. It does not claim that the coarse lifted Solovev stress case reaches the certified alpha=1 root: ns=13-51 lifts retain large near-axis second-derivative defects, and the experimental mode-band preconditioner did not reduce total Krylov work. Public solve polish integration, p/h refinement, and a certified production case remain follow-up gates. Existing unpolished solve behavior is untouched.