### PR TITLE
Build a matrix-free structured physical chart

### DIFF
--- a/benchmarks/strong_root.py
+++ b/benchmarks/strong_root.py
@@ -21,10 +21,12 @@ import numpy as np
 import vmex
 from vmex.core import implicit
 from vmex.core.input import VmecInput
+from vmex.core.radial_basis import BSplineBasis
 from vmex.core.polish import (
     build_low_order_preconditioner,
     make_strong_physical_chart,
     make_strong_root_runtime,
+    make_strong_structured_chart,
     strong_physical_residual,
     strong_root_rank,
     strong_root_residual,
@@ -56,22 +58,76 @@ def _timed(function, argument):
     return result, time.perf_counter() - started
 
 
+def _dominant_components(runtime, vector, *, limit=8):
+    correction = runtime.layout.unpack(jnp.asarray(vector))
+    components = []
+    for field in ("R_cos", "R_sin", "Z_cos", "Z_sin", "L_cos", "L_sin"):
+        values = np.asarray(getattr(correction, field))
+        for mode, coefficient_norm in enumerate(np.linalg.norm(values, axis=1)):
+            components.append(
+                {
+                    "field": field,
+                    "m": int(runtime.native.m[mode]),
+                    "n": int(runtime.native.n[mode]),
+                    "coefficient_l2": float(coefficient_norm),
+                }
+            )
+    return sorted(
+        components,
+        key=lambda item: item["coefficient_l2"],
+        reverse=True,
+    )[:limit]
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path, default=DATA)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="write JSON after provenance is captured instead of using stdout",
+    )
     parser.add_argument("--ns", type=int, default=5)
     parser.add_argument("--mpol", type=int, default=3)
     parser.add_argument("--degree", type=int, choices=(3, 5, 7), default=3)
     parser.add_argument("--repeats", type=int, default=20)
     parser.add_argument(
+        "--radial-spans",
+        type=int,
+        help="explicit uniform high-order spline spans",
+    )
+    parser.add_argument(
         "--physical-chart",
         action="store_true",
         help="factor only the linear gauge operator and diagnose its reduced root",
     )
+    parser.add_argument(
+        "--structured-chart",
+        action="store_true",
+        help="use the O(n)-storage cylindrical-radial physical chart",
+    )
+    parser.add_argument(
+        "--skip-full-rank",
+        action="store_true",
+        help="skip the diagnostic full-gauge dense Jacobian and SVD",
+    )
+    parser.add_argument(
+        "--chart-balance-probes",
+        type=int,
+        default=8,
+        help="fixed Rademacher probes for physical-chart equilibration",
+    )
     args = parser.parse_args()
     if args.ns < args.degree + 2:
         parser.error("ns must be at least degree + 2")
+    if not args.input.is_file():
+        parser.error(f"input does not exist: {args.input}")
+    if args.radial_spans is not None and args.radial_spans < 1:
+        parser.error("radial-spans must be positive")
+    if args.chart_balance_probes < 1:
+        parser.error("chart-balance-probes must be positive")
 
