### PR TITLE
Add direct WOUT field-line geometry adapter

### DIFF
--- a/docs/reference/objectives.rst
+++ b/docs/reference/objectives.rst
@@ -539,10 +539,13 @@ JAX-native Hermite–Laguerre flux-tube solver, formerly SPECTRAX-GK;
 (plan R26h.h4):
 
 - :func:`~vmex.core.turbulence.gk_fieldline_geometry` /
+  :func:`~vmex.core.turbulence.gk_fieldline_geometry_from_wout` /
   :func:`~vmex.core.turbulence.flux_tube_geometry` — sample one field
   line of the converged interior solution into GS2/GX-normalized flux-tube
   geometry (``bmag``, ``gds2/gds21/gds22``, curvature/grad-B drifts, …),
-  pure JAX, no gkx import needed;
+  pure JAX, no gkx import needed.  The WOUT route accepts an in-memory object
+  or any VMEC-compatible file and evaluates the same spectral contract without
+  reconstructing or re-solving an equilibrium;
 - :func:`~vmex.core.turbulence.turbulent_growth_rate` — the dominant
   linear ITG/TEM growth rate on that flux tube.  Fully differentiable in
   *both* gradient modes.  ``r_over_lt``/``r_over_ln`` are ``R/L`` and are

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -170,6 +170,37 @@ def test_surface_index_validation(shaped_eq):
         turb.gk_fieldline_geometry(shaped_eq.state, shaped_eq.runtime, ntheta=4)
 
 
+def test_wout_geometry_matches_live_state_without_reconstruction(shaped_eq, tmp_path):
+    """The read-only WOUT route reproduces the live-state mapping."""
+    import vmex
+
+    kwargs = dict(s_index=7, alpha=0.3, zeta0=0.2, ntheta=32,
+                  equal_arc=False)
+    live = turb.gk_fieldline_geometry(shaped_eq.state, shaped_eq.runtime, **kwargs)
+    memory = turb.gk_fieldline_geometry_from_wout(shaped_eq.wout, **kwargs)
+    path = vmex.write_wout(tmp_path / "wout_geometry.nc", shaped_eq.wout)
+    file_mapping = turb.gk_fieldline_geometry_from_wout(path, **kwargs)
+
+    for name in turb.GK_GEOMETRY_FIELDS + ("jacobian", "grho"):
+        expected = np.asarray(live[name])
+        np.testing.assert_allclose(np.asarray(memory[name]), expected,
+                                   rtol=2e-11, atol=2e-12, err_msg=name)
+        np.testing.assert_allclose(np.asarray(file_mapping[name]), expected,
+                                   rtol=2e-11, atol=2e-12, err_msg=name)
+    for name in ("q", "s_hat", "epsilon", "R0", "B0"):
+        assert float(memory[name]) == pytest.approx(float(live[name]), rel=2e-11,
+                                                    abs=2e-12)
+        assert float(file_mapping[name]) == pytest.approx(float(live[name]), rel=2e-11,
+                                                          abs=2e-12)
+    assert memory["nfp"] == file_mapping["nfp"] == live["nfp"]
+
+
+def test_wout_geometry_rejects_invalid_normalization(shaped_eq):
+    with pytest.raises(ValueError, match="Aminor_p"):
+        turb.gk_fieldline_geometry_from_wout(
+            dataclasses.replace(shaped_eq.wout, Aminor_p=0.0))
+
+
 # ---------------------------------------------------------------------------
 # GKX contract + proxies (importorskip-gated, like freeboundary_diff)
 # ---------------------------------------------------------------------------
