### PR TITLE
Exercise continuation in physical coordinates

### DIFF
--- a/benchmarks/strong_certificate.py
+++ b/benchmarks/strong_certificate.py
@@ -49,6 +49,11 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
     parser.add_argument(
+        "--output",
+        type=Path,
+        help="write JSON after provenance is captured instead of using stdout",
+    )
+    parser.add_argument(
         "--wout",
         type=Path,
         help="optional VMEX/VMEC2000/VMEC++/DESC-exported compatible wout",
@@ -138,6 +143,7 @@ def main() -> None:
         "angular_spectral_tail",
         "radial_refinement_difference",
         "minimum_signed_jacobian",
+        "nestedness_margin",
         "boundary_residual",
         "gauge_residual",
     )
@@ -163,6 +169,13 @@ def main() -> None:
         "normalization": report.normalization,
         "coordinate_convention": report.coordinate_convention,
         "metrics": {name: float(np.asarray(getattr(report, name))) for name in scalar_fields},
+        "radial_profile": {
+            "rho": np.asarray(report.radial_nodes).tolist(),
+            "flux_surface_average_force_density": np.asarray(
+                report.flux_surface_average
+            ).tolist(),
+            "units": "N m^-3",
+        },
         "platform": platform.platform(),
         "versions": {
             "python": platform.python_version(),
@@ -174,7 +187,11 @@ def main() -> None:
         **git_state(REPO),
         "vmex_module": assert_repo_vmex(vmex.__file__, REPO),
     }
-    print(json.dumps(result, indent=2, sort_keys=True))
+    serialized = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(serialized, end="")
+    else:
+        args.output.write_text(serialized)
 
 
 if __name__ == "__main__":

