### PR TITLE
Reuse branch-connected polish startup work

### DIFF
--- a/docs/explanation/high-order-force-balance.rst
+++ b/docs/explanation/high-order-force-balance.rst
@@ -217,8 +217,12 @@ bounded number of JVP/low-inverse applications; it is stored as
 Branch-preserving driver
 ------------------------
 
-The fixed-boundary host driver first solves the ``alpha=0`` legacy consistency
-endpoint, then calls SOLVAX adaptive continuation with state-dependent JVPs,
+The fixed-boundary host driver first verifies the ``alpha=0`` legacy
+consistency endpoint before row equilibration.  Because that endpoint
+subtracts the stored legacy defect, the zero correction is its mathematical
+root; accepting its roundoff-level remainder avoids an unnecessary nonlinear
+solve below floating-point noise.  A genuinely inconsistent endpoint still
+uses PTC.  The driver then calls SOLVAX adaptive continuation with state-dependent JVPs,
 Eisenstat--Walker forcing, and stored bounded mode-block factors.  The measured
 initial pseudo-time scale is large because the legacy endpoint has already
 been row equilibrated; ``dtau=1e6`` reaches the Newton regime on the structural
@@ -234,7 +238,9 @@ If ordinary parameter continuation exhausts its minimum step, the driver can
 form a matrix-free branch tangent and invoke SOLVAX's bordered
 pseudo-arclength corrector.  Its block-elimination preconditioner reuses the
 same Fourier-band factors and an explicit scalar Schur complement; no
-production-scale dense high-order Jacobian is formed.  A compact report
+production-scale dense high-order Jacobian is formed.  Tangents and predictors
+are dynamic arguments to one compiled bordered solve, so branch steps do not
+create fresh tangent-capturing JAX callables.  A compact report
 retains accepted/rejected stages, nonlinear and linear work, residual
 evaluations, arclength work, minimum Jacobian margin, factor time, and wall
 time.  Failure to reach

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -39,6 +39,7 @@ from vmex.core.polish_driver import (
     _build_mode_block_preconditioner,
     _continuation_precondition,
     _low_inverse,
+    _normalized_low_residual_norm,
     _ptc_config,
     _residual_evaluations,
     _supports_keyword,
@@ -111,10 +112,14 @@ def test_arclength_crossing_runs_target_correction_and_counts_work(monkeypatch):
         predictor,
         config,
         admissible,
-        precond,
+        parameterized_precond,
     ):
-        del residual, initial, tangent, config, precond
+        del residual, initial, config
         assert bool(admissible(*predictor))
+        np.testing.assert_array_equal(
+            parameterized_precond(predictor, predictor, 1.0, tangent, predictor)[0],
+            predictor[0],
+        )
         return SimpleNamespace(
             x=predictor,
             steps=2,
@@ -149,8 +154,8 @@ def test_arclength_crossing_runs_target_correction_and_counts_work(monkeypatch):
         lambda *args, **kwargs: (jnp.zeros_like(zero), jnp.asarray(1.0)),
     )
     monkeypatch.setattr(
-        "vmex.core.polish_driver._bordered_preconditioner",
-        lambda *args, **kwargs: lambda state, rhs, dtau: rhs,
+        "vmex.core.polish_driver._apply_bordered_preconditioner",
+        lambda state, rhs, dtau, tangent, runtime, block: rhs,
     )
     monkeypatch.setattr(
         "vmex.core.polish_driver._low_inverse", lambda rhs, runtime: rhs
@@ -813,6 +818,29 @@ def test_polish_ptc_stopping_is_invariant_to_positive_residual_scaling():
     assert config.rtol == tolerance
     assert config.atol == pytest.approx(tolerance * 3.0e-4)
     assert rescaled.atol == pytest.approx(7.0 * config.atol)
+
+
+def test_low_endpoint_check_ignores_numerical_row_equilibration():
+    residual = jnp.asarray([2.0e-9, -6.0e-9])
+    runtime = SimpleNamespace(
+        equation_scale=jnp.asarray([2.0, 3.0]),
+        layout=SimpleNamespace(size=2),
+    )
+    rescaled_runtime = SimpleNamespace(
+        equation_scale=7.0 * runtime.equation_scale,
+        layout=runtime.layout,
+    )
+    expected = jnp.linalg.norm(residual / runtime.equation_scale) / jnp.sqrt(2.0)
+    np.testing.assert_allclose(
+        _normalized_low_residual_norm(residual, runtime),
+        expected,
+        rtol=2.0e-13,
+    )
+    np.testing.assert_allclose(
+        _normalized_low_residual_norm(7.0 * residual, rescaled_runtime),
+        expected,
+        rtol=2.0e-13,
+    )
 
 
 def test_public_solver_rejects_unknown_polish_mode_before_solving():

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -246,6 +246,16 @@ def _low_inverse(rhs: jax.Array, runtime: StrongRootRuntime) -> jax.Array:
     )
 
 
