### PR TITLE
Regularize the strong-force radial lift

### DIFF
--- a/benchmarks/polish_implicit.py
+++ b/benchmarks/polish_implicit.py
@@ -31,6 +31,7 @@ from vmex.core.polish_implicit import (
     strong_root_adjoint,
     strong_root_tangent,
 )
+from vmex.core.radial_basis import BSplineBasis
 from vmex.core.strong_force import lift_high_order_state
 
 from _provenance import assert_repo_vmex, git_state
@@ -102,7 +103,16 @@ def main() -> None:
     params = implicit.params_from_input(inp)
     state, mask = implicit.solve_implicit_with_aux(params, legacy_config)
     legacy_runtime = implicit.runtime_from_params(params, legacy_config)
-    native = lift_high_order_state(state, legacy_runtime, degree=args.degree)
+    native = lift_high_order_state(
+        state,
+        legacy_runtime,
+        radial_basis=BSplineBasis.clamped(
+            np.linspace(0.0, 1.0, args.ns - args.degree + 1),
+            degree=args.degree,
+            quadrature_order=args.degree + 3,
+        ),
+        degree=args.degree,
+    )
     adapter = build_low_order_preconditioner(
         native,
         params,

--- a/benchmarks/polish_preconditioner.py
+++ b/benchmarks/polish_preconditioner.py
@@ -21,6 +21,7 @@ import vmex
 from vmex.core import implicit
 from vmex.core.input import VmecInput
 from vmex.core.polish import build_low_order_preconditioner
+from vmex.core.radial_basis import BSplineBasis
 from vmex.core.strong_force import lift_high_order_state
 
 from _provenance import assert_repo_vmex, git_state
@@ -92,7 +93,16 @@ def main() -> None:
     params = implicit.params_from_input(inp)
     state, mask = implicit.solve_implicit_with_aux(params, config)
     runtime = implicit.runtime_from_params(params, config)
-    native = lift_high_order_state(state, runtime, degree=args.degree)
+    native = lift_high_order_state(
+        state,
+        runtime,
+        radial_basis=BSplineBasis.clamped(
+            np.linspace(0.0, 1.0, args.ns - args.degree + 1),
+            degree=args.degree,
+            quadrature_order=args.degree + 3,
+        ),
+        degree=args.degree,
+    )
 
     rss_before_factor = _peak_rss_mib()
     adapter = build_low_order_preconditioner(

--- a/benchmarks/strong_root.py
+++ b/benchmarks/strong_root.py
@@ -26,6 +26,7 @@ from vmex.core.polish import (
     strong_root_rank,
     strong_root_residual,
 )
+from vmex.core.radial_basis import BSplineBasis
 from vmex.core.strong_force import lift_high_order_state
 
 from _provenance import assert_repo_vmex, git_state
@@ -79,7 +80,16 @@ def main() -> None:
     params = implicit.params_from_input(inp)
     state, mask = implicit.solve_implicit_with_aux(params, config)
     legacy_runtime = implicit.runtime_from_params(params, config)
-    native = lift_high_order_state(state, legacy_runtime, degree=args.degree)
+    native = lift_high_order_state(
+        state,
+        legacy_runtime,
+        radial_basis=BSplineBasis.clamped(
+            np.linspace(0.0, 1.0, args.ns - args.degree + 1),
+            degree=args.degree,
+            quadrature_order=args.degree + 3,
+        ),
+        degree=args.degree,
+    )
     adapter = build_low_order_preconditioner(
         native,
         params,

--- a/docs/explanation/high-order-force-balance.rst
+++ b/docs/explanation/high-order-force-balance.rst
@@ -40,6 +40,16 @@ from VMEX, VMEC2000, or VMEC++ enters through the same tested mode-remapping and
 lambda inversion used by hot restart.  DESC is used only as an external oracle;
 VMEX does not import or depend on DESC.
 
+The legacy radial mesh is first order, so the default reconstruction is an
+overdetermined fit with roughly two mesh samples per free spline span.  An
+equal-size interpolant reproduces mesh-scale noise exactly and can turn that
+noise into very large second derivatives in ``curl(B)`` even when the sampled
+surface coordinates look accurate.  Callers with a genuinely high-order
+source may supply an explicit ``radial_basis``.  The current legacy-coordinate
+polishing chart temporarily retains an equal-size basis after the independent
+certificate has failed; replacing those redundant legacy coordinates with
+native spline coefficients is tracked separately and rank tests remain strict.
+
 Independent continuum oracle
 ----------------------------
 

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -48,6 +48,7 @@ from vmex.core.polish_implicit import (
     strong_root_adjoint,
     strong_root_tangent,
 )
+from vmex.core.radial_basis import BSplineBasis
 from vmex.core.strong_force import lift_high_order_state
 
 jax.config.update("jax_enable_x64", True)
@@ -253,7 +254,14 @@ def small_adapter():
     params = implicit.params_from_input(inp)
     state, mask = implicit.solve_implicit_with_aux(params, config)
     runtime = implicit.runtime_from_params(params, config)
-    native = lift_high_order_state(state, runtime, degree=3)
+    native = lift_high_order_state(
+        state,
+        runtime,
+        radial_basis=BSplineBasis.clamped(
+            np.linspace(0.0, 1.0, 3), degree=3, quadrature_order=6
+        ),
+        degree=3,
+    )
     adapter = build_low_order_preconditioner(
         native,
         params,
@@ -792,4 +800,4 @@ def test_public_solver_auto_attaches_an_already_certified_native_state():
     assert result.polish_report.converged
     assert result.polish_report.termination_reason == "already-certified"
     assert result.state.R_cos.shape == (5, 3)
-    assert result.native_equilibrium.R_cos.shape == (3, 5)
+    assert result.native_equilibrium.R_cos.shape == (3, 4)

--- a/tests/test_strong_force.py
+++ b/tests/test_strong_force.py
@@ -240,6 +240,34 @@ def test_legacy_lift_preserves_axis_boundary_and_lambda_gauge():
     np.testing.assert_allclose(imported.boundary_R_cos, high_order.boundary_R_cos, rtol=0.0, atol=2e-13)
 
 
+def test_legacy_lift_is_overdetermined_for_stable_second_derivatives():
+    """The default must smooth first-order mesh noise, not interpolate it."""
+
+    inp = VmecInput.from_file("examples/data/input.solovev").change_resolution(
+        mpol=3, ntor=0, ntheta=12, nzeta=4
+    )
+    resolution = replace(resolution_from_input(inp), ns=11)
+    runtime = prepare_runtime(inp, resolution)
+    lifted = lift_high_order_state(
+        _initial_state(runtime.setup), runtime, degree=5
+    )
+    interpolating = lift_high_order_state(
+        _initial_state(runtime.setup),
+        runtime,
+        radial_basis=BSplineBasis.clamped(np.linspace(0.0, 1.0, 7), degree=5),
+        degree=5,
+    )
+    stable = certify_strong_force(lifted)
+    unstable = certify_strong_force(interpolating)
+    assert lifted.radial_basis.size == 8
+    assert lifted.radial_basis.size < resolution.ns
+    assert float(stable.absolute_l2) < 1.0e-2 * float(unstable.absolute_l2)
+    assert float(stable.radial_refinement_difference) < 1.0e-8
+    assert float(stable.minimum_signed_jacobian) > 10.0 * float(
+        unstable.minimum_signed_jacobian
+    )
+
+
 @pytest.mark.parametrize("name", ["R_cos", "R_sin", "Z_cos", "Z_sin", "L_cos", "L_sin"])
 def test_state_rejects_malformed_fourier_tables(name):
     state = _constant_toroidal_field_state()

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -811,9 +811,11 @@ def polish_legacy_solution(
 ) -> PolishResult:
     """Refine and lift one converged legacy solve, then run the strong driver."""
 
+    started = perf_counter()
     from . import implicit
     from .input import VmecInput
-    from .strong_force import lift_high_order_state
+    from .radial_basis import BSplineBasis
+    from .strong_force import certify_strong_force, lift_high_order_state
 
     if not isinstance(source, VmecInput):
         raise TypeError("strong-force polishing requires a VmecInput source")
@@ -833,9 +835,54 @@ def polish_legacy_solution(
         legacy_state,
         dof_mask,
     )
+    # Certification is a reconstruction problem, not a requirement to retain
+    # one spline coefficient per legacy sample. Evaluate the stable,
+    # overdetermined lift first; an already-certified result needs neither the
+    # compatibility chart nor a factorization. The empty correction records
+    # that no root coordinates were constructed or applied.
+    certified_native = lift_high_order_state(
+        refined_state,
+        legacy_runtime,
+        degree=config.radial_degree,
+    )
+    initial_certificate = certify_strong_force(certified_native)
+    if float(initial_certificate.normalized_l2) <= config.certificate_tolerance:
+        report = PolishReport(
+            converged=True,
+            termination_reason="already-certified",
+            final_alpha=1.0,
+            initial_normalized_l2=float(initial_certificate.normalized_l2),
+            final_normalized_l2=float(initial_certificate.normalized_l2),
+            continuation_accepted=0,
+            continuation_rejected=0,
+            nonlinear_iterations=0,
+            linear_iterations=0,
+            residual_evaluations=0,
+            arclength_steps=0,
+            minimum_signed_jacobian=float(initial_certificate.minimum_signed_jacobian),
+            factor_build_seconds=0.0,
+            solve_seconds=perf_counter() - started,
+        )
+        return PolishResult(
+            certified_native,
+            initial_certificate,
+            report,
+            jnp.zeros((0,), dtype=jnp.asarray(refined_state.R_cos).dtype),
+        )
+    # The current square system is expressed in every legacy radial degree of
+    # freedom. Keep an equal-size spline chart here until the native-spline
+    # coordinate reduction lands; the independent oracle/import path uses the
+    # overdetermined default fit and must not inherit this compatibility chart.
+    spans = max(1, int(resolution.ns) - int(config.radial_degree))
+    polish_basis = BSplineBasis.clamped(
+        np.linspace(0.0, 1.0, spans + 1),
+        degree=config.radial_degree,
+        quadrature_order=config.radial_degree + 3,
+    )
     native = lift_high_order_state(
         refined_state,
         legacy_runtime,
+        radial_basis=polish_basis,
         degree=config.radial_degree,
     )
     low_preconditioner = build_low_order_preconditioner(

--- a/vmex/core/strong_force.py
+++ b/vmex/core/strong_force.py
@@ -423,7 +423,20 @@ def lift_high_order_state(
     modes = runtime.modes
     s = np.asarray(setup.s_full, dtype=float)
     if radial_basis is None:
-        spans = max(1, min(int(max_spans), max(1, s.size - int(degree))))
+        # The legacy full mesh is only a first-order radial representation.
+        # Giving a degree-p spline one coefficient per sample interpolates
+        # that mesh noise exactly; its second derivatives then oscillate even
+        # though R/Z/lambda values look innocuous.  This is catastrophic for
+        # curl(B): on the ns=11 Solovev regression the interpolating degree-5
+        # lift reports |JxB-grad(p)|_L2 = 4.97e7 N/m^3 and a 0.81 quadrature
+        # change, whereas the overdetermined eight-coefficient fit reports
+        # 9.73e1 N/m^3 and 3.8e-5.  Start with roughly two mesh samples per
+        # free span.  Explicit ``radial_basis=`` remains the seam for a caller
+        # that has a genuinely high-order source or has selected knots by a
+        # refinement certificate.
+        available_spans = max(1, s.size - int(degree))
+        regularized_spans = max(1, (available_spans + 1) // 2)
+        spans = max(1, min(int(max_spans), regularized_spans))
         radial_basis = BSplineBasis.clamped(
             np.linspace(0.0, 1.0, spans + 1),
             degree=degree,


### PR DESCRIPTION
## Summary

- use an overdetermined degree-3/5/7 spline fit for the legacy-to-continuum lift instead of interpolating first-order radial mesh noise
- certify stable reconstruction before allocating the temporary legacy-coordinate chart
- keep the square polisher on the explicit compatibility chart until the following native-spline slice

## Measured reconstruction

For the ns=11 Solovev diagnostic, the overdetermined default reduced the lifted absolute force from `4.97e7` to `97.3 N/m^3`, radial quadrature change from `0.807` to `3.78e-5`, and improved the minimum signed Jacobian from `0.258` to `5.41`.

## Restack and claim boundary

This draft is stacked directly on #171; it no longer contains WSL changes. It improves the initial representation but does not claim completion of the corrected strong root. The independent alpha=1 certificate remains mandatory.
