### PR TITLE
Diagnose WSL2 CUDA and upstream JAX warnings

### DIFF
--- a/docs/howto/run-on-gpu.md
+++ b/docs/howto/run-on-gpu.md
@@ -81,5 +81,9 @@ vmex --doctor
 ```
 
 prints the JAX backend, visible devices, the active default device, and
-VMEX's forward/implicit placement policies. Per-deck CPU-vs-GPU timings and
-the decision sweep for a new machine are in {doc}`/reference/performance`.
+VMEX's forward/implicit placement policies. It also executes a small float64
+JIT calculation on the selected JAX device; on WSL2 it reports the NVIDIA GPU
+and Windows driver visible through `nvidia-smi`. See {doc}`/installation` for
+the JAX 0.9.2 PJRT/cache and two-component WSL driver-version fixes. Per-deck
+CPU-vs-GPU timings and the decision sweep for a new machine are in
+{doc}`/reference/performance`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,8 +20,10 @@ vmex --test
 
 `vmex --doctor` diagnoses mixed-Python environments: it prints the active
 interpreter, pip location, package versions, JAX backend and devices, the
-active JAX default device, and VMEX's forward/implicit placement policies. If
-an install misbehaves, first check that `pip --version` and
+active JAX default device, a real float64 JIT device probe, and VMEX's
+forward/implicit placement policies. Under WSL2 it also reports the
+Windows-provided NVIDIA driver seen by `nvidia-smi`. If an install misbehaves,
+first check that `pip --version` and
 `python -m pip --version` point at the same Python.
 
 `vmex --test` runs the bundled fixed-boundary QH case end to end: it copies
@@ -85,6 +87,43 @@ versions, package resolution can select an older JAX release whose
 accelerator extras differ; always confirm the result with `vmex --doctor`.
 CUDA 12, ROCm, TPU, and platform-specific alternatives remain documented in
 JAX's installation matrix.
+
+### Windows with WSL2 and NVIDIA GPUs
+
+Use the NVIDIA driver installed on Windows. Do not install a Linux NVIDIA
+driver inside WSL2; NVIDIA exposes the Windows driver there through a stub
+`libcuda.so`. If `nvidia-smi` is not on `PATH`, VMEX also checks its standard
+WSL location, `/usr/lib/wsl/lib/nvidia-smi`.
+
+JAX/jaxlib 0.9.2 has two upstream logging defects that are especially visible
+in this environment:
+
+```text
+Assume version compatibility. PjRt-IFRT does not track XLA executable versions.
+Could not get kernel mode driver version: Version does not match the format X.Y.Z
+```
+
+The first is a spurious message on persistent-compilation-cache hits
+([JAX issue 36294](https://github.com/jax-ml/jax/issues/36294), fixed by
+[OpenXLA PR 40018](https://github.com/openxla/xla/pull/40018)). The second
+rejects a valid two-component Windows driver version such as `566.36`; it does
+not by itself mean CUDA failed ([OpenXLA PR
+41380](https://github.com/openxla/xla/pull/41380)). Both upstream fixes are
+present in JAX/jaxlib 0.10.1 and newer. Upgrade the matching accelerator
+installation, then rerun the doctor:
+
+```console
+python -m pip install --upgrade "jax[cuda13]>=0.10.1"
+vmex --doctor
+```
+
+Use the CUDA extra selected by the current official JAX installation matrix
+if CUDA 13 is not appropriate. A healthy report must show the `gpu` backend,
+at least one `cuda:` device, and a passed JIT device probe. VMEX retains
+error-level XLA logging: setting `TF_CPP_MIN_LOG_LEVEL=3` would hide genuine
+CUDA failures and is not recommended. Disabling VMEX's persistent cache also
+removes the PJRT cache-hit message on affected JAX releases, but makes cold
+processes slower and is not the fix.
 
 VMEX then picks CPU or GPU per forward solve using a measured device policy —
 when the GPU actually pays off, and how to pin a device explicitly, is

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -142,6 +142,21 @@ def test_cache_machine_fingerprint_shape_and_stability():
     assert fp == _compat._cache_machine_fingerprint()
 
 
+def test_cache_machine_fingerprint_changes_with_jaxlib(monkeypatch):
+    real_version = _compat.importlib_metadata.version
+    selected = {"jax": "0.9.2", "jaxlib": "0.9.2"}
+
+    def version(name):
+        return selected.get(name, real_version(name))
+
+    monkeypatch.setattr(_compat.importlib_metadata, "version", version)
+    old = _compat._cache_machine_fingerprint()
+    selected["jax"] = "0.10.1"
+    selected["jaxlib"] = "0.10.1"
+    new = _compat._cache_machine_fingerprint()
+    assert old != new
+
+
 class _FakeConfig:
     def __init__(self, fail_keys=()):
         self.updates = {}

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -195,6 +195,62 @@ def test_nvidia_smi_failure_is_actionable(monkeypatch):
     assert error == "nvidia-smi failed: driver unavailable"
 
 
+def test_nvidia_smi_uses_the_standard_wsl_fallback(monkeypatch):
+    observed = {}
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
+    monkeypatch.setattr(doctor.os.path, "isfile", lambda path: True)
+
+    def run(args, **kwargs):
+        observed["args"] = args
+        return types.SimpleNamespace(
+            returncode=0,
+            stdout="NVIDIA RTX 4090, 566.36\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(doctor.subprocess, "run", run)
+    summary, error = doctor._nvidia_smi()
+    assert observed["args"][0] == "/usr/lib/wsl/lib/nvidia-smi"
+    assert summary == "NVIDIA RTX 4090, 566.36"
+    assert error is None
+
+
+def test_jax_probe_covers_empty_bad_and_legacy_device_paths(monkeypatch):
+    import jax
+
+    monkeypatch.setattr(jax, "default_backend", lambda: "gpu")
+    monkeypatch.setattr(jax, "devices", lambda: ())
+    backend, devices, probe, error = doctor._jax_info()
+    assert backend is None and devices == () and probe is None
+    assert error == "JAX returned no devices"
+
+    class FakeResult:
+        def __init__(self, value):
+            self.value = value
+
+        def block_until_ready(self):
+            return self
+
+        def __float__(self):
+            return float(self.value)
+
+        def device(self):
+            return "cuda:0"
+
+    monkeypatch.setattr(jax, "devices", lambda: ("cuda:0",))
+    monkeypatch.setattr(jax, "device_put", lambda values, device: values)
+    monkeypatch.setattr(jax, "device_get", lambda result: result)
+    monkeypatch.setattr(jax, "jit", lambda function: lambda values: FakeResult(14.0))
+    backend, devices, probe, error = doctor._jax_info()
+    assert backend == "gpu" and devices == ("cuda:0",)
+    assert probe.startswith("passed on cuda:0") and error is None
+
+    monkeypatch.setattr(jax, "jit", lambda function: lambda values: FakeResult(13.0))
+    backend, devices, probe, error = doctor._jax_info()
+    assert backend is None and devices == () and probe is None
+    assert error == "JIT device probe returned 13.0, expected 14.0"
+
+
 def test_wsl2_visible_gpu_but_cpu_jax_warns(monkeypatch):
     monkeypatch.setattr(doctor, "_is_wsl2", lambda: True)
     monkeypatch.setattr(doctor, "_nvidia_smi", lambda: ("NVIDIA RTX, 580.1", None))

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import dataclasses
 import sys
+import types
 
 from vmex import doctor
 
@@ -34,6 +35,8 @@ def test_collect_report_reflects_interpreter():
     assert report.jax_backend is not None
     assert report.jax_default_device is None or isinstance(report.jax_default_device, str)
     assert len(report.jax_devices) >= 1
+    assert report.jax_probe is not None and report.jax_probe.startswith("passed on ")
+    assert isinstance(report.wsl2, bool)
     assert set(doctor._CORE_PACKAGES) == set(report.versions)
     assert report.versions["numpy"] != "not installed"
     assert "pip" in report.pip_report.lower() or "unavailable" in report.pip_report
@@ -47,6 +50,8 @@ def test_format_report_healthy_and_warning_paths():
     assert "Status: no obvious installation problems detected." in text
     assert "JAX backend:" in text
     assert "JAX default device:" in text
+    assert "JAX JIT probe:" in text
+    assert "WSL2:" in text
     assert "VMEX forward default:" in text
     assert "VMEX implicit default:" in text
     assert "VMEX mirror default:" in text
@@ -68,7 +73,7 @@ def test_format_report_healthy_and_warning_paths():
 def test_warning_heuristics(monkeypatch):
     # missing setuptools/packaging/pip and a failing JAX import must each warn
     monkeypatch.setattr(doctor, "_package_version", lambda name: "not installed")
-    monkeypatch.setattr(doctor, "_jax_info", lambda: (None, (), "boom"))
+    monkeypatch.setattr(doctor, "_jax_info", lambda: (None, (), None, "boom"))
     monkeypatch.setattr(doctor, "_pip_report", lambda: "pip 25.0 from /elsewhere/site-packages (python 3.12)")
     report = doctor.collect_report()
     joined = "\n".join(report.warnings)
@@ -89,8 +94,8 @@ def test_user_site_and_jax_info_failure_paths(monkeypatch):
 
     # a broken jax module surfaces as (None, (), error-text)
     monkeypatch.setitem(sys.modules, "jax", object())
-    backend, devices, err = doctor._jax_info()
-    assert backend is None and devices == () and err
+    backend, devices, probe, err = doctor._jax_info()
+    assert backend is None and devices == () and probe is None and err
 
 
 def test_old_packaging_and_user_site_warnings(monkeypatch):
@@ -112,6 +117,114 @@ def test_main_prints_report_and_returns_zero(capsys):
     assert doctor.main() == 0
     out = capsys.readouterr().out
     assert "vmex installation doctor" in out
+
+
+def test_wsl2_gpu_reports_known_jaxlib_fixes(monkeypatch):
+    real_version = doctor._package_version
+    monkeypatch.setattr(doctor, "_is_wsl2", lambda: True)
+    monkeypatch.setattr(
+        doctor,
+        "_package_version",
+        lambda name: "0.9.2" if name in ("jax", "jaxlib") else real_version(name),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "_nvidia_smi",
+        lambda: ("NVIDIA GeForce RTX 4090, 566.36", None),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "_jax_info",
+        lambda: ("gpu", ("cuda:0",), "passed on cuda:0 (0.100 s)", None),
+    )
+    report = doctor.collect_report()
+    joined = "\n".join(report.warnings)
+    assert report.wsl2
+    assert report.nvidia_smi == "NVIDIA GeForce RTX 4090, 566.36"
+    assert "0.10.1 or newer" in joined
+    assert "PJRT" in joined
+    assert "two-component Windows NVIDIA driver versions" in joined
+    text = doctor.format_report(report)
+    assert "WSL2:        yes" in text
+    assert "WSL2 NVIDIA: NVIDIA GeForce RTX 4090, 566.36" in text
+
+
+def test_wsl2_detection_and_nvidia_smi_fallback(monkeypatch):
+    monkeypatch.delenv("WSL_INTEROP", raising=False)
+    monkeypatch.setattr(doctor.platform, "release", lambda: "6.6.0-linux")
+    monkeypatch.setattr(doctor.platform, "version", lambda: "plain Linux")
+    assert not doctor._is_wsl2()
+    monkeypatch.setattr(
+        doctor.platform, "release", lambda: "6.6.87.2-microsoft-standard-WSL2"
+    )
+    assert doctor._is_wsl2()
+
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: "/usr/bin/nvidia-smi")
+    monkeypatch.setattr(
+        doctor.subprocess,
+        "run",
+        lambda *args, **kwargs: types.SimpleNamespace(
+            returncode=0,
+            stdout="NVIDIA RTX A6000, 572.61\n",
+            stderr="",
+        ),
+    )
+    summary, error = doctor._nvidia_smi()
+    assert summary == "NVIDIA RTX A6000, 572.61"
+    assert error is None
+
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
+    monkeypatch.setattr(doctor.os.path, "isfile", lambda path: False)
+    summary, error = doctor._nvidia_smi()
+    assert summary is None and "not found" in error
+
+
+def test_nvidia_smi_failure_is_actionable(monkeypatch):
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: "/usr/bin/nvidia-smi")
+    monkeypatch.setattr(
+        doctor.subprocess,
+        "run",
+        lambda *args, **kwargs: types.SimpleNamespace(
+            returncode=9,
+            stdout="",
+            stderr="driver unavailable",
+        ),
+    )
+    summary, error = doctor._nvidia_smi()
+    assert summary is None
+    assert error == "nvidia-smi failed: driver unavailable"
+
+
+def test_wsl2_visible_gpu_but_cpu_jax_warns(monkeypatch):
+    monkeypatch.setattr(doctor, "_is_wsl2", lambda: True)
+    monkeypatch.setattr(doctor, "_nvidia_smi", lambda: ("NVIDIA RTX, 580.1", None))
+    monkeypatch.setattr(
+        doctor,
+        "_jax_info",
+        lambda: ("cpu", ("TFRT_CPU_0",), "passed on TFRT_CPU_0 (0.010 s)", None),
+    )
+    report = doctor.collect_report()
+    assert any("JAX selected the cpu backend" in item for item in report.warnings)
+
+
+def test_current_wsl2_gpu_does_not_warn_about_fixed_jaxlib(monkeypatch):
+    real_version = doctor._package_version
+    monkeypatch.setattr(doctor, "_is_wsl2", lambda: True)
+    monkeypatch.setattr(
+        doctor,
+        "_package_version",
+        lambda name: "0.10.1" if name in ("jax", "jaxlib") else real_version(name),
+    )
+    monkeypatch.setattr(doctor, "_nvidia_smi", lambda: (None, "driver query failed"))
+    monkeypatch.setattr(
+        doctor,
+        "_jax_info",
+        lambda: ("gpu", ("cuda:0",), "passed on cuda:0 (0.100 s)", None),
+    )
+    report = doctor.collect_report()
+    joined = "\n".join(report.warnings)
+    assert "0.10.1 or newer" not in joined
+    assert "driver query failed" in joined
 
 
 def test_compilation_cache_line_reports_each_cache_state(monkeypatch, tmp_path):

--- a/vmex/_compat.py
+++ b/vmex/_compat.py
@@ -310,10 +310,12 @@ def _configure_jax_environment() -> None:
         # memory is reclaimed at callback boundaries; users can still override
         # this before import with JAX_CPU_ENABLE_ASYNC_DISPATCH=true.
         os.environ.setdefault("JAX_CPU_ENABLE_ASYNC_DISPATCH", "false")
-        # Suppress harmless informational C++ logs from XLA/PjRt (e.g.
-        # repeated "Assume version compatibility..." on persistent-cache
-        # hits).  Level 0=INFO, 1=WARNING, 2=ERROR — default to ERROR-only so
-        # genuine errors still surface.
+        # Suppress harmless informational C++ logs from XLA/PjRt.  Level
+        # 0=INFO, 1=WARNING, 2=ERROR — default to ERROR-only so genuine errors
+        # still surface.  JAX/jaxlib 0.9.1-0.9.2 can nevertheless print a
+        # spurious PJRT warning on persistent-cache hits; the upstream fix is
+        # in 0.10.0+, and the WSL driver-parser fix joins it in 0.10.1.  Do not
+        # raise this to level 3 merely to hide the separate CUDA error stream.
         os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
         os.environ.setdefault("ABSL_MIN_LOG_LEVEL", "2")
         os.environ.setdefault("GLOG_minloglevel", "2")

--- a/vmex/doctor.py
+++ b/vmex/doctor.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 import os
 import platform
+import shutil
 import site
 import subprocess
 import sys
+from time import perf_counter
 from importlib import metadata
 
 from packaging.version import InvalidVersion, Version
@@ -43,9 +45,12 @@ class DoctorReport:
     user_site_on_path: bool
     pip_report: str
     versions: dict[str, str]
+    wsl2: bool
+    nvidia_smi: str | None
     jax_backend: str | None
     jax_default_device: str | None
     jax_devices: tuple[str, ...]
+    jax_probe: str | None
     warnings: tuple[str, ...]
 
 
@@ -110,15 +115,66 @@ def _user_site() -> str | None:
         return None
 
 
-def _jax_info() -> tuple[str | None, tuple[str, ...], str | None]:
+def _is_wsl2() -> bool:
+    """Return whether this process is running under Windows Subsystem for Linux."""
+
+    marker = f"{platform.release()} {platform.version()}".lower()
+    return "microsoft" in marker or bool(os.environ.get("WSL_INTEROP"))
+
+
+def _nvidia_smi() -> tuple[str | None, str | None]:
+    """Return GPU/driver rows from the Windows-provided WSL NVIDIA utility."""
+
+    executable = shutil.which("nvidia-smi")
+    if executable is None and os.path.isfile("/usr/lib/wsl/lib/nvidia-smi"):
+        executable = "/usr/lib/wsl/lib/nvidia-smi"
+    if executable is None:
+        return None, "nvidia-smi was not found (also checked /usr/lib/wsl/lib)."
+    try:
+        proc = subprocess.run(
+            [
+                executable,
+                "--query-gpu=name,driver_version",
+                "--format=csv,noheader",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception as exc:  # pragma: no cover - host utility failure.
+        return None, f"nvidia-smi could not run: {exc}"
+    output = (proc.stdout or "").strip()
+    if proc.returncode != 0 or not output:
+        detail = (proc.stderr or output or f"exit code {proc.returncode}").strip()
+        return None, f"nvidia-smi failed: {detail}"
+    return "; ".join(line.strip() for line in output.splitlines() if line.strip()), None
+
+
+def _jax_info() -> tuple[str | None, tuple[str, ...], str | None, str | None]:
     try:
         import jax
+        import jax.numpy as jnp
 
+        started = perf_counter()
         backend = str(jax.default_backend())
-        devices = tuple(str(device) for device in jax.devices())
-        return backend, devices, None
+        live_devices = tuple(jax.devices())
+        devices = tuple(str(device) for device in live_devices)
+        if not live_devices:
+            raise RuntimeError("JAX returned no devices")
+        values = jax.device_put(jnp.arange(4, dtype=jnp.float64), live_devices[0])
+        result = jax.jit(lambda value: jnp.vdot(value, value))(values)
+        result.block_until_ready()
+        observed = float(jax.device_get(result))
+        if abs(observed - 14.0) > 1.0e-12:
+            raise RuntimeError(f"JIT device probe returned {observed}, expected 14.0")
+        result_device = getattr(result, "device", live_devices[0])
+        if callable(result_device):  # JAX releases before Array.device became a property.
+            result_device = result_device()
+        probe = f"passed on {result_device} ({perf_counter() - started:.3f} s)"
+        return backend, devices, probe, None
     except Exception as exc:
-        return None, (), str(exc)
+        return None, (), None, str(exc)
 
 
 def _jax_default_device() -> str | None:
@@ -139,7 +195,9 @@ def collect_report() -> DoctorReport:
     in_virtualenv = sys.prefix != sys.base_prefix
     conda_prefix = os.environ.get("CONDA_PREFIX")
     user_site_on_path = bool(user_site and user_site in sys.path)
-    backend, devices, jax_error = _jax_info()
+    wsl2 = _is_wsl2()
+    nvidia_smi, nvidia_error = _nvidia_smi() if wsl2 else (None, None)
+    backend, devices, jax_probe, jax_error = _jax_info()
 
     warnings: list[str] = []
     if versions["setuptools"] == "not installed":
@@ -160,6 +218,20 @@ def collect_report() -> DoctorReport:
         warnings.append("pip appears to come from a different prefix than the active Python environment.")
     if jax_error is not None:
         warnings.append(f"JAX import/backend check failed: {jax_error}")
+    if wsl2 and backend in ("gpu", "cuda"):
+        if not _version_at_least(versions["jaxlib"], "0.10.1"):
+            warnings.append(
+                f"WSL2 GPU is using jaxlib {versions['jaxlib']}. Upgrade JAX and "
+                "jaxlib together to 0.10.1 or newer: this is the first verified "
+                "release containing the upstream fixes for the spurious PJRT "
+                "cache-hit warning and two-component Windows NVIDIA driver versions."
+            )
+        if nvidia_error is not None:
+            warnings.append(nvidia_error)
+    elif wsl2 and nvidia_smi is not None and backend not in (None, "gpu", "cuda"):
+        warnings.append(
+            f"nvidia-smi sees {nvidia_smi}, but JAX selected the {backend} backend."
+        )
 
     return DoctorReport(
         python=sys.version.replace("\n", " "),
@@ -173,9 +245,12 @@ def collect_report() -> DoctorReport:
         user_site_on_path=user_site_on_path,
         pip_report=pip_text,
         versions=versions,
+        wsl2=wsl2,
+        nvidia_smi=nvidia_smi,
         jax_backend=backend,
         jax_default_device=_jax_default_device(),
         jax_devices=devices,
+        jax_probe=jax_probe,
         warnings=tuple(warnings),
     )
 
@@ -190,6 +265,7 @@ def format_report(report: DoctorReport) -> str:
         f"Prefix:      {report.prefix}",
         f"Base prefix: {report.base_prefix}",
         f"Platform:    {report.platform}",
+        f"WSL2:        {'yes' if report.wsl2 else 'no'}",
         f"Virtualenv:  {'yes' if report.in_virtualenv else 'no'}",
     ]
     if report.conda_prefix:
@@ -211,6 +287,7 @@ def format_report(report: DoctorReport) -> str:
             "",
             f"JAX backend: {report.jax_backend or 'unavailable'}",
             f"JAX default device: {report.jax_default_device or 'automatic'}",
+            f"JAX JIT probe: {report.jax_probe or 'failed or unavailable'}",
             "JAX devices:",
         ]
     )
@@ -218,6 +295,8 @@ def format_report(report: DoctorReport) -> str:
         lines.extend(f"  - {device}" for device in report.jax_devices)
     else:
         lines.append("  - none detected")
+    if report.wsl2:
+        lines.append(f"WSL2 NVIDIA: {report.nvidia_smi or 'unavailable'}")
     lines.extend(
         [
             "VMEX forward default:  automatic work/mode-based CPU/GPU policy",


### PR DESCRIPTION
## Summary
- classify Windows-hosted WSL2 explicitly in `vmex installation doctor`
- include JAX/jaxlib, backend, platform, machine, and accelerator identity in compilation-cache provenance
- probe `nvidia-smi` plus a real x64 JAX computation instead of hiding CUDA/PJRT diagnostics
- point affected old JAX stacks to the upstream fixed jaxlib release while keeping failed backend initialization visible
- document WSL2 driver/JAX remediation and VMEX's automatic CPU/GPU placement policy

## Scope repair
This PR is now based directly on `main` and contains only the WSL2 doctor/cache work. It no longer carries the experimental strong-polish stack.

## Verification
- `pytest -q tests/test_doctor.py tests/test_compat.py`: 27 passed
- Ruff: pass
- mypy on both changed source modules: pass
- strict Sphinx HTML build: pass
- GitHub aggregate CI required before merge

## Claim boundary
The doctor diagnoses and classifies the reported PJRT/XLA messages by testing the actual device. It does not globally suppress C++ logging and cannot validate a Windows NVIDIA driver from macOS CI. The paired WSL2/CPU startup and cache-reload benchmark remains PR #173.