@@ -416,6 +447,11 @@ def test_gk_geometry_matches_simsopt_vmec_fieldlines(deck, overrides, ns, tmp_pa
     alpha, s_index = 0.7, int(round(0.4 * (ns - 1)))
     geom = turb.gk_fieldline_geometry(eq.state, eq.runtime, s_index=s_index,
                                       alpha=alpha, ntheta=16, equal_arc=False)
+    imported = turb.gk_fieldline_geometry_from_wout(
+        wout_path, s_index=s_index, alpha=alpha, ntheta=16, equal_arc=False)
+    for name in turb.GK_GEOMETRY_FIELDS + ("jacobian", "grho"):
+        np.testing.assert_allclose(np.asarray(imported[name]), np.asarray(geom[name]),
+                                   rtol=2e-10, atol=2e-11, err_msg=name)
     s_value = float(np.asarray(stab._ballooning_context(
         eq.state, eq.runtime)["s"])[s_index])
     theta = np.asarray(geom["theta"])

--- a/vmex/__init__.py
+++ b/vmex/__init__.py
@@ -13,6 +13,8 @@ Public API (lazily imported; ``import vmex as vj``):
   / :func:`~vmex.core.wout.wout_from_state` / :class:`~vmex.core.wout.WoutData`
 - :func:`~vmex.core.restart.state_from_wout` /
   :func:`~vmex.core.restart.restart_state` — hot restart from any wout
+- :func:`~vmex.core.turbulence.gk_fieldline_geometry_from_wout` — GK
+  field-line geometry from any compatible wout, without a solve
   (also ``solve*(..., restart_from=...)``)
 - :class:`~vmex.core.strong_force.HighOrderEquilibriumState` /
   :func:`~vmex.core.strong_force.certify_strong_force` — axis-regular
@@ -144,6 +146,8 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
     "read_wout": (".core.wout", "read_wout"),
     "write_wout": (".core.wout", "write_wout"),
     "wout_from_state": (".core.wout", "wout_from_state"),
+    "gk_fieldline_geometry_from_wout": (
+        ".core.turbulence", "gk_fieldline_geometry_from_wout"),
     # hot restart
     "restart_state": (".core.restart", "restart_state"),
     "state_from_wout": (".core.restart", "state_from_wout"),

--- a/vmex/core/turbulence.py
+++ b/vmex/core/turbulence.py
@@ -15,7 +15,9 @@ two layers:
    ballooning objective in :mod:`vmex.core.stability`, whose spectral
    point-evaluation machinery is reused here, extended with the
    ``grad s``/``grad psi`` metric and drift projections.  Exact trig sums
-   + JAX AD throughout: jit/grad-transparent, no gkx import.
+   + JAX AD throughout: jit/grad-transparent, no gkx import.  The read-only
+   :func:`gk_fieldline_geometry_from_wout` route evaluates the same contract
+   from any compatible WOUT without reconstructing or re-solving a state.
 
 2. **Objective wrappers** — thin two-positional ``(state, runtime)``
    callables around the proxies GKX itself promotes for VMEX-side
@@ -82,6 +84,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from .solver import SolverRuntime, SpectralState
 from .statephysics import aspect_ratio
@@ -95,6 +98,7 @@ __all__ = [
     "GK_GEOMETRY_FIELDS",
     "TURBULENCE_OBJECTIVE_NAMES",
     "gk_fieldline_geometry",
+    "gk_fieldline_geometry_from_wout",
     "flux_tube_geometry",
     "turbulence_objective_vector",
     "turbulent_growth_rate",
@@ -219,10 +223,10 @@ def _line_arrays(ctx: dict, j: int, alpha: float, zeta0: float, x: Array):
 # ---------------------------------------------------------------------------
 
 
-def gk_fieldline_geometry(
-    state: SpectralState,
-    rt: SolverRuntime,
+def _gk_fieldline_geometry_from_context(
+    ctx: dict,
     *,
+    nfp: int,
     s_index: int | None = None,
     alpha: float = 0.0,
     zeta0: float = 0.0,
@@ -230,7 +234,7 @@ def gk_fieldline_geometry(
     equal_arc: bool = True,
     arc_oversample: int = 4,
 ) -> dict:
-    """Flux-tube geometry mapping of one field line of a converged state.
+    """Flux-tube geometry mapping from a normalized spectral context.
 
     Returns the in-memory geometry contract consumed by
     ``gkx.flux_tube_geometry_from_mapping`` (keys
@@ -269,7 +273,6 @@ def gk_fieldline_geometry(
     """
     if int(ntheta) < 8:
         raise ValueError("ntheta must be >= 8")
-    ctx = _ballooning_context(state, rt)
     j = _resolve_surface(s_index, ctx["ns"])
     dtype = ctx["s"].dtype
 
@@ -344,7 +347,7 @@ def gk_fieldline_geometry(
         "R0": L_ref,
         "B0": B_ref,
         "alpha": float(alpha),
-        "nfp": int(rt.resolution.nfp),
+        "nfp": int(nfp),
         "vmex": {
             "surface_index": j,
             "s": s_j,
@@ -363,6 +366,132 @@ def gk_fieldline_geometry(
                 "vmec_fieldlines normalizations; internal signed psi_edge",
         },
     }
+
+
+def gk_fieldline_geometry(
+    state: SpectralState,
+    rt: SolverRuntime,
+    *,
+    s_index: int | None = None,
+    alpha: float = 0.0,
+    zeta0: float = 0.0,
+    ntheta: int = 32,
+    equal_arc: bool = True,
+    arc_oversample: int = 4,
+) -> dict:
+    """Flux-tube geometry mapping of one field line of a converged state.
+
+    This is the differentiable live-state route.  See
+    :func:`gk_fieldline_geometry_from_wout` for read-only evaluation of an
+    existing VMEC-compatible WOUT without reconstructing or solving an
+    equilibrium.
+    """
+    return _gk_fieldline_geometry_from_context(
+        _ballooning_context(state, rt),
+        nfp=int(rt.resolution.nfp),
+        s_index=s_index,
+        alpha=alpha,
+        zeta0=zeta0,
+        ntheta=ntheta,
+        equal_arc=equal_arc,
+        arc_oversample=arc_oversample,
+    )
+
+
+def _wout_ballooning_context(wout: Any) -> dict:
+    """Normalize a VMEC-compatible WOUT to the live-state spectral context."""
+    from .postprocess import MU0, lambda_full_mesh_from_wout
+
+    ns = int(wout.ns)
+    if ns < 5:
+        raise ValueError(f"field-line geometry needs ns >= 5, got ns = {ns}")
+    s = np.linspace(0.0, 1.0, ns)
+    hs = s[1] - s[0]
+    m = np.asarray(wout.xm, dtype=int)
+    signgs = int(wout.signgs)
+    if signgs not in (-1, 1):
+        raise ValueError(f"WOUT signgs must be -1 or 1, got {signgs}")
+    phipf = np.asarray(wout.phipf, dtype=float) / (2.0 * np.pi * signgs)
+    unit_flux = np.ones(ns, dtype=float)
+    lmns = lambda_full_mesh_from_wout(
+        lmns_half=wout.lmns,
+        m_modes=m,
+        s=s,
+        phipf_internal=unit_flux,
+        lamscale=1.0,
+    )
+    lmnc = None
+    if bool(wout.lasym):
+        lmnc = lambda_full_mesh_from_wout(
+            lmns_half=wout.lmnc,
+            m_modes=m,
+            s=s,
+            phipf_internal=unit_flux,
+            lamscale=1.0,
+        )
+    L_ref = float(wout.Aminor_p)
+    if not np.isfinite(L_ref) or L_ref <= 0.0:
+        raise ValueError(f"WOUT Aminor_p must be finite and positive, got {L_ref}")
+    psi_edge = float(np.asarray(wout.phi, dtype=float)[-1]) / (2.0 * np.pi * signgs)
+    if not np.isfinite(psi_edge) or psi_edge == 0.0:
+        raise ValueError(f"WOUT edge toroidal flux must be finite and nonzero, got {psi_edge}")
+    return {
+        "s": jnp.asarray(s),
+        "hs": jnp.asarray(hs),
+        "ns": ns,
+        "m": jnp.asarray(m, dtype=float),
+        "xn": jnp.asarray(np.asarray(wout.xn, dtype=float)),
+        "rmnc": jnp.asarray(wout.rmnc),
+        "zmns": jnp.asarray(wout.zmns),
+        "lmns": jnp.asarray(lmns),
+        "rmns": None if not bool(wout.lasym) else jnp.asarray(wout.rmns),
+        "zmnc": None if not bool(wout.lasym) else jnp.asarray(wout.zmnc),
+        "lmnc": None if lmnc is None else jnp.asarray(lmnc),
+        "lasym": bool(wout.lasym),
+        "iotas": jnp.asarray(wout.iotas),
+        "pres": jnp.asarray(np.asarray(wout.pres, dtype=float) * MU0),
+        "phipf": jnp.asarray(phipf),
+        "psi_edge": jnp.asarray(psi_edge),
+        "sign_psi": jnp.asarray(np.sign(psi_edge)),
+        "L_ref": jnp.asarray(L_ref),
+        "B_ref": jnp.asarray(2.0 * abs(psi_edge) / (L_ref * L_ref)),
+    }
+
+
+def gk_fieldline_geometry_from_wout(
+    wout: Any,
+    *,
+    s_index: int | None = None,
+    alpha: float = 0.0,
+    zeta0: float = 0.0,
+    ntheta: int = 32,
+    equal_arc: bool = True,
+    arc_oversample: int = 4,
+) -> dict:
+    """Flux-tube mapping from a VMEC-compatible WOUT, without a solve.
+
+    ``wout`` may be a :class:`~vmex.core.wout.WoutData` or a filesystem path
+    accepted by :func:`vmex.read_wout`.  The returned mapping has the same
+    keys, normalization, field-line policy, and spectral evaluation as
+    :func:`gk_fieldline_geometry`.  This read-only route does not reconstruct
+    a solver state and does not re-converge the equilibrium.
+    """
+    from pathlib import Path
+
+    from .wout import read_wout
+
+    if isinstance(wout, (str, Path)):
+        wout = read_wout(wout)
+    return _gk_fieldline_geometry_from_context(
+        _wout_ballooning_context(wout),
+        nfp=int(wout.nfp),
+        s_index=s_index,
+        alpha=alpha,
+        zeta0=zeta0,
+        ntheta=ntheta,
+        equal_arc=equal_arc,
+        arc_oversample=arc_oversample,
+    )
 
 
 def flux_tube_geometry(


### PR DESCRIPTION
## Summary

- add `gk_fieldline_geometry_from_wout(...)` for any VMEC-compatible WOUT path or in-memory `WoutData`
- reuse the exact live-state spectral evaluator after a thin WOUT normalization step; no equilibrium reconstruction, re-solve, GKX import, or duplicate metric/drift formulas
- expose the API lazily at package root and document the read-only workflow

## Validation

- live-state, in-memory WOUT, and file WOUT mappings agree for every geometry array and scalar
- symmetric and LASYM WOUT mappings pass the existing independent simsopt `vmec_fieldlines` oracle
- invalid reference normalization is rejected explicitly
- `ruff` and focused `mypy` pass
- focused turbulence/WOUT tests: 4 passed (including both external-oracle symmetry rows)
- package API: 19 passed, 2 skipped
- Sphinx `-W`: passed

## Performance evidence

Apple CPU, shaped 13-surface equilibrium, 32-point non-equal-arc tube, synchronized result: live-state cold 3.451 s / warm median 0.0490 s; WOUT route after the shared JAX kernels were compiled 2.728 s first call / 0.0578 s warm median (0.0391 s minimum). The WOUT route adds only its host normalization step and shares all spectral metric/drift work with the live route.