### PR TITLE
Cut QA optimization startup time and memory

### DIFF
--- a/benchmarks/qa_optimization_startup.py
+++ b/benchmarks/qa_optimization_startup.py
@@ -111,10 +111,17 @@ def main() -> None:
         evaluation = problem.compile_residual_and_jacobian(progress=False)
     compile_seconds = time.perf_counter() - started
 
+    # FunctionProblem intentionally memoizes an identical decision vector, so
+    # repeating x0 would measure a key lookup rather than the warm equilibrium
+    # plus implicit-derivative path used by an optimizer.  Use deterministic,
+    # distinct, in-bounds steps after compilation instead.
+    direction = np.linspace(-0.5, 0.5, problem.x0.size)
+    direction /= np.linalg.norm(direction)
     warm = []
-    for _ in range(args.repeats):
+    for repeat in range(args.repeats):
+        point = problem.x0 + (repeat + 1) * 1.0e-5 * problem.scales * direction
         started = time.perf_counter()
-        problem.value_and_grad(problem.x0)
+        problem.value_and_grad(point)
         warm.append(time.perf_counter() - started)
 
     report = {
@@ -127,6 +134,9 @@ def main() -> None:
         "persistent_compilation_cache": False,
         "lane": args.lane,
         "max_mode": args.max_mode,
+        "repeats": args.repeats,
+        "warm_distinct_points": True,
+        "warm_relative_step": 1.0e-5,
         "dofs": int(problem.x0.size),
         "residual_rows": (
             None if evaluation.residual is None else int(evaluation.residual.size)

--- a/benchmarks/qa_optimization_startup.py
+++ b/benchmarks/qa_optimization_startup.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+"""Measure cold QA problem startup, warm gradient latency, and peak RSS."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import replace
+from importlib import metadata
+import json
+import os
+import platform
+from pathlib import Path
+import resource
+import statistics
+import time
+
+# Cold means no executable restored from a previous process.
+os.environ["VMEX_COMPILATION_CACHE"] = "disabled"
+
+import jax.numpy as jnp
+import numpy as np
+
+import vmex
+from vmex import optimize as opt
+
+from _provenance import assert_repo_vmex, file_sha256, git_state
+
+
+REPO = Path(__file__).resolve().parents[1]
+DATA = REPO / "examples" / "data" / "input.minimal_seed_nfp2"
+
+
+def _version(name: str) -> str | None:
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _peak_rss_mib() -> float:
+    value = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    divisor = 1024.0**2 if platform.system() == "Darwin" else 1024.0
+    return value / divisor
+
+
+def _qa_input():
+    inp = vmex.VmecInput.from_file(DATA)
+    rbc, zbs = inp.rbc.copy(), inp.zbs.copy()
+    rbc[inp.ntor - 1, 1], zbs[inp.ntor - 1, 1] = -0.05, 0.05
+    return replace(inp, rbc=rbc, zbs=zbs)
+
+
+def _terms():
+    qs = opt.QuasisymmetryRatioResidual(
+        np.linspace(0.1, 1.0, 10), helicity_m=1, helicity_n=0)
+
+    def iota_floor(state, runtime):
+        return jnp.maximum(0.42 - opt.min_abs_iota(state, runtime), 0.0)
+
+    return [
+        (qs, 0.0, 1.0),
+        (opt.aspect_ratio, 5.0, 1.0),
+        (iota_floor, 0.0, 10.0),
+        (opt.magnetic_well, 0.01, 1.0),
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--lane", choices=("scalar", "least-squares"),
+                        default="scalar")
+    parser.add_argument("--max-mode", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=10)
+    args = parser.parse_args()
+
+    inp = _qa_input()
+    terms = _terms()
+    initial_solve_seconds = 0.0
+    restart = None
+    if args.lane == "least-squares":
+        started = time.perf_counter()
+        restart = opt.solve_equilibrium(inp)
+        initial_solve_seconds = time.perf_counter() - started
+
+    mpol = max(args.max_mode + 2, 5)
+    inp = replace(inp, delt=0.5).change_resolution(
+        mpol=mpol,
+        ntor=mpol,
+        ntheta=2 * mpol + 6,
+        nzeta=2 * mpol + 4,
+    )
+    started = time.perf_counter()
+    if args.lane == "scalar":
+        def loss(state, runtime):
+            rows = opt.residuals_from_tuples(state, runtime, terms)
+            return 0.5 * jnp.vdot(rows, rows)
+
+        problem = opt.VmecProblem.from_loss(
+            inp, loss, max_mode=args.max_mode, use_ess=True, ess_alpha=1.2,
+            progress=False, evaluation_progress=False)
+    else:
+        problem = opt.VmecProblem.from_tuples(
+            inp, terms, max_mode=args.max_mode, use_ess=True, ess_alpha=1.2,
+            restart_from=restart, progress=False, evaluation_progress=False)
+    build_seconds = time.perf_counter() - started
+
+    started = time.perf_counter()
+    if args.lane == "scalar":
+        evaluation = problem.compile_value_and_gradient(progress=False)
+    else:
+        evaluation = problem.compile_residual_and_jacobian(progress=False)
+    compile_seconds = time.perf_counter() - started
+
+    warm = []
+    for _ in range(args.repeats):
+        started = time.perf_counter()
+        problem.value_and_grad(problem.x0)
+        warm.append(time.perf_counter() - started)
+
+    report = {
+        "schema": "vmex.qa-optimization-startup/1",
+        "command": (
+            "JAX_ENABLE_X64=1 python benchmarks/qa_optimization_startup.py "
+            f"--lane {args.lane} --max-mode {args.max_mode} "
+            f"--repeats {args.repeats}"
+        ),
+        "persistent_compilation_cache": False,
+        "lane": args.lane,
+        "max_mode": args.max_mode,
+        "dofs": int(problem.x0.size),
+        "residual_rows": (
+            None if evaluation.residual is None else int(evaluation.residual.size)
+        ),
+        "initial_solve_seconds": initial_solve_seconds,
+        "build_seconds": build_seconds,
+        "compile_seconds": compile_seconds,
+        "cold_startup_seconds": initial_solve_seconds + build_seconds + compile_seconds,
+        "warm_value_gradient_median_seconds": statistics.median(warm),
+        "initial_value": float(evaluation.value),
+        "initial_gradient_norm": float(np.linalg.norm(evaluation.gradient)),
+        "peak_rss_mib": _peak_rss_mib(),
+        "input_sha256": file_sha256(DATA),
+        "platform": platform.platform(),
+        "versions": {
+            "python": platform.python_version(),
+            "vmex": vmex.__version__,
+            "jax": _version("jax"),
+            "jaxlib": _version("jaxlib"),
+            "numpy": np.__version__,
+        },
+        **git_state(REPO),
+        "vmex_module": assert_repo_vmex(vmex.__file__, REPO),
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/qa_optimization_startup_least_squares_m4.json
+++ b/benchmarks/qa_optimization_startup_least_squares_m4.json
@@ -1,0 +1,30 @@
+{
+  "build_seconds": 16.046397916972637,
+  "cold_startup_seconds": 40.44648699997924,
+  "command": "JAX_ENABLE_X64=1 python benchmarks/qa_optimization_startup.py --lane least-squares --max-mode 3 --repeats 10",
+  "compile_seconds": 20.489819125039503,
+  "dofs": 48,
+  "initial_gradient_norm": 800.218678661816,
+  "initial_solve_seconds": 3.9102699579671025,
+  "initial_value": 21.448752427232517,
+  "input_data_embedded": false,
+  "input_sha256": "d76efbd4d584c91a985b147a07302660f7bb515f23dfdebc721bc35b703c9bbb",
+  "lane": "least-squares",
+  "max_mode": 3,
+  "measurement_commit": "def0108aeee53070eaaf1f3db13b5b14d451ca16",
+  "measurement_dirty": false,
+  "peak_rss_mib": 2776.078125,
+  "persistent_compilation_cache": false,
+  "platform": "macOS-26.5.1-arm64-arm-64bit",
+  "residual_rows": 6723,
+  "schema": "vmex.qa-optimization-startup/1",
+  "versions": {
+    "jax": "0.11.1",
+    "jaxlib": "0.11.1",
+    "numpy": "2.5.2",
+    "python": "3.12.13",
+    "vmex": "0.7.0"
+  },
+  "vmex_module": "vmex/__init__.py",
+  "warm_value_gradient_median_seconds": 9.5803989097476e-07
+}

--- a/benchmarks/qa_optimization_startup_main_m4.json
+++ b/benchmarks/qa_optimization_startup_main_m4.json
@@ -1,22 +1,22 @@
 {
-  "build_seconds": 18.245019292000507,
-  "cold_startup_seconds": 44.726379333000295,
-  "command": "JAX_ENABLE_X64=1 python benchmarks/qa_optimization_startup.py --lane least-squares --max-mode 3 --repeats 3",
-  "compile_seconds": 22.140775500000018,
+  "build_seconds": 30.264485792000414,
+  "cold_startup_seconds": 55.92575025100086,
+  "command": "JAX_ENABLE_X64=1 python benchmarks/qa_optimization_startup.py --lane least-squares --max-mode 3 --repeats 1",
+  "compile_seconds": 21.426515458999347,
   "dofs": 48,
-  "initial_gradient_norm": 800.218678661816,
-  "initial_solve_seconds": 4.340584540999771,
+  "initial_gradient_norm": 800.2186786618643,
+  "initial_solve_seconds": 4.234749000001102,
   "initial_value": 21.448752427232517,
   "input_data_embedded": false,
   "input_sha256": "d76efbd4d584c91a985b147a07302660f7bb515f23dfdebc721bc35b703c9bbb",
   "lane": "least-squares",
   "max_mode": 3,
-  "measurement_commit": "63b1f5123794457eb7cf6f6668244fd5013a4ec8",
+  "measurement_commit": "980b602a4af987d745caf90b10e22ba37b6aaf9d",
   "measurement_dirty": false,
-  "peak_rss_mib": 2965.0625,
+  "peak_rss_mib": 3705.59375,
   "persistent_compilation_cache": false,
   "platform": "macOS-26.6.2-arm64-arm-64bit",
-  "repeats": 3,
+  "repeats": 1,
   "residual_rows": 6723,
   "schema": "vmex.qa-optimization-startup/1",
   "versions": {
@@ -29,5 +29,5 @@
   "vmex_module": "vmex/__init__.py",
   "warm_distinct_points": true,
   "warm_relative_step": 1e-05,
-  "warm_value_gradient_median_seconds": 16.573728916999244
+  "warm_value_gradient_median_seconds": 15.02162695899824
 }

--- a/benchmarks/qa_optimization_startup_scalar_m4.json
+++ b/benchmarks/qa_optimization_startup_scalar_m4.json
@@ -1,8 +1,8 @@
 {
-  "build_seconds": 15.450792083051056,
-  "cold_startup_seconds": 30.620075958082452,
-  "command": "JAX_ENABLE_X64=1 python benchmarks/qa_optimization_startup.py --lane scalar --max-mode 3 --repeats 10",
-  "compile_seconds": 15.169283875031397,
+  "build_seconds": 16.379704791999757,
+  "cold_startup_seconds": 32.206163750001,
+  "command": "JAX_ENABLE_X64=1 python benchmarks/qa_optimization_startup.py --lane scalar --max-mode 3 --repeats 3",
+  "compile_seconds": 15.82645895800124,
   "dofs": 48,
   "initial_gradient_norm": 800.2186595262949,
   "initial_solve_seconds": 0.0,
@@ -11,11 +11,12 @@
   "input_sha256": "d76efbd4d584c91a985b147a07302660f7bb515f23dfdebc721bc35b703c9bbb",
   "lane": "scalar",
   "max_mode": 3,
-  "measurement_commit": "def0108aeee53070eaaf1f3db13b5b14d451ca16",
+  "measurement_commit": "63b1f5123794457eb7cf6f6668244fd5013a4ec8",
   "measurement_dirty": false,
-  "peak_rss_mib": 2022.953125,
+  "peak_rss_mib": 2574.0,
   "persistent_compilation_cache": false,
-  "platform": "macOS-26.5.1-arm64-arm-64bit",
+  "platform": "macOS-26.6.2-arm64-arm-64bit",
+  "repeats": 3,
   "residual_rows": null,
   "schema": "vmex.qa-optimization-startup/1",
   "versions": {
@@ -26,5 +27,7 @@
     "vmex": "0.7.0"
   },
   "vmex_module": "vmex/__init__.py",
-  "warm_value_gradient_median_seconds": 6.664195097982883e-07
+  "warm_distinct_points": true,
+  "warm_relative_step": 1e-05,
+  "warm_value_gradient_median_seconds": 17.37849795799957
 }

--- a/benchmarks/qa_optimization_startup_scalar_m4.json
+++ b/benchmarks/qa_optimization_startup_scalar_m4.json
@@ -1,0 +1,30 @@
+{
+  "build_seconds": 15.450792083051056,
+  "cold_startup_seconds": 30.620075958082452,
+  "command": "JAX_ENABLE_X64=1 python benchmarks/qa_optimization_startup.py --lane scalar --max-mode 3 --repeats 10",
+  "compile_seconds": 15.169283875031397,
+  "dofs": 48,
+  "initial_gradient_norm": 800.2186595262949,
+  "initial_solve_seconds": 0.0,
+  "initial_value": 21.448752455551784,
+  "input_data_embedded": false,
+  "input_sha256": "d76efbd4d584c91a985b147a07302660f7bb515f23dfdebc721bc35b703c9bbb",
+  "lane": "scalar",
+  "max_mode": 3,
+  "measurement_commit": "def0108aeee53070eaaf1f3db13b5b14d451ca16",
+  "measurement_dirty": false,
+  "peak_rss_mib": 2022.953125,
+  "persistent_compilation_cache": false,
+  "platform": "macOS-26.5.1-arm64-arm-64bit",
+  "residual_rows": null,
+  "schema": "vmex.qa-optimization-startup/1",
+  "versions": {
+    "jax": "0.11.1",
+    "jaxlib": "0.11.1",
+    "numpy": "2.5.2",
+    "python": "3.12.13",
+    "vmex": "0.7.0"
+  },
+  "vmex_module": "vmex/__init__.py",
+  "warm_value_gradient_median_seconds": 6.664195097982883e-07
+}

--- a/examples/optimization/QA_optimization.py
+++ b/examples/optimization/QA_optimization.py
@@ -96,6 +96,7 @@ def x_from_y(y):
 
 def value_and_gradient(y):
     value, gradient = problem.value_and_grad(x_from_y(y))
+    evaluation_costs.append(float(value))
     return value, step * gradient
 
 
@@ -105,12 +106,17 @@ def monitor_y(intermediate_result):
              "jac": value_and_gradient(intermediate_result.x)[1]})
 
 
+evaluation_costs = []
 result = minimize(
     value_and_gradient, np.zeros_like(x0), jac=True, method="L-BFGS-B",
     bounds=[(-MAX_PARAMETER_CHANGE, MAX_PARAMETER_CHANGE)] * x0.size,
     callback=monitor_y,
     options={"maxiter": MAXITER, "gtol": 1.0e-6, "ftol": 1.0e-12,
              "maxls": 20, "maxcor": 20})
+print(
+    "optimizer scalar cost: "
+    f"{evaluation_costs[0]:.16e} -> {float(result.fun):.16e}"
+)
 result.x = x_from_y(result.x)
 inp = problem.input_from_x(result.x)
 equilibrium = problem.equilibrium_from_x(result.x)

--- a/examples/optimization/QA_optimization.py
+++ b/examples/optimization/QA_optimization.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python
-"""Quasi-axisymmetric boundary optimization with a magnetic well."""
+"""Fast-start quasi-axisymmetric optimization with a magnetic well.
+
+The scalar objective uses one reverse implicit solve per gradient, avoiding
+the large pointwise residual Jacobian that made the former staged
+least-squares example spend minutes compiling before its first optimizer
+iteration.  The objective value and gradient are exactly the scalarization of
+the same weighted residual tuples.
+"""
 
 from dataclasses import replace
 import os
@@ -7,17 +14,17 @@ from pathlib import Path
 
 import jax.numpy as jnp
 import numpy as np
-from scipy.optimize import least_squares
+from scipy.optimize import minimize
 
 import vmex as vj
 from vmex import optimize as opt
 
 nfp = 2  # number of field periods
 SURFACES = np.linspace(0.1, 1.0, 10)
-MAX_MODES, MAX_NFEV = [1,2,3], [10, 10, 15]
+MAX_MODE, MAXITER = 3, 30
 MAGNETIC_WELL_TARGET = 0.01
 ASPECT_TARGET = 5.0
-# MAX_MODES, MAX_NFEV = [1,2,3,4,5,6,7,8,9], [10, 10, 15, 20, 25, 40, 50, 60, 60]
+# For a larger design space use MAX_MODE, MAXITER = 9, 60.
 # MAGNETIC_WELL_TARGET = 0.07
 # ASPECT_TARGET = 3.5
 IOTA_FLOOR = 0.42
@@ -29,7 +36,7 @@ SEED_PERTURBATION = 0.05
 
 ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
 if ci_smoke:
-    MAX_MODES, MAX_NFEV = [1], [4]
+    MAX_MODE, MAXITER = 1, 4
 
 DATA = Path(__file__).resolve().parents[1] / "data" / f"input.minimal_seed_nfp{nfp}"
 inp = vj.VmecInput.from_file(DATA)
@@ -61,39 +68,53 @@ report = opt.EquilibriumReporter(
     ("mean iota", opt.mean_iota, ".4f"), ("magnetic well", opt.magnetic_well, ".4f"))
 monitor = opt.OptimizationMonitor(stream=None)
 
-# Optimize for QA first, then add the pressure-stability proxy locally.
-equilibrium = opt.solve_equilibrium(inp)
-# If a RuntimeWarning reports uncertified Jacobian columns, it is expected
-# once the optimizer leaves the seed and needs no action: the shipped
-# jacobian_adjoint_tol=1e-4 and jacobian_adjoint_maxiter=10 are the measured
-# optimum, since ten times that budget moved the Jacobian by 2e-8 and
-# certified no extra column. Both are from_tuples arguments; pass
-# evaluation_progress=False to drop the per-evaluation timing lines.
-for stage, (max_mode, max_nfev) in enumerate(zip(MAX_MODES, MAX_NFEV)):
-    print(f"\n===== QA stage, max_mode = {max_mode} =====")
-    mpol = max(max_mode + 2, MINIMUM_MPOL)
-    inp = replace(inp, delt=0.5).change_resolution(
-        mpol=mpol, ntor=mpol, ntheta=2 * mpol + 6, nzeta=2 * mpol + 4)
-    stage_terms = objective_function_terms
-    problem = opt.VmecProblem.from_tuples(inp, stage_terms, max_mode=max_mode,
-        vary_major_radius=VARY_MAJOR_RADIUS, use_ess=True, ess_alpha=ESS_ALPHA,
-        restart_from=equilibrium)
-    print(f"dof_names = {problem.dof_names}")
-    monitor.problem = problem
-    if not ci_smoke:
-        problem.compile_residual_and_jacobian()
-    step = PARAMETER_STEP * problem.scales
-    result = least_squares(
-        problem.residual, problem.x0, jac=problem.residual_jac,
-        x_scale=step,max_nfev=max_nfev, bounds=(
-                problem.x0 - MAX_PARAMETER_CHANGE * step,
-                problem.x0 + MAX_PARAMETER_CHANGE * step),
-        ftol=1e-6, xtol=1e-10, verbose=2, callback=monitor
-    )
-    inp = problem.input_from_x(result.x)
-    equilibrium = problem.equilibrium_from_x(result.x)
-    report(f"mode {max_mode}", equilibrium)
-    # inp.to_indata(f"input.QA_max_mode_{max_mode:03d}")
+# Scalarize the exact least-squares rows before differentiating. Reverse-mode
+# implicit differentiation then needs one adjoint regardless of boundary dof
+# count, instead of materializing the 6723 x 48 pointwise Jacobian.
+def loss(equilibrium_state, solver_context):
+    rows = opt.residuals_from_tuples(
+        equilibrium_state, solver_context, objective_function_terms)
+    return 0.5 * jnp.vdot(rows, rows)
+
+
+mpol = max(MAX_MODE + 2, MINIMUM_MPOL)
+inp = replace(inp, delt=0.5).change_resolution(
+    mpol=mpol, ntor=mpol, ntheta=2 * mpol + 6, nzeta=2 * mpol + 4)
+problem = opt.VmecProblem.from_loss(
+    inp, loss, max_mode=MAX_MODE, vary_major_radius=VARY_MAJOR_RADIUS,
+    use_ess=True, ess_alpha=ESS_ALPHA)
+print(f"dof_names = {problem.dof_names}")
+monitor.problem = problem
+problem.compile_value_and_gradient()
+
+x0 = problem.x0
+step = PARAMETER_STEP * problem.scales
+
+def x_from_y(y):
+    return x0 + step * y
+
+
+def value_and_gradient(y):
+    value, gradient = problem.value_and_grad(x_from_y(y))
+    return value, step * gradient
+
+
+def monitor_y(intermediate_result):
+    x = x_from_y(intermediate_result.x)
+    monitor({"x": x, "fun": intermediate_result.fun,
+             "jac": value_and_gradient(intermediate_result.x)[1]})
+
+
+result = minimize(
+    value_and_gradient, np.zeros_like(x0), jac=True, method="L-BFGS-B",
+    bounds=[(-MAX_PARAMETER_CHANGE, MAX_PARAMETER_CHANGE)] * x0.size,
+    callback=monitor_y,
+    options={"maxiter": MAXITER, "gtol": 1.0e-6, "ftol": 1.0e-12,
+             "maxls": 20, "maxcor": 20})
+result.x = x_from_y(result.x)
+inp = problem.input_from_x(result.x)
+equilibrium = problem.equilibrium_from_x(result.x)
+report(f"mode {MAX_MODE}", equilibrium)
 
 # Print results
 final_input = replace(inp,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -26,6 +26,8 @@ EXAMPLES = REPO / "examples"
 DATA_DIR = EXAMPLES / "data"
 
 _COST_RE = re.compile(r"^\s*\d+\s+\d+\s+([0-9.eE+-]+)", re.MULTILINE)
+_SCALAR_COST_RE = re.compile(
+    r"optimizer scalar cost:\s*([0-9.eE+-]+)\s*->\s*([0-9.eE+-]+)")
 
 ESSOS_BRANCH_EXAMPLES = (
     EXAMPLES / "take_free_boundary_gradients.py",
@@ -107,9 +109,13 @@ def _run_example(script: Path, cwd: Path, timeout: int = 2400,
 
 def _assert_cost_decreased(stdout: str, name: str) -> None:
     costs = [float(c) for c in _COST_RE.findall(stdout)]
-    assert len(costs) >= 2, f"{name}: expected scipy iteration rows, got {costs}"
+    if len(costs) < 2:
+        scalar_costs = _SCALAR_COST_RE.search(stdout)
+        costs = [] if scalar_costs is None else [
+            float(scalar_costs.group(1)), float(scalar_costs.group(2))]
+    assert len(costs) >= 2, f"{name}: expected optimizer cost evidence, got {costs}"
     assert min(costs) < costs[0], (
-        f"{name}: least-squares cost did not decrease: first {costs[0]:.6e}, "
+        f"{name}: optimizer cost did not decrease: first {costs[0]:.6e}, "
         f"best {min(costs):.6e}")
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -227,6 +227,18 @@ def test_global_optimization_example_exposes_optimizer_contract():
     assert "ess_alpha=ESS_ALPHA" in text
 
 
+def test_qa_optimization_uses_fast_scalar_adjoint_lane():
+    """The canonical QA example must not rebuild a pointwise Jacobian."""
+
+    text = (EXAMPLES / "optimization" / "QA_optimization.py").read_text()
+    assert "VmecProblem.from_loss" in text
+    assert "residuals_from_tuples" in text
+    assert "compile_value_and_gradient" in text
+    assert "compile_residual_and_jacobian" not in text
+    assert "minimize(" in text
+    assert "ess_alpha=ESS_ALPHA" in text
+
+
 @pytest.mark.parametrize("case", ["QA", "QH", "QP", "QI"])
 @pytest.mark.parametrize("suffix", ["", "_finite_beta"])
 def test_stellarator_asymmetry_examples_expose_all_boundary_families(case, suffix):

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -261,6 +261,9 @@ def test_three_surface_raw_kernel_matches_global_nonlinear_rows(case):
 
 def test_residual_zero_at_fixed_point(case):
     name, inp, cfg, p0, x_star, rt, mask = case
+    assert _mask_bit_ident(mask, im._fixed_boundary_dof_mask(cfg)), (
+        f"{name}: analytic fixed-boundary support differs from the VJP oracle"
+    )
     P = im._dof_projector(cfg, mask)
     F = im.residual_fn(cfg, jax.lax.stop_gradient(x_star), mask)
     r0 = _tnorm(F(P(x_star), p0))
@@ -306,6 +309,7 @@ def test_dof_mask_structural_invariance_and_cache(solovev):
     mask_pert = im._dof_mask(x_star, rt1, cfg, seed=0)
     assert _mask_bit_ident(mask, mask_seed), f"{name}: mask not seed-invariant"
     assert _mask_bit_ident(mask, mask_pert), f"{name}: mask not parameter-invariant"
+    assert _mask_bit_ident(mask, im._fixed_boundary_dof_mask(cfg))
 
     # end-to-end: the module cache hits across two fresh configs (one entry).
     saved = dict(im._MASK_CACHE)
@@ -713,6 +717,13 @@ def lasym():
     return "up_down_asymmetric_tokamak", inp, cfg, p0, result.state, rt, mask
 
 
+def test_lasym_fixed_boundary_mask_matches_vjp_oracle(lasym):
+    """Exact 2-D asymmetric support retains both parity families."""
+
+    name, _inp, cfg, _p0, _state, _rt, mask = lasym
+    assert _mask_bit_ident(mask, im._fixed_boundary_dof_mask(cfg)), name
+
+
 def test_lasym_delta_rotation_traceable():
     """The traceable delta rotation reproduces ``setup._lasym_delta_rotation``
     to ~1e-12 and stays differentiable in the (0,1) coefficients."""
@@ -1026,7 +1037,8 @@ def test_lasym_3d_gradient_vs_frozen_path_fd(lasym_3d):
     """``jax.grad`` through ``im.run`` on a 3D lasym boundary vs frozen-path
     central FD: toroidal (n = 1) rbs/zbc dofs plus the symmetric rbc family
     as a regression guard; measured agreement ~1e-6..1e-8 (printed)."""
-    name, inp, cfg, p0, _, _, _ = lasym_3d
+    name, inp, cfg, p0, _, _, mask = lasym_3d
+    assert _mask_bit_ident(mask, im._fixed_boundary_dof_mask(cfg)), name
     ntor = int(inp.ntor)
 
     def outs(p):

--- a/tests/test_implicit_multi_rhs.py
+++ b/tests/test_implicit_multi_rhs.py
@@ -159,6 +159,28 @@ def test_block_response_forward_transpose_and_fd():
         )
 
 
+def test_raw_block_probe_chunking_preserves_exact_factors():
+    """Bounded VJP batches assemble the same local block Jacobian."""
+
+    _, cfg, params = _small_solovev_setup()
+    state, mask = im.solve_implicit_with_aux(params, cfg)
+    active = im._active_state_fields(cfg)
+    scalar = im._raw_block_system(
+        params, cfg, state, mask, active, probe_chunk_size=1
+    )
+    chunked = im._raw_block_system(
+        params, cfg, state, mask, active, probe_chunk_size=4
+    )
+    for name in ("lower", "diagonal", "upper", "row_scale", "column_scale"):
+        np.testing.assert_allclose(
+            getattr(chunked, name), getattr(scalar, name), rtol=2e-13, atol=2e-13
+        )
+    with pytest.raises(ValueError, match="probe_chunk_size"):
+        im._raw_block_system(
+            params, cfg, state, mask, active, probe_chunk_size=0
+        )
+
+
 @pytest.mark.full
 def test_block_pullback_rejects_unconverged_response():
     """The opt-in transpose path cannot return an uncertified gradient."""

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -69,10 +69,9 @@ state is assembled as ``x = mask*z + edge_mask*boundary(p) + frozen`` where
 ``z`` are the evolved dofs, the edge row comes (differentiably) from the
 boundary parameters, and the remaining entries (structurally zero families,
 released m=1 combinations, the lambda axis row overwritten by the ``totzsp``
-closure) are frozen constants.  The dof mask is computed once per forward
-solve from the *exact structural zero patterns* of ``gc`` (row support) and
-of the ``x``-dependence of ``gc`` (column support, one VJP with a random
-cotangent) at a generically perturbed state — see ``_dof_mask``.
+closure) are frozen constants.  The fixed-boundary dof mask is constructed
+directly from those mode-table invariants; :func:`_dof_mask` remains the
+independent structural-zero oracle and handles coupled free-boundary maps.
 
 Gradient checking solver-sensitive metrics
 ------------------------------------------
@@ -805,6 +804,53 @@ def _m1_pair_columns(cfg: ImplicitConfig) -> tuple[np.ndarray, np.ndarray]:
     return pos, neg
 
 
+def _fixed_boundary_dof_mask(cfg: ImplicitConfig) -> SpectralState:
+    """Exact evolved-dof mask for the fixed-boundary force equations.
+
+    Unlike the coupled free-boundary problem, this support is known from the
+    signed mode table alone.  Constructing it avoids two full force passes and
+    two reverse sweeps during the first implicit solve at a new resolution.
+    ``_dof_mask`` is kept as an independent numerical oracle in the tests.
+    """
+
+    res = cfg.resolution
+    modes = _static_tables(res)[0]
+    m = np.asarray(modes.m, dtype=int)
+    n = np.asarray(modes.n, dtype=int)
+    shape = (int(res.ns), int(m.size))
+    constant = (m == 0) & (n == 0)
+    nonconstant = ~constant
+    symmetric = not bool(res.lasym)
+
+    def rz(allowed: np.ndarray) -> jax.Array:
+        mask = np.broadcast_to(allowed, shape).copy()
+        mask[0, :] = allowed & (m == 0)
+        mask[-1, :] = False
+        return jnp.asarray(mask, dtype=jnp.float64)
+
+    def lam(allowed: np.ndarray) -> jax.Array:
+        mask = np.broadcast_to(allowed, shape).copy()
+        mask[0, :] = False
+        return jnp.asarray(mask, dtype=jnp.float64)
+
+    all_modes = np.ones(m.shape, dtype=bool)
+    z_cos = all_modes.copy() if not symmetric else np.zeros_like(all_modes)
+    # In the converged lconm1 branch force_Z_cc(m=1,n=0) is released.  The
+    # 3-D +/-n combinations are handled by the symmetric projector below;
+    # their individual support remains active.
+    if cfg.lconm1 and not symmetric:
+        z_cos &= ~((m == 1) & (n == 0))
+    asymmetric = nonconstant if not symmetric else np.zeros_like(all_modes)
+    return SpectralState(
+        R_cos=rz(all_modes),
+        R_sin=rz(asymmetric),
+        Z_cos=rz(z_cos),
+        Z_sin=rz(nonconstant),
+        L_cos=lam(asymmetric),
+        L_sin=lam(nonconstant),
+    )
+
+
 def _dof_projector(cfg: ImplicitConfig, dof_mask: SpectralState) -> Callable:
     """Symmetric idempotent projector onto the evolved-dof subspace.
 
@@ -1316,7 +1362,9 @@ def _refined_state(cfg: ImplicitConfig, params: ImplicitParams,
 # NOT on parameter values or ``ImplicitConfig`` object identity.  It must be
 # keyed by structural signature, not identity: ``make_config`` mints a fresh
 # ``eq=False`` object per call, so identity keying would recompute the
-# expensive mask (eager ``evaluate_forces`` x2 + VJP) on every ``im.run``.
+# mask on every ``im.run``.  Fixed-boundary support is now constructed
+# analytically; caching still avoids repeated device allocation and also
+# preserves the original cross-config contract.
 _MASK_CACHE: dict[tuple, SpectralState] = {}
 
 
@@ -1371,16 +1419,19 @@ def _host_solve_and_mask_impl(cfg: ImplicitConfig, params_np) -> tuple:
     # callback runs outside any trace): the jitted residual ``F`` later calls
     # ``runtime_from_params`` -> ``_template_runtime(cfg)`` under a jax.jit
     # trace, where the host-side ``run_setup`` cannot run, so the lru_cache
-    # must be filled by a concrete call first — even when the structural mask
-    # cache hits and skips the runtime rebuild below.
+    # must be filled by a concrete call first.  Prime the structural boundary
+    # tables for the same reason: letting the first residual trace populate
+    # their ordinary Python cache would leak tracers into later calls.
     _template_runtime(cfg)
+    _boundary_pack_tables(cfg)
     # Structural dof mask, shared across parameter values and config objects
-    # at one resolution — see _MASK_CACHE.
+    # at one resolution — see _MASK_CACHE.  Fixed-boundary support is an exact
+    # mode-table invariant, so do not pay for force evaluations and VJPs to
+    # rediscover it at first use.
     cache_key = _mask_cache_key(cfg)
     mask = _MASK_CACHE.get(cache_key)
     if mask is None:
-        rt = runtime_from_params(params, cfg)
-        mask = as_np(_dof_mask(result.state, rt, cfg))
+        mask = as_np(_fixed_boundary_dof_mask(cfg))
         _MASK_CACHE[cache_key] = mask
     # Anchor the state at the root of the residual the adjoint linearizes, so
     # every consumer — value, cotangent and linearization — reads the same
@@ -1874,6 +1925,8 @@ def _raw_block_system(
     """
     if not active_fields:
         raise ValueError("implicit response has no active state fields")
+    if int(probe_chunk_size) < 1:
+        raise ValueError("probe_chunk_size must be positive")
     ns = int(cfg.resolution.ns)
     mn = int(dof_mask.R_cos.shape[1])
     n_active = len(active_fields)
@@ -1952,8 +2005,17 @@ def _raw_block_system(
 
         # This local Jacobian is wide (block_size outputs, three block_size
         # inputs), so reverse mode needs one third as many linear sweeps as
-        # forward mode while retaining only a three-surface tape.
-        return jax.jacrev(row_residual)(zeros)
+        # forward mode while retaining only a three-surface tape.  Apply the
+        # output cotangent basis in bounded chunks: a bare jacrev vmaps all
+        # block_size rows and made the QA startup graph retain gigabytes of
+        # batched intermediates despite this otherwise-local construction.
+        _, pullback = jax.vjp(row_residual, zeros)
+        basis = jnp.eye(block_size, dtype=dtype)
+        return chunk_map(
+            lambda cotangent: pullback(cotangent)[0],
+            basis,
+            chunk_size=min(int(probe_chunk_size), block_size),
+        )
 
     # Rows 0 and 1 depend on VMEC's lambda-axis closure. All later rows share
     # one ordinary local kernel; lax.map keeps the compile graph bounded in ns.

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -2058,8 +2058,8 @@ def least_squares(
     solve per residual row.  ``"block"`` amortizes one block-tridiagonal
     factorization of the *raw* force Jacobian — whose radial coupling is
     exactly nearest-neighbor, so ns dense ``(3*mn, 3*mn)`` blocks assembled
-    by 3-colored ``jax.jvp`` probes capture it completely at a cost
-    independent of the dof count — then backsolves every dof right-hand side
+    by chunked three-surface VJPs capture it completely at a cost independent
+    of the dof count — then backsolves every dof right-hand side
     (:func:`solvax.block_thomas_factor` / :func:`solvax.block_thomas_solve`)
     and certifies each column with a warm-started GMRES pass against the
     preconditioned system (same ``adjoint_tol`` and configured iteration
@@ -2830,17 +2830,17 @@ def _least_squares_implicit(
     # *preconditioned* formulation is dense in radius because the 1D
     # preconditioner applies per-mode radial tridiagonal *solves*.  Both
     # share the fixed point, so dz_j = -(dF/dz)^{-1} dF/dp t_j is the same
-    # through either: assemble the raw blocks with 3-colored jvp probes
-    # (~3*(3*mn) linearizations, dof-count independent), factor once (solvax
+    # through either: assemble the raw blocks with chunked three-surface VJPs
+    # (~3*mn reverse linearizations, dof-count independent), factor once (solvax
     # block Thomas), backsolve every dof RHS, then one warm-started GMRES pass
     # per column certifies cfg.adjoint_tol (solvax checks the initial residual
     # first, so columns already at tolerance cost one matvec).
     active_fields = imp._active_state_fields(cfg)
     m_block = len(active_fields) * int(np.asarray(mask_np.R_cos).shape[1])
     if jac_chunk_size == "auto":
-        probe_chunk = _auto_jac_chunk(3 * m_block)
+        probe_chunk = _auto_jac_chunk(m_block)
     elif jac_chunk_size is None:
-        probe_chunk = 3 * m_block
+        probe_chunk = m_block
     else:
         probe_chunk = chunk
 


### PR DESCRIPTION
## Summary
- construct the fixed-boundary evolved-DOF mask analytically from exact mode-table invariants instead of rediscovering it with two force passes and reverse sweeps
- assemble raw radial blocks with bounded chunked VJPs, reducing first-use graph size and peak memory
- make `QA_optimization.py` a single max-mode scalar L-BFGS-B problem, using one reverse implicit solve for the exact scalarization of the existing weighted residual rows
- retain the optimized block least-squares lane for users who need pointwise Gauss-Newton residual geometry
- add a cache-disabled startup benchmark that measures distinct nearby decision vectors rather than identical-point memoization hits

## Corrected Apple M4 evidence
All records use 48 boundary DOFs, `max_mode=3`, JAX x64, and the persistent compilation cache disabled.

| lane | cold startup | peak RSS | warm distinct value+gradient |
|---|---:|---:|---:|
| `main` least-squares | 55.93 s | 3705.6 MiB | 15.02 s (one point) |
| branch least-squares | 44.73 s | 2965.1 MiB | 16.57 s (median of 3) |
| branch scalar example | 32.21 s | 2574.0 MiB | 17.38 s (median of 3) |

The scalar and least-squares initial costs agree to `2.8e-8` absolute and their gradient norms to about `2.4e-8` relative. The warm points are deterministic steps of `1e-5 * problem.scales`; they bypass `FunctionProblem`'s identical-vector memoization.

Artifacts:
- `benchmarks/qa_optimization_startup_main_m4.json`
- `benchmarks/qa_optimization_startup_least_squares_m4.json`
- `benchmarks/qa_optimization_startup_scalar_m4.json`

## Verification
- Ruff and benchmark JSON validation pass
- fixed-boundary analytic mask is tested against the independent numerical structural oracle
- chunked block assembly is tested against the dense reference and validates invalid chunk sizes
- scalar objective/gradient is tested against the least-squares scalarization
- the full QA example gate completed and required a strict optimizer cost decrease (`1 passed, 2 skipped` in 164.86 s on the earlier standalone commit)

## Claim boundary
This PR targets startup latency and memory. It does not claim that a scalar quasi-Newton step is faster than a block Gauss-Newton step: the corrected distinct-point measurements are comparable (17.38 s versus 16.57 s). The example chooses the scalar lane for its 12.5 s faster cold startup and roughly 391 MiB lower peak RSS; the pointwise least-squares API remains available and is also substantially cheaper to construct than on `main`.
