### PR TITLE
Expose opt-in polishing on fixed-boundary solve

### DIFF
--- a/docs/reference/api/advanced.rst
+++ b/docs/reference/api/advanced.rst
@@ -33,6 +33,12 @@ High-order correction transfer and preconditioner
 .. automodule:: vmex.core.polish_driver
    :members:
 
+The single-grid :func:`vmex.solve` entry point accepts ``polish=False``
+(unchanged behavior), ``polish=True`` (required correction), or
+``polish="auto"`` (skip an already-certified state).  Polished data is attached
+to the result without replacing its legacy sampled state or wout-compatible
+arrays.
+
 Spectral representation and physics kernels
 -------------------------------------------
 

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -490,6 +490,7 @@ def test_polish_driver_skips_an_already_certified_state(small_strong_root):
     [
         ({"tolerance": 0.0}, "tolerances"),
         ({"validation_tolerance": 0.0}, "tolerances"),
+        ({"radial_degree": 4}, "radial_degree"),
         ({"alpha_min_step": 0.1}, "alpha_min_step"),
         ({"ptc_initial_dtau": 0.0}, "ptc_initial_dtau"),
         ({"max_continuation_stages": 0}, "iteration limits"),
@@ -505,3 +506,41 @@ def test_polish_driver_skips_an_already_certified_state(small_strong_root):
 def test_polish_config_validation(updates, message):
     with pytest.raises(ValueError, match=message):
         PolishConfig(**updates)
+
+
+def test_public_solver_rejects_unknown_polish_mode_before_solving():
+    inp = VmecInput.from_file(DATA / "input.solovev")
+    with pytest.raises(ValueError, match="False, True, or 'auto'"):
+        solver.solve(inp, polish="unknown")
+
+
+def test_public_solver_auto_attaches_an_already_certified_native_state():
+    inp = VmecInput.from_file(DATA / "input.solovev").change_resolution(
+        mpol=3,
+        ntor=0,
+        ntheta=12,
+        nzeta=4,
+    )
+    inp = dataclasses.replace(
+        inp,
+        ns_array=np.asarray([5]),
+        ftol_array=np.asarray([1.0e-10]),
+        niter_array=np.asarray([1000]),
+    )
+    result = solver.solve(
+        inp,
+        ftol=1.0e-10,
+        max_iterations=1000,
+        polish="auto",
+        polish_config=PolishConfig(
+            radial_degree=3,
+            validation_tolerance=3.0,
+        ),
+    )
+    assert result.converged
+    assert result.native_equilibrium is not None
+    assert result.strong_force is not None
+    assert result.polish_report.converged
+    assert result.polish_report.termination_reason == "already-certified"
+    assert result.state.R_cos.shape == (5, 3)
+    assert result.native_equilibrium.R_cos.shape == (3, 5)

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -21,6 +21,8 @@ from .errors import StrongForceCertificationError, StrongForceContinuationError
 from .polish import (
     StrongRootRuntime,
     apply_high_order_correction,
+    build_low_order_preconditioner,
+    make_strong_root_runtime,
     strong_root_residual,
 )
 from .strong_force import (
@@ -65,6 +67,7 @@ class PolishConfig:
 
     tolerance: float = 1.0e-8
     validation_tolerance: float | None = None
+    radial_degree: int = 5
     max_continuation_stages: int = 32
     alpha_initial_step: float = 1.0e-3
     alpha_min_step: float = 1.0e-5
@@ -105,6 +108,8 @@ class PolishConfig:
             and self.validation_tolerance <= 0.0
         ):
             raise ValueError("polish tolerances must be positive")
+        if self.radial_degree not in (3, 5, 7):
+            raise ValueError("radial_degree must be 3, 5, or 7")
         if not 0.0 < self.alpha_min_step <= self.alpha_initial_step <= self.alpha_max_step:
             raise ValueError("require alpha_min_step <= alpha_initial_step <= alpha_max_step")
         if not 0.0 < self.ptc_initial_dtau <= self.ptc_max_dtau:
@@ -758,4 +763,58 @@ def polish_strong_root(
     return PolishResult(state, certificate, report, vector)
 
 
-__all__ = ["PolishConfig", "PolishReport", "PolishResult", "polish_strong_root"]
+def polish_legacy_solution(
+    source,
+    resolution,
+    legacy_state,
+    *,
+    config: PolishConfig | None = None,
+    lconm1: bool = True,
+) -> PolishResult:
+    """Refine and lift one converged legacy solve, then run the strong driver."""
+
+    from . import implicit
+    from .input import VmecInput
+    from .strong_force import lift_high_order_state
+
+    if not isinstance(source, VmecInput):
+        raise TypeError("strong-force polishing requires a VmecInput source")
+    config = PolishConfig() if config is None else config
+    implicit_config = implicit.make_config(
+        source,
+        ns=int(resolution.ns),
+        lconm1=bool(lconm1),
+        multigrid=False,
+    )
+    params = implicit.params_from_input(source)
+    legacy_runtime = implicit.runtime_from_params(params, implicit_config)
+    dof_mask = implicit._dof_mask(legacy_state, legacy_runtime, implicit_config)
+    refined_state = implicit._refined_state(
+        implicit_config,
+        params,
+        legacy_state,
+        dof_mask,
+    )
+    native = lift_high_order_state(
+        refined_state,
+        legacy_runtime,
+        degree=config.radial_degree,
+    )
+    low_preconditioner = build_low_order_preconditioner(
+        native,
+        params,
+        implicit_config,
+        refined_state,
+        dof_mask,
+    )
+    runtime = make_strong_root_runtime(native, low_preconditioner, dof_mask)
+    return polish_strong_root(runtime, config=config)
+
+
+__all__ = [
+    "PolishConfig",
+    "PolishReport",
+    "PolishResult",
+    "polish_legacy_solution",
+    "polish_strong_root",
+]

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -1640,7 +1640,8 @@ class SolveResult:
     ``ncurr = 1``.  ``fsq_history`` has one row per iteration:
     ``(fsqr, fsqz, fsql, fsqr1, fsqz1, fsql1)``.  ``wmhd`` is the printed
     ``WMHD = (wb + wp/(gamma-1)) * (2 pi)^2``.  ``vacuum`` is ``None`` for
-    fixed-boundary solves.
+    fixed-boundary solves.  The three polish fields are ``None`` on the
+    unchanged default path.
     """
 
     converged: bool; iterations: int; ier_flag: int
@@ -1653,6 +1654,9 @@ class SolveResult:
     rmns: np.ndarray | None; zmnc: np.ndarray | None
     iotaf: np.ndarray; fsq_history: np.ndarray
     vacuum: VacuumOutput | None = None
+    native_equilibrium: Any = None
+    strong_force: Any = None
+    polish_report: Any = None
 
 
 def _result_from_carry(carry: _LoopCarry, rt: SolverRuntime) -> SolveResult:
@@ -2124,6 +2128,8 @@ def solve(
     prec2d: Prec2DConfig | None = None,
     use_fft: bool | None = None,
     jacobian_retries: int = 2,
+    polish: bool | str = False,
+    polish_config: Any = None,
 ) -> SolveResult:
     """Single-grid fixed-boundary solve (VMEC2000 ``eqsolve.f``).
 
@@ -2188,11 +2194,22 @@ def solve(
     products via ``jax.jvp``, solved with :func:`solvax.gmres`), converging
     stiff cases (high beta/aspect/mode-number) in far fewer iterations.  The
     default (``NONE``) path is byte-identical to the 1D-only solver.
+
+    ``polish=False`` preserves the legacy result exactly.  ``polish=True``
+    requires a converged legacy solve, constructs the high-order fixed-boundary
+    root, and follows :class:`~vmex.core.polish_driver.PolishConfig` failure
+    semantics.  ``polish="auto"`` additionally permits the driver to return
+    immediately when the independent certificate already passes.  Polishing
+    requires a :class:`VmecInput` source; the legacy sampled ``state`` and wout
+    arrays remain unchanged, while ``native_equilibrium``, ``strong_force``,
+    and ``polish_report`` carry the high-order result.
     """
     if resolution is None and isinstance(source, VmecInput):
         resolution = resolution_from_input(source)
     if resolution is None:
         raise ValueError("solve(RunSetup) requires a Resolution")
+    if polish is not False and polish is not True and polish != "auto":
+        raise ValueError("polish must be False, True, or 'auto'")
     if restart_from is not None:
         if initial_state is not None:
             raise ValueError(
@@ -2238,4 +2255,23 @@ def solve(
             use_fft=use_fft_resolved,
             jacobian_retries=jacobian_retries,
         )
-        return _finalize(carry, rt)
+        result = _finalize(carry, rt)
+        if polish is False:
+            return result
+        from .polish_driver import PolishConfig, polish_legacy_solution
+
+        if polish_config is not None and not isinstance(polish_config, PolishConfig):
+            raise TypeError("polish_config must be a PolishConfig")
+        polished = polish_legacy_solution(
+            source,
+            rt.resolution,
+            result.state,
+            config=polish_config,
+            lconm1=lconm1,
+        )
+        return replace(
+            result,
+            native_equilibrium=polished.native_equilibrium,
+            strong_force=polished.strong_force,
+            polish_report=polished.polish_report,
+        )


### PR DESCRIPTION
## Summary
- add False, True, and auto polish modes to the single-grid fixed-boundary solve
- preserve the existing legacy state and wout-compatible arrays exactly
- attach the native high-order equilibrium, independent force report, and polish report in new default-None result fields
- run the same fixed-point refinement used by implicit differentiation before lifting
- add the radial-degree control and validate API inputs before work begins

## Evidence
- Ruff and mypy pass
- real five-surface auto-polish integration smoke passes and preserves legacy/native shapes
- invalid-mode unit test passes
- strict Sphinx HTML build passes
- the preceding driver module has 29 passing focused tests and package API has 21 passing tests

## Claim boundary
This PR exposes only the non-differentiable fixed-boundary solve path. It does not claim polished implicit gradients; that requires the separate polished-root tangent and adjoint registration. Existing calls default to polish disabled.