### PR TITLE
Weight strong roots by coordinate volume

### DIFF
--- a/benchmarks/strong_root_m6_volume_weighted_m4.json
+++ b/benchmarks/strong_root_m6_volume_weighted_m4.json
@@ -1,0 +1,56 @@
+{
+  "case": "solovev",
+  "cold_jvp_seconds": 0.9538727920007659,
+  "cold_residual_seconds": 0.37170395900466247,
+  "compilation_cache": "default",
+  "condition_number": 8828386081.32041,
+  "coordinate_scale_range": [
+    7.797769613049024e-07,
+    0.009102074687804574
+  ],
+  "degree": 5,
+  "equation_scale_range": [
+    3.847172085464133e-06,
+    2675.7953759327415
+  ],
+  "free_dofs": 117,
+  "initial_low_residual_norm": 7.387614345725676e-13,
+  "initial_scaled_residual_norm": 8.982800554888583e-08,
+  "input_data_embedded": false,
+  "jvp_peak_rss_increase_mib": 170.453125,
+  "jvp_relative_error": 5.803914906696761e-09,
+  "largest_singular_value": 9.303057871762458e-10,
+  "measurement_commit": "504073e49a6d9dbe91d1874daea03627717f230a",
+  "measurement_dirty": false,
+  "mpol": 6,
+  "ns": 11,
+  "operator_balance": 120415161.84510404,
+  "platform": "macOS-26.6.2-arm64-arm-64bit",
+  "rank": 113,
+  "rank_seconds": 1.8418251249968307,
+  "repeats": 3,
+  "residual_peak_rss_increase_mib": 0.0,
+  "runtime_build_seconds": 14.519875291996868,
+  "runtime_peak_rss_increase_mib": 866.921875,
+  "smallest_singular_value": 1.0537665419330025e-19,
+  "solve_grid": [
+    24,
+    13,
+    3
+  ],
+  "strong_block_sign": [
+    -1.0,
+    -1.0,
+    1.0
+  ],
+  "versions": {
+    "jax": "0.11.1",
+    "jaxlib": "0.11.1",
+    "numpy": "2.5.2",
+    "python": "3.12.13",
+    "vmex": "0.7.0"
+  },
+  "vmex_module": "vmex/__init__.py",
+  "warm_jvp_median_seconds": 0.004600457999913488,
+  "warm_residual_median_seconds": 0.003012541994394269
+}

--- a/docs/explanation/high-order-force-balance.rst
+++ b/docs/explanation/high-order-force-balance.rst
@@ -103,7 +103,12 @@ vector is therefore
        \in \mathbb{R}^{N_R+N_Z+N_\lambda}.
 
 At shifted radial collocation points, the independent oracle forms signed
-physical radial and helical force densities.  Their symmetric normalization
+physical radial and helical force densities.  Following DESC's force-balance
+objective, both root channels include the coordinate-volume factor
+``abs(sqrt(g))`` before Fourier projection.  This leaves the off-axis physical
+zero set unchanged and gives the projected equations the regular near-axis
+measure; it is part of the residual definition rather than a post-fit row
+scale.  Their symmetric normalization
 uses smooth ``sqrt(|v|^2 + force_floor^2)`` norms, so the root is differentiable
 even when one physical contribution vanishes.  The normalization scale is
 frozen from the lifted branch root for the solve, so it conditions but cannot

--- a/docs/explanation/high-order-force-balance.rst
+++ b/docs/explanation/high-order-force-balance.rst
@@ -179,6 +179,17 @@ runtime construction from 56.1 s to 98.7 s and warm residual/JVP cost from
 production endpoint claim: five numerical directions and the added cold cost
 remain acceptance gates.
 
