### PR TITLE
geometry: export differentiable closed-mirror flux tubes

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,27 @@ VMEX also solves open-ended mirrors. `examples/mirror/mirror_fixed_boundary_nona
 
 ![Free-boundary mirror beta scan](docs/_static/figures/mirror_free_boundary_beta_scan.webp)
 
+Closed stellarator–mirror hybrids also expose a differentiable, equal-arc
+field-line contract for GKX. VMEX owns the Cartesian metric and drift
+calculation; GKX converts the returned mapping to its generic flux-tube type.
+The interface accepts only a field line that closes on the periodic racetrack,
+and makes no open-end, sheath, source, or loss-cone claim. The
+[model and equations](https://vmex.readthedocs.io/en/latest/explanation/mirror-gyrokinetics.html)
+spell out that boundary explicitly.
+
+```python
+from vmex.mirror import gk_closed_fieldline_geometry
+
+geometry = gk_closed_fieldline_geometry(
+    result.evaluated.state,
+    setup.discretization,
+    setup.axis,
+    axial_flux_derivative=AXIAL_FLUX_DERIVATIVE,
+    current_derivative=0.0,
+    ntheta=32,
+)
+```
+
 ## Equilibrium and kinetic diagnostics
 
 `vmex --plot wout_X.nc` produces cross-sections, profiles, a full-resolution 3-D LCFS, and the compact summaries below. They combine Mercier `DMerc`, Glasser `DR`, and $V''(s)$ on zero-aligned axes; add a 3-D LCFS; and show the second adiabatic invariant in the Velasco polar coordinates $x=s\cos\alpha$, $y=s\sin\alpha$. A separate stability figure decomposes `DMerc` and shows the frozen-geometry response to a pressure ramp; finite-pressure points must be re-solved for certification. Boozer $|B|$ appears automatically, while `--booz` only saves a reusable `boozmn_*.nc` file.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -39,6 +39,7 @@ confinement
 :maxdepth: 1
 
 mirror-geometry
+mirror-gyrokinetics
 architecture
 parallelization
 ```

