### PR TITLE
Release VMEX 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vmex"
-version = "0.7.0"
+version = "0.7.1"
 description = "JAX implementation of VMEC2000 with differentiable fixed-boundary and branch-local free-boundary research paths."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Patch release for the Windows/WSL2 CUDA installation improvements already merged on main.

Highlights:
- vmex --doctor now detects WSL2, reports the NVIDIA GPU and Windows driver visible through nvidia-smi, and runs an actual JIT device calculation.
- Affected JAX/jaxlib 0.9.2 installations get actionable guidance to upgrade to 0.10.1+, which contains the upstream PJRT cache-message and two-component Windows driver parsing fixes. VMEX does not hide error-level CUDA diagnostics.
- The device benchmark separates cold compile, persistent-cache reload, and warm execution costs, including gradients and placement.
- QA optimization startup improvements and the other fixes already merged since 0.7.0 are included.

Release validation performed locally:
- python -m build produced vmex-0.7.1-py3-none-any.whl and vmex-0.7.1.tar.gz.
- tests/test_packaging_metadata.py: 6 passed.

This PR changes only the package version. Publishing v0.7.1 after merge will invoke the existing build, wheel/sdist smoke, and trusted PyPI publication workflow.