+The follow-up coordinate-volume formulation applies ``abs(sqrt(g))`` to both
+physical channels before projection, matching DESC's force objective while
+preserving the off-axis zero set.  The clean-commit Apple M4 record
+``benchmarks/strong_root_m6_volume_weighted_m4.json`` improves the same
+diagnostic to rank 113/117 and condition number ``8.83e9``.  Median warm
+residual/JVP costs are 3.01/4.60 ms, while runtime construction still peaks at
+867 MiB.  Weighting only one physical channel was measured and rejected because
+it severely imbalances the singular spectrum.  Four directions and the large
+construction-memory cost remain open; this result is conditioning evidence,
+not an alpha-one convergence claim.
+
 Low-order physics preconditioner
 --------------------------------
 

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -746,6 +746,41 @@ def test_polish_driver_records_bounded_unpolished_return(
         del args, kwargs
         raise StrongForceContinuationError("test tangent failure")
 
+    def endpoint(residual, initial, **kwargs):
+        del residual, kwargs
+        return SimpleNamespace(
+            x=initial,
+            steps=2,
+            linear_iterations=3,
+            residual_evaluations=4,
+            converged=True,
+            linear_converged=True,
+        )
+
+    def continuation(residual, initial, *, accept_stage, **kwargs):
+        del residual, kwargs
+        alpha = 1.0e-3
+        accept_stage(initial, alpha, None)
+        stage = SimpleNamespace(
+            nonlinear_steps=5,
+            linear_iterations=6,
+            residual_evaluations=7,
+            accepted=True,
+        )
+        return SimpleNamespace(
+            x=initial,
+            alpha=alpha,
+            steps=(stage,),
+            converged=False,
+        )
+
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._solvax_continuation_api",
+        lambda: (lambda **kwargs: object(), None, continuation, None, endpoint),
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._ptc_config", lambda config, **kwargs: object()
+    )
     monkeypatch.setattr(
         "vmex.core.polish_driver._arclength_to_target", fail_tangent
     )

--- a/vmex/core/polish.py
+++ b/vmex/core/polish.py
@@ -685,8 +685,17 @@ def _strong_residual_unscaled(
     rr, tt, zz = jnp.meshgrid(radial, theta, zeta, indexing="ij")
     samples = evaluate_strong_force(state, rr, tt, zz)
     denominator = jnp.asarray(runtime.normalization_denominator)
-    radial_force = 2.0 * samples.signed_radial_force_density / denominator
-    helical_force = 2.0 * samples.signed_helical_force_density / denominator
+    # DESC's two-component force objective uses the coordinate-volume factor
+    # on both physical channels.  This preserves the off-axis zero set while
+    # giving the projected equations their regular near-axis measure.  Apply
+    # it before Fourier/radial fitting; post-fit row scaling is not equivalent.
+    volume_weight = jnp.abs(samples.sqrt_g)
+    radial_force = (
+        2.0 * samples.signed_radial_force_density * volume_weight / denominator
+    )
+    helical_force = (
+        2.0 * samples.signed_helical_force_density * volume_weight / denominator
+    )
     points = jnp.stack((rr.reshape(-1), tt.reshape(-1), zz.reshape(-1)), axis=-1)
 
     def coordinate_gauge(point):


### PR DESCRIPTION
## Summary

- multiply both independent physical strong-force channels by `abs(sqrt(g))` before Fourier/radial projection, matching the DESC force objective
- preserve the off-axis zero set and leave the coordinate-gauge channel unchanged
- commit clean production-size conditioning, timing, and peak-memory evidence

## Measured production diagnostic

At `ns=11`, `mpol=6`, degree 5, 117 free coordinates on Apple M4:

- numerical rank at relative tolerance `1e-8`: 112 -> 113
- condition estimate: `8.07e10` -> `8.83e9`
- median warm residual/JVP: `3.01/4.60 ms`
- JVP finite-difference relative error: `5.80e-9`
- runtime-build peak RSS increase: `867 MiB`

Weighting only one force channel was rejected because it badly imbalances the singular spectrum. Adding tested spectral-condensation gauge weights raises rank to 114 but worsens the best condition estimate to `1.43e10`; those weights are diagnostic only.

## Production continuation result

The dependent startup fix in #181 removes 80 nonlinear / 1423 linear iterations spent chasing a `7.39e-13` alpha=0 remainder below an artificial `~9e-16` floor. The corrected run reached pseudo-arclength, but cold compilation exceeded 6.5 minutes and about 3.3 GiB RSS before the first bordered corrector completed. The run was stopped at the explicit performance gate.

This means the volume-weighted formulation improves the local spectrum but currently fails the cold-runtime gate; it is not a merge candidate. SOLVAX#94 and VMEX #181 remove repeated branch-data recompilation before the production continuation is reconsidered.

## Verification

- `tests/test_polish_preconditioner.py`: 41 passed on the stacked startup head
- `tests/test_performance_docs.py`: 7 passed
- Ruff, docs prose/media, JSON parse, and `git diff --check`: pass
- clean-commit benchmark: `benchmarks/strong_root_m6_volume_weighted_m4.json`

## Claim boundary

This is conditioning evidence, not an alpha=1 solution. Rank is still 113/117. The weakest right direction is dominated by axisymmetric `L_sin(m=1)`; the next three by `R_cos(m=0)`, with all four left vectors dominated by the highest retained `m=5` coordinate-gauge equations. The remaining defect is mixed physical/gauge coupling. The public polish/implicit APIs stay draft until the independent certificate and runtime gates pass. Full hosted CI is intentionally deferred while this remains an experiment.