--- a/docs/explanation/mirror-gyrokinetics.rst
+++ b/docs/explanation/mirror-gyrokinetics.rst
@@ -1,0 +1,180 @@
+Closed mirror geometry for gyrokinetics
+========================================
+
+This page defines the model exported by
+:func:`vmex.mirror.gk_closed_fieldline_geometry`.  It is a local gyrokinetic
+flux tube on VMEX's **periodic** stellarator--mirror hybrid.  It is not an
+open-ended mirror calculation: end losses, sheaths, ambipolar-potential
+formation, sources, and loss-cone replenishment are not periodic-geometry
+effects and are not modeled by this interface.
+
+Equilibrium coordinates and field
+---------------------------------
+
+Let :math:`u\in[0,2\pi)` parameterize the closed racetrack axis
+:math:`\boldsymbol c(u)`.  VMEX uses the rotation-minimizing normal frame
+:math:`(\boldsymbol n,\boldsymbol b)` and the embedding
+
+.. math::
+
+   \boldsymbol x(s,\theta,u)=\boldsymbol c(u)+\sqrt{s}\,a(s,\theta,u)
+   [\cos\theta\,\boldsymbol n(u)+\sin\theta\,\boldsymbol b(u)].
+
+The stream-function representation is discretely divergence free,
+
+.. math::
+
+   \sqrt g B^s=0,\qquad
+   \sqrt g B^\theta=I'(s)-\partial_u\lambda,\qquad
+   \sqrt g B^u=\Psi'(s)+\partial_\theta\lambda.
+
+For the first public interface :math:`\Psi'` and :math:`I'` are scalar.  The
+dimensionless Clebsch label
+
+.. math::
+
+   \alpha=\theta-\frac{I'}{\Psi'}u+\frac{\lambda}{\Psi'}
+
+then satisfies :math:`\boldsymbol B\boldsymbol\cdot\nabla\alpha=0` exactly up
+to the common spline/Fourier discretization.  Cartesian dual vectors are
+obtained by inverting the coordinate basis
+:math:`(\boldsymbol e_s,\boldsymbol e_\theta,\boldsymbol e_u)` only on the
+selected non-axis surface.  This avoids manufacturing toroidal coordinates
+or passing the racetrack through a WOUT representation.
+
+Closed-tube and equal-arc contract
+----------------------------------
+
+The field line is integrated with periodic RK4 through one axis circuit.  Its
+poloidal advance must be an integer multiple of :math:`2\pi` within the
+requested closure tolerance.  The zero-current mirror closes exactly;
+integer-transform tubes are also accepted.  A general irrational-transform
+line requires a future twist-linked tube and is rejected rather than silently
+made periodic.
+
+If :math:`u` is the raw line parameter, the local parallel factor is
+
+.. math::
+
+   g_\parallel(u)=L_{\rm ref}\frac{|B^u|}{|B|}.
+
+VMEX remaps it to :math:`z\in[-\pi,\pi)` using
+
+.. math::
+
+   z(u)=-\pi+2\pi
+   \frac{\int_{u_0}^{u}du'/g_\parallel(u')}
+        {\int_{u_0}^{u_0+2\pi}du'/g_\parallel(u')},\qquad
+   {\tt gradpar}=\frac{2\pi}{\int du/g_\parallel}.
+
+Thus ``gradpar`` is constant, matching the GKX/GX equal-arc contract.  The
+normalizations are
+
+.. math::
+
+   L_{\rm ref}=\sqrt{\frac{V}{\pi L_{\rm axis}}},\qquad
+   B_{\rm ref}=\frac{2|\Psi'|}{L_{\rm ref}^2},\qquad \rho=\sqrt{s}.
+
+At zero magnetic shear GKX interprets :math:`k_x` as the direct normalized
+radial wavenumber.  The complete perpendicular metric remains
+
+.. math::
+
+   g_{yy}=L_{\rm ref}^2s|\nabla\alpha|^2,\qquad
+   g_{xy}=\frac{L_{\rm ref}^2}{2}\nabla\alpha\boldsymbol\cdot\nabla s,
+   \qquad
+   g_{xx}=\frac{L_{\rm ref}^2}{4s}|\nabla s|^2,
+
+exported as ``gds2``, ``gds21``, and ``gds22``.  Consequently
+
+.. math::
+
+   k_\perp^2=k_y^2g_{yy}+2k_xk_yg_{xy}+k_x^2g_{xx}
+
+without a small-shear division.
+
+Mirror force and magnetic drifts
+--------------------------------
+
+The magnetic-mirror coefficient consumed by the Hermite--Laguerre coupling is
+
+.. math::
+
+   {\tt bgrad}=L_{\rm ref}
+   \frac{\boldsymbol B\boldsymbol\cdot\nabla|B|}{|B|^2}
+   ={\tt gradpar}\,\partial_z\ln |B|.
+
+The grad-B projections are evaluated in Cartesian space from
+:math:`\boldsymbol B\times\nabla|B|`.  With
+:math:`\sigma_\Psi={\rm sign}(\Psi')`,
+
+.. math::
+
+   {\tt gbdrift}=-\frac{2B_{\rm ref}L_{\rm ref}^2\sqrt{s}\,\sigma_\Psi}
+   {|B|^3}(\boldsymbol B\times\nabla|B|)\boldsymbol\cdot\nabla\alpha,
+
+.. math::
+
+   {\tt gbdrift0}=\frac{B_{\rm ref}L_{\rm ref}^2\sigma_\Psi}
+   {|B|^3\sqrt{s}}(\boldsymbol B\times\nabla|B|)\boldsymbol\cdot\nabla s.
+
+For vacuum, curvature and grad-B coefficients coincide.  A supplied
+``mu0_dp_ds`` adds the standard pressure-curvature term to ``cvdrift``;
+``cvdrift0`` retains the radial grad-B projection, consistently with the
+existing VMEX/GS2 geometry contract.
+
+Differentiability and performance
+---------------------------------
+
+All dynamic evaluation is in JAX: field-line RK4, B-spline evaluation,
+Fourier interpolation, equal-arc mapping, Cartesian duals, metrics, and
+drifts.  The spline recovery matrix and mode numbers are static arrays.  The
+mapping imports no GKX code, so VMEX remains independently installable; GKX's
+adapter only converts the returned dictionary to its generic sampled geometry.
+
+The validation ladder is deliberately ordered:
+
+#. positive Jacobian, divergence, axis/frame closure, and field-line closure;
+#. constant equal-arc ``gradpar``, positive perpendicular metric determinant,
+   and the independent spectral identity for ``bgrad``;
+#. JAX directional derivatives against centered finite differences;
+#. CPU/GPU value and gradient parity plus cold/warm JIT and memory audits;
+#. GKX constant-field and manufactured mirror-force tests;
+#. linear resolution/eigenfunction convergence, then quasilinear and matched
+   nonlinear audits, then held-out differentiable optimization.
+
+Open-ended mirror roadmap
+--------------------------
+
+A physical open-mirror extension needs a nonperiodic parallel operator,
+absorbing or kinetic-sheath boundaries, sources, self-consistent ambipolar
+potential, collisions that resolve loss-cone replenishment, and a background
+ordering suitable for strongly non-Maxwellian plasmas.  Its benchmarks are
+uniform open streaming, particle magnetic-moment and bounce invariants,
+loss-cone geometry, Pastukhov potential/confinement, velocity-space
+convergence, and published full-f Gkeyll cases.  Force softening is acceptable
+only beside an unsoftened convergence reference.  None of those claims attach
+to the periodic interface documented here.
+
+Primary references and independent inputs
+-----------------------------------------
+
+* Xanthopoulos *et al.*, `A geometry interface for gyrokinetic
+  microturbulence codes <https://doi.org/10.1063/1.3212262>`_, defines the
+  field-line metric/drift interface conventions used by GS2-family solvers.
+* Rodríguez, Helander, and Goodman, `The maximum-J property in
+  quasi-isodynamic stellarators
+  <https://doi.org/10.1017/S0022377824000345>`_, Appendix C, supplies VMEX's
+  independent rotating-ellipse paraxial oracle.
+* Francisquez *et al.*, `Towards continuum gyrokinetic study of high-field
+  mirrors <https://arxiv.org/abs/2305.06372>`_, and its `published Gkeyll input
+  decks
+  <https://github.com/gkeyllorg/gkyl-paper-inp/tree/master/2023_PoP_gkwham1x2v>`_
+  define the first open-lane Pastukhov, resolution, and force-softening
+  comparisons.
+* Rosen *et al.*, `Gyrokinetic equilibria of high temperature superconducting
+  magnetic mirrors <https://arxiv.org/abs/2604.11684>`_, and its `versioned
+  simulation/analysis inputs
+  <https://github.com/gkeyllorg/gkyl-paper-inp/tree/master/2026_PRE_hts_mirror_equilibria>`_
+  provide kinetic-equilibrium, potential, confinement, source, and mirror-ratio
+  comparisons for the future open lane.

--- a/tests/mirror/test_turbulence.py
+++ b/tests/mirror/test_turbulence.py
@@ -1,0 +1,112 @@
+"""Closed-mirror geometry contract for local gyrokinetic solvers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp  # noqa: E402
+
+from vmex.mirror import (  # noqa: E402
+    MirrorResolution,
+    build_stellarator_mirror_hybrid,
+    gk_closed_fieldline_geometry,
+)
+from vmex.mirror.model import MirrorState  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def closed_mirror():
+    resolution = MirrorResolution(ns=5, mpol=4, nxi=4)
+    setup = build_stellarator_mirror_hybrid(
+        resolution,
+        coefficient_count=16,
+        straight_length=4.0,
+        return_radius=2.0,
+        semi_major=0.4,
+        semi_minor=0.3,
+        section_turns=0,
+        axial_flux_derivative=0.02,
+        quadrature_order=3,
+    )
+    return setup, setup.discretization.evaluate_state(setup.initial_state)
+
+
+def test_closed_mirror_contract_is_periodic_equal_arc_and_positive(closed_mirror) -> None:
+    setup, state = closed_mirror
+    mapping = gk_closed_fieldline_geometry(
+        state,
+        setup.discretization,
+        setup.axis,
+        axial_flux_derivative=0.02,
+        ntheta=32,
+        arc_oversample=8,
+    )
+
+    for name in (
+        "theta",
+        "gradpar",
+        "bmag",
+        "bgrad",
+        "gds2",
+        "gds21",
+        "gds22",
+        "cvdrift",
+        "gbdrift",
+        "cvdrift0",
+        "gbdrift0",
+    ):
+        values = np.asarray(mapping[name])
+        assert values.shape == (32,)
+        assert np.all(np.isfinite(values))
+
+    np.testing.assert_allclose(mapping["gradpar"], mapping["gradpar"][0], rtol=0.0, atol=0.0)
+    metric_determinant = np.asarray(mapping["gds2"]) * np.asarray(mapping["gds22"]) - np.asarray(mapping["gds21"]) ** 2
+    assert np.min(metric_determinant) > 0.0
+    assert np.max(mapping["bmag"]) / np.min(mapping["bmag"]) > 1.5
+    assert abs(float(mapping["vmex_mirror"]["closure_residual"])) < 1.0e-12
+    assert mapping["s_hat"] == 0.0
+
+    # Independent periodic spectral derivative of the emitted field strength.
+    modes = jnp.fft.fftfreq(32, d=1.0 / 32)
+    d_log_b_dz = jnp.fft.ifft(1j * modes * jnp.fft.fft(jnp.log(mapping["bmag"]))).real
+    reconstructed = mapping["gradpar"] * d_log_b_dz
+    np.testing.assert_allclose(mapping["bgrad"], reconstructed, rtol=6.0e-2, atol=2.0e-3)
+
+
+def test_geometry_directional_derivative_matches_centered_difference(closed_mirror) -> None:
+    setup, state = closed_mirror
+
+    def objective(scale):
+        scaled = MirrorState(state.radius_scale * scale, state.lambda_stream)
+        mapping = gk_closed_fieldline_geometry(
+            scaled,
+            setup.discretization,
+            setup.axis,
+            axial_flux_derivative=0.02,
+            ntheta=8,
+            arc_oversample=2,
+        )
+        return jnp.mean(mapping["bmag"] ** 2)
+
+    derivative = jax.grad(objective)(1.0)
+    step = 1.0e-4
+    finite_difference = (objective(1.0 + step) - objective(1.0 - step)) / (2.0 * step)
+    assert np.isfinite(float(derivative))
+    np.testing.assert_allclose(derivative, finite_difference, rtol=2.0e-5, atol=2.0e-8)
+
+
+def test_nonclosing_field_line_is_rejected(closed_mirror) -> None:
+    setup, state = closed_mirror
+    with pytest.raises(ValueError, match="does not close"):
+        gk_closed_fieldline_geometry(
+            state,
+            setup.discretization,
+            setup.axis,
+            axial_flux_derivative=0.02,
+            current_derivative=0.002,
+            ntheta=8,
+            arc_oversample=2,
+        )

--- a/vmex/mirror/__init__.py
+++ b/vmex/mirror/__init__.py
@@ -29,6 +29,10 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
     "splice_straight_legs": (".splines", "splice_straight_legs"),
     "QIMirrorSplice": (".splines", "QIMirrorSplice"),
     "trace_closed_field_line": (".splines", "trace_closed_field_line"),
+    "gk_closed_fieldline_geometry": (
+        ".turbulence",
+        "gk_closed_fieldline_geometry",
+    ),
     "solve_fixed_boundary": (".splines", "solve_fixed_boundary"),
     "solve_fixed_boundary_from_radius": (
         ".splines",

--- a/vmex/mirror/turbulence.py
+++ b/vmex/mirror/turbulence.py
@@ -1,0 +1,317 @@
+"""Differentiable local gyrokinetic geometry for closed VMEX mirrors.
+
+This module deliberately supports the periodic stellarator--mirror lane.  An
+open mirror needs particle, sheath, source, and end-loss boundary conditions;
+turning its two end cuts into a periodic flux tube would be a different model.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from .geometry import (
+    ClosedAxisGeometry,
+    contravariant_field,
+    evaluate_closed_geometry,
+    magnetic_field_squared,
+    magnetic_field_xyz,
+    radial_derivative,
+)
+from .model import MirrorState
+from .splines import SplineMirrorDiscretization, trace_closed_field_line
+
+Array = Any
+
+GK_GEOMETRY_FIELDS = (
+    "theta",
+    "gradpar",
+    "bmag",
+    "bgrad",
+    "gds2",
+    "gds21",
+    "gds22",
+    "cvdrift",
+    "gbdrift",
+    "cvdrift0",
+    "gbdrift0",
+)
+
+__all__ = ["GK_GEOMETRY_FIELDS", "gk_closed_fieldline_geometry"]
+
+
+def _is_traced(value: Any) -> bool:
+    return isinstance(value, jax.core.Tracer)
+
+
+def _surface_interpolate(
+    values: Array,
+    discretization: SplineMirrorDiscretization,
+    theta: Array,
+    axial_parameter: Array,
+) -> Array:
+    """Evaluate a ``(theta, u, ...)`` quadrature array at paired points."""
+
+    values = jnp.asarray(values)
+    theta = jnp.asarray(theta)
+    axial_parameter = jnp.asarray(axial_parameter)
+    # Recover spline coefficients once and evaluate them with JAX.  The
+    # convenience ``axial_basis.interpolate`` builds a NumPy matrix and is
+    # therefore intentionally not used here: field-line locations are dynamic
+    # under differentiation.
+    moved = jnp.moveaxis(values, 1, -1)
+    coefficients_u = jnp.tensordot(
+        moved,
+        jnp.asarray(discretization.grid.axial_basis.recovery_matrix).T,
+        axes=((-1,), (0,)),
+    )
+    axial = discretization.spline.evaluate(coefficients_u, axial_parameter, axis=-1)
+    axial = jnp.moveaxis(axial, -1, 1)
+    modes = jnp.asarray(np.fft.fftfreq(discretization.grid.ntheta, d=1.0 / discretization.grid.ntheta))
+    coefficients = jnp.fft.fft(axial, axis=0) / discretization.grid.ntheta
+    phase = jnp.exp(1j * modes[:, None] * theta[None, :])
+    phase = phase.reshape(phase.shape + (1,) * (values.ndim - 2))
+    return jnp.real(jnp.sum(coefficients * phase, axis=0))
+
+
+def _closed_surface_tensors(
+    state: MirrorState,
+    discretization: SplineMirrorDiscretization,
+    axis: ClosedAxisGeometry,
+    *,
+    radial_index: int,
+    axial_flux_derivative: Array,
+    current_derivative: Array,
+) -> tuple[dict[str, Array], Any, Any]:
+    """Build exact coordinate tensors before field-line interpolation."""
+
+    grid = discretization.grid
+    geometry = evaluate_closed_geometry(state, grid, axis)
+    field = contravariant_field(
+        state,
+        geometry,
+        grid,
+        axial_flux_derivative=axial_flux_derivative,
+        current_derivative=current_derivative,
+    )
+    mod_b = jnp.sqrt(jnp.maximum(magnetic_field_squared(field, geometry), 0.0))
+    b_xyz = magnetic_field_xyz(field, geometry)
+
+    j = radial_index
+    coordinate_basis = jnp.stack(
+        (geometry.e_s_xyz[j], geometry.e_theta_xyz[j], geometry.e_xi_xyz[j]),
+        axis=-1,
+    )
+    dual = jnp.linalg.inv(coordinate_basis)
+    grad_s, grad_theta, grad_u = dual[..., 0, :], dual[..., 1, :], dual[..., 2, :]
+
+    ds = float(grid.s[1] - grid.s[0])
+    lam = jnp.asarray(state.lambda_stream)
+    lam_s = radial_derivative(lam, ds)[j]
+    lam_theta = grid.theta_basis.differentiate(lam, axis=1)[j]
+    lam_u = grid.axial_basis.differentiate(lam, axis=2)[j]
+    psi_prime = jnp.asarray(axial_flux_derivative, dtype=lam.dtype)
+    current_prime = jnp.asarray(current_derivative, dtype=lam.dtype)
+    grad_alpha = (
+        (lam_s / psi_prime)[..., None] * grad_s
+        + (1.0 + lam_theta / psi_prime)[..., None] * grad_theta
+        + (-current_prime / psi_prime + lam_u / psi_prime)[..., None] * grad_u
+    )
+
+    mod_b_s = radial_derivative(mod_b, ds)[j]
+    mod_b_theta = grid.theta_basis.differentiate(mod_b, axis=1)[j]
+    mod_b_u = grid.axial_basis.differentiate(mod_b, axis=2)[j]
+    grad_mod_b = mod_b_s[..., None] * grad_s + mod_b_theta[..., None] * grad_theta + mod_b_u[..., None] * grad_u
+    b_cross_grad_b = jnp.cross(b_xyz[j], grad_mod_b)
+    b_dot_grad_b = jnp.sum(b_xyz[j] * grad_mod_b, axis=-1)
+
+    tensors = {
+        "mod_b": mod_b[j],
+        "b_sup_u": field.b_sup_xi[j],
+        "grad_alpha_sq": jnp.sum(grad_alpha * grad_alpha, axis=-1),
+        "grad_alpha_dot_grad_s": jnp.sum(grad_alpha * grad_s, axis=-1),
+        "grad_s_sq": jnp.sum(grad_s * grad_s, axis=-1),
+        "b_cross_grad_b_dot_grad_alpha": jnp.sum(b_cross_grad_b * grad_alpha, axis=-1),
+        "b_cross_grad_b_dot_grad_s": jnp.sum(b_cross_grad_b * grad_s, axis=-1),
+        "b_dot_grad_b": b_dot_grad_b,
+        "xyz": geometry.xyz[j],
+    }
+    return tensors, field, geometry
+
+
+def gk_closed_fieldline_geometry(
+    state: MirrorState,
+    discretization: SplineMirrorDiscretization,
+    axis: ClosedAxisGeometry,
+    *,
+    axial_flux_derivative: Array,
+    current_derivative: Array = 0.0,
+    radial_index: int | None = None,
+    theta0: float = 0.0,
+    ntheta: int = 32,
+    arc_oversample: int = 4,
+    mu0_dp_ds: Array = 0.0,
+    closure_tolerance: float = 2.0e-5,
+) -> dict[str, Any]:
+    """Return the GKX geometry contract on one closed mirror field line.
+
+    The exact Clebsch label is
+
+    ``alpha = theta - I'(s) u / Psi'(s) + lambda(s,theta,u) / Psi'(s)``.
+
+    The perpendicular metric and magnetic drifts are evaluated from the
+    Cartesian coordinate basis.  The parallel coordinate is remapped to equal
+    arc so ``b . grad z`` is constant, as required by GKX/GX.  The returned
+    ``s_hat=0`` means that ``kx`` is the direct normalized radial wavenumber;
+    the three metric arrays still retain the complete local cross metric.
+
+    Only a field line that closes after one periodic-axis circuit is accepted.
+    This is exact for the zero-current closed mirror and for integer-transform
+    cases.  Irrational-transform tubes need a separate twist-linked contract.
+    Open mirrors are intentionally rejected by requiring a closed
+    discretization.
+    """
+
+    if not discretization.closed:
+        raise ValueError("GK mirror flux tubes require a closed periodic discretization")
+    if int(ntheta) < 8:
+        raise ValueError("ntheta must be at least 8")
+    if int(arc_oversample) < 2:
+        raise ValueError("arc_oversample must be at least 2")
+    if np.ndim(axial_flux_derivative) or np.ndim(current_derivative):
+        raise ValueError("the first closed-mirror GK contract requires scalar flux derivatives")
+    if not _is_traced(axial_flux_derivative) and float(axial_flux_derivative) == 0.0:
+        raise ValueError("axial_flux_derivative must be nonzero")
+
+    grid = discretization.grid
+    j = grid.ns - 2 if radial_index is None else int(radial_index)
+    if not 1 <= j < grid.ns:
+        raise ValueError("radial_index must select a non-axis surface")
+    s_value = jnp.asarray(grid.s[j])
+    sqrt_s = jnp.sqrt(s_value)
+
+    tensors, field, geometry = _closed_surface_tensors(
+        state,
+        discretization,
+        axis,
+        radial_index=j,
+        axial_flux_derivative=axial_flux_derivative,
+        current_derivative=current_derivative,
+    )
+
+    fine_steps = int(arc_oversample) * int(ntheta)
+    line = trace_closed_field_line(
+        field,
+        discretization,
+        radial_index=j,
+        theta0=theta0,
+        turns=1,
+        steps_per_turn=fine_steps,
+    )
+    poloidal_advance = line.theta[-1] - line.theta[0]
+    closure_residual = poloidal_advance - 2.0 * jnp.pi * jnp.round(poloidal_advance / (2.0 * jnp.pi))
+    if not _is_traced(closure_residual) and abs(float(closure_residual)) > float(closure_tolerance):
+        raise ValueError(
+            "the selected mirror field line does not close after one axis circuit; "
+            "use zero current/an integer transform or a future twist-linked adapter "
+            f"(closure residual {float(closure_residual):.3e} rad)"
+        )
+
+    mod_b_fine = _surface_interpolate(tensors["mod_b"], discretization, line.theta, line.axial_parameter)
+    b_sup_u_fine = _surface_interpolate(tensors["b_sup_u"], discretization, line.theta, line.axial_parameter)
+
+    effective_minor_radius = jnp.sqrt(geometry.volume / (jnp.pi * jnp.asarray(axis.arc_length)))
+    b_reference = 2.0 * jnp.abs(jnp.asarray(axial_flux_derivative)) / (effective_minor_radius**2)
+    gradpar_fine = effective_minor_radius * jnp.abs(b_sup_u_fine) / mod_b_fine
+    du = line.axial_parameter[1] - line.axial_parameter[0]
+    inverse_gradpar = 1.0 / gradpar_fine
+    cumulative = jnp.concatenate(
+        (
+            jnp.zeros((1,), dtype=mod_b_fine.dtype),
+            jnp.cumsum(0.5 * (inverse_gradpar[1:] + inverse_gradpar[:-1]) * du),
+        )
+    )
+    equal_theta_fine = -jnp.pi + 2.0 * jnp.pi * cumulative / cumulative[-1]
+    theta = jnp.linspace(-jnp.pi, jnp.pi, int(ntheta), endpoint=False)
+    u_eval = jnp.interp(theta, equal_theta_fine, line.axial_parameter)
+    theta_eval = jnp.interp(theta, equal_theta_fine, line.theta)
+    gradpar_value = 2.0 * jnp.pi / cumulative[-1]
+
+    sampled = {
+        name: _surface_interpolate(values, discretization, theta_eval, u_eval) for name, values in tensors.items()
+    }
+    mod_b = sampled["mod_b"]
+    sign_psi = jnp.sign(jnp.asarray(axial_flux_derivative))
+    bmag = mod_b / b_reference
+    gds2 = effective_minor_radius**2 * s_value * sampled["grad_alpha_sq"]
+    gds21 = 0.5 * effective_minor_radius**2 * sampled["grad_alpha_dot_grad_s"]
+    gds22 = effective_minor_radius**2 * sampled["grad_s_sq"] / (4.0 * s_value)
+    gbdrift = (
+        -2.0
+        * b_reference
+        * effective_minor_radius**2
+        * sqrt_s
+        * sign_psi
+        * sampled["b_cross_grad_b_dot_grad_alpha"]
+        / mod_b**3
+    )
+    gbdrift0 = (
+        b_reference * effective_minor_radius**2 * sign_psi * sampled["b_cross_grad_b_dot_grad_s"] / (mod_b**3 * sqrt_s)
+    )
+    cvdrift = gbdrift - (
+        2.0
+        * b_reference
+        * effective_minor_radius**2
+        * sqrt_s
+        * jnp.asarray(mu0_dp_ds)
+        / (jnp.abs(jnp.asarray(axial_flux_derivative)) * mod_b**2)
+    )
+    bgrad = effective_minor_radius * sampled["b_dot_grad_b"] / mod_b**2
+    grad_rho = effective_minor_radius * jnp.sqrt(sampled["grad_s_sq"]) / (2.0 * sqrt_s)
+    iota = poloidal_advance / (2.0 * jnp.pi)
+    q = jnp.where(jnp.abs(iota) > 1.0e-10, 1.0 / jnp.abs(iota), 1.0)
+
+    return {
+        "theta": theta,
+        "gradpar": gradpar_value * jnp.ones_like(theta),
+        "bmag": bmag,
+        "bgrad": bgrad,
+        "gds2": gds2,
+        "gds21": gds21,
+        "gds22": gds22,
+        "cvdrift": cvdrift,
+        "gbdrift": gbdrift,
+        "cvdrift0": gbdrift0,
+        "gbdrift0": gbdrift0,
+        "jacobian": 1.0 / (gradpar_value * bmag),
+        "grho": grad_rho,
+        "q": q,
+        "s_hat": 0.0,
+        "epsilon": jnp.std(bmag) / jnp.mean(bmag),
+        "R0": effective_minor_radius,
+        "B0": b_reference,
+        "alpha": float(theta0),
+        "nfp": 1,
+        "vmex_mirror": {
+            "surface_index": j,
+            "s": s_value,
+            "iota": iota,
+            "closure_residual": closure_residual,
+            "axis_arc_length": axis.arc_length,
+            "L_ref": effective_minor_radius,
+            "B_ref": b_reference,
+            "u": u_eval,
+            "fieldline_theta": theta_eval,
+            "xyz": sampled["xyz"],
+            "field_line_convention": (
+                "closed Clebsch alpha = theta - I'/Psi' u + lambda/Psi'; "
+                "equal-arc periodic GKX coordinate; direct zero-shear radial kx"
+            ),
+            "scope": (
+                "closed periodic mirror-hybrid equilibrium; no open-end loss, sheath, source, or loss-cone model"
+            ),
+        },
+    }


### PR DESCRIPTION
## Summary

- add `vmex.mirror.gk_closed_fieldline_geometry`, a JAX-native full GK metric/drift contract on the periodic stellarator–mirror racetrack
- derive the exact Clebsch label from VMEX's stream-function field, evaluate Cartesian dual metrics and magnetic drifts, and remap the closed line to equal arc
- reject open discretizations and nonclosing one-circuit lines instead of silently imposing periodic physics
- document the model, equations, normalization, acceptance ladder, literature, and the separate future open-end kinetic lane

## Scientific scope

This PR runs the valid **closed periodic mirror-hybrid** geometry lane. It makes no claim about open-end losses, sheaths, sources, ambipolar potential, or loss-cone replenishment. Those require a new GKX parallel-boundary/kinetic model and are explicitly staged separately in the docs.

The first contract uses scalar `Psi'`/`I'` and a one-circuit-closing field line (zero current or integer transform). It exports the complete zero-shear local perpendicular metric, both grad-B projections, pressure-corrected curvature drift, mirror coefficient, equal-arc `gradpar`, Cartesian trace points, and normalization metadata without importing GKX.

## Validation

- `ruff check vmex/mirror/turbulence.py vmex/mirror/__init__.py tests/mirror/test_turbulence.py`
- `mypy vmex/mirror/turbulence.py`
- `sphinx-build -W -b html docs <private-path>`
- `pytest -q tests/mirror/test_mirror_geometry_fields.py tests/mirror/test_splines.py tests/mirror/test_turbulence.py` -> 34 passed, 7 skipped
- public mapping consumed successfully by GKX `flux_tube_geometry_from_mapping(validate_finite=True)`
- test geometry: closure residual 1.09e-17 rad, `B/Bref=0.768..1.366`, positive metric determinant, exact constant `gradpar`
- JAX derivative of a geometry objective agrees with centered finite difference to ~1e-8 relative