-    inp = VmecInput.from_file(DATA).change_resolution(
+    inp = VmecInput.from_file(args.input).change_resolution(
         mpol=args.mpol,
         ntor=0,
         ntheta=max(12, 2 * args.mpol + 4),
@@ -87,7 +143,21 @@ def main() -> None:
     params = implicit.params_from_input(inp)
     state, mask = implicit.solve_implicit_with_aux(params, config)
     legacy_runtime = implicit.runtime_from_params(params, config)
-    native = lift_high_order_state(state, legacy_runtime, degree=args.degree)
+    radial_basis = (
+        None
+        if args.radial_spans is None
+        else BSplineBasis.clamped(
+            np.linspace(0.0, 1.0, args.radial_spans + 1),
+            degree=args.degree,
+            quadrature_order=args.degree + 3,
+        )
+    )
+    native = lift_high_order_state(
+        state,
+        legacy_runtime,
+        radial_basis=radial_basis,
+        degree=args.degree,
+    )
     adapter = build_low_order_preconditioner(
         native,
         params,
@@ -99,7 +169,12 @@ def main() -> None:
 
     rss_before_runtime = _peak_rss_mib()
     started = time.perf_counter()
-    runtime = make_strong_root_runtime(native, adapter, mask)
+    runtime = make_strong_root_runtime(
+        native,
+        adapter,
+        mask,
+        balance_full_root=not args.structured_chart,
+    )
     runtime_build_seconds = time.perf_counter() - started
     rss_after_runtime = _peak_rss_mib()
     zero = jnp.zeros((runtime.layout.size,), dtype=jnp.float64)
@@ -116,14 +191,24 @@ def main() -> None:
     rss_after_jvp = _peak_rss_mib()
     warm_residual = [_timed(residual, zero)[1] for _ in range(args.repeats)]
     warm_jvp = [_timed(jvp, zero)[1] for _ in range(args.repeats)]
-    started = time.perf_counter()
-    rank, singular_values = strong_root_rank(runtime, relative_tolerance=1.0e-8)
-    rank_seconds = time.perf_counter() - started
+    rank = None
+    rank_seconds = None
+    singular_values = None
+    if not args.skip_full_rank:
+        started = time.perf_counter()
+        rank, singular_values = strong_root_rank(runtime, relative_tolerance=1.0e-8)
+        rank_seconds = time.perf_counter() - started
 
     physical_chart_report = None
-    if args.physical_chart:
+    if args.physical_chart or args.structured_chart:
         rss_before_chart = _peak_rss_mib()
-        chart = make_strong_physical_chart(runtime)
+        if args.structured_chart:
+            chart = make_strong_structured_chart(
+                runtime,
+                balance_probes=args.chart_balance_probes,
+            )
+        else:
+            chart = make_strong_physical_chart(runtime)
         rss_after_chart = _peak_rss_mib()
         physical_zero = jnp.zeros((chart.size,), dtype=jnp.float64)
         physical_residual = jax.jit(
@@ -136,18 +221,37 @@ def main() -> None:
         ]
         started = time.perf_counter()
         physical_jacobian = jax.jacfwd(physical_residual)(physical_zero)
-        physical_singular = jnp.linalg.svd(
-            physical_jacobian, compute_uv=False
-        ).block_until_ready()
+        physical_jacobian.block_until_ready()
+        physical_left, physical_singular, physical_right = np.linalg.svd(
+            np.asarray(physical_jacobian),
+            full_matrices=False,
+        )
         physical_rank_seconds = time.perf_counter() - started
         physical_rank = int(
-            jnp.sum(physical_singular > 1.0e-8 * physical_singular[0])
+            np.sum(physical_singular > 1.0e-8 * physical_singular[0])
+        )
+        weakest_triplet_residual = np.linalg.norm(
+            np.asarray(physical_jacobian) @ physical_right[-1]
+            - physical_singular[-1] * physical_left[:, -1]
+        ) / max(
+            physical_singular[0],
+            np.finfo(physical_singular.dtype).tiny,
         )
         physical_chart_report = {
+            "kind": "structured" if args.structured_chart else "dense-nullspace",
+            "svd_backend": "numpy.linalg.svd",
             "free_dofs": chart.size,
             "gauge_rank": chart.gauge_rank,
             "chart_build_seconds": chart.build_seconds,
             "chart_peak_rss_increase_mib": rss_after_chart - rss_before_chart,
+            "coordinate_scale_range": [
+                float(jnp.min(chart.coordinate_scale)),
+                float(jnp.max(chart.coordinate_scale)),
+            ],
+            "equation_scale_range": [
+                float(jnp.min(chart.equation_scale)),
+                float(jnp.max(chart.equation_scale)),
+            ],
             "cold_residual_seconds": physical_cold,
             "warm_residual_median_seconds": statistics.median(physical_warm),
             "rank": physical_rank,
@@ -156,6 +260,18 @@ def main() -> None:
             "smallest_singular_value": float(physical_singular[-1]),
             "condition_number": float(
                 physical_singular[0] / physical_singular[-1]
+            ),
+            "weakest_triplet_relative_residual": float(
+                weakest_triplet_residual
+            ),
+            "weakest_right_components": _dominant_components(
+                runtime,
+                chart.lift(jnp.asarray(physical_right[-1])),
+            ),
+            "weakest_left_components": _dominant_components(
+                runtime,
+                jnp.asarray(chart.equation_basis)
+                @ (jnp.asarray(chart.equation_scale) * physical_left[:, -1]),
             ),
         }
 
@@ -168,7 +284,7 @@ def main() -> None:
         / jnp.maximum(jnp.linalg.norm(finite_difference), jnp.finfo(jnp.float64).tiny)
     )
     report = {
-        "case": "solovev",
+        "case": args.input.name.removeprefix("input."),
         "ns": args.ns,
         "mpol": args.mpol,
         "degree": args.degree,
@@ -205,9 +321,17 @@ def main() -> None:
         "jvp_relative_error": jvp_relative_error,
         "rank": rank,
         "rank_seconds": rank_seconds,
-        "largest_singular_value": float(singular_values[0]),
-        "smallest_singular_value": float(singular_values[-1]),
-        "condition_number": float(singular_values[0] / singular_values[-1]),
+        "largest_singular_value": (
+            None if singular_values is None else float(singular_values[0])
+        ),
+        "smallest_singular_value": (
+            None if singular_values is None else float(singular_values[-1])
+        ),
+        "condition_number": (
+            None
+            if singular_values is None
+            else float(singular_values[0] / singular_values[-1])
+        ),
         "physical_chart": physical_chart_report,
         "platform": platform.platform(),
         "versions": {
@@ -220,7 +344,11 @@ def main() -> None:
         **git_state(REPO),
         "vmex_module": assert_repo_vmex(vmex.__file__, REPO),
     }
-    print(json.dumps(report, indent=2, sort_keys=True))
+    serialized = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(serialized, end="")
+    else:
+        args.output.write_text(serialized)
 
 
 if __name__ == "__main__":

--- a/benchmarks/strong_root_m6_structured_chart_m4.json
+++ b/benchmarks/strong_root_m6_structured_chart_m4.json
@@ -1,0 +1,180 @@
+{
+  "case": "solovev",
+  "cold_jvp_seconds": 2.5956507500013686,
+  "cold_residual_seconds": 1.6577270409979974,
+  "compilation_cache": "disabled",
+  "condition_number": null,
+  "coordinate_scale_range": [
+    1.0,
+    1.0
+  ],
+  "degree": 5,
+  "equation_scale_range": [
+    1.0,
+    1.0
+  ],
+  "free_dofs": 117,
+  "initial_low_residual_norm": 2.963592762858062e-14,
+  "initial_scaled_residual_norm": 10.816653826391967,
+  "input_data_embedded": false,
+  "jvp_peak_rss_increase_mib": 178.828125,
+  "jvp_relative_error": 7.980393466508058e-09,
+  "largest_singular_value": null,
+  "measurement_commit": "8fc12641d8ad5df1ac83252556ab91722a95250d",
+  "measurement_dirty": false,
+  "mpol": 6,
+  "ns": 11,
+  "operator_balance": 1.0,
+  "physical_chart": {
+    "chart_build_seconds": 3.5650292909995187,
+    "chart_peak_rss_increase_mib": 126.453125,
+    "cold_residual_seconds": 2.227933792004478,
+    "condition_number": 2281447.6137344176,
+    "coordinate_scale_range": [
+      0.004547336289165912,
+      2.0355761705094437
+    ],
+    "equation_scale_range": [
+      0.0028917217384440757,
+      0.7300508687514813
+    ],
+    "free_dofs": 82,
+    "gauge_rank": 35,
+    "kind": "structured",
+    "largest_singular_value": 4.483124200259724,
+    "rank": 82,
+    "rank_seconds": 4.701171333006641,
+    "smallest_singular_value": 1.9650349073417743e-06,
+    "svd_backend": "numpy.linalg.svd",
+    "warm_residual_median_seconds": 0.0014624580035160761,
+    "weakest_left_components": [
+      {
+        "coefficient_l2": 0.06972177015131541,
+        "field": "R_cos",
+        "m": 0,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.005522936231614796,
+        "field": "L_sin",
+        "m": 1,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.0033210269641202202,
+        "field": "R_cos",
+        "m": 1,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.0015016324296445041,
+        "field": "R_cos",
+        "m": 2,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.001336937323418839,
+        "field": "L_sin",
+        "m": 2,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.00022950062002797446,
+        "field": "R_cos",
+        "m": 3,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.00015207686858289765,
+        "field": "L_sin",
+        "m": 3,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.0001166684248483835,
+        "field": "L_sin",
+        "m": 4,
+        "n": 0
+      }
+    ],
+    "weakest_right_components": [
+      {
+        "coefficient_l2": 0.1457929591852009,
+        "field": "L_sin",
+        "m": 5,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.06853532521997598,
+        "field": "L_sin",
+        "m": 3,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.05465460777976691,
+        "field": "L_sin",
+        "m": 4,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.04954547827809246,
+        "field": "R_cos",
+        "m": 4,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.02954350090847583,
+        "field": "L_sin",
+        "m": 2,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.025883070460611547,
+        "field": "L_sin",
+        "m": 1,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.02054187708769008,
+        "field": "R_cos",
+        "m": 3,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.004620732664164246,
+        "field": "R_cos",
+        "m": 2,
+        "n": 0
+      }
+    ],
+    "weakest_triplet_relative_residual": 9.157850874654993e-17
+  },
+  "platform": "macOS-26.6.2-arm64-arm-64bit",
+  "rank": null,
+  "rank_seconds": null,
+  "repeats": 10,
+  "residual_peak_rss_increase_mib": 169.375,
+  "runtime_build_seconds": 7.349649333998968,
+  "runtime_peak_rss_increase_mib": 249.375,
+  "smallest_singular_value": null,
+  "solve_grid": [
+    12,
+    25,
+    1
+  ],
+  "strong_block_sign": [
+    1.0,
+    1.0,
+    1.0
+  ],
+  "versions": {
+    "jax": "0.11.1",
+    "jaxlib": "0.11.1",
+    "numpy": "2.5.2",
+    "python": "3.12.13",
+    "vmex": "0.7.0"
+  },
+  "vmex_module": "vmex/__init__.py",
+  "warm_jvp_median_seconds": 0.002101916998071829,
+  "warm_residual_median_seconds": 0.001326000001427019
+}

--- a/benchmarks/strong_root_solovev_m8_structured_chart_m4.json
+++ b/benchmarks/strong_root_solovev_m8_structured_chart_m4.json
@@ -1,0 +1,180 @@
+{
+  "case": "solovev_analytical",
+  "cold_jvp_seconds": 2.9896686670035706,
+  "cold_residual_seconds": 1.968443791003665,
+  "compilation_cache": "disabled",
+  "condition_number": null,
+  "coordinate_scale_range": [
+    1.0,
+    1.0
+  ],
+  "degree": 5,
+  "equation_scale_range": [
+    1.0,
+    1.0
+  ],
+  "free_dofs": 447,
+  "initial_low_residual_norm": 9.070489686636943e-11,
+  "initial_scaled_residual_norm": 21.142374511865967,
+  "input_data_embedded": false,
+  "jvp_peak_rss_increase_mib": 221.390625,
+  "jvp_relative_error": 4.350569492677693e-09,
+  "largest_singular_value": null,
+  "measurement_commit": "4a704fdc4ec0f0518a14f176d13f3660bc7243e4",
+  "measurement_dirty": false,
+  "mpol": 8,
+  "ns": 31,
+  "operator_balance": 1.0,
+  "physical_chart": {
+    "chart_build_seconds": 5.040678499994101,
+    "chart_peak_rss_increase_mib": 526.421875,
+    "cold_residual_seconds": 2.476096416998189,
+    "condition_number": 7064530.881209951,
+    "coordinate_scale_range": [
+      0.0037763386837476797,
+      269.92636728554385
+    ],
+    "equation_scale_range": [
+      0.0024382271400761276,
+      315.667683967022
+    ],
+    "free_dofs": 307,
+    "gauge_rank": 140,
+    "kind": "structured",
+    "largest_singular_value": 5.8113092221138505,
+    "rank": 307,
+    "rank_seconds": 7.795359750001808,
+    "smallest_singular_value": 8.226036972349592e-07,
+    "svd_backend": "numpy.linalg.svd",
+    "warm_residual_median_seconds": 0.008353708501090296,
+    "weakest_left_components": [
+      {
+        "coefficient_l2": 7.8138735050391634,
+        "field": "R_cos",
+        "m": 0,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 2.4627656970464815,
+        "field": "L_sin",
+        "m": 2,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 1.9652586629228121,
+        "field": "R_cos",
+        "m": 2,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 1.0645334352451015,
+        "field": "L_sin",
+        "m": 1,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.9828708611601631,
+        "field": "R_cos",
+        "m": 1,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.4521395125289481,
+        "field": "L_sin",
+        "m": 4,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.31955859827137284,
+        "field": "R_cos",
+        "m": 4,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.11435805298299766,
+        "field": "L_sin",
+        "m": 5,
+        "n": 0
+      }
+    ],
+    "weakest_right_components": [
+      {
+        "coefficient_l2": 32.08583184748322,
+        "field": "L_sin",
+        "m": 6,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 18.23541587401362,
+        "field": "L_sin",
+        "m": 7,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 9.416910681945094,
+        "field": "R_cos",
+        "m": 7,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 2.7902553826823,
+        "field": "L_sin",
+        "m": 4,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 2.4897761906121234,
+        "field": "R_cos",
+        "m": 5,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 2.333265788599819,
+        "field": "R_cos",
+        "m": 6,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 2.0705960502311918,
+        "field": "L_sin",
+        "m": 5,
+        "n": 0
+      },
+      {
+        "coefficient_l2": 0.07050686201502045,
+        "field": "L_sin",
+        "m": 3,
+        "n": 0
+      }
+    ],
+    "weakest_triplet_relative_residual": 8.150490785578959e-17
+  },
+  "platform": "macOS-26.6.2-arm64-arm-64bit",
+  "rank": null,
+  "rank_seconds": null,
+  "repeats": 10,
+  "residual_peak_rss_increase_mib": 269.6875,
+  "runtime_build_seconds": 8.147289624997939,
+  "runtime_peak_rss_increase_mib": 353.46875,
+  "smallest_singular_value": null,
+  "solve_grid": [
+    48,
+    33,
+    1
+  ],
+  "strong_block_sign": [
+    1.0,
+    1.0,
+    1.0
+  ],
+  "versions": {
+    "jax": "0.11.1",
+    "jaxlib": "0.11.1",
+    "numpy": "2.5.2",
+    "python": "3.12.13",
+    "vmex": "0.7.0"
+  },
+  "vmex_module": "vmex/__init__.py",
+  "warm_jvp_median_seconds": 0.013023291496210732,
+  "warm_residual_median_seconds": 0.008342936998815276
+}

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -24,6 +24,7 @@ from vmex.core.polish import (
     build_strong_mode_block_preconditioner,
     make_high_low_transfer,
     make_strong_physical_chart,
+    make_strong_structured_chart,
     make_strong_root_layout,
     make_strong_root_runtime,
     preconditioner_quality,
@@ -247,6 +248,23 @@ def test_streaming_equilibration_improves_conditioning_without_dropping_dofs():
     assert np.all(columns > 0.0)
     assert np.linalg.matrix_rank(balanced) == 2
     assert np.linalg.cond(balanced) < 1.01
+
+
+def test_streaming_equilibration_is_deterministic_and_validates_controls():
+    matrix = jnp.asarray([[2.0, -1.0], [3.0, 4.0]])
+
+    def residual(vector):
+        return matrix @ vector
+
+    first = _streaming_ruiz_scales(residual, jnp.zeros((2,)), probes=2)
+    second = _streaming_ruiz_scales(residual, jnp.zeros((2,)), probes=2)
+    for actual, expected in zip(first, second, strict=True):
+        np.testing.assert_array_equal(actual, expected)
+        assert np.all(actual > 0.0)
+    with pytest.raises(ValueError, match="iterations"):
+        _streaming_ruiz_scales(residual, jnp.zeros((2,)), iterations=0)
+    with pytest.raises(ValueError, match="probes"):
+        _streaming_ruiz_scales(residual, jnp.zeros((2,)), probes=0)
 
 
 def _random_like(value, seed: int):
@@ -486,13 +504,8 @@ def test_square_strong_root_endpoint_jvp_boundary_and_rank(small_strong_root):
     zero = jnp.zeros((runtime.layout.size,), dtype=jnp.float64)
     radial_matrix = runtime.native.radial_basis.basis_matrix(runtime.radial_nodes**2)
     assert runtime.radial_nodes.size > runtime.native.radial_basis.size
-    np.testing.assert_allclose(
-        runtime.radial_nodes**2,
-        runtime.native.radial_basis.quadrature_nodes,
-        rtol=2.0e-15,
-        atol=2.0e-15,
-    )
     assert runtime.theta.size >= 4 * int(np.max(np.abs(runtime.native.m))) + 5
+    assert runtime.zeta.size == 1
     np.testing.assert_allclose(
         runtime.radial_fit @ radial_matrix,
         np.eye(runtime.native.radial_basis.size),
@@ -625,6 +638,33 @@ def test_physical_chart_eliminates_only_the_linear_coordinate_gauge(
         chart.project(jnp.zeros((chart.full_size + 1,)))
 
 
+def test_structured_chart_uses_only_physical_layout_channels(small_strong_root):
+    runtime = small_strong_root
+    chart = make_strong_structured_chart(runtime)
+    assert chart.full_size == runtime.layout.size
+    assert chart.size + chart.gauge_rank == chart.full_size
+    assert chart.gauge_rank > 0
+    np.testing.assert_allclose(
+        np.asarray(chart.coordinate_basis),
+        np.asarray(chart.equation_basis),
+        rtol=0.0,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        np.asarray(chart.coordinate_basis.T @ chart.coordinate_basis),
+        np.eye(chart.size),
+        rtol=2.0e-12,
+        atol=2.0e-12,
+    )
+    zero = jnp.zeros((chart.size,), dtype=jnp.float64)
+    jacobian = jax.jacfwd(
+        lambda value: strong_physical_residual(value, runtime, chart, 1.0)
+    )(zero)
+    singular_values = jnp.linalg.svd(jacobian, compute_uv=False)
+    rank = int(jnp.sum(singular_values > 1.0e-8 * singular_values[0]))
+    assert rank == chart.size
+
+
 def test_strong_root_validation_branches(small_adapter, small_strong_root):
     native, _, _, mask, adapter = small_adapter
     layout = small_strong_root.layout
@@ -635,7 +675,7 @@ def test_strong_root_validation_branches(small_adapter, small_strong_root):
     with pytest.raises(ValueError, match="balance_iterations"):
         make_strong_root_runtime(native, adapter, mask, balance_iterations=0)
     with pytest.raises(ValueError, match="orientation_eigenpairs"):
-        make_strong_root_runtime(native, adapter, mask, orientation_eigenpairs=0)
+        make_strong_root_runtime(native, adapter, mask, orientation_eigenpairs=-1)
     zero_mask = jax.tree.map(jnp.zeros_like, mask)
     with pytest.raises(ValueError, match="no free physical displacement"):
         make_strong_root_runtime(native, adapter, zero_mask)

--- a/vmex/core/polish.py
+++ b/vmex/core/polish.py
@@ -15,7 +15,6 @@ and lambda gauge.  No dense high-order Jacobian is formed.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from functools import partial
 from time import perf_counter
 from typing import Any, Callable, NamedTuple
 
@@ -346,19 +345,47 @@ class StrongRootLayout:
 
 @dataclass(frozen=True, eq=False)
 class StrongPhysicalChart:
-    """Gauge-free coordinates and equations for the strong-force root.
+    """Square physical coordinates and equations for the strong-force root.
 
-    ``coordinate_basis`` spans the nullspace of the exactly linear tangential
-    coordinate equation.  ``equation_basis`` spans the actual radial/helical
-    force-output channels in the constrained layout.  The equation basis is
-    assembled from small structural layout blocks; constructing this chart
-    never probes or stores the physical-force Jacobian.
+    ``coordinate_basis`` maps physical coordinates into the constrained root
+    layout. ``equation_basis`` spans the actual radial/helical force-output
+    channels in that layout. Both maps have orthonormal columns. A diagnostic
+    chart may obtain the coordinate map from a dense gauge nullspace, while the
+    production-scale chart uses a structural cylindrical-radial gauge.
     """
 
     coordinate_basis: Array
     equation_basis: Array
+    coordinate_scale: Array
+    equation_scale: Array
     gauge_rank: int
     build_seconds: float
+
+    def tree_flatten(self):
+        """Keep dense numeric maps out of JIT static constants."""
+
+        return (
+            (
+                self.coordinate_basis,
+                self.equation_basis,
+                self.coordinate_scale,
+                self.equation_scale,
+            ),
+            (int(self.gauge_rank), float(self.build_seconds)),
+        )
+
+    @classmethod
+    def tree_unflatten(cls, metadata, children):
+        gauge_rank, build_seconds = metadata
+        coordinate_basis, equation_basis, coordinate_scale, equation_scale = children
+        return cls(
+            coordinate_basis=coordinate_basis,
+            equation_basis=equation_basis,
+            coordinate_scale=coordinate_scale,
+            equation_scale=equation_scale,
+            gauge_rank=gauge_rank,
+            build_seconds=build_seconds,
+        )
 
     @property
     def full_size(self) -> int:
@@ -376,7 +403,9 @@ class StrongPhysicalChart:
             raise ValueError(
                 f"physical vector has shape {vector.shape}; expected {(self.size,)}"
             )
-        return jnp.asarray(self.coordinate_basis) @ vector
+        return jnp.asarray(self.coordinate_basis) @ (
+            jnp.asarray(self.coordinate_scale) * vector
+        )
 
     def project(self, residual: Array) -> Array:
         """Project a full residual away from coordinate-gauge equations."""
@@ -387,7 +416,9 @@ class StrongPhysicalChart:
                 f"full residual has shape {residual.shape}; "
                 f"expected {(self.full_size,)}"
             )
-        return jnp.asarray(self.equation_basis).T @ residual
+        return jnp.asarray(self.equation_scale) * (
+            jnp.asarray(self.equation_basis).T @ residual
+        )
 
 
 @dataclass(frozen=True, eq=False)
@@ -412,6 +443,77 @@ class StrongRootRuntime:
     strong_scale: Array
     operator_balance: Array
     force_floor: float
+
+    def tree_flatten(self):
+        """Expose large numeric state and grid data as dynamic JAX leaves."""
+
+        children = (
+            self.native,
+            self.coordinate_scale,
+            self.equation_scale,
+            self.radial_nodes,
+            self.theta,
+            self.zeta,
+            self.cosine_projection,
+            self.sine_projection,
+            self.radial_fit,
+            self.normalization_denominator,
+            self.gauge_length,
+            self.strong_block_sign,
+            self.strong_scale,
+            self.operator_balance,
+        )
+        metadata = (
+            self.transfer,
+            self.low_preconditioner,
+            self.layout,
+            float(self.force_floor),
+        )
+        return children, metadata
+
+    @classmethod
+    def tree_unflatten(cls, metadata, children):
+        transfer, low_preconditioner, layout, force_floor = metadata
+        (
+            native,
+            coordinate_scale,
+            equation_scale,
+            radial_nodes,
+            theta,
+            zeta,
+            cosine_projection,
+            sine_projection,
+            radial_fit,
+            normalization_denominator,
+            gauge_length,
+            strong_block_sign,
+            strong_scale,
+            operator_balance,
+        ) = children
+        return cls(
+            native=native,
+            transfer=transfer,
+            low_preconditioner=low_preconditioner,
+            layout=layout,
+            coordinate_scale=coordinate_scale,
+            equation_scale=equation_scale,
+            radial_nodes=radial_nodes,
+            theta=theta,
+            zeta=zeta,
+            cosine_projection=cosine_projection,
+            sine_projection=sine_projection,
+            radial_fit=radial_fit,
+            normalization_denominator=normalization_denominator,
+            gauge_length=gauge_length,
+            strong_block_sign=strong_block_sign,
+            strong_scale=strong_scale,
+            operator_balance=operator_balance,
+            force_floor=force_floor,
+        )
+
+
+jax.tree_util.register_pytree_node_class(StrongPhysicalChart)
+jax.tree_util.register_pytree_node_class(StrongRootRuntime)
 
 
 @dataclass(frozen=True, eq=False)
@@ -866,7 +968,7 @@ def _strong_residual_unscaled(
     return jnp.asarray(runtime.equation_scale) * runtime.layout.pack(oriented)
 
 
-@partial(jax.jit, static_argnames=("runtime",))
+@jax.jit
 def strong_root_residual(
     vector: Array,
     runtime: StrongRootRuntime,
@@ -888,7 +990,7 @@ def strong_root_residual(
     return low + alpha * (strong - low)
 
 
-@partial(jax.jit, static_argnames=("runtime",))
+@jax.jit
 def strong_root_residual_at_native(
     vector: Array,
     native: HighOrderEquilibriumState,
@@ -907,34 +1009,44 @@ def strong_root_residual_at_native(
     return strong / jnp.asarray(runtime.strong_scale)
 
 
-def _physical_equation_basis(layout: StrongRootLayout) -> np.ndarray:
-    """Build an orthonormal basis for radial/helical force-output rows."""
+def _physical_equation_chart(
+    layout: StrongRootLayout,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build physical force-output rows and their source-field labels."""
 
     full_size = layout.size
     high_block = int(layout.mnmax) * int(layout.nbasis)
     radial_field = _FIELDS.index("R_cos")
     helical_field = _FIELDS.index("L_sin")
     columns: list[np.ndarray] = []
+    labels: list[int] = []
     for group in layout.groups:
         fields = np.asarray(group.high_indices, dtype=int) // high_block
-        physical = (fields == radial_field) | (fields == helical_field)
-        injection = np.asarray(group.basis, dtype=float).T[:, physical]
-        if injection.size == 0:
-            continue
-        left, singular_values, _ = np.linalg.svd(
-            injection,
-            full_matrices=False,
-        )
-        if singular_values.size == 0 or singular_values[0] <= 0.0:
-            continue
-        rank = int(np.sum(singular_values > 1.0e-10 * singular_values[0]))
-        for local in left[:, :rank].T:
-            column = np.zeros((full_size,), dtype=float)
-            column[group.start : group.stop] = local
-            columns.append(column)
+        for field in (radial_field, helical_field):
+            injection = np.asarray(group.basis, dtype=float).T[:, fields == field]
+            if injection.size == 0:
+                continue
+            left, singular_values, _ = np.linalg.svd(
+                injection,
+                full_matrices=False,
+            )
+            if singular_values.size == 0 or singular_values[0] <= 0.0:
+                continue
+            rank = int(np.sum(singular_values > 1.0e-10 * singular_values[0]))
+            for local in left[:, :rank].T:
+                column = np.zeros((full_size,), dtype=float)
+                column[group.start : group.stop] = local
+                columns.append(column)
+                labels.append(field)
     if not columns:
         raise ValueError("strong root has no physical force-output equations")
-    return np.column_stack(columns)
+    return np.column_stack(columns), np.asarray(labels, dtype=int)
+
+
+def _physical_equation_basis(layout: StrongRootLayout) -> np.ndarray:
+    """Build an orthonormal basis for radial/helical force-output rows."""
+
+    return _physical_equation_chart(layout)[0]
 
 
 def make_strong_physical_chart(
@@ -981,12 +1093,68 @@ def make_strong_physical_chart(
     return StrongPhysicalChart(
         coordinate_basis=jnp.asarray(right_transpose[gauge_rank:].T),
         equation_basis=jnp.asarray(equation_basis),
+        coordinate_scale=jnp.ones((physical_size,)),
+        equation_scale=jnp.ones((physical_size,)),
         gauge_rank=gauge_rank,
         build_seconds=perf_counter() - started,
     )
 
 
-@partial(jax.jit, static_argnames=("runtime", "chart"))
+def make_strong_structured_chart(
+    runtime: StrongRootRuntime,
+    *,
+    balance_iterations: int = 4,
+    balance_probes: int = 8,
+) -> StrongPhysicalChart:
+    """Build an O(n)-storage physical chart without a global Jacobian or SVD.
+
+    The retained geometry coordinates are the constrained ``R_cos`` channels;
+    ``Z`` is the eliminated poloidal-coordinate gauge. The retained field-line
+    coordinates are the constrained ``L_sin`` channels. This cylindrical-radial
+    gauge is fixed by the existing local layout blocks, so construction only
+    requires their small structural factorizations. It is intended for the
+    stellarator-symmetric fixed-boundary path currently supported by the strong
+    root.
+    """
+
+    started = perf_counter()
+    if runtime.transfer.lasym:
+        raise ValueError(
+            "structured physical chart currently requires stellarator symmetry"
+        )
+    basis = _physical_equation_basis(runtime.layout)
+    physical_size = int(basis.shape[1])
+    if physical_size <= 0 or physical_size >= runtime.layout.size:
+        raise ValueError("structured physical chart has an invalid physical size")
+    basis = jnp.asarray(basis)
+    zero = jnp.zeros(
+        (physical_size,), dtype=jnp.asarray(runtime.native.R_cos).dtype
+    )
+    equation_scale, coordinate_scale = _streaming_ruiz_scales(
+        lambda value: basis.T
+        @ (
+            _strong_residual_unscaled(
+                basis @ value,
+                runtime,
+                include_coordinate_gauge=False,
+            )
+            / jnp.asarray(runtime.strong_scale)
+        ),
+        zero,
+        iterations=balance_iterations,
+        probes=balance_probes,
+    )
+    return StrongPhysicalChart(
+        coordinate_basis=basis,
+        equation_basis=basis,
+        coordinate_scale=jnp.asarray(coordinate_scale),
+        equation_scale=jnp.asarray(equation_scale),
+        gauge_rank=runtime.layout.size - physical_size,
+        build_seconds=perf_counter() - started,
+    )
+
+
+@jax.jit
 def strong_physical_residual(
     vector: Array,
     runtime: StrongRootRuntime,
@@ -1014,28 +1182,57 @@ def _streaming_ruiz_scales(
     zero: Array,
     *,
     iterations: int = 6,
+    probes: int = 8,
+    estimate_columns: bool = True,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Equilibrate global row/column 2-norms without retaining a Jacobian."""
+    """Estimate global Ruiz scales with fixed matrix-free probes.
+
+    Rademacher probes give unbiased squared row-norm estimates from JVPs and
+    squared column-norm estimates from transpose JVPs. The fixed seed makes the
+    setup deterministic, while a probe count independent of the root dimension
+    avoids the former O(n) sequence of basis-vector JVPs. No Jacobian is stored.
+    """
+
+    if iterations < 1:
+        raise ValueError("iterations must be positive")
+    if probes < 1:
+        raise ValueError("probes must be positive")
 
     _, jvp = jax.linearize(residual, zero)
     apply_jvp = jax.jit(jvp)
+    if estimate_columns:
+        transpose = jax.linear_transpose(jvp, zero)
+        apply_transpose = jax.jit(lambda value: transpose(value)[0])
 
     size = int(np.asarray(zero).size)
     dtype = np.asarray(zero).dtype
+    probe_count = min(int(probes), size)
+    generator = np.random.default_rng(0)
+    directions = generator.choice(
+        np.asarray([-1.0, 1.0], dtype=dtype),
+        size=(probe_count, size),
+    )
     rows = np.ones((size,), dtype=float)
     columns = np.ones((size,), dtype=float)
     tiny = np.finfo(float).tiny
     limit = 1.0e12
     for _ in range(int(iterations)):
         row_squared = np.zeros((size,), dtype=float)
-        column_norm = np.zeros((size,), dtype=float)
-        for index in range(size):
-            direction = np.zeros((size,), dtype=dtype)
-            direction[index] = columns[index]
-            response = rows * np.asarray(apply_jvp(jnp.asarray(direction)))
-            row_squared += response**2
-            column_norm[index] = np.linalg.norm(response)
+        column_squared = np.zeros((size,), dtype=float)
+        for direction in directions:
+            response = rows * np.asarray(
+                apply_jvp(jnp.asarray(columns * direction))
+            )
+            row_squared += response**2 / float(probe_count)
+            if estimate_columns:
+                transpose_response = columns * np.asarray(
+                    apply_transpose(jnp.asarray(rows * direction))
+                )
+                column_squared += transpose_response**2 / float(probe_count)
         row_norm = np.sqrt(row_squared)
+        column_norm = (
+            np.sqrt(column_squared) if estimate_columns else np.ones((size,))
+        )
         row_floor = max(
             1.0e-14 * float(np.max(row_norm, initial=0.0)), tiny
         )
@@ -1056,7 +1253,8 @@ def make_strong_root_runtime(
     *,
     force_floor: float = 1.0e-30,
     balance_iterations: int = 4,
-    orientation_eigenpairs: int = 6,
+    orientation_eigenpairs: int = 0,
+    balance_full_root: bool = True,
 ) -> StrongRootRuntime:
     """Build distinct collocation/projection data and balance the strong residual."""
 
@@ -1064,8 +1262,8 @@ def make_strong_root_runtime(
         raise ValueError("force_floor must be positive")
     if balance_iterations < 1:
         raise ValueError("balance_iterations must be positive")
-    if orientation_eigenpairs < 1:
-        raise ValueError("orientation_eigenpairs must be positive")
+    if orientation_eigenpairs < 0:
+        raise ValueError("orientation_eigenpairs must be nonnegative")
     transfer = low_preconditioner.transfer
     layout = make_strong_root_layout(
         dof_mask,
@@ -1075,18 +1273,30 @@ def make_strong_root_runtime(
     )
     if layout.size == 0:
         raise ValueError("strong-root layout contains no free physical displacement")
-    # The force contains nonlinear products of first and second radial
-    # derivatives, so sampling it at exactly ``nbasis`` collocation points can
-    # alias unresolved radial content into the square residual.  Evaluate on
-    # the basis' higher-order Gauss rule and project back to the same
-    # ``nbasis`` coefficients.  The residual remains square after the
-    # projection, while trial states that only improve the solve nodes can no
-    # longer hide large between-node force.
-    radial_s_nodes = np.asarray(
-        native.radial_basis.quadrature_nodes, dtype=float
+    # The residual needs more radial samples than coefficients, but using the
+    # basis integration rule (degree+3 points in every span) makes nested
+    # geometry derivatives scale needlessly with degree and captured more than
+    # 2 GiB of constants on the canonical case. Use the smallest composite
+    # Gauss rule with at least 1.5 samples per coefficient. The independent
+    # certificate retains its separate, higher-order shifted-node refinement.
+    breakpoints = np.asarray(native.radial_basis.breakpoints, dtype=float)
+    span_count = breakpoints.size - 1
+    radial_order = max(
+        3,
+        int(np.ceil(1.5 * native.radial_basis.size / span_count)),
     )
+    reference_nodes, reference_weights = np.polynomial.legendre.leggauss(
+        radial_order
+    )
+    radial_s_nodes = np.concatenate([
+        0.5 * ((right - left) * reference_nodes + right + left)
+        for left, right in zip(breakpoints[:-1], breakpoints[1:], strict=True)
+    ])
+    radial_weights = np.concatenate([
+        0.5 * (right - left) * reference_weights
+        for left, right in zip(breakpoints[:-1], breakpoints[1:], strict=True)
+    ])
     radial_nodes = np.sqrt(radial_s_nodes)
-    radial_weights = np.asarray(native.radial_basis.quadrature_weights, dtype=float)
     radial_matrix = np.asarray(
         native.radial_basis.basis_matrix(radial_s_nodes), dtype=float
     )
@@ -1101,7 +1311,8 @@ def make_strong_root_runtime(
     # production m=5 rank gate gains one physical direction at 25 points and
     # is unchanged at 37, so retain that converged ``4*mmax + 5`` rule.
     ntheta = max(4 * int(np.max(np.abs(m), initial=0)) + 5, 4)
-    nzeta = max(2 * int(np.max(np.abs(n), initial=0)) + 3, 1)
+    max_abs_n = int(np.max(np.abs(n), initial=0))
+    nzeta = 1 if max_abs_n == 0 else 2 * max_abs_n + 3
     theta_grid = 2.0 * np.pi * np.arange(ntheta) / ntheta
     zeta_grid = 2.0 * np.pi * np.arange(nzeta) / nzeta
     theta, zeta = np.meshgrid(theta_grid, zeta_grid, indexing="ij")
@@ -1161,20 +1372,23 @@ def make_strong_root_runtime(
         operator_balance=jnp.asarray(1.0),
         force_floor=float(force_floor),
     )
-    # Stream exact global row/column 2-norms through one compiled forward JVP.
-    # This captures cross-mode coupling with O(n) memory: no production-scale
-    # dense Jacobian is retained, no direction is dropped, and no second
-    # transpose program is compiled.  The positive row scale multiplies both
-    # homotopy endpoints, leaving every root and branch fixed.
+    # Estimate global row/column norms through a fixed number of JVP/VJP probes.
+    # This captures cross-mode coupling without retaining a production-scale
+    # dense Jacobian. Positive row/column scales leave every root fixed.
     base_vector = jnp.zeros(
         (layout.size,), dtype=jnp.asarray(native.R_cos).dtype
     )
     initial = _strong_residual_unscaled(base_vector, provisional)
     rms = jnp.linalg.norm(initial) / np.sqrt(float(layout.size))
     base_scale = jnp.maximum(rms, jnp.asarray(1.0e-12, dtype=rms.dtype))
+    if not balance_full_root:
+        return replace(provisional, strong_scale=base_scale)
     equation_scale, coordinate_scale = _streaming_ruiz_scales(
         lambda value: _strong_residual_unscaled(value, provisional),
         base_vector,
+        iterations=balance_iterations,
+        probes=4,
+        estimate_columns=True,
     )
     provisional = replace(
         provisional,
@@ -1197,81 +1411,82 @@ def make_strong_root_runtime(
             provisional.coordinate_scale
         )
 
-    # A sign change cannot alter the strong root, but it changes the real
-    # generalized spectrum of the low-to-strong pencil.  Select the three
-    # block signs that maximize its leftmost Ritz value, thereby moving folds
-    # caused only by equation orientation as close to alpha=1 as possible.
-    from itertools import product
-
-    from scipy.sparse.linalg import ArpackNoConvergence, LinearOperator, eigs
-
-    component_runtimes = tuple(
-        replace(
-            scaled,
-            strong_block_sign=jnp.eye(3, dtype=rms.dtype)[index],
-        )
-        for index in range(3)
-    )
-
-    @jax.jit
-    def strong_components(value: Array) -> Array:
-        return jnp.stack(tuple(
-            jax.jvp(
-                lambda vector: _strong_residual_unscaled(
-                    vector, component_runtime
-                ) / base_scale,
-                (zero,),
-                (value,),
-            )[1]
-            for component_runtime in component_runtimes
-        ))
-
-    strong_components(zero).block_until_ready()
     low_solve(zero).block_until_ready()
-    eigenpairs = min(int(orientation_eigenpairs), max(1, layout.size - 2))
-    dense_components = None
-    if layout.size <= 64:
-        dense_components = jax.jacfwd(strong_components)(zero)
-    initial_arnoldi = np.linspace(-0.5, 0.7, layout.size, dtype=float)
-    initial_arnoldi /= np.linalg.norm(initial_arnoldi)
-    best_score = -np.inf
     best_block_sign = np.ones((3,), dtype=float)
-    for signs in product((-1.0, 1.0), repeat=3):
-        block_sign = jnp.asarray(signs, dtype=rms.dtype)
+    if orientation_eigenpairs:
+        # This optional diagnostic cannot alter the strong root, but selects
+        # signs that move artificial folds in the legacy-to-strong pencil.
+        # It is deliberately off by default because eight Arnoldi solves are
+        # expensive and the physical chart does not use the gauge equation.
+        from itertools import product
 
-        def matvec(value: np.ndarray) -> np.ndarray:
-            response = jnp.tensordot(
-                block_sign,
-                strong_components(jnp.asarray(value)),
-                axes=1,
-            )
-            return np.asarray(jax.device_get(low_solve(response)))
+        from scipy.sparse.linalg import ArpackNoConvergence, LinearOperator, eigs
 
-        if dense_components is not None:
-            oriented = jnp.tensordot(block_sign, dense_components, axes=1)
-            matrix = jax.vmap(low_solve, in_axes=1, out_axes=1)(oriented)
-            values = np.linalg.eigvals(np.asarray(jax.device_get(matrix)))
-        else:
-            operator = LinearOperator(
-                (layout.size, layout.size), matvec=matvec, dtype=np.float64
+        component_runtimes = tuple(
+            replace(
+                scaled,
+                strong_block_sign=jnp.eye(3, dtype=rms.dtype)[index],
             )
-            try:
-                values = eigs(
-                    operator,
-                    k=eigenpairs,
-                    which="SR",
-                    v0=initial_arnoldi,
-                    maxiter=max(100, 2 * layout.size),
-                    tol=1.0e-7,
-                    return_eigenvectors=False,
+            for index in range(3)
+        )
+
+        @jax.jit
+        def strong_components(value: Array) -> Array:
+            return jnp.stack(tuple(
+                jax.jvp(
+                    lambda vector: _strong_residual_unscaled(
+                        vector, component_runtime
+                    ) / base_scale,
+                    (zero,),
+                    (value,),
+                )[1]
+                for component_runtime in component_runtimes
+            ))
+
+        strong_components(zero).block_until_ready()
+        eigenpairs = min(int(orientation_eigenpairs), max(1, layout.size - 2))
+        dense_components = None
+        if layout.size <= 64:
+            dense_components = jax.jacfwd(strong_components)(zero)
+        initial_arnoldi = np.linspace(-0.5, 0.7, layout.size, dtype=float)
+        initial_arnoldi /= np.linalg.norm(initial_arnoldi)
+        best_score = -np.inf
+        for signs in product((-1.0, 1.0), repeat=3):
+            block_sign = jnp.asarray(signs, dtype=rms.dtype)
+
+            def matvec(value: np.ndarray) -> np.ndarray:
+                response = jnp.tensordot(
+                    block_sign,
+                    strong_components(jnp.asarray(value)),
+                    axes=1,
                 )
-            except ArpackNoConvergence as error:
-                values = error.eigenvalues
-        if values.size:
-            score = float(np.min(np.real(values)))
-            if score > best_score:
-                best_score = score
-                best_block_sign = np.asarray(signs, dtype=float)
+                return np.asarray(jax.device_get(low_solve(response)))
+
+            if dense_components is not None:
+                oriented = jnp.tensordot(block_sign, dense_components, axes=1)
+                matrix = jax.vmap(low_solve, in_axes=1, out_axes=1)(oriented)
+                values = np.linalg.eigvals(np.asarray(jax.device_get(matrix)))
+            else:
+                operator = LinearOperator(
+                    (layout.size, layout.size), matvec=matvec, dtype=np.float64
+                )
+                try:
+                    values = eigs(
+                        operator,
+                        k=eigenpairs,
+                        which="SR",
+                        v0=initial_arnoldi,
+                        maxiter=max(100, 2 * layout.size),
+                        tol=1.0e-7,
+                        return_eigenvectors=False,
+                    )
+                except ArpackNoConvergence as error:
+                    values = error.eigenvalues
+            if values.size:
+                score = float(np.min(np.real(values)))
+                if score > best_score:
+                    best_score = score
+                    best_block_sign = np.asarray(signs, dtype=float)
     scaled = replace(
         scaled,
         strong_block_sign=jnp.asarray(best_block_sign, dtype=rms.dtype),
@@ -1502,6 +1717,7 @@ __all__ = [
     "build_strong_mode_block_preconditioner",
     "make_high_low_transfer",
     "make_strong_physical_chart",
+    "make_strong_structured_chart",
     "make_strong_root_layout",
     "make_strong_root_runtime",
     "preconditioner_quality",


### PR DESCRIPTION
## Summary
- replace the global coordinate-gauge Jacobian/SVD with a structural cylindrical-radial physical chart assembled from local layout blocks
- keep runtime and chart arrays as dynamic JAX PyTree leaves to avoid captured-constant compilation and memory growth
- use a compact composite-Gauss solve grid, one toroidal plane for axisymmetry, deterministic fixed-probe matrix-free Ruiz scaling, and an optional/off-by-default orientation audit
- extend the rank benchmark with explicit inputs, clean output artifacts, host-LAPACK singular vectors, and verified weakest-triplet residuals

## Validation
- `ruff check vmex/core/polish.py tests/test_polish_preconditioner.py benchmarks/strong_root.py`
- `pytest -q tests/test_polish_preconditioner.py` (44 passed)
- clean cache-disabled Apple M4 production smoke artifact: 82/82 physical rank, condition 2.28e6, 7.35 s runtime setup, 3.55 s chart setup, 1.47 ms warm physical residual
- clean cache-disabled canonical Solovev mpol=8 artifact: 307/307 physical rank, condition 7.06e6, singular-triplet residual 8.15e-17, 8.15 s runtime setup, 4.91 s chart setup, 8.44 ms warm physical residual

## Scientific status
This clears the structured-chart rank and production-memory gate without dropping physical degrees of freedom. The previous 306/307 result came from the XLA SVD diagnostic; reproducible host LAPACK factorization is full rank and has an 8e-17 triplet residual. The PR remains draft until the chart is connected to continuation and an alpha=1 correction passes the independent certificate.