+def _normalized_low_residual_norm(
+    residual: jax.Array,
+    runtime: StrongRootRuntime,
+) -> jax.Array:
+    """Return the low-endpoint RMS before numerical row equilibration."""
+
+    unscaled = jnp.asarray(residual) / jnp.asarray(runtime.equation_scale)
+    return jnp.linalg.norm(unscaled) / np.sqrt(float(runtime.layout.size))
+
+
 def _ptc_config(config: PolishConfig, *, residual_scale: float) -> Any:
     _, PseudoTransientConfig, _, _, _ = _solvax_continuation_api()
     return PseudoTransientConfig(
@@ -359,34 +369,53 @@ def _bordered_preconditioner(
 ):
     """Return a low-order block-elimination preconditioner for a bordered root."""
 
-    tangent_x, tangent_alpha = tangent
-
     def apply(state, rhs, dtau):
-        vector, alpha = state
-        rhs_x, rhs_alpha = rhs
-        parameter_direction = strong_root_residual(
-            vector, runtime, 1.0
-        ) - strong_root_residual(vector, runtime, 0.0)
-        inverse = (
-            (lambda rhs: _low_inverse(rhs, runtime))
-            if block_preconditioner is None
-            else lambda rhs: block_preconditioner.apply(rhs, alpha, dtau)
+        return _apply_bordered_preconditioner(
+            state,
+            rhs,
+            dtau,
+            tangent,
+            runtime,
+            block_preconditioner,
         )
-        q_rhs = inverse(rhs_x)
-        q_parameter = inverse(parameter_direction)
-        schur = tangent_alpha - jnp.vdot(tangent_x, q_parameter).real
-        tiny = jnp.sqrt(jnp.finfo(jnp.asarray(schur).dtype).eps)
-        safe_schur = jnp.where(
-            jnp.abs(schur) > tiny,
-            schur,
-            jnp.where(schur < 0.0, -tiny, tiny),
-        )
-        delta_alpha = (
-            rhs_alpha - jnp.vdot(tangent_x, q_rhs).real
-        ) / safe_schur
-        return q_rhs - q_parameter * delta_alpha, delta_alpha
 
     return apply
+
+
+def _apply_bordered_preconditioner(
+    state,
+    rhs,
+    dtau,
+    tangent,
+    runtime: StrongRootRuntime,
+    block_preconditioner: StrongModeBlockPreconditioner | None = None,
+):
+    """Apply bordered block elimination with dynamic branch data."""
+
+    vector, alpha = state
+    rhs_x, rhs_alpha = rhs
+    tangent_x, tangent_alpha = tangent
+    parameter_direction = strong_root_residual(
+        vector, runtime, 1.0
+    ) - strong_root_residual(vector, runtime, 0.0)
+    inverse = (
+        (lambda value: _low_inverse(value, runtime))
+        if block_preconditioner is None
+        else lambda value: block_preconditioner.apply(value, alpha, dtau)
+    )
+    q_rhs = inverse(rhs_x)
+    q_parameter = inverse(parameter_direction)
+    schur = tangent_alpha - jnp.vdot(tangent_x, q_parameter).real
+    tiny = jnp.sqrt(jnp.finfo(jnp.asarray(schur).dtype).eps)
+    safe_schur = jnp.where(
+        jnp.abs(schur) > tiny,
+        schur,
+        jnp.where(schur < 0.0, -tiny, tiny),
+    )
+    delta_alpha = (
+        rhs_alpha - jnp.vdot(tangent_x, q_rhs).real
+    ) / safe_schur
+    return q_rhs - q_parameter * delta_alpha, delta_alpha
 
 
 def _arclength_to_target(
@@ -411,29 +440,48 @@ def _arclength_to_target(
     )
     nonlinear = _ptc_config(config, residual_scale=residual_scale)
     total_nonlinear = total_linear = total_evaluations = 0
+    arclength_residual = lambda value, parameter: strong_root_residual(  # noqa: E731
+        value, runtime, parameter
+    )
+    arclength_admissible = lambda value, parameter: admissible(  # noqa: E731
+        value, parameter
+    )
+    parameterized_precondition = (  # noqa: E731
+        lambda state, rhs, dtau, branch_tangent, predictor: (
+            _apply_bordered_preconditioner(
+                state,
+                rhs,
+                dtau,
+                branch_tangent,
+                runtime,
+                block_preconditioner,
+            )
+        )
+    )
     for step in range(config.max_arclength_steps):
         predictor = (
             vector + config.arclength_step * tangent[0],
             jnp.asarray(alpha) + config.arclength_step * tangent[1],
         )
-        corrector_kwargs = (
-            {
+        if _supports_keyword(pseudo_arclength_corrector, "parameterized_precond"):
+            corrector_kwargs = {
+                "parameterized_precond": parameterized_precondition
+            }
+        elif _supports_keyword(pseudo_arclength_corrector, "precond"):
+            corrector_kwargs = {
                 "precond": _bordered_preconditioner(
                     runtime, tangent, block_preconditioner
                 )
             }
-            if _supports_keyword(pseudo_arclength_corrector, "precond")
-            else {}
-        )
+        else:
+            corrector_kwargs = {}
         corrected = pseudo_arclength_corrector(
-            lambda value, parameter: strong_root_residual(
-                value, runtime, parameter
-            ),
+            arclength_residual,
             predictor,
             tangent=tangent,
             predictor=predictor,
             config=nonlinear,
-            admissible=lambda value, parameter: admissible(value, parameter),
+            admissible=arclength_admissible,
             **corrector_kwargs,
         )
         total_nonlinear += int(corrected.steps)
@@ -554,21 +602,37 @@ def polish_strong_root(
     )
     nonlinear = _ptc_config(config, residual_scale=residual_scale)
     precondition = lambda state, rhs, dtau: _low_inverse(rhs, runtime)  # noqa: E731
-    endpoint = pseudo_transient_continuation(
-        lambda vector: strong_root_residual(vector, runtime, 0.0),
-        zero,
-        precond=precondition,
-        admissible=lambda vector: admissible(vector, 0.0),
-        config=nonlinear,
-    )
-    nonlinear_iterations = int(endpoint.steps)
-    linear_iterations = int(endpoint.linear_iterations)
-    residual_evaluations = _residual_evaluations(endpoint)
+    # The low homotopy endpoint subtracts the stored legacy defect, so zero is
+    # its mathematical root.  Roundoff from restrict/project/prolong may leave
+    # a tiny row-equilibrated remainder.  Check that remainder before row
+    # scaling and avoid asking PTC to reduce it below floating-point noise.
+    # A genuinely inconsistent endpoint still takes the globalized solve.
+    endpoint_residual = strong_root_residual(zero, runtime, 0.0)
+    endpoint_solved = float(
+        _normalized_low_residual_norm(endpoint_residual, runtime)
+    ) <= config.tolerance
+    if endpoint_solved:
+        vector = zero
+        nonlinear_iterations = 0
+        linear_iterations = 0
+        residual_evaluations = 1
+        converged = True
+    else:
+        endpoint = pseudo_transient_continuation(
+            lambda vector: strong_root_residual(vector, runtime, 0.0),
+            zero,
+            precond=precondition,
+            admissible=lambda vector: admissible(vector, 0.0),
+            config=nonlinear,
+        )
+        vector = endpoint.x
+        nonlinear_iterations = int(endpoint.steps)
+        linear_iterations = int(endpoint.linear_iterations)
+        residual_evaluations = 1 + _residual_evaluations(endpoint)
+        converged = bool(endpoint.converged) and bool(endpoint.linear_converged)
     steps: tuple[Any, ...] = ()
     arclength_steps = 0
-    vector = endpoint.x
     alpha = 0.0
-    converged = bool(endpoint.converged) and bool(endpoint.linear_converged)
     reason = "alpha-zero-failed"
     if converged:
         accepted_states: list[tuple[jax.Array, float]] = [(vector, 0.0)]


### PR DESCRIPTION
## Summary

- accept the mathematically solved alpha=0 endpoint from its pre-equilibration RMS instead of driving roundoff through PTC
- pass tangent and predictor dynamically to one reusable SOLVAX bordered corrector
- retain the old PTC fallback for a genuinely inconsistent low endpoint and compatibility with older SOLVAX call shapes

## Production diagnosis

At `ns=11`, `mpol=6`, degree 5, the low endpoint residual was `7.39e-13`, but the old operator-balance floor demanded about `9e-16`. Both legacy and mode-block paths spent 80 nonlinear / 1423 linear iterations and failed at alpha=0.

After bypassing that roundoff chase, the volume-weighted diagnostic reached arclength, but cold compilation exceeded 6.5 minutes and about 3.3 GiB RSS. The dependent SOLVAX PR #94 makes branch data dynamic so later correctors reuse one compiled executable. Its scalar gate measured 0.278 s cold and 0.00012 s for a second corrector with different branch data; this is mechanism evidence, not an end-to-end VMEX speedup claim.

## Verification

- `tests/test_polish_preconditioner.py`: 41 passed in 143.67 s
- Ruff and `git diff --check`: pass
- normalized endpoint rescaling regression: pass
- parameterized bordered-preconditioner path: pass

## Dependencies and claim boundary

- stacked on draft #178
- repeated-compile path requires uwplasma/SOLVAX#94
- remains draft until the production alpha=1 certificate and runtime gate pass