### PR TITLE
Use physical force equations in gauge-free chart

### DIFF
--- a/benchmarks/strong_root_m6_physical_equations_m4.json
+++ b/benchmarks/strong_root_m6_physical_equations_m4.json
@@ -1,0 +1,69 @@
+{
+  "case": "solovev",
+  "cold_jvp_seconds": 2.7183557499956805,
+  "cold_residual_seconds": 1.7298190419969615,
+  "compilation_cache": "disabled",
+  "condition_number": 4871246.047640218,
+  "coordinate_scale_range": [
+    4.061863631513496e-05,
+    0.007934178826405819
+  ],
+  "degree": 5,
+  "equation_scale_range": [
+    7.266217182431619e-05,
+    1400.3026537345252
+  ],
+  "free_dofs": 117,
+  "initial_low_residual_norm": 1.4972216879705128e-12,
+  "initial_scaled_residual_norm": 1.2195492304733608e-08,
+  "input_data_embedded": false,
+  "jvp_peak_rss_increase_mib": 110.59375,
+  "jvp_relative_error": 9.535997508907029e-09,
+  "largest_singular_value": 1.1948999366025793e-08,
+  "measurement_commit": "45d81a9d05749106bc469e87a2d7ef4b5b8eb991",
+  "measurement_dirty": false,
+  "mpol": 6,
+  "ns": 11,
+  "operator_balance": 886938678.3339187,
+  "physical_chart": {
+    "chart_build_seconds": 3.055037165999238,
+    "chart_peak_rss_increase_mib": 156.75,
+    "cold_residual_seconds": 2.171842541996739,
+    "condition_number": 4308253.401224336,
+    "free_dofs": 82,
+    "gauge_rank": 35,
+    "largest_singular_value": 1.0626615563390728e-08,
+    "rank": 82,
+    "rank_seconds": 5.075352583997301,
+    "smallest_singular_value": 2.466571618180773e-15,
+    "warm_residual_median_seconds": 0.00615250000191736
+  },
+  "platform": "macOS-26.6.2-arm64-arm-64bit-Mach-O",
+  "rank": 117,
+  "rank_seconds": 4.778523792003398,
+  "repeats": 20,
+  "residual_peak_rss_increase_mib": 47.953125,
+  "runtime_build_seconds": 25.84157525000046,
+  "runtime_peak_rss_increase_mib": 1381.421875,
+  "smallest_singular_value": 2.4529656784251856e-15,
+  "solve_grid": [
+    24,
+    25,
+    3
+  ],
+  "strong_block_sign": [
+    -1.0,
+    1.0,
+    1.0
+  ],
+  "versions": {
+    "jax": "0.11.0",
+    "jaxlib": "0.11.0",
+    "numpy": "2.5.1",
+    "python": "3.13.7",
+    "vmex": "0.7.0"
+  },
+  "vmex_module": "vmex/__init__.py",
+  "warm_jvp_median_seconds": 0.00999893700281973,
+  "warm_residual_median_seconds": 0.005976041498797713
+}

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -28,6 +28,7 @@ from vmex.core.polish import (
     make_strong_root_runtime,
     preconditioner_quality,
     preconditioner_refresh_decision,
+    _strong_residual_unscaled,
     _streaming_ruiz_scales,
     strong_physical_residual,
     strong_root_rank,
@@ -579,6 +580,24 @@ def test_physical_chart_eliminates_only_the_linear_coordinate_gauge(
 
     zero = jnp.zeros((chart.size,), dtype=jnp.float64)
     np.testing.assert_array_equal(strong_physical_residual(zero, runtime, chart, 0.0), 0.0)
+    probe = jnp.linspace(-0.01, 0.015, chart.size)
+    full_probe = chart.lift(probe)
+    low_probe = chart.project(strong_root_residual(full_probe, runtime, 0.0))
+    strong_probe = chart.project(
+        _strong_residual_unscaled(
+            full_probe,
+            runtime,
+            include_coordinate_gauge=False,
+        )
+        / runtime.strong_scale
+    )
+    alpha = 0.37
+    np.testing.assert_allclose(
+        strong_physical_residual(probe, runtime, chart, alpha),
+        low_probe + alpha * (strong_probe - low_probe),
+        rtol=2.0e-13,
+        atol=2.0e-13,
+    )
     direction = jnp.linspace(-0.2, 0.3, chart.size)
     _, tangent = jax.jvp(
         lambda value: strong_physical_residual(value, runtime, chart, 1.0),

--- a/vmex/core/polish.py
+++ b/vmex/core/polish.py
@@ -349,10 +349,10 @@ class StrongPhysicalChart:
     """Gauge-free coordinates and equations for the strong-force root.
 
     ``coordinate_basis`` spans the nullspace of the exactly linear tangential
-    coordinate equation.  ``equation_basis`` spans the orthogonal complement
-    of that equation's image.  Both bases are built from the gauge operator
-    alone; constructing this chart never probes or stores the physical-force
-    Jacobian.
+    coordinate equation.  ``equation_basis`` spans the actual radial/helical
+    force-output channels in the constrained layout.  The equation basis is
+    assembled from small structural layout blocks; constructing this chart
+    never probes or stores the physical-force Jacobian.
     """
 
     coordinate_basis: Array
@@ -798,6 +798,8 @@ def _strong_residual_unscaled(
     vector: Array,
     runtime: StrongRootRuntime,
     native: HighOrderEquilibriumState | None = None,
+    *,
+    include_coordinate_gauge: bool = True,
 ) -> Array:
     """Project normalized physical force onto the reduced solve space."""
 
@@ -825,24 +827,29 @@ def _strong_residual_unscaled(
     helical_force = (
         2.0 * samples.signed_helical_force_density * volume_weight / denominator
     )
-    points = jnp.stack((rr.reshape(-1), tt.reshape(-1), zz.reshape(-1)), axis=-1)
-
-    gauge = _coordinate_gauge_samples(state, native, runtime, points)
     radial_coefficients = _fit_regularized_channel(
         radial_force, runtime.cosine_projection, radial, runtime
     )
     helical_coefficients = _fit_regularized_channel(
         helical_force, runtime.sine_projection, radial, runtime
     )
-    gauge_coefficients = _fit_regularized_channel(
-        gauge, runtime.sine_projection, radial, runtime
-    )
     zero = jnp.zeros_like(jnp.asarray(runtime.native.R_cos))
+    if include_coordinate_gauge:
+        points = jnp.stack(
+            (rr.reshape(-1), tt.reshape(-1), zz.reshape(-1)),
+            axis=-1,
+        )
+        gauge = _coordinate_gauge_samples(state, native, runtime, points)
+        gauge_coefficients = _fit_regularized_channel(
+            gauge, runtime.sine_projection, radial, runtime
+        ).T
+    else:
+        gauge_coefficients = zero
     force_coefficients = HighOrderCorrection(
         R_cos=radial_coefficients.T,
         R_sin=zero,
         Z_cos=zero,
-        Z_sin=gauge_coefficients.T,
+        Z_sin=gauge_coefficients,
         L_cos=zero,
         L_sin=helical_coefficients.T,
     )
@@ -900,6 +907,36 @@ def strong_root_residual_at_native(
     return strong / jnp.asarray(runtime.strong_scale)
 
 
+def _physical_equation_basis(layout: StrongRootLayout) -> np.ndarray:
+    """Build an orthonormal basis for radial/helical force-output rows."""
+
+    full_size = layout.size
+    high_block = int(layout.mnmax) * int(layout.nbasis)
+    radial_field = _FIELDS.index("R_cos")
+    helical_field = _FIELDS.index("L_sin")
+    columns: list[np.ndarray] = []
+    for group in layout.groups:
+        fields = np.asarray(group.high_indices, dtype=int) // high_block
+        physical = (fields == radial_field) | (fields == helical_field)
+        injection = np.asarray(group.basis, dtype=float).T[:, physical]
+        if injection.size == 0:
+            continue
+        left, singular_values, _ = np.linalg.svd(
+            injection,
+            full_matrices=False,
+        )
+        if singular_values.size == 0 or singular_values[0] <= 0.0:
+            continue
+        rank = int(np.sum(singular_values > 1.0e-10 * singular_values[0]))
+        for local in left[:, :rank].T:
+            column = np.zeros((full_size,), dtype=float)
+            column[group.start : group.stop] = local
+            columns.append(column)
+    if not columns:
+        raise ValueError("strong root has no physical force-output equations")
+    return np.column_stack(columns)
+
+
 def make_strong_physical_chart(
     runtime: StrongRootRuntime,
     *,
@@ -921,7 +958,7 @@ def make_strong_physical_chart(
     gauge_operator = jax.jacfwd(
         lambda value: _coordinate_gauge_residual_unscaled(value, runtime)
     )(zero)
-    left, singular_values, right_transpose = np.linalg.svd(
+    _, singular_values, right_transpose = np.linalg.svd(
         np.asarray(jax.device_get(gauge_operator)),
         full_matrices=True,
     )
@@ -934,9 +971,16 @@ def make_strong_physical_chart(
         raise ValueError(
             "coordinate-gauge rank must be positive and smaller than the root"
         )
+    equation_basis = _physical_equation_basis(runtime.layout)
+    physical_size = size - gauge_rank
+    if equation_basis.shape != (size, physical_size):
+        raise ValueError(
+            "physical force-output equation count does not match gauge-free "
+            f"coordinates: {equation_basis.shape[1]} != {physical_size}"
+        )
     return StrongPhysicalChart(
         coordinate_basis=jnp.asarray(right_transpose[gauge_rank:].T),
-        equation_basis=jnp.asarray(left[:, gauge_rank:]),
+        equation_basis=jnp.asarray(equation_basis),
         gauge_rank=gauge_rank,
         build_seconds=perf_counter() - started,
     )
@@ -951,7 +995,18 @@ def strong_physical_residual(
 ) -> Array:
     """Evaluate the square strong root in exact gauge-free coordinates."""
 
-    return chart.project(strong_root_residual(chart.lift(vector), runtime, alpha))
+    full = chart.lift(vector)
+    low = chart.project(strong_root_residual(full, runtime, 0.0))
+    strong = chart.project(
+        _strong_residual_unscaled(
+            full,
+            runtime,
+            include_coordinate_gauge=False,
+        )
+        / jnp.asarray(runtime.strong_scale)
+    )
+    alpha = jnp.asarray(alpha, dtype=jnp.asarray(vector).dtype)
+    return low + alpha * (strong - low)
 
 
 def _streaming_ruiz_scales(


### PR DESCRIPTION
## Summary
- construct the reduced equation basis from the actual radial/helical force-output channels in small existing layout blocks
- exclude the tangential coordinate-gauge channel from the gauge-free strong endpoint
- retain the exact gauge-null coordinate chart and root-preserving affine homotopy
- record a clean cache-disabled production rank/runtime/memory artifact

## Evidence
- `ruff check vmex/core/polish.py tests/test_polish_preconditioner.py`
- `PYTHONPATH=. pytest -q tests/test_polish_preconditioner.py` (41 passed; one environment-only failure from the released SOLVAX lacking the merged continuation API)
- `PYTHONPATH=../SOLVAX/src:. pytest -q tests/test_polish_preconditioner.py::test_polish_ptc_stopping_is_invariant_to_positive_residual_scaling` (passed)
- targeted physical-chart test passed with an explicit gauge-free endpoint identity
- clean `VMEX_COMPILATION_CACHE=disabled` production diagnostic: full rank 117/117, physical rank 82/82, physical condition 4.31e6, JVP FD error 9.54e-9

## Performance
Compared with the preceding flux-consistent artifact, physical-chart build is 3.06 s vs 4.56 s, cold reduced residual 2.17 s vs 2.68 s, and warm reduced residual 6.15 ms vs 7.44 ms. Total runtime construction is still 25.84 s with 1.38 GiB incremental peak RSS, so the global coordinate-nullspace construction remains a release blocker.

## Scientific status
This corrects equation semantics and preserves the full-rank gate. It does not expose the public polish API or claim an independently certified alpha=1 equilibrium. The PR remains draft on the scientific stack.