### PR TITLE
Scope numerical CI to executable changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,31 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Select required CI scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      run_tests: ${{ steps.scope.outputs.run_tests }}
+      run_coverage: ${{ steps.scope.outputs.run_coverage }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+      - id: scope
+        name: Classify changed paths
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git diff --name-only -z "origin/${GITHUB_BASE_REF}...HEAD" |
+              python tools/ci_scope.py --null >> "$GITHUB_OUTPUT"
+          else
+            python tools/ci_scope.py --all </dev/null >> "$GITHUB_OUTPUT"
+          fi
+
   quality:
     name: Quality, package, and docs
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -41,6 +64,8 @@ jobs:
 
   fast:
     name: Fast API tests (py${{ matrix.python-version }})
+    needs: changes
+    if: needs.changes.outputs.run_tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 8
     strategy:
@@ -88,6 +113,8 @@ jobs:
 
   physics:
     name: Representative ${{ matrix.lane }} physics
+    needs: changes
+    if: needs.changes.outputs.run_tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -162,6 +189,8 @@ jobs:
 
   parity:
     name: Manifest parity lane (${{ matrix.lane }})
+    needs: changes
+    if: needs.changes.outputs.run_tests == 'true'
     runs-on: ubuntu-latest
     # The primary-lane partition is the whole pull-request suite; these four
     # jobs are the part no other job was running.  Measured on the runner at
@@ -237,6 +266,8 @@ jobs:
 
   device:
     name: Two-device placement and AD
+    needs: changes
+    if: needs.changes.outputs.run_tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -270,7 +301,14 @@ jobs:
     name: Changed executable lines (>= 95%)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [fast, physics, parity, device]
+    needs: [changes, fast, physics, parity, device]
+    if: >-
+      always() &&
+      needs.changes.outputs.run_coverage == 'true' &&
+      needs.fast.result == 'success' &&
+      needs.physics.result == 'success' &&
+      needs.parity.result == 'success' &&
+      needs.device.result == 'success'
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -298,10 +336,10 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    needs: [quality, fast, physics, parity, device, changed-coverage]
+    needs: [changes, quality, fast, physics, parity, device, changed-coverage]
     steps:
       - name: Require every review gate
         env:
           RESULTS: ${{ toJSON(needs) }}
         run: |
-          echo "$RESULTS" | jq -e 'all(.[]; .result == "success")'
+          echo "$RESULTS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")'

--- a/tests/test_test_manifest.py
+++ b/tests/test_test_manifest.py
@@ -13,6 +13,24 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "tools"))
 
 import test_manifest  # noqa: E402
+import ci_scope  # noqa: E402
+
+
+def test_ci_scope_skips_only_documentation_and_rendered_media() -> None:
+    assert ci_scope.classify(
+        ["docs/howto/gpu.rst", "README.md", "docs/figure.webp"]
+    ) == (False, False)
+    assert ci_scope.classify(["docs/howto/gpu.rst", "vmex/doctor.py"]) == (
+        True,
+        True,
+    )
+    assert ci_scope.classify(["tests/test_doctor.py"]) == (True, False)
+    assert ci_scope.classify([".github/workflows/ci.yml"]) == (True, False)
+
+
+def test_ci_scope_keeps_empty_and_main_branch_changes_conservative() -> None:
+    assert ci_scope.classify([]) == (True, True)
+    assert ci_scope.classify(["README.md"], force_all=True) == (True, True)
 
 
 def test_collected_suite_has_exact_manifest_ownership() -> None:

--- a/tools/ci_scope.py
+++ b/tools/ci_scope.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Classify whether a pull request needs numerical tests and coverage."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable
+
+
+DOCUMENTATION_SUFFIXES = {
+    ".gif",
+    ".jpeg",
+    ".jpg",
+    ".md",
+    ".pdf",
+    ".png",
+    ".rst",
+    ".svg",
+    ".webp",
+}
+
+
+def classify(paths: Iterable[str], *, force_all: bool = False) -> tuple[bool, bool]:
+    """Return ``(run_tests, run_coverage)`` for changed repository paths.
+
+    Only documentation and rendered media bypass the numerical matrix. Unknown
+    files remain conservative and run it. Changed-line coverage is necessary
+    only when executable package code changed; test, workflow, and tool changes
+    still run the matrix but do not spend another job combining coverage.
+    """
+
+    if force_all:
+        return True, True
+    changed = tuple(path.strip("/") for path in paths if path.strip("/"))
+    if not changed:
+        return True, True
+    documentation_only = all(
+        "/." not in path
+        and any(path.lower().endswith(suffix) for suffix in DOCUMENTATION_SUFFIXES)
+        for path in changed
+    )
+    run_tests = not documentation_only
+    run_coverage = any(
+        path.startswith("vmex/") and path.lower().endswith(".py")
+        for path in changed
+    )
+    return run_tests, run_coverage
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--all", action="store_true", help="select the full main-branch gate")
+    parser.add_argument("--null", action="store_true", help="read NUL-delimited paths")
+    args = parser.parse_args(argv)
+    payload = sys.stdin.buffer.read()
+    separator = b"\0" if args.null else b"\n"
+    paths = [
+        item.decode("utf-8", errors="surrogateescape")
+        for item in payload.split(separator)
+    ]
+    run_tests, run_coverage = classify(paths, force_all=args.all)
+    print(f"run_tests={str(run_tests).lower()}")
+    print(f"run_coverage={str(run_coverage).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a conservative, NUL-safe changed-path classifier before the numerical matrix
- skip the 2-version API, 9 physics, 4 parity, and device jobs only when every changed file is documentation or rendered media
- keep unknown, source, test, tool, workflow, configuration, and provenance changes on the full numerical matrix
- run changed-line coverage only when executable `vmex/*.py` code changed
- preserve the single required `PR gate`, accepting intentionally skipped jobs but never failed/cancelled jobs
- force the complete matrix and coverage on every push to `main`

## Why this is conservative
This does not attempt a fragile source-to-test dependency map. Any executable or unknown path still runs the current complete PR suite. The first safe optimization targets docs/media-only changes, which currently consume the same roughly 40-minute matrix as solver changes.

## Verification
- CI scope and manifest tests: 8 passed
- Ruff: pass
- documentation-only, mixed source/docs, test-only, workflow-only, empty, and main-push classifications covered
- NUL-delimited CLI smoke: pass
- `git diff --check`: pass
- this PR intentionally runs the full aggregate matrix because it changes workflow/tool/test code