--- a/benchmarks/strong_polish.py
+++ b/benchmarks/strong_polish.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python
+"""Measure one structured-chart strong-root correction and certificate."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+from pathlib import Path
+import platform
+import resource
+import time
+
+import jax
+import numpy as np
+
+import vmex
+from solvax import pseudo_transient_continuation
+from vmex.core import implicit
+from vmex.core.input import VmecInput
+from vmex.core.polish import (
+    build_low_order_preconditioner,
+    make_strong_root_runtime,
+    make_strong_structured_chart,
+    strong_physical_residual,
+)
+from vmex.core.polish_driver import (
+    PolishConfig,
+    _corrected_state,
+    _minimum_signed_jacobian,
+    _ptc_config,
+    polish_strong_root,
+)
+from vmex.core.radial_basis import BSplineBasis
+from vmex.core.strong_force import certify_strong_force, lift_high_order_state
+
+from _provenance import assert_repo_vmex, git_state
+
+REPO = Path(__file__).resolve().parents[1]
+DATA = REPO / "examples" / "data" / "input.solovev"
+
+
+def _peak_rss_mib() -> float:
+    value = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    divisor = 1024.0**2 if platform.system() == "Darwin" else 1024.0
+    return value / divisor
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path, default=DATA)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--ns", type=int, default=11)
+    parser.add_argument("--mpol", type=int, default=6)
+    parser.add_argument("--degree", type=int, choices=(3, 5, 7), default=5)
+    parser.add_argument("--radial-spans", type=int)
+    parser.add_argument("--solve-tolerance", type=float, default=1.0e-6)
+    parser.add_argument("--validation-tolerance", type=float, default=1.0e-8)
+    parser.add_argument("--max-stages", type=int, default=32)
+    parser.add_argument("--max-nonlinear-iterations", type=int, default=80)
+    parser.add_argument(
+        "--preconditioner",
+        choices=("none", "legacy", "mode-block"),
+        default="mode-block",
+    )
+    parser.add_argument("--linear-restart", type=int, default=30)
+    parser.add_argument("--linear-max-restarts", type=int, default=20)
+    parser.add_argument("--no-arclength", action="store_true")
+    parser.add_argument("--direct-endpoint", action="store_true")
+    args = parser.parse_args()
+    if not args.input.is_file():
+        parser.error(f"input does not exist: {args.input}")
+    if args.ns < args.degree + 2:
+        parser.error("ns must be at least degree + 2")
+    if args.radial_spans is not None and args.radial_spans < 1:
+        parser.error("radial-spans must be positive")
+
+    started = time.perf_counter()
+    rss_initial = _peak_rss_mib()
+    inp = VmecInput.from_file(args.input).change_resolution(
+        mpol=args.mpol,
+        ntor=0,
+        ntheta=max(12, 2 * args.mpol + 4),
+        nzeta=4,
+    )
+    inp = dataclasses.replace(
+        inp,
+        ns_array=np.asarray([args.ns]),
+        ftol_array=np.asarray([1.0e-10]),
+        niter_array=np.asarray([1000]),
+    )
+    implicit_config = implicit.make_config(
+        inp,
+        ftol=1.0e-10,
+        max_iterations=1000,
+    )
+    params = implicit.params_from_input(inp)
+    legacy_state, dof_mask = implicit.solve_implicit_with_aux(
+        params, implicit_config
+    )
+    legacy_runtime = implicit.runtime_from_params(params, implicit_config)
+    radial_basis = (
+        None
+        if args.radial_spans is None
+        else BSplineBasis.clamped(
+            np.linspace(0.0, 1.0, args.radial_spans + 1),
+            degree=args.degree,
+            quadrature_order=args.degree + 3,
+        )
+    )
+    native = lift_high_order_state(
+        legacy_state,
+        legacy_runtime,
+        radial_basis=radial_basis,
+        degree=args.degree,
+    )
+    initial_certificate = certify_strong_force(native)
+    low_preconditioner = build_low_order_preconditioner(
+        native,
+        params,
+        implicit_config,
+        legacy_state,
+        dof_mask,
+        probe_chunk_size=4,
+    )
+    runtime = make_strong_root_runtime(
+        native,
+        low_preconditioner,
+        dof_mask,
+        balance_full_root=False,
+    )
+    chart = make_strong_structured_chart(runtime)
+    setup_seconds = time.perf_counter() - started
+    rss_after_setup = _peak_rss_mib()
+    polish_config = PolishConfig(
+        tolerance=args.solve_tolerance,
+        validation_tolerance=args.validation_tolerance,
+        max_continuation_stages=args.max_stages,
+        max_nonlinear_iterations=args.max_nonlinear_iterations,
+        ptc_initial_dtau=1.0e12,
+        preconditioner=args.preconditioner,
+        linear_restart=args.linear_restart,
+        linear_max_restarts=args.linear_max_restarts,
+        use_pseudo_arclength=not args.no_arclength,
+        fail_policy="return_unpolished",
+    )
+    if args.direct_endpoint:
+        zero = np.zeros((chart.size,), dtype=float)
+        margin = float(_minimum_signed_jacobian(zero, runtime, chart))
+        direct = pseudo_transient_continuation(
+            lambda value: strong_physical_residual(value, runtime, chart, 1.0),
+            zero,
+            admissible=lambda value: (
+                _minimum_signed_jacobian(value, runtime, chart) >= 0.1 * margin
+            ),
+            config=_ptc_config(
+                polish_config,
+                residual_scale=np.sqrt(float(chart.size)),
+            ),
+        )
+        state = _corrected_state(direct.x, runtime, chart)
+        final_certificate = certify_strong_force(state)
+        polish_report = {
+            "converged": bool(direct.converged and direct.linear_converged),
+            "termination_reason": "direct-endpoint",
+            "final_alpha": 1.0,
+            "initial_normalized_l2": float(initial_certificate.normalized_l2),
+            "final_normalized_l2": float(final_certificate.normalized_l2),
+            "continuation_accepted": 0,
+            "continuation_rejected": 0,
+            "nonlinear_iterations": int(direct.steps),
+            "linear_iterations": int(direct.linear_iterations),
+            "residual_evaluations": int(direct.residual_evaluations),
+            "arclength_steps": 0,
+            "minimum_signed_jacobian": float(
+                final_certificate.minimum_signed_jacobian
+            ),
+            "factor_build_seconds": low_preconditioner.factor_build_seconds,
+            "solve_seconds": time.perf_counter() - started - setup_seconds,
+        }
+    else:
+        result = polish_strong_root(
+            runtime,
+            config=polish_config,
+            initial_certificate=initial_certificate,
+            chart=chart,
+        )
+        jax.block_until_ready(result.native_equilibrium)
+        final_certificate = result.strong_force
+        polish_report = dataclasses.asdict(result.polish_report)
+    report = {
+        "schema": "vmex.strong-polish-benchmark/1",
+        "case": args.input.name.removeprefix("input."),
+        "ns": args.ns,
+        "mpol": args.mpol,
+        "degree": args.degree,
+        "radial_spans": args.radial_spans,
+        "full_dofs": runtime.layout.size,
+        "physical_dofs": chart.size,
+        "direct_endpoint": args.direct_endpoint,
+        "solve_grid": [
+            int(runtime.radial_nodes.size),
+            int(runtime.theta.size),
+            int(runtime.zeta.size),
+        ],
+        "setup_seconds": setup_seconds,
+        "setup_peak_rss_increase_mib": rss_after_setup - rss_initial,
+        "total_seconds": time.perf_counter() - started,
+        "total_peak_rss_increase_mib": _peak_rss_mib() - rss_initial,
+        "initial_certificate": {
+            "normalized_l2": float(initial_certificate.normalized_l2),
+            "radial_refinement": float(
+                initial_certificate.radial_refinement_difference
+            ),
+            "angular_tail": float(initial_certificate.angular_spectral_tail),
+        },
+        "final_certificate": {
+            "normalized_l2": float(final_certificate.normalized_l2),
+            "radial_refinement": float(
+                final_certificate.radial_refinement_difference
+            ),
+            "angular_tail": float(final_certificate.angular_spectral_tail),
+        },
+        "polish_report": polish_report,
+        "platform": platform.platform(),
+        "versions": {
+            "python": platform.python_version(),
+            "vmex": vmex.__version__,
+            "jax": jax.__version__,
+            "numpy": np.__version__,
+        },
+        **git_state(REPO),
+        "vmex_module": assert_repo_vmex(vmex.__file__, REPO),
+    }
+    serialized = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(serialized, end="")
+    else:
+        args.output.write_text(serialized)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/strong_polish_m6_physical_none_m4.json
+++ b/benchmarks/strong_polish_m6_physical_none_m4.json
@@ -1,0 +1,57 @@
+{
+  "case": "solovev",
+  "degree": 5,
+  "direct_endpoint": false,
+  "final_certificate": {
+    "angular_tail": 0.30773757503802374,
+    "normalized_l2": 1.9901984569329478,
+    "radial_refinement": 0.00026128549975110545
+  },
+  "full_dofs": 117,
+  "initial_certificate": {
+    "angular_tail": 0.30773757503802374,
+    "normalized_l2": 1.9901984569329478,
+    "radial_refinement": 0.00026128549975110545
+  },
+  "input_data_embedded": false,
+  "measurement_commit": "54e4ec8c73e29558c9fcffc307626b7324ba3a2d",
+  "measurement_dirty": false,
+  "mpol": 6,
+  "ns": 11,
+  "physical_dofs": 82,
+  "platform": "macOS-26.6.2-arm64-arm-64bit",
+  "polish_report": {
+    "arclength_steps": 0,
+    "continuation_accepted": 18,
+    "continuation_rejected": 2,
+    "converged": false,
+    "factor_build_seconds": 5.614646207999613,
+    "final_alpha": 0.858428816896,
+    "final_normalized_l2": 1.9901984569329478,
+    "initial_normalized_l2": 1.9901984569329478,
+    "linear_iterations": 8819,
+    "minimum_signed_jacobian": 5.272240364972131,
+    "nonlinear_iterations": 141,
+    "residual_evaluations": 573,
+    "solve_seconds": 45.487333707998914,
+    "termination_reason": "continuation-stalled"
+  },
+  "radial_spans": null,
+  "schema": "vmex.strong-polish-benchmark/1",
+  "setup_peak_rss_increase_mib": 1700.234375,
+  "setup_seconds": 31.48794933300087,
+  "solve_grid": [
+    12,
+    25,
+    1
+  ],
+  "total_peak_rss_increase_mib": 3211.953125,
+  "total_seconds": 76.97541016700416,
+  "versions": {
+    "jax": "0.11.1",
+    "numpy": "2.5.2",
+    "python": "3.12.13",
+    "vmex": "0.7.0"
+  },
+  "vmex_module": "vmex/__init__.py"
+}

--- a/benchmarks/strong_polish_solovev_m5_direct_m4.json
+++ b/benchmarks/strong_polish_solovev_m5_direct_m4.json
@@ -1,0 +1,57 @@
+{
+  "case": "solovev_analytical",
+  "degree": 5,
+  "direct_endpoint": true,
+  "final_certificate": {
+    "angular_tail": 0.535521026538766,
+    "normalized_l2": 0.5918641616736336,
+    "radial_refinement": 0.022653240057239003
+  },
+  "full_dofs": 264,
+  "initial_certificate": {
+    "angular_tail": 0.22870016115835554,
+    "normalized_l2": 0.11475032466581055,
+    "radial_refinement": 7.621075212167915e-05
+  },
+  "input_data_embedded": false,
+  "measurement_commit": "60a245ebc2041404982ec55f7f0b716263f801cc",
+  "measurement_dirty": false,
+  "mpol": 5,
+  "ns": 31,
+  "physical_dofs": 184,
+  "platform": "macOS-26.6.2-arm64-arm-64bit",
+  "polish_report": {
+    "arclength_steps": 0,
+    "continuation_accepted": 0,
+    "continuation_rejected": 0,
+    "converged": false,
+    "factor_build_seconds": 5.632759584004816,
+    "final_alpha": 1.0,
+    "final_normalized_l2": 0.5918641616736336,
+    "initial_normalized_l2": 0.11475032466581055,
+    "linear_iterations": 4336,
+    "minimum_signed_jacobian": 3.7750239395330416,
+    "nonlinear_iterations": 30,
+    "residual_evaluations": 94,
+    "solve_seconds": 62.33072362499661,
+    "termination_reason": "direct-endpoint"
+  },
+  "radial_spans": 16,
+  "schema": "vmex.strong-polish-benchmark/1",
+  "setup_peak_rss_increase_mib": 1948.84375,
+  "setup_seconds": 34.16598312499991,
+  "solve_grid": [
+    48,
+    21,
+    1
+  ],
+  "total_peak_rss_increase_mib": 3301.90625,
+  "total_seconds": 96.49671862499963,
+  "versions": {
+    "jax": "0.11.1",
+    "numpy": "2.5.2",
+    "python": "3.12.13",
+    "vmex": "0.7.0"
+  },
+  "vmex_module": "vmex/__init__.py"
+}

--- a/benchmarks/strong_root.py
+++ b/benchmarks/strong_root.py
@@ -24,6 +24,7 @@ from vmex.core.input import VmecInput
 from vmex.core.radial_basis import BSplineBasis
 from vmex.core.polish import (
     build_low_order_preconditioner,
+    build_strong_physical_block_preconditioner,
     make_strong_physical_chart,
     make_strong_root_runtime,
     make_strong_structured_chart,
@@ -117,6 +118,11 @@ def main() -> None:
         default=8,
         help="fixed Rademacher probes for physical-chart equilibration",
     )
+    parser.add_argument(
+        "--physical-block-bandwidth",
+        type=int,
+        help="diagnose physical-chart mode blocks with this poloidal width",
+    )
     args = parser.parse_args()
     if args.ns < args.degree + 2:
         parser.error("ns must be at least degree + 2")
@@ -126,6 +132,11 @@ def main() -> None:
         parser.error("radial-spans must be positive")
     if args.chart_balance_probes < 1:
         parser.error("chart-balance-probes must be positive")
+    if (
+        args.physical_block_bandwidth is not None
+        and args.physical_block_bandwidth < 1
+    ):
+        parser.error("physical-block-bandwidth must be positive")
 
     inp = VmecInput.from_file(args.input).change_resolution(
         mpol=args.mpol,
@@ -274,6 +285,29 @@ def main() -> None:
                 @ (jnp.asarray(chart.equation_scale) * physical_left[:, -1]),
             ),
         }
+        if args.physical_block_bandwidth is not None:
+            block = build_strong_physical_block_preconditioner(
+                runtime,
+                chart,
+                poloidal_bandwidth=args.physical_block_bandwidth,
+            )
+            preconditioner_matrix = jax.vmap(
+                lambda column: block.apply(column, 1.0),
+                in_axes=1,
+                out_axes=1,
+            )(jnp.eye(chart.size, dtype=physical_jacobian.dtype))
+            preconditioned = physical_jacobian @ preconditioner_matrix
+            preconditioned_singular = np.linalg.svd(
+                np.asarray(preconditioned),
+                compute_uv=False,
+            )
+            physical_chart_report["block_preconditioner"] = {
+                "poloidal_bandwidth": args.physical_block_bandwidth,
+                "build_seconds": block.build_seconds,
+                "condition_number": float(
+                    preconditioned_singular[0] / preconditioned_singular[-1]
+                ),
+            }
 
     step = 2.0e-5
     finite_difference = (residual(step * direction) - residual(-step * direction)) / (

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -21,6 +21,7 @@ from vmex.core.polish import (
     PreconditionerSnapshot,
     apply_high_order_correction,
     build_low_order_preconditioner,
+    build_strong_physical_block_preconditioner,
     build_strong_mode_block_preconditioner,
     make_high_low_transfer,
     make_strong_physical_chart,
@@ -37,6 +38,7 @@ from vmex.core.polish import (
 )
 from vmex.core.polish_driver import (
     PolishConfig,
+    _IdentityPreconditioner,
     _arclength_to_target,
     _bordered_preconditioner,
     _branch_tangent,
@@ -102,6 +104,18 @@ def test_parameterized_continuation_preconditioner_switches_at_half(monkeypatch)
         _continuation_precondition(rhs, 0.75, 1.0, SimpleNamespace(), block),
         3.0 * rhs,
     )
+    identity = _IdentityPreconditioner()
+    np.testing.assert_array_equal(identity.apply(rhs), rhs)
+    np.testing.assert_array_equal(
+        _continuation_precondition(
+            rhs,
+            0.25,
+            1.0,
+            SimpleNamespace(),
+            identity,
+        ),
+        rhs,
+    )
 
 
 def test_arclength_crossing_runs_target_correction_and_counts_work(monkeypatch):
@@ -159,7 +173,7 @@ def test_arclength_crossing_runs_target_correction_and_counts_work(monkeypatch):
     )
     monkeypatch.setattr(
         "vmex.core.polish_driver._apply_bordered_preconditioner",
-        lambda state, rhs, dtau, tangent, runtime, block: rhs,
+        lambda state, rhs, dtau, tangent, runtime, block, chart=None: rhs,
     )
     monkeypatch.setattr(
         "vmex.core.polish_driver._low_inverse", lambda rhs, runtime: rhs
@@ -665,6 +679,42 @@ def test_structured_chart_uses_only_physical_layout_channels(small_strong_root):
     assert rank == chart.size
 
 
+def test_structured_chart_mode_blocks_recover_local_jacobian(small_strong_root):
+    runtime = small_strong_root
+    chart = make_strong_structured_chart(runtime)
+    preconditioner = build_strong_physical_block_preconditioner(
+        runtime,
+        chart,
+        poloidal_bandwidth=64,
+    )
+    zero = jnp.zeros((chart.size,), dtype=jnp.float64)
+    direction = jnp.linspace(-0.15, 0.25, chart.size)
+    _, response = jax.jvp(
+        lambda value: strong_physical_residual(value, runtime, chart, 1.0),
+        (zero,),
+        (direction,),
+    )
+    np.testing.assert_allclose(
+        preconditioner.apply(response, 1.0),
+        direction,
+        rtol=5.0e-8,
+        atol=5.0e-8,
+    )
+    with pytest.raises(ValueError, match="poloidal_bandwidth"):
+        build_strong_physical_block_preconditioner(
+            runtime, chart, poloidal_bandwidth=0
+        )
+    with pytest.raises(ValueError, match="physical block linearization"):
+        build_strong_physical_block_preconditioner(
+            runtime,
+            chart,
+            jnp.zeros((chart.size + 1,)),
+        )
+    dense_chart = make_strong_physical_chart(runtime)
+    with pytest.raises(ValueError, match="local structured chart"):
+        build_strong_physical_block_preconditioner(runtime, dense_chart)
+
+
 def test_strong_root_validation_branches(small_adapter, small_strong_root):
     native, _, _, mask, adapter = small_adapter
     layout = small_strong_root.layout
@@ -857,6 +907,7 @@ def test_polish_driver_records_bounded_unpolished_return(
         alpha_min_step=1.0e-3,
         alpha_max_step=1.0e-3,
         max_nonlinear_iterations=12,
+        preconditioner="legacy",
         use_pseudo_arclength=True,
         fail_policy="return_unpolished",
     )
@@ -903,10 +954,12 @@ def test_polish_driver_records_bounded_unpolished_return(
     monkeypatch.setattr(
         "vmex.core.polish_driver._arclength_to_target", fail_tangent
     )
+    chart = make_strong_structured_chart(small_strong_root)
     result = polish_strong_root(
         small_strong_root,
         config=config,
         initial_certificate=InitialCertificate(),
+        chart=chart,
     )
     report = result.polish_report
     assert not report.converged

--- a/vmex/core/polish.py
+++ b/vmex/core/polish.py
@@ -377,7 +377,12 @@ class StrongPhysicalChart:
     @classmethod
     def tree_unflatten(cls, metadata, children):
         gauge_rank, build_seconds = metadata
-        coordinate_basis, equation_basis, coordinate_scale, equation_scale = children
+        (
+            coordinate_basis,
+            equation_basis,
+            coordinate_scale,
+            equation_scale,
+        ) = children
         return cls(
             coordinate_basis=coordinate_basis,
             equation_basis=equation_basis,
@@ -1049,6 +1054,40 @@ def _physical_equation_basis(layout: StrongRootLayout) -> np.ndarray:
     return _physical_equation_chart(layout)[0]
 
 
+def _physical_coordinate_blocks(
+    runtime: StrongRootRuntime,
+    chart: StrongPhysicalChart,
+    poloidal_bandwidth: int,
+) -> tuple[Array, ...]:
+    """Group every local structured-chart coordinate exactly once."""
+
+    if poloidal_bandwidth < 1:
+        raise ValueError("poloidal_bandwidth must be positive")
+    basis = np.asarray(chart.coordinate_basis)
+    grouped: dict[tuple[int, int], list[int]] = {}
+    assigned = np.zeros((chart.size,), dtype=int)
+    for group in runtime.layout.groups:
+        support = np.flatnonzero(
+            np.linalg.norm(basis[group.start : group.stop], axis=0) > 1.0e-12
+        )
+        if support.size == 0:
+            continue
+        assigned[support] += 1
+        key = (
+            int(group.abs_n),
+            int(group.m) // int(poloidal_bandwidth),
+        )
+        grouped.setdefault(key, []).extend(support.tolist())
+    if not np.all(assigned == 1):
+        raise ValueError(
+            "physical block operations require a local structured chart"
+        )
+    return tuple(
+        jnp.asarray(sorted(set(grouped[key])), dtype=jnp.int32)
+        for key in sorted(grouped)
+    )
+
+
 def make_strong_physical_chart(
     runtime: StrongRootRuntime,
     *,
@@ -1597,6 +1636,62 @@ def build_strong_mode_block_preconditioner(
     )
 
 
+def build_strong_physical_block_preconditioner(
+    runtime: StrongRootRuntime,
+    chart: StrongPhysicalChart,
+    vector: Array | None = None,
+    *,
+    poloidal_bandwidth: int = 3,
+) -> StrongModeBlockPreconditioner:
+    """Probe bounded mode blocks directly in structured physical coordinates."""
+
+    if poloidal_bandwidth < 1:
+        raise ValueError("poloidal_bandwidth must be positive")
+    started = perf_counter()
+    base = (
+        jnp.zeros(
+            (chart.size,),
+            dtype=jnp.asarray(runtime.native.R_cos).dtype,
+        )
+        if vector is None
+        else jnp.asarray(vector)
+    )
+    if base.shape != (chart.size,):
+        raise ValueError(
+            f"physical block linearization has shape {base.shape}; "
+            f"expected {(chart.size,)}"
+        )
+    indices = _physical_coordinate_blocks(
+        runtime,
+        chart,
+        poloidal_bandwidth,
+    )
+    low_blocks: list[Array] = []
+    strong_blocks: list[Array] = []
+    for block_indices in indices:
+        local_zero = jnp.zeros((block_indices.size,), dtype=base.dtype)
+
+        def block_residual(local: Array, alpha: float) -> Array:
+            candidate = base.at[block_indices].add(local)
+            return strong_physical_residual(
+                candidate, runtime, chart, alpha
+            )[block_indices]
+
+        low_blocks.append(
+            jax.jacfwd(lambda local: block_residual(local, 0.0))(local_zero)
+        )
+        strong_blocks.append(
+            jax.jacfwd(lambda local: block_residual(local, 1.0))(local_zero)
+        )
+    jax.block_until_ready((low_blocks, strong_blocks))
+    return StrongModeBlockPreconditioner(
+        indices,
+        tuple(low_blocks),
+        tuple(strong_blocks),
+        perf_counter() - started,
+    )
+
+
 def build_low_order_preconditioner(
     native: HighOrderEquilibriumState,
     params: Any,
@@ -1714,6 +1809,7 @@ __all__ = [
     "StrongRootRuntime",
     "apply_high_order_correction",
     "build_low_order_preconditioner",
+    "build_strong_physical_block_preconditioner",
     "build_strong_mode_block_preconditioner",
     "make_high_low_transfer",
     "make_strong_physical_chart",

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -21,11 +21,14 @@ from solvax import gmres
 from .errors import StrongForceCertificationError, StrongForceContinuationError
 from .polish import (
     StrongModeBlockPreconditioner,
+    StrongPhysicalChart,
     StrongRootRuntime,
     apply_high_order_correction,
     build_low_order_preconditioner,
+    build_strong_physical_block_preconditioner,
     build_strong_mode_block_preconditioner,
     make_strong_root_runtime,
+    strong_physical_residual,
     strong_root_residual,
 )
 from .strong_force import (
@@ -97,7 +100,7 @@ class PolishConfig:
     max_backtracks: int = 12
     linear_restart: int = 30
     linear_max_restarts: int = 20
-    preconditioner: Literal["legacy", "mode-block"] = "mode-block"
+    preconditioner: Literal["none", "legacy", "mode-block"] = "mode-block"
     minimum_jacobian_ratio: float = 0.1
     minimum_jacobian_floor: float = 1.0e-8
     use_pseudo_arclength: bool = True
@@ -137,8 +140,10 @@ class PolishConfig:
             raise ValueError("polish iteration limits must be positive")
         if self.max_backtracks < 0 or self.linear_restart < 1 or self.linear_max_restarts < 1:
             raise ValueError("polish linear/backtracking limits are invalid")
-        if self.preconditioner not in ("legacy", "mode-block"):
-            raise ValueError("preconditioner must be 'legacy' or 'mode-block'")
+        if self.preconditioner not in ("none", "legacy", "mode-block"):
+            raise ValueError(
+                "preconditioner must be 'none', 'legacy', or 'mode-block'"
+            )
         if not 0.0 < self.minimum_jacobian_ratio <= 1.0:
             raise ValueError("minimum_jacobian_ratio must lie in (0, 1]")
         if self.minimum_jacobian_floor <= 0.0:
@@ -188,12 +193,48 @@ class PolishResult(NamedTuple):
     correction: jax.Array
 
 
+@dataclass(frozen=True)
+class _IdentityPreconditioner:
+    """Explicit identity action used to benchmark unpreconditioned JFNK."""
+
+    build_seconds: float = 0.0
+
+    def apply(self, rhs, alpha=1.0, dtau=jnp.inf):
+        del alpha, dtau
+        return rhs
+
+
 def _build_mode_block_preconditioner(
     runtime: StrongRootRuntime,
+    chart: StrongPhysicalChart | None = None,
 ) -> StrongModeBlockPreconditioner:
     """Backward-compatible private seam for the shared block builder."""
 
-    return build_strong_mode_block_preconditioner(runtime)
+    if chart is None:
+        return build_strong_mode_block_preconditioner(runtime)
+    return build_strong_physical_block_preconditioner(runtime, chart)
+
+
+def _solve_residual(
+    vector: jax.Array,
+    runtime: StrongRootRuntime,
+    alpha: jax.Array,
+    chart: StrongPhysicalChart | None = None,
+) -> jax.Array:
+    """Evaluate either the legacy full chart or the structured physical chart."""
+
+    if chart is None:
+        return strong_root_residual(vector, runtime, alpha)
+    return strong_physical_residual(vector, runtime, chart, alpha)
+
+
+def _full_solve_vector(
+    vector: jax.Array,
+    chart: StrongPhysicalChart | None,
+) -> jax.Array:
+    """Lift physical solve coordinates into the existing full root layout."""
+
+    return jnp.asarray(vector) if chart is None else chart.lift(vector)
 
 
 def _continuation_precondition(
@@ -202,9 +243,14 @@ def _continuation_precondition(
     dtau: jax.Array,
     runtime: StrongRootRuntime,
     block_preconditioner: StrongModeBlockPreconditioner,
+    chart: StrongPhysicalChart | None = None,
 ) -> jax.Array:
     """Use the exact legacy inverse early and mode bands near strong force."""
 
+    if isinstance(block_preconditioner, _IdentityPreconditioner):
+        return rhs
+    if chart is not None:
+        return block_preconditioner.apply(rhs, alpha, dtau)
     return jax.lax.cond(
         jnp.asarray(alpha) < 0.5,
         lambda value: _low_inverse(value, runtime),
@@ -213,15 +259,24 @@ def _continuation_precondition(
     )
 
 
-def _corrected_state(vector: jax.Array, runtime: StrongRootRuntime):
+def _corrected_state(
+    vector: jax.Array,
+    runtime: StrongRootRuntime,
+    chart: StrongPhysicalChart | None = None,
+):
+    vector = _full_solve_vector(vector, chart)
     correction = runtime.layout.unpack(
         jnp.asarray(runtime.coordinate_scale) * jnp.asarray(vector)
     )
     return apply_high_order_correction(runtime.native, correction)
 
 
-def _minimum_signed_jacobian(vector: jax.Array, runtime: StrongRootRuntime) -> jax.Array:
-    state = _corrected_state(vector, runtime)
+def _minimum_signed_jacobian(
+    vector: jax.Array,
+    runtime: StrongRootRuntime,
+    chart: StrongPhysicalChart | None = None,
+) -> jax.Array:
+    state = _corrected_state(vector, runtime, chart)
     rr, tt, zz = jnp.meshgrid(
         jnp.asarray(runtime.radial_nodes),
         jnp.asarray(runtime.theta),
@@ -246,14 +301,37 @@ def _low_inverse(rhs: jax.Array, runtime: StrongRootRuntime) -> jax.Array:
     )
 
 
+def _solve_low_inverse(
+    rhs: jax.Array,
+    runtime: StrongRootRuntime,
+    chart: StrongPhysicalChart | None = None,
+) -> jax.Array:
+    """Apply the legacy inverse in the active solve-coordinate chart."""
+
+    if chart is None:
+        return _low_inverse(rhs, runtime)
+    full_rhs = jnp.asarray(chart.equation_basis) @ (
+        jnp.asarray(rhs) / jnp.asarray(chart.equation_scale)
+    )
+    full_solution = _low_inverse(full_rhs, runtime)
+    return (
+        jnp.asarray(chart.coordinate_basis).T @ full_solution
+    ) / jnp.asarray(chart.coordinate_scale)
+
+
 def _normalized_low_residual_norm(
     residual: jax.Array,
     runtime: StrongRootRuntime,
+    chart: StrongPhysicalChart | None = None,
 ) -> jax.Array:
     """Return the low-endpoint RMS before numerical row equilibration."""
 
-    unscaled = jnp.asarray(residual) / jnp.asarray(runtime.equation_scale)
-    return jnp.linalg.norm(unscaled) / np.sqrt(float(runtime.layout.size))
+    equation_scale = (
+        runtime.equation_scale if chart is None else chart.equation_scale
+    )
+    size = runtime.layout.size if chart is None else chart.size
+    unscaled = jnp.asarray(residual) / jnp.asarray(equation_scale)
+    return jnp.linalg.norm(unscaled) / np.sqrt(float(size))
 
 
 def _ptc_config(config: PolishConfig, *, residual_scale: float) -> Any:
@@ -293,18 +371,21 @@ def _branch_tangent(
     config: PolishConfig,
     previous: tuple[jax.Array, jax.Array] | None,
     block_preconditioner: StrongModeBlockPreconditioner | None = None,
+    chart: StrongPhysicalChart | None = None,
 ) -> tuple[jax.Array, jax.Array]:
-    residual = lambda value: strong_root_residual(value, runtime, alpha)  # noqa: E731
+    residual = lambda value: _solve_residual(  # noqa: E731
+        value, runtime, alpha, chart
+    )
     _, jvp = jax.linearize(residual, vector)
-    parameter_direction = strong_root_residual(
-        vector, runtime, 1.0
-    ) - strong_root_residual(vector, runtime, 0.0)
+    parameter_direction = _solve_residual(
+        vector, runtime, 1.0, chart
+    ) - _solve_residual(vector, runtime, 0.0, chart)
     if previous is None:
         linear = gmres(
             jvp,
             -parameter_direction,
             precond=(
-                (lambda value: _low_inverse(value, runtime))
+                (lambda value: _solve_low_inverse(value, runtime, chart))
                 if block_preconditioner is None
                 else lambda value: block_preconditioner.apply(value, alpha)
             ),
@@ -335,7 +416,7 @@ def _branch_tangent(
             bordered,
             (jnp.zeros_like(vector), jnp.asarray(1.0, dtype=vector.dtype)),
             precond=lambda rhs: _bordered_preconditioner(
-                runtime, previous, block_preconditioner
+                runtime, previous, block_preconditioner, chart
             )((vector, jnp.asarray(alpha)), rhs, jnp.inf),
             restart=config.linear_restart,
             rtol=min(1.0e-6, config.tolerance),
@@ -366,6 +447,7 @@ def _bordered_preconditioner(
     runtime: StrongRootRuntime,
     tangent: tuple[jax.Array, jax.Array],
     block_preconditioner: StrongModeBlockPreconditioner | None = None,
+    chart: StrongPhysicalChart | None = None,
 ):
     """Return a low-order block-elimination preconditioner for a bordered root."""
 
@@ -377,6 +459,7 @@ def _bordered_preconditioner(
             tangent,
             runtime,
             block_preconditioner,
+            chart,
         )
 
     return apply
@@ -389,17 +472,18 @@ def _apply_bordered_preconditioner(
     tangent,
     runtime: StrongRootRuntime,
     block_preconditioner: StrongModeBlockPreconditioner | None = None,
+    chart: StrongPhysicalChart | None = None,
 ):
     """Apply bordered block elimination with dynamic branch data."""
 
     vector, alpha = state
     rhs_x, rhs_alpha = rhs
     tangent_x, tangent_alpha = tangent
-    parameter_direction = strong_root_residual(
-        vector, runtime, 1.0
-    ) - strong_root_residual(vector, runtime, 0.0)
+    parameter_direction = _solve_residual(
+        vector, runtime, 1.0, chart
+    ) - _solve_residual(vector, runtime, 0.0, chart)
     inverse = (
-        (lambda value: _low_inverse(value, runtime))
+        (lambda value: _solve_low_inverse(value, runtime, chart))
         if block_preconditioner is None
         else lambda value: block_preconditioner.apply(value, alpha, dtau)
     )
@@ -426,22 +510,32 @@ def _arclength_to_target(
     admissible,
     block_preconditioner: StrongModeBlockPreconditioner | None,
     initial_tangent: tuple[jax.Array, jax.Array] | None,
+    chart: StrongPhysicalChart | None = None,
 ):
     _, _, _, pseudo_arclength_corrector, pseudo_transient_continuation = (
         _solvax_continuation_api()
     )
     tangent = (
-        _branch_tangent(vector, alpha, runtime, config, None, block_preconditioner)
+        _branch_tangent(
+            vector,
+            alpha,
+            runtime,
+            config,
+            None,
+            block_preconditioner,
+            chart,
+        )
         if initial_tangent is None
         else initial_tangent
     )
-    residual_scale = np.sqrt(float(runtime.layout.size)) / float(
+    solve_size = runtime.layout.size if chart is None else chart.size
+    residual_scale = np.sqrt(float(solve_size)) / float(
         runtime.operator_balance
     )
     nonlinear = _ptc_config(config, residual_scale=residual_scale)
     total_nonlinear = total_linear = total_evaluations = 0
-    arclength_residual = lambda value, parameter: strong_root_residual(  # noqa: E731
-        value, runtime, parameter
+    arclength_residual = lambda value, parameter: _solve_residual(  # noqa: E731
+        value, runtime, parameter, chart
     )
     arclength_admissible = lambda value, parameter: admissible(  # noqa: E731
         value, parameter
@@ -455,6 +549,7 @@ def _arclength_to_target(
                 branch_tangent,
                 runtime,
                 block_preconditioner,
+                chart,
             )
         )
     )
@@ -470,7 +565,7 @@ def _arclength_to_target(
         elif _supports_keyword(pseudo_arclength_corrector, "precond"):
             corrector_kwargs = {
                 "precond": _bordered_preconditioner(
-                    runtime, tangent, block_preconditioner
+                    runtime, tangent, block_preconditioner, chart
                 )
             }
         else:
@@ -494,10 +589,14 @@ def _arclength_to_target(
         alpha = float(alpha_array)
         if (previous_alpha - 1.0) * (alpha - 1.0) <= 0.0:
             target = pseudo_transient_continuation(
-                lambda value: strong_root_residual(value, runtime, 1.0),
+                lambda value: _solve_residual(value, runtime, 1.0, chart),
                 vector,
                 precond=(
-                    (lambda state, rhs, dtau: _low_inverse(rhs, runtime))
+                    (
+                        lambda state, rhs, dtau: _solve_low_inverse(
+                            rhs, runtime, chart
+                        )
+                    )
                     if block_preconditioner is None
                     else lambda state, rhs, dtau: block_preconditioner.apply(
                         rhs, 1.0, dtau
@@ -525,6 +624,7 @@ def _arclength_to_target(
             config,
             tangent,
             block_preconditioner,
+            chart,
         )
     return (
         vector,
@@ -541,6 +641,7 @@ def polish_strong_root(
     *,
     config: PolishConfig | None = None,
     initial_certificate: StrongForceReport | None = None,
+    chart: StrongPhysicalChart | None = None,
 ) -> PolishResult:
     """Follow the legacy-connected fixed-boundary branch to strong force."""
 
@@ -551,7 +652,11 @@ def polish_strong_root(
         if initial_certificate is None
         else initial_certificate
     )
-    zero = jnp.zeros((runtime.layout.size,), dtype=jnp.asarray(runtime.native.R_cos).dtype)
+    solve_size = runtime.layout.size if chart is None else chart.size
+    zero = jnp.zeros(
+        (solve_size,), dtype=jnp.asarray(runtime.native.R_cos).dtype
+    )
+    full_zero = jnp.zeros((runtime.layout.size,), dtype=zero.dtype)
     if float(initial_certificate.normalized_l2) <= config.certificate_tolerance:
         report = PolishReport(
             converged=True,
@@ -569,16 +674,17 @@ def polish_strong_root(
             factor_build_seconds=runtime.low_preconditioner.factor_build_seconds,
             solve_seconds=perf_counter() - started,
         )
-        return PolishResult(runtime.native, initial_certificate, report, zero)
+        return PolishResult(runtime.native, initial_certificate, report, full_zero)
     _, _, adaptive_continuation, _, pseudo_transient_continuation = (
         _solvax_continuation_api()
     )
-    initial_margin = float(_minimum_signed_jacobian(zero, runtime))
-    block_preconditioner = (
-        _build_mode_block_preconditioner(runtime)
-        if config.preconditioner == "mode-block"
-        else None
-    )
+    initial_margin = float(_minimum_signed_jacobian(zero, runtime, chart))
+    if config.preconditioner == "mode-block":
+        block_preconditioner = _build_mode_block_preconditioner(runtime, chart)
+    elif config.preconditioner == "none":
+        block_preconditioner = _IdentityPreconditioner()
+    else:
+        block_preconditioner = None
     factor_build_seconds = (
         runtime.low_preconditioner.factor_build_seconds
         + (0.0 if block_preconditioner is None else block_preconditioner.build_seconds)
@@ -590,26 +696,30 @@ def polish_strong_root(
 
     def admissible(vector, alpha):
         del alpha
-        residual = strong_root_residual(vector, runtime, 1.0)
+        residual = _solve_residual(vector, runtime, 1.0, chart)
         return (
             jnp.all(jnp.isfinite(vector))
             & jnp.all(jnp.isfinite(residual))
-            & (_minimum_signed_jacobian(vector, runtime) >= margin_floor)
+            & (_minimum_signed_jacobian(vector, runtime, chart) >= margin_floor)
         )
 
-    residual_scale = np.sqrt(float(runtime.layout.size)) / float(
+    residual_scale = np.sqrt(float(solve_size)) / float(
         runtime.operator_balance
     )
     nonlinear = _ptc_config(config, residual_scale=residual_scale)
-    precondition = lambda state, rhs, dtau: _low_inverse(rhs, runtime)  # noqa: E731
+    precondition = (  # noqa: E731
+        (lambda state, rhs, dtau: rhs)
+        if config.preconditioner == "none"
+        else lambda state, rhs, dtau: _solve_low_inverse(rhs, runtime, chart)
+    )
     # The low homotopy endpoint subtracts the stored legacy defect, so zero is
     # its mathematical root.  Roundoff from restrict/project/prolong may leave
     # a tiny row-equilibrated remainder.  Check that remainder before row
     # scaling and avoid asking PTC to reduce it below floating-point noise.
     # A genuinely inconsistent endpoint still takes the globalized solve.
-    endpoint_residual = strong_root_residual(zero, runtime, 0.0)
+    endpoint_residual = _solve_residual(zero, runtime, 0.0, chart)
     endpoint_solved = float(
-        _normalized_low_residual_norm(endpoint_residual, runtime)
+        _normalized_low_residual_norm(endpoint_residual, runtime, chart)
     ) <= config.tolerance
     if endpoint_solved:
         vector = zero
@@ -619,7 +729,7 @@ def polish_strong_root(
         converged = True
     else:
         endpoint = pseudo_transient_continuation(
-            lambda vector: strong_root_residual(vector, runtime, 0.0),
+            lambda vector: _solve_residual(vector, runtime, 0.0, chart),
             zero,
             precond=precondition,
             admissible=lambda vector: admissible(vector, 0.0),
@@ -656,13 +766,14 @@ def polish_strong_root(
                         dtau,
                         runtime,
                         block_preconditioner,
+                        chart,
                     )
                 )
             }
         )
         continuation = adaptive_continuation(
-            lambda value, parameter: strong_root_residual(
-                value, runtime, parameter
+            lambda value, parameter: _solve_residual(
+                value, runtime, parameter, chart
             ),
             vector,
             alpha0=0.0,
@@ -708,6 +819,7 @@ def polish_strong_root(
                     admissible,
                     block_preconditioner,
                     initial_tangent,
+                    chart,
                 )
             except StrongForceContinuationError:
                 reason = "pseudo-arclength-tangent-failed"
@@ -735,7 +847,9 @@ def polish_strong_root(
             linear_iterations=linear_iterations,
             residual_evaluations=residual_evaluations,
             arclength_steps=arclength_steps,
-            minimum_signed_jacobian=float(_minimum_signed_jacobian(vector, runtime)),
+            minimum_signed_jacobian=float(
+                _minimum_signed_jacobian(vector, runtime, chart)
+            ),
             factor_build_seconds=factor_build_seconds,
             solve_seconds=perf_counter() - started,
         )
@@ -744,15 +858,19 @@ def polish_strong_root(
                 "strong-force continuation did not reach alpha=1",
                 hint="inspect the continuation report and refine the radial representation",
                 alpha=float(alpha),
-                residual_norm=float(jnp.linalg.norm(strong_root_residual(vector, runtime, alpha))),
+                residual_norm=float(
+                    jnp.linalg.norm(
+                        _solve_residual(vector, runtime, alpha, chart)
+                    )
+                ),
                 nonlinear_iterations=nonlinear_iterations,
                 linear_iterations=linear_iterations,
                 accepted_stages=accepted,
                 rejected_stages=rejected,
             )
-        return PolishResult(runtime.native, initial_certificate, report, zero)
+        return PolishResult(runtime.native, initial_certificate, report, full_zero)
 
-    state = _corrected_state(vector, runtime)
+    state = _corrected_state(vector, runtime, chart)
     certificate = certify_strong_force(state)
     certified = float(certificate.normalized_l2) <= config.certificate_tolerance
     report = PolishReport(
@@ -779,8 +897,13 @@ def polish_strong_root(
             tolerance=config.certificate_tolerance,
         )
     if not certified:
-        return PolishResult(runtime.native, initial_certificate, report, zero)
-    return PolishResult(state, certificate, report, vector)
+        return PolishResult(runtime.native, initial_certificate, report, full_zero)
+    return PolishResult(
+        state,
+        certificate,
+        report,
+        _full_solve_vector(vector, chart),
+    )
 
 
 def polish_legacy_solution(


### PR DESCRIPTION
## Summary
- make the continuation driver capable of operating in an explicit structured physical chart while preserving its existing default full-root path
- build optional physical-coordinate mode blocks, expose an identity/no-preconditioner diagnostic, and retain full-layout corrections at the result boundary
- add a reproducible bounded strong-polish benchmark plus right-preconditioner diagnostics
- serialize certificate radial profiles for the final cross-code figure

## Validation
- `ruff check` on every changed source/test/benchmark
- `pytest -q tests/test_polish_preconditioner.py` (45 passed)
- clean cache-disabled smoke artifact and clean canonical direct-endpoint artifact committed

## Evidence and status
- the default 3-mode physical block is harmful: right-preconditioned endpoint condition rises from 2.28e6 to 1.37e9
- identity JFNK follows 18 accepted stages to alpha=0.8584 in 76.98 s total, but does not cross the known homotopy fold
- pseudo-arclength and endpoint-alignment experiments were measured and rejected for runtime/memory; their speculative implementation was removed
- a bounded canonical mpol=5 direct endpoint attempt exhausts 30 nonlinear steps and worsens the independent certificate from 0.11475 to 0.59186

This PR is a diagnostic checkpoint, not a merge candidate. It keeps the user-facing/default polish path unchanged. The next scientific gate is solve/certificate projection consistency, not more continuation tuning.