### PR TITLE
Move polish execution metadata into run_options, add solve_file and CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ tokamak, the `56.9 s` VMEX path includes JIT and polishing.
 Enable polishing in a VMEC input without breaking VMEC2000:
 
 ```fortran
-! VMEX: POLISH_FORCE_BALANCE = .TRUE.
+!@VMEX POLISH = AUTO
 &INDATA
   ...
 /
@@ -62,7 +62,10 @@ multigrid solves:
 ```python
 import vmex as vj
 
-inp = vj.VmecInput.from_file("input.my_case")
+result = vj.solve_file("input.my_case", polish="auto")  # honors !@VMEX lines
+print(result.polish_report.final_normalized_l2)
+
+inp = vj.VmecInput.from_file("input.my_case")           # physics only
 result = vj.solve_multigrid(inp, polish_force_balance=True)
 print(result.polish_report.initial_normalized_l2)
 print(result.polish_report.final_normalized_l2)

--- a/docs/reference/api/advanced.rst
+++ b/docs/reference/api/advanced.rst
@@ -40,12 +40,29 @@ Both :func:`vmex.solve` and :func:`vmex.solve_multigrid` accept
 ``polish_force_balance=False`` (unchanged behavior), ``True`` (required
 correction), or ``"auto"`` (skip an already-certified state). The shorter
 ``polish`` keyword remains an alias on the single-grid call. A standard VMEC
-deck enables the same path with a comment outside ``&INDATA``::
+deck enables the same path with comment directives that VMEC2000 ignores::
 
-   ! VMEX: POLISH_FORCE_BALANCE = .TRUE.
+   !@VMEX POLISH = AUTO
+   !@VMEX POLISH_TOL = 1.0E-8
+   !@VMEX POLISH_FAIL = ERROR
+   !@VMEX POLISH_DEGREE = 5
 
-VMEX reads this directive; VMEC2000 ignores the comment and solves the ordinary
-equilibrium. A successful result retains the ordinary ``state`` and exposes
+(the original single-flag spelling ``! VMEX: POLISH_FORCE_BALANCE = .TRUE.``
+still parses).  Directives are execution metadata, owned by
+:mod:`vmex.core.run_options` — they never become :class:`vmex.VmecInput`
+fields, and ``VmecInput.from_file`` ignores them while preserving all physics.
+Structured JSON carries the same keys in a reserved ``_vmex`` section that is
+removed before schema validation.  :func:`vmex.solve_file` runs a deck the way
+the CLI does — directives honored, ``wout_<case>.nc`` written — and explicit
+Python keywords override the file::
+
+   result = vmex.solve_file("input.case", polish="auto")
+
+Precedence is exactly ``CLI option > Python keyword > file directive >
+package default``; the CLI prints which layer a polish request came from.
+``polish_fail`` selects the failure behavior: ``"error"`` raises,
+``"fallback"`` returns the unpolished state, ``"warn"`` does the same with a
+:class:`RuntimeWarning` — never a failure silently presented as polished. A successful result retains the ordinary ``state`` and exposes
 the VMEC-grid projection as ``polished_state``. CLI WOUT files and an
 :class:`vmex.core.optimize.Equilibrium` requested with polishing use that
 projected state, while the continuous solution remains in

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -87,6 +87,19 @@ Options
      - Override the final-stage ``FTOL_ARRAY`` tolerance.
    * - ``--max-iter N``
      - Override the final-stage ``NITER_ARRAY`` iteration cap.
+   * - ``--polish [MODE]`` / ``--no-polish``
+     - Force-balance polishing after the finest fixed-boundary stage:
+       ``auto``, ``true`` (the bare flag), or ``false``. Overrides the
+       ``!@VMEX POLISH`` input directive; the default follows the file.
+       Precedence is ``CLI > Python keyword > file directive > default``.
+   * - ``--polish-tol VALUE``
+     - Override the polish force tolerance
+       (:class:`vmex.PolishConfig` ``tolerance``).
+   * - ``--polish-fail {error,fallback,warn}``
+     - What a failed polish does: raise, return the unpolished state, or
+       return it and print a warning. Never a silent substitution.
+   * - ``--polish-degree {3,5,7}``
+     - Radial B-spline degree of the polished representation.
    * - ``--restart WOUT``
      - Hot-restart the solve from a ``wout_*.nc`` file (VMEX- or
        VMEC2000-written): the equilibrium state is rebuilt from the file,

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -78,6 +78,7 @@
     ["tests/test_plot_summary.py", "diagnostics", "integration", "medium", "cpu", "none", "analytic", ["pr-parity-c2", "pr-fast", "full-core-n-s"]],
     ["tests/test_plotting_boozer.py", "diagnostics", "integration", "medium", "cpu", "golden", "external", ["pr-parity-c2", "full-core-n-s"]],
     ["tests/test_polish_preconditioner.py", "equilibrium", "ad", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c3", "full-core-n-s"]],
+    ["tests/test_run_options.py", "equilibrium", "unit", "medium", "cpu", "none", "analytic", ["pr-parity-c3", "full-core-n-s"]],
     ["tests/test_postprocess_currents.py", "diagnostics", "oracle", "medium", "cpu-gpu", "golden", "vmec2000", ["pr-parity-c2", "full-core-n-s"]],
     ["tests/test_preconditioner.py", "equilibrium", "unit", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "pr-fast", "full-core-n-s"]],
     ["tests/test_preconditioner_2d.py", "equilibrium", "integration", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "full-core-n-s"]],

--- a/tests/test_cli_device.py
+++ b/tests/test_cli_device.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from vmex.core import cli, multigrid
+from vmex.core.run_options import InputRequest, RunOptions
 
 
 def test_device_option_parses_supported_choices():
@@ -32,7 +33,10 @@ def test_fixed_boundary_cli_forwards_device(monkeypatch, tmp_path, choice, expec
     inp = SimpleNamespace(lfull3d1out=False)
     seen = {}
 
-    monkeypatch.setattr(cli, "_read_input", lambda _: inp)
+    monkeypatch.setattr(
+        cli, "_read_request",
+        lambda path: InputRequest(input=inp, options=RunOptions(), source=path),
+    )
     monkeypatch.setattr(cli, "_free_boundary_plan", lambda *a, **k: None)
     monkeypatch.setattr(cli, "_stage_overrides", lambda *a, **k: (None, None))
     monkeypatch.setattr(cli, "_write_wout_from_result", lambda *a, **k: object())
@@ -61,7 +65,10 @@ def test_free_boundary_cli_forwards_device(monkeypatch, tmp_path):
     seen = {}
     ftol_array, niter_array = [1e-8], [3]
 
-    monkeypatch.setattr(cli, "_read_input", lambda _: inp)
+    monkeypatch.setattr(
+        cli, "_read_request",
+        lambda path: InputRequest(input=inp, options=RunOptions(), source=path),
+    )
     monkeypatch.setattr(cli, "_free_boundary_plan", lambda *a, **k: plan)
     monkeypatch.setattr(
         cli, "_stage_overrides", lambda *a, **k: (ftol_array, niter_array),

--- a/tests/test_input_profiles.py
+++ b/tests/test_input_profiles.py
@@ -154,33 +154,39 @@ def test_lfull3d1out_default_explicit_true_and_indata_round_trip(
     ).lfull3d1out is True
 
 
-def test_vmex_polish_directive_is_a_vmec_safe_comment(tmp_path: Path) -> None:
-    """The extension round-trips without adding an unknown INDATA variable."""
+def test_vmex_polish_directive_is_execution_metadata_not_physics(
+        tmp_path: Path) -> None:
+    """Directives never become VmecInput fields; run_options owns them.
+
+    ``VmecInput.from_file`` ignores execution metadata while preserving all
+    physics, and ``to_indata`` writes physics only.  The directive still
+    round-trips through :func:`vmex.core.run_options.read_input_request` and
+    :func:`~vmex.core.run_options.format_indata_directives`, which is the
+    contract the CLI and ``solve_file`` use.
+    """
+    from vmex.core.run_options import (
+        RunOptions, format_indata_directives, read_input_request,
+    )
+
     text = "! VMEX: POLISH_FORCE_BALANCE = .TRUE.\n&INDATA\nMPOL = 3\n/\n"
     inp = VmecInput.from_indata_text(text)
-    assert inp.polish_force_balance is True
+    assert not hasattr(inp, "polish_force_balance")
+    assert inp.mpol == 3
 
-    path = inp.to_indata(tmp_path / "input.polished")
-    written = path.read_text(encoding="utf-8")
-    assert written.splitlines()[0] == "! VMEX: POLISH_FORCE_BALANCE = .TRUE."
-    assert "POLISH_FORCE_BALANCE" not in written.split("&INDATA", 1)[1]
-    assert VmecInput.from_file(path).polish_force_balance is True
+    source = tmp_path / "input.polished"
+    source.write_text(text, encoding="utf-8")
+    request = read_input_request(source)
+    assert request.options.polish is True
+    assert request.input.mpol == 3
 
+    written = inp.to_indata(tmp_path / "input.physics_only")
+    assert "POLISH" not in written.read_text(encoding="utf-8")
 
-@pytest.mark.parametrize(
-    "text, message",
-    [
-        ("! VMEX: POLISH_FORCE_BALANCE = sometimes\n&INDATA\n/", "true or false"),
-        (
-            "! VMEX: POLISH_FORCE_BALANCE = true\n"
-            "! VMEX: POLISH_FORCE_BALANCE = false\n&INDATA\n/",
-            "conflicting",
-        ),
-    ],
-)
-def test_vmex_polish_directive_rejects_ambiguous_values(text, message) -> None:
-    with pytest.raises(ValueError, match=message):
-        VmecInput.from_indata_text(text)
+    directives = format_indata_directives(RunOptions(polish=True))
+    rewritten = tmp_path / "input.rewritten"
+    rewritten.write_text(
+        directives + written.read_text(encoding="utf-8"), encoding="utf-8")
+    assert read_input_request(rewritten).options.polish is True
 
 
 def test_legacy_ns_array_zero_expands_via_nsin() -> None:

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -192,6 +192,9 @@ def test_solve_equilibrium_forwards_verbose(monkeypatch, solovev_eq):
         fsql=solovev_eq.result.fsql,
         iterations=solovev_eq.result.iterations,
         converged=solovev_eq.result.converged,
+        # solve_equilibrium prefers the polished state when one exists, so
+        # the stub must carry the real result's polished_state=None default.
+        polished_state=None,
     )
 
     def fake_solve_multigrid(inp, **kwargs):

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -1335,13 +1335,12 @@ def test_public_solver_rejects_unknown_polish_mode_before_solving():
         solver.solve(inp, polish="unknown")
 
 
-def test_public_solver_resolves_input_flag_and_rejects_two_api_spellings():
-    inp = dataclasses.replace(
-        VmecInput.from_file(DATA / "input.solovev"),
-        polish_force_balance=True,
-    )
-    assert solver._resolve_force_balance_polish(inp, None, None) is True
-    assert solver._resolve_force_balance_polish(inp, False, None) is False
+def test_public_solver_resolves_polish_keywords_only():
+    """Directives live in run_options; the solver sees only its keywords."""
+    inp = VmecInput.from_file(DATA / "input.solovev")
+    assert solver._resolve_force_balance_polish(inp, None, None) is False
+    assert solver._resolve_force_balance_polish(inp, True, None) is True
+    assert solver._resolve_force_balance_polish(inp, "auto", None) == "auto"
     with pytest.raises(ValueError, match="either polish or polish_force_balance"):
         solver._resolve_force_balance_polish(inp, False, True)
 

--- a/tests/test_run_options.py
+++ b/tests/test_run_options.py
@@ -1,0 +1,252 @@
+"""VMEX execution directives: parsing, precedence, and solve_file semantics.
+
+The contract under test (plan section 8): run controls travel as VMEC-safe
+comments or a reserved ``_vmex`` JSON section, ``VmecInput`` stays physics
+only, precedence is ``CLI > Python keyword > file directive > default``, and
+a failed polish behaves per ``polish_fail`` without a second solve.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from vmex.core.errors import VmecInputError
+from vmex.core.input import VmecInput
+from vmex.core.run_options import (
+    RunOptions,
+    format_indata_directives,
+    parse_indata_run_options,
+    polish_config_from_options,
+    read_input_request,
+    resolve_run_options,
+    strip_vmex_json,
+)
+
+DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
+
+
+# ---------------------------------------------------------------------------
+# INDATA directive parsing
+# ---------------------------------------------------------------------------
+
+
+def test_all_directives_parse_together_with_inline_comments():
+    options = parse_indata_run_options(
+        "!@VMEX POLISH = AUTO\n"
+        "  ! @ VMEX  POLISH_TOL = 2.5E-4   ! tighter than default\n"
+        "!@vmex polish_fail = FALLBACK\n"
+        "!@VMEX POLISH_DEGREE = 5\n"
+        "&INDATA\nMPOL = 3\n/\n"
+    )
+    assert options == RunOptions(
+        polish="auto", polish_tol=2.5e-4, polish_fail="fallback",
+        polish_degree=5)
+
+
+def test_no_directives_means_package_defaults():
+    assert parse_indata_run_options("&INDATA\nMPOL = 3\n/\n") == RunOptions()
+
+
+def test_legacy_polish_force_balance_spelling_still_parses():
+    text = "! VMEX: POLISH_FORCE_BALANCE = .TRUE.\n&INDATA\n/\n"
+    assert parse_indata_run_options(text).polish is True
+
+
+def test_consistent_repetition_is_allowed_and_conflict_is_an_error():
+    twice = "!@VMEX POLISH = AUTO\n!@VMEX POLISH = AUTO\n&INDATA\n/\n"
+    assert parse_indata_run_options(twice).polish == "auto"
+    conflict = "!@VMEX POLISH = AUTO\n!@VMEX POLISH = .FALSE.\n&INDATA\n/\n"
+    with pytest.raises(VmecInputError, match="conflicting"):
+        parse_indata_run_options(conflict)
+    # The two spellings must agree with each other too.
+    mixed = ("!@VMEX POLISH = .FALSE.\n"
+             "! VMEX: POLISH_FORCE_BALANCE = .TRUE.\n&INDATA\n/\n")
+    with pytest.raises(VmecInputError, match="conflicting"):
+        parse_indata_run_options(mixed)
+
+
+@pytest.mark.parametrize(
+    "line, message",
+    [
+        ("!@VMEX POLISH = sometimes", "AUTO, TRUE, or FALSE"),
+        ("!@VMEX POLISH_TOL = tight", "real number"),
+        ("!@VMEX POLISH_TOL = -1.0", "positive"),
+        ("!@VMEX POLISH_DEGREE = 4", "3, 5, 7"),
+        ("!@VMEX POLISH_DEGREE = five", "integer"),
+        ("!@VMEX POLISH_FAIL = explode", "error"),
+        ("!@VMEX POLISH_MODE = auto", "unknown VMEX directive"),
+    ],
+)
+def test_invalid_directives_fail_with_named_errors(line, message):
+    with pytest.raises(VmecInputError, match=message):
+        parse_indata_run_options(line + "\n&INDATA\n/\n")
+
+
+def test_quoted_exclamation_marks_do_not_become_directives():
+    """A '!' inside a namelist string is data; directives are comment lines."""
+    text = "&INDATA\nMGRID_FILE = 'weird!@VMEX POLISH = AUTO'\nMPOL = 3\n/\n"
+    assert parse_indata_run_options(text) == RunOptions()
+    inp = VmecInput.from_indata_text(text)
+    assert "!@VMEX" in inp.mgrid_file
+
+
+def test_directive_round_trip_through_format():
+    options = RunOptions(polish="auto", polish_tol=1e-8, polish_fail="warn",
+                         polish_degree=7)
+    text = format_indata_directives(options) + "&INDATA\nMPOL = 3\n/\n"
+    assert parse_indata_run_options(text) == options
+    assert format_indata_directives(RunOptions()) == ""
+
+
+# ---------------------------------------------------------------------------
+# JSON _vmex section
+# ---------------------------------------------------------------------------
+
+
+def test_json_vmex_section_round_trip(tmp_path):
+    payload = {"mpol": 4, "ntor": 0,
+               "_vmex": {"polish": "auto", "polish_degree": 5}}
+    physics, options = strip_vmex_json(payload)
+    assert "_vmex" not in physics and physics["mpol"] == 4
+    assert options == RunOptions(polish="auto", polish_degree=5)
+
+    path = tmp_path / "case.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    request = read_input_request(path)
+    assert request.options.polish == "auto"
+    assert request.input.mpol == 4
+    # VmecInput.from_file ignores execution metadata but keeps all physics.
+    assert VmecInput.from_file(path).mpol == 4
+
+
+@pytest.mark.parametrize(
+    "section, message",
+    [({"polish_mode": "auto"}, "unknown _vmex keys"),
+     ("auto", "JSON object"),
+     ({"polish": "sometimes"}, "AUTO, TRUE, or FALSE")],
+)
+def test_json_vmex_section_rejects_bad_content(section, message):
+    with pytest.raises(VmecInputError, match=message):
+        strip_vmex_json({"mpol": 4, "_vmex": section})
+
+
+# ---------------------------------------------------------------------------
+# Precedence and config mapping
+# ---------------------------------------------------------------------------
+
+
+def test_precedence_python_over_file_over_default():
+    file_options = RunOptions(polish="auto", polish_degree=5)
+    resolved, sources = resolve_run_options(file_options)
+    assert resolved == file_options
+    assert sources["polish"] == "file" and sources["polish_tol"] == "default"
+
+    resolved, sources = resolve_run_options(file_options, polish=False,
+                                            polish_tol=1e-6)
+    assert resolved.polish is False and resolved.polish_tol == 1e-6
+    assert resolved.polish_degree == 5          # untouched file value
+    assert sources["polish"] == "python" and sources["polish_degree"] == "file"
+
+
+def test_polish_config_mapping_and_explicit_config_priority():
+    from vmex.core.polish_driver import PolishConfig
+
+    options = RunOptions(polish=True, polish_tol=1e-5, polish_degree=5,
+                         polish_fail="fallback")
+    config = polish_config_from_options(options)
+    assert config.tolerance == 1e-5
+    assert config.radial_degree == 5
+    assert config.fail_policy == "return_unpolished"
+    # Nothing beyond driver defaults requested -> no config object at all,
+    # keeping the plain path identical to before this module existed.
+    assert polish_config_from_options(RunOptions(polish=True)) is None
+    # An explicit PolishConfig wins over every directive-level scalar.
+    base = PolishConfig(tolerance=3e-3)
+    assert polish_config_from_options(options, base) is base
+
+
+# ---------------------------------------------------------------------------
+# solve_file
+# ---------------------------------------------------------------------------
+
+
+def test_solve_file_runs_and_writes_wout(tmp_path):
+    import vmex as vj
+
+    source = tmp_path / "input.solovev"
+    source.write_text((DATA / "input.solovev").read_text(encoding="utf-8"),
+                      encoding="utf-8")
+    result = vj.solve_file(source, polish=False, outdir=tmp_path)
+    assert result.converged
+    wout_path = tmp_path / "wout_solovev.nc"
+    assert wout_path.exists()
+    from vmex.core.wout import read_wout
+
+    assert int(read_wout(wout_path).ier_flag) == 0
+
+
+def test_solve_file_rejects_polish_on_a_free_boundary_deck(tmp_path):
+    source = tmp_path / "input.freeb"
+    # MGRID_FILE must name something: readin.f (and VmecInput) force
+    # LFREEB = F when it is 'NONE', which would silently reroute this deck to
+    # the fixed-boundary branch and never reach the gate under test.
+    source.write_text(
+        "!@VMEX POLISH = .TRUE.\n"
+        "&INDATA\nLFREEB = T\nMGRID_FILE = 'mgrid_missing.nc'\nMPOL = 3\n"
+        "NS_ARRAY = 5\nRBC(0,0) = 1.0\nRBC(0,1) = 0.3\nZBS(0,1) = 0.3\n/\n",
+        encoding="utf-8")
+    import vmex as vj
+
+    with pytest.raises(ValueError, match="fixed-boundary.*file"):
+        vj.solve_file(source, write_wout=False)
+    # --no-polish equivalent: the Python keyword overrides the directive, so
+    # the gate no longer fires.  The deck then proceeds into the free-boundary
+    # ladder and fails there for its own reason (no usable mgrid), which is
+    # the point: the rejection above is the polish gate, not deck validation.
+    with pytest.raises(Exception) as info:
+        vj.solve_file(source, polish=False, write_wout=False,
+                      niter_array=np.array([3]))
+    assert "polishing requires" not in str(info.value)
+
+
+def test_solve_file_polish_directive_activates_polishing(tmp_path):
+    """One documented input runs the whole flow: directive -> polished wout.
+
+    The deck is the fast certified case from the polish suite (solovev at
+    mpol = 3, ns = 5 with the loose validation tolerance); the property under
+    test is that the *file directive alone* turns polishing on, so the
+    explicit PolishConfig only makes the certificate affordable, while the
+    activation comes from the ``!@VMEX`` line.
+    """
+    import dataclasses
+
+    import vmex as vj
+
+    inp = VmecInput.from_file(DATA / "input.solovev").change_resolution(
+        mpol=3, ntor=0, ntheta=12, nzeta=4)
+    inp = dataclasses.replace(
+        inp, ns_array=np.asarray([5]), ftol_array=np.asarray([1.0e-10]),
+        niter_array=np.asarray([1000]))
+    physics = inp.to_indata(tmp_path / "input.polished_case")
+    source = tmp_path / "input.polished_case_directive"
+    source.write_text("!@VMEX POLISH = .TRUE.\n"
+                      + physics.read_text(encoding="utf-8"), encoding="utf-8")
+
+    from vmex.core.polish_driver import PolishConfig
+
+    config = PolishConfig(radial_degree=3, validation_tolerance=3.0)
+    result = vj.solve_file(source, outdir=tmp_path, polish_config=config)
+    assert result.converged
+    assert result.polish_report is not None
+    assert bool(result.polish_report.converged)
+    assert result.polished_state is not None
+    assert (tmp_path / "wout_polished_case_directive.nc").exists()
+
+    # Without the directive the same solve does not polish: the activation
+    # really came from the file.
+    plain = vj.solve_file(physics, outdir=tmp_path, polish_config=config)
+    assert plain.polish_report is None

--- a/vmex/__init__.py
+++ b/vmex/__init__.py
@@ -201,6 +201,10 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
     "PolishReport": (".core.polish_driver", "PolishReport"),
     "PolishResult": (".core.polish_driver", "PolishResult"),
     "PolishLinearConfig": (".core.polish_implicit", "PolishLinearConfig"),
+    "InputRequest": (".core.run_options", "InputRequest"),
+    "RunOptions": (".core.run_options", "RunOptions"),
+    "read_input_request": (".core.run_options", "read_input_request"),
+    "solve_file": (".core.multigrid", "solve_file"),
     "collocation_polish_adjoint": (
         ".core.polish_implicit", "collocation_polish_adjoint"),
     "collocation_polish_tangent": (

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -270,6 +270,43 @@ def build_parser() -> argparse.ArgumentParser:
             "follow JAX, or an explicit platform."
         ),
     )
+    p.add_argument(
+        "--polish",
+        metavar="MODE",
+        type=str,
+        nargs="?",
+        const="true",
+        default=None,
+        choices=("auto", "true", "false"),
+        help=(
+            "Force-balance polishing after the finest fixed-boundary stage: "
+            "'auto', 'true' (the bare flag), or 'false'. Overrides the "
+            "!@VMEX POLISH input directive; the default follows the file."
+        ),
+    )
+    p.add_argument(
+        "--no-polish",
+        dest="polish",
+        action="store_const",
+        const="false",
+        help="Disable polishing regardless of the input directive.",
+    )
+    p.add_argument(
+        "--polish-tol", type=float, default=None,
+        help="Override the polish force tolerance (PolishConfig.tolerance).")
+    p.add_argument(
+        "--polish-fail",
+        type=str,
+        default=None,
+        choices=("error", "fallback", "warn"),
+        help=(
+            "What a failed polish does: raise (error), return the unpolished "
+            "state (fallback), or return it with a warning (warn)."
+        ),
+    )
+    p.add_argument(
+        "--polish-degree", type=int, default=None, choices=(3, 5, 7),
+        help="Radial B-spline degree of the polished representation.")
     p.add_argument("--ftol", type=float, default=None, help="Override the final-stage FTOL_ARRAY tolerance.")
     p.add_argument("--max-iter", type=int, default=None, help="Override the final-stage NITER_ARRAY iteration cap.")
     p.add_argument(
@@ -427,10 +464,15 @@ def _timing_block(read_s: float, solve_s: float, wout_s: float) -> str:
 
 def _read_input(input_path: Path):
     """Parse the deck into a :class:`VmecInput` (typed error on failure)."""
-    from .input import VmecInput
+    return _read_request(input_path).input
+
+
+def _read_request(input_path: Path):
+    """Parse the deck plus its VMEX execution directives."""
+    from .run_options import read_input_request
 
     try:
-        return VmecInput.from_file(input_path)
+        return read_input_request(input_path)
     except VmecError:
         raise
     except Exception as exc:
@@ -438,6 +480,29 @@ def _read_input(input_path: Path):
             WERROR_MESSAGES[INPUT_ERROR_FLAG],
             hint=f"{input_path.name}: {exc}",
         ) from exc
+
+
+def _resolve_polish_cli(args, file_options):
+    """CLI flags > file directive > default, with the source recorded."""
+    from .run_options import resolve_run_options
+
+    polish = None
+    if args.polish is not None:
+        polish = {"auto": "auto", "true": True, "false": False}[args.polish]
+    options, sources = resolve_run_options(
+        file_options,
+        polish=polish,
+        polish_tol=args.polish_tol,
+        polish_fail=args.polish_fail,
+        polish_degree=args.polish_degree,
+    )
+    cli_supplied = {
+        "polish": args.polish, "polish_tol": args.polish_tol,
+        "polish_fail": args.polish_fail, "polish_degree": args.polish_degree,
+    }
+    sources = {name: ("cli" if cli_supplied[name] is not None else origin)
+               for name, origin in sources.items()}
+    return options, sources
 
 
 #: MGRID_FILE sentinel selecting the direct-coil Biot-Savart external field.
@@ -646,7 +711,9 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
     verbose = not bool(args.quiet)
 
     t0 = time.perf_counter()
-    inp = _read_input(input_path)
+    request = _read_request(input_path)
+    inp = request.input
+    polish_options, polish_sources = _resolve_polish_cli(args, request.options)
     read_s = time.perf_counter() - t0
 
     if verbose:
@@ -668,8 +735,19 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
 
         effective_inp = dataclasses.replace(inp, lfreeb=False)
 
+    if verbose and polish_options.polish is not False:
+        emit(f" POLISH  : {polish_options.polish!r} "
+             f"(from {polish_sources['polish']})")
+
     t1 = time.perf_counter()
     if freeb_plan is not None:
+        if polish_options.polish is not False:
+            raise VmecInputError(
+                "force-balance polishing requires a fixed-boundary input",
+                hint=("the polish request came from the "
+                      f"{polish_sources['polish']}; drop it or pass "
+                      "--no-polish"),
+            )
         from .multigrid import solve_free_boundary_multigrid
 
         ftol_array, niter_array = _stage_overrides(
@@ -693,9 +771,13 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
     else:
         from .multigrid import solve_multigrid
 
+        from .run_options import polish_config_from_options
+
         ftol_array, niter_array = _stage_overrides(inp, ftol=args.ftol, max_iter=args.max_iter)
         result = solve_multigrid(
             effective_inp,
+            polish_force_balance=polish_options.polish,
+            polish_config=polish_config_from_options(polish_options),
             ftol_array=ftol_array,
             niter_array=niter_array,
             restart_from=restart_source,
@@ -711,6 +793,12 @@ def _solve_input_file(args, input_path: Path, outdir: Path | None, *, emit) -> i
             prefetch_compile=bool(args.prefetch_compile),
             jacobian_retries=int(args.jacobian_retries),
         )
+        if (polish_options.polish_fail == "warn"
+                and result.polish_report is not None
+                and not bool(result.polish_report.converged)):
+            emit(" POLISH  : failed "
+                 f"({result.polish_report.termination_reason}); "
+                 "returning the unpolished equilibrium")
     solve_s = time.perf_counter() - t1
 
     wout_path = resolve_wout_path(input_path=input_path, outdir=outdir)

--- a/vmex/core/input.py
+++ b/vmex/core/input.py
@@ -140,26 +140,6 @@ _KNOWN_INDATA_NAMES = {
     "RESTART_WOUT",
 }
 
-_VMEX_POLISH_DIRECTIVE = re.compile(
-    r"^\s*!\s*VMEX\s*:\s*POLISH_FORCE_BALANCE\s*=\s*([^\s,!]+)",
-    flags=re.IGNORECASE | re.MULTILINE,
-)
-
-
-def _polish_force_balance_directive(text: str) -> bool:
-    """Read the VMEX-only polish flag from a VMEC-safe comment."""
-
-    matches = _VMEX_POLISH_DIRECTIVE.findall(text)
-    if not matches:
-        return False
-    values = [_parse_scalar(token) for token in matches]
-    if any(not isinstance(value, bool) for value in values):
-        raise ValueError("POLISH_FORCE_BALANCE must be true or false")
-    if len(set(values)) != 1:
-        raise ValueError("conflicting VMEX POLISH_FORCE_BALANCE directives")
-    return bool(values[0])
-
-
 def _strip_fortran_comments(line: str) -> str:
     """Remove ``!`` comments outside single- or double-quoted strings."""
     out: List[str] = []
@@ -782,7 +762,6 @@ class VmecInput:
 
     # -- VMEX extension: hot restart (no VMEC2000 equivalent) --
     restart_wout: str = ""       #: wout path to seed the solve from ('' = cold)
-    polish_force_balance: bool = False  #: high-order post-solve correction
 
     def __post_init__(self) -> None:
         set_ = object.__setattr__
@@ -802,7 +781,6 @@ class VmecInput:
         set_(self, "precon_type", str(self.precon_type).strip())
         set_(self, "mgrid_file", str(self.mgrid_file).strip())
         set_(self, "restart_wout", str(self.restart_wout).strip())
-        set_(self, "polish_force_balance", bool(self.polish_force_balance))
 
         # readin.f stops at the first nonpositive or decreasing entry; later
         # values are outside multi_ns_grid and never reach runvmec.f.
@@ -959,7 +937,6 @@ class VmecInput:
     @classmethod
     def from_indata_text(cls, text: str) -> "VmecInput":
         """Build from ``&INDATA`` namelist text (VMEC2000 read_indata_namelist)."""
-        polish_force_balance = _polish_force_balance_directive(text)
         scalars, indexed = _read_indata_text(text)
         _validate_indata_modes(scalars, indexed)
 
@@ -1131,7 +1108,6 @@ class VmecInput:
             precon_type=str(get("PRECON_TYPE", "NONE")),
             prec2d_threshold=float(get("PREC2D_THRESHOLD", 1e-30)),
             restart_wout=str(get("RESTART_WOUT", "")),
-            polish_force_balance=polish_force_balance,
         )
 
     @classmethod
@@ -1146,6 +1122,10 @@ class VmecInput:
         being silently ignored.
         """
         data = json.loads(text)
+        # Reserved execution-metadata section: run controls, never physics.
+        # ``vmex.core.run_options`` validates and consumes it; the physics
+        # schema stays VMEC++ compatible once it is removed.
+        data.pop("_vmex", None)
         _validate_json_modes(data)
         if "adiabatic_index" in data and "gamma" not in data:
             data["gamma"] = data["adiabatic_index"]
@@ -1223,11 +1203,7 @@ class VmecInput:
                 return f"{float(value):.17E}"
             return "'" + str(value).replace("'", "''") + "'"
 
-        lines: List[str] = [
-            "! VMEX: POLISH_FORCE_BALANCE = "
-            + (".TRUE." if self.polish_force_balance else ".FALSE."),
-            "&INDATA",
-        ]
+        lines: List[str] = ["&INDATA"]
 
         def put(name: str, value) -> None:
             if isinstance(value, np.ndarray):

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -665,8 +665,6 @@ def solve_free_boundary_multigrid(
     """
     if not bool(inp.lfreeb):
         raise ValueError("solve_free_boundary_multigrid requires an LFREEB=T input")
-    if bool(inp.polish_force_balance):
-        raise ValueError("force-balance polishing currently requires fixed boundary")
 
     ns_arr = _vmec_ns_prefix(inp.ns_array if ns_array is None else ns_array)
     if ns_arr.size == 0:
@@ -952,3 +950,87 @@ def solve_free_boundary_multigrid(
     if stage_result is None:  # defensive; positive ns_arr guarantees a stage
         raise ValueError("ns_array has no executable stages")
     return stage_result.result
+
+
+def solve_file(
+    path,
+    *,
+    polish: bool | str | None = None,
+    polish_config: Any = None,
+    polish_tol: float | None = None,
+    polish_fail: str | None = None,
+    polish_degree: int | None = None,
+    write_wout: bool = True,
+    outdir=None,
+    **solve_kwargs,
+):
+    """Solve one input file the way the CLI does, honoring its directives.
+
+    ``VmecInput.from_file`` returns physics only; this entry point also reads
+    the VMEX execution directives (``!@VMEX POLISH = AUTO`` and friends, or a
+    ``_vmex`` JSON section) and applies the documented precedence: an explicit
+    Python keyword overrides the file, and ``None`` means use the file.
+
+    ``polish_fail`` selects what a failed polish does: ``"error"`` raises
+    (driver default), ``"fallback"`` returns the unpolished state, ``"warn"``
+    does the same and emits a :class:`RuntimeWarning`.  An explicit
+    ``polish_config`` wins over the scalar overrides entirely.
+
+    ``write_wout=True`` writes ``wout_<case>.nc`` beside the input (or into
+    ``outdir``), sampled from the polished state when polishing succeeded —
+    the same output contract as ``vmex <input>``.  Free-boundary decks solve
+    through the free-boundary ladder and reject polish requests, matching the
+    fixed-boundary-only scope of the polishing lane.
+
+    Returns the final :class:`~vmex.core.solver.SolveResult`.
+    """
+    from pathlib import Path as _Path
+
+    from .run_options import (
+        polish_config_from_options, read_input_request, resolve_run_options,
+    )
+
+    request = read_input_request(path)
+    options, sources = resolve_run_options(
+        request.options, polish=polish, polish_tol=polish_tol,
+        polish_fail=polish_fail, polish_degree=polish_degree,
+    )
+    config = polish_config_from_options(options, polish_config)
+    inp = request.input
+
+    if bool(inp.lfreeb):
+        if options.polish is not False:
+            raise ValueError(
+                "force-balance polishing requires a fixed-boundary input; "
+                f"the polish request came from the {sources['polish']}"
+            )
+        result = solve_free_boundary_multigrid(inp, **solve_kwargs)
+    else:
+        if bool(solve_kwargs.get("verbose")) and options.polish is not False:
+            print(f"polish = {options.polish!r} (from {sources['polish']})")
+        result = solve_multigrid(
+            inp, polish_force_balance=options.polish,
+            polish_config=config, **solve_kwargs,
+        )
+        # "fallback"/"warn" mapped onto the driver's return_unpolished, so a
+        # failed polish arrives here as an unconverged report rather than an
+        # exception -- no second solve, the legacy state is the checkpoint.
+        if (options.polish_fail == "warn"
+                and result.polish_report is not None
+                and not bool(result.polish_report.converged)):
+            import warnings
+
+            warnings.warn(
+                "force-balance polishing failed "
+                f"({result.polish_report.termination_reason}); returning the "
+                "unpolished equilibrium", RuntimeWarning, stacklevel=2)
+
+    if write_wout:
+        from .cli import _write_wout_from_result, case_from_input
+
+        source = _Path(path)
+        directory = _Path(outdir) if outdir is not None else source.parent
+        directory.mkdir(parents=True, exist_ok=True)
+        wout_path = directory / f"wout_{case_from_input(source)}.nc"
+        _write_wout_from_result(inp, source, result, wout_path)
+    return result

--- a/vmex/core/run_options.py
+++ b/vmex/core/run_options.py
@@ -1,0 +1,293 @@
+"""VMEX execution metadata carried outside the VMEC physics schema.
+
+VMEX-only run controls travel in places every legacy reader ignores: comment
+directives in ``&INDATA`` text and a reserved ``_vmex`` section in structured
+JSON.  VMEC2000 treats the directive lines as comments and solves the ordinary
+input; a VMEC++-compatible JSON reader sees the physics schema once ``_vmex``
+is removed.  :class:`~vmex.core.input.VmecInput` stays a pure physics object —
+these options control *execution*, not equilibrium physics, so they never
+become dataclass fields on it.
+
+Two directive spellings are accepted, both VMEC-safe comments::
+
+    !@VMEX POLISH = AUTO
+    !@VMEX POLISH_TOL = 1.0E-8
+    !@VMEX POLISH_FAIL = ERROR
+    !@VMEX POLISH_DEGREE = 5
+
+and the original single-flag form from the polishing integration::
+
+    ! VMEX: POLISH_FORCE_BALANCE = .TRUE.
+
+Precedence, resolved by :func:`resolve_run_options`, is exactly::
+
+    CLI option > explicit Python keyword > file directive > package default.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, fields, replace
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Mapping
+
+from .errors import VmecInputError
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard, typing only
+    from .input import VmecInput
+
+__all__ = [
+    "InputRequest",
+    "RunOptions",
+    "format_indata_directives",
+    "parse_indata_run_options",
+    "read_input_request",
+    "resolve_run_options",
+    "strip_vmex_json",
+]
+
+_POLISH_MODES = (False, True, "auto")
+_FAIL_MODES = ("error", "fallback", "warn")
+_DEGREES = (3, 5, 7)
+
+#: ``!@VMEX KEY = VALUE`` — the canonical directive family.
+# [ \t] rather than \s throughout: a greedy \s* would consume the newline
+# and let the optional trailing-comment group swallow the next directive line.
+_DIRECTIVE = re.compile(
+    r"^[ \t]*![ \t]*@[ \t]*VMEX[ \t]+([A-Za-z_]+)[ \t]*=[ \t]*"
+    r"([^\s!]+)[ \t]*(?:!.*)?$",
+    flags=re.MULTILINE | re.IGNORECASE,
+)
+
+#: ``! VMEX: POLISH_FORCE_BALANCE = .TRUE.`` — the original single flag.
+_LEGACY_POLISH = re.compile(
+    r"^\s*!\s*VMEX\s*:\s*POLISH_FORCE_BALANCE\s*=\s*([^\s,!]+)",
+    flags=re.IGNORECASE | re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class RunOptions:
+    """How to execute a solve; never what equilibrium to solve.
+
+    ``polish`` is ``False``, ``True``, or ``"auto"`` (polish only when the
+    legacy solve converged and the physics is in the supported set).
+    ``polish_tol``/``polish_degree`` override the matching
+    :class:`~vmex.core.polish_driver.PolishConfig` fields when set.
+    ``polish_fail`` maps onto the driver's fail policy: ``"error"`` raises,
+    ``"fallback"`` returns the unpolished state silently, ``"warn"`` returns
+    it with a :class:`RuntimeWarning`.
+    """
+
+    polish: bool | str = False
+    polish_tol: float | None = None
+    polish_fail: str = "error"
+    polish_degree: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.polish not in _POLISH_MODES:
+            raise VmecInputError(
+                f"POLISH must be one of {_POLISH_MODES}, got {self.polish!r}")
+        if self.polish_fail not in _FAIL_MODES:
+            raise VmecInputError(
+                f"POLISH_FAIL must be one of {_FAIL_MODES}, "
+                f"got {self.polish_fail!r}")
+        if self.polish_tol is not None and not self.polish_tol > 0.0:
+            raise VmecInputError(
+                f"POLISH_TOL must be positive, got {self.polish_tol!r}")
+        if self.polish_degree is not None and self.polish_degree not in _DEGREES:
+            raise VmecInputError(
+                f"POLISH_DEGREE must be one of {_DEGREES}, "
+                f"got {self.polish_degree!r}")
+
+
+@dataclass(frozen=True)
+class InputRequest:
+    """One parsed input file: the physics and how to run it."""
+
+    input: "VmecInput"
+    options: RunOptions
+    source: Path
+
+
+def _parse_polish(token: str, *, key: str) -> bool | str:
+    lowered = token.strip().lower().strip(".")
+    if lowered in ("auto",):
+        return "auto"
+    if lowered in ("true", "t", "1", "yes", "on"):
+        return True
+    if lowered in ("false", "f", "0", "no", "off"):
+        return False
+    raise VmecInputError(
+        f"{key} must be AUTO, TRUE, or FALSE, got {token!r}")
+
+
+def _parse_directive_value(key: str, token: str) -> tuple[str, Any]:
+    """Map one directive assignment onto a :class:`RunOptions` field."""
+    if key == "POLISH":
+        return "polish", _parse_polish(token, key=key)
+    if key == "POLISH_TOL":
+        try:
+            return "polish_tol", float(token.rstrip(","))
+        except ValueError as error:
+            raise VmecInputError(
+                f"POLISH_TOL must be a real number, got {token!r}") from error
+    if key == "POLISH_FAIL":
+        return "polish_fail", token.strip().lower()
+    if key == "POLISH_DEGREE":
+        try:
+            return "polish_degree", int(token.rstrip(","))
+        except ValueError as error:
+            raise VmecInputError(
+                f"POLISH_DEGREE must be an integer, got {token!r}") from error
+    raise VmecInputError(
+        f"unknown VMEX directive {key!r} "
+        "(known: POLISH, POLISH_TOL, POLISH_FAIL, POLISH_DEGREE)")
+
+
+def parse_indata_run_options(text: str) -> RunOptions:
+    """Read every VMEX directive from raw ``&INDATA`` text.
+
+    Both spellings are read; a repeated key must repeat the same value, and a
+    conflicting repetition is an error rather than a silent last-one-wins.
+    Ordinary Fortran comments and quoted ``!`` characters are unaffected: the
+    directive patterns anchor on comment lines only, and VMEC2000 discards
+    those lines entirely.
+    """
+    assignments: dict[str, Any] = {}
+
+    def record(field: str, value: Any, *, key: str) -> None:
+        if field in assignments and assignments[field] != value:
+            raise VmecInputError(
+                f"conflicting VMEX {key} directives: "
+                f"{assignments[field]!r} then {value!r}")
+        assignments[field] = value
+
+    for key, token in _DIRECTIVE.findall(text):
+        field, value = _parse_directive_value(key.upper(), token)
+        record(field, value, key=key.upper())
+    for token in _LEGACY_POLISH.findall(text):
+        record("polish", _parse_polish(token, key="POLISH_FORCE_BALANCE"),
+               key="POLISH_FORCE_BALANCE")
+    return RunOptions(**assignments)
+
+
+def strip_vmex_json(data: Mapping[str, Any]) -> tuple[dict[str, Any], RunOptions]:
+    """Split a structured-JSON mapping into physics data and run options.
+
+    The physics schema remains VMEC++ compatible after ``_vmex`` is removed.
+    Unknown ``_vmex`` keys fail explicitly — a typo must not silently run
+    with defaults.
+    """
+    physics = dict(data)
+    section = physics.pop("_vmex", None)
+    if section is None:
+        return physics, RunOptions()
+    if not isinstance(section, Mapping):
+        raise VmecInputError("_vmex must be a JSON object")
+    known = {field.name for field in fields(RunOptions)}
+    unknown = sorted(set(section) - known)
+    if unknown:
+        raise VmecInputError(
+            f"unknown _vmex keys {unknown} (known: {sorted(known)})")
+    options = dict(section)
+    if isinstance(options.get("polish"), str):
+        options["polish"] = _parse_polish(options["polish"], key="polish")
+    return physics, RunOptions(**options)
+
+
+def format_indata_directives(options: RunOptions) -> str:
+    """Serialize non-default options as canonical directive lines."""
+    lines = []
+    defaults = RunOptions()
+    if options.polish != defaults.polish:
+        token = "AUTO" if options.polish == "auto" else (
+            ".TRUE." if options.polish else ".FALSE.")
+        lines.append(f"!@VMEX POLISH = {token}")
+    if options.polish_tol is not None:
+        lines.append(f"!@VMEX POLISH_TOL = {options.polish_tol:.6E}")
+    if options.polish_fail != defaults.polish_fail:
+        lines.append(f"!@VMEX POLISH_FAIL = {options.polish_fail.upper()}")
+    if options.polish_degree is not None:
+        lines.append(f"!@VMEX POLISH_DEGREE = {options.polish_degree}")
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def read_input_request(path: str | Path) -> InputRequest:
+    """Read one input file into physics plus execution options.
+
+    ``VmecInput.from_file`` remains physics-only; this is the entry point the
+    CLI and :func:`~vmex.core.multigrid.solve_file` share.
+    """
+    from .input import VmecInput
+
+    path = Path(path)
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".json" or text.lstrip()[:1] == "{":
+        import json
+
+        # strip_vmex_json validates the section; from_json_text discards it
+        # unvalidated so VmecInput.from_file keeps ignoring execution
+        # metadata while preserving every physics key.
+        _, options = strip_vmex_json(json.loads(text))
+        inp = VmecInput.from_json_text(text)
+    else:
+        options = parse_indata_run_options(text)
+        inp = VmecInput.from_indata_text(text)
+    return InputRequest(input=inp, options=options, source=path)
+
+
+def resolve_run_options(
+    file_options: RunOptions | None,
+    *,
+    polish: bool | str | None = None,
+    polish_tol: float | None = None,
+    polish_fail: str | None = None,
+    polish_degree: int | None = None,
+) -> tuple[RunOptions, dict[str, str]]:
+    """Apply the documented precedence and record where each value came from.
+
+    Explicit Python keywords override the file; the CLI passes its flags
+    through the same keywords, so ``CLI > Python > file > default`` reduces to
+    one merge.  The source map (``"python"``, ``"file"``, ``"default"`` per
+    field) goes into the run report so a surprising activation is traceable.
+    """
+    resolved = file_options if file_options is not None else RunOptions()
+    source = {
+        field.name: ("file" if file_options is not None
+                     and getattr(file_options, field.name)
+                     != getattr(RunOptions(), field.name) else "default")
+        for field in fields(RunOptions)
+    }
+    overrides = {"polish": polish, "polish_tol": polish_tol,
+                 "polish_fail": polish_fail, "polish_degree": polish_degree}
+    updates = {name: value for name, value in overrides.items()
+               if value is not None}
+    if updates:
+        resolved = replace(resolved, **updates)
+        source.update({name: "python" for name in updates})
+    return resolved, source
+
+
+def polish_config_from_options(options: RunOptions, base: Any = None) -> Any:
+    """Build the driver :class:`PolishConfig` implied by the run options.
+
+    ``base`` is an explicit ``polish_config`` from the caller; explicit
+    configuration wins over directive-level scalars, so options only fill a
+    ``None`` base.  Returns ``None`` when nothing beyond driver defaults is
+    requested, keeping the no-directive path bit-identical to before.
+    """
+    if base is not None:
+        return base
+    from .polish_driver import PolishConfig
+
+    updates: dict[str, Any] = {}
+    if options.polish_tol is not None:
+        updates["tolerance"] = options.polish_tol
+    if options.polish_degree is not None:
+        updates["radial_degree"] = options.polish_degree
+    if options.polish_fail in ("fallback", "warn"):
+        updates["fail_policy"] = "return_unpolished"
+    if not updates:
+        return None
+    return PolishConfig(**updates)

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -2119,15 +2119,21 @@ def _resolve_force_balance_polish(
     polish: bool | str | None,
     polish_force_balance: bool | str | None,
 ) -> bool | str:
-    """Resolve the input directive and the two Python API spellings."""
+    """Resolve the two Python API spellings.
 
+    Input-file directives are execution metadata and never live on
+    :class:`VmecInput`; the CLI and :func:`~vmex.core.multigrid.solve_file`
+    resolve them through :mod:`vmex.core.run_options` and pass the result in
+    through these keywords.  ``source`` stays in the signature so the polish
+    request can be validated against the input type by the caller.
+    """
+
+    del source
     if polish is not None and polish_force_balance is not None:
         raise ValueError("pass either polish or polish_force_balance, not both")
     requested = polish_force_balance if polish_force_balance is not None else polish
     if requested is None:
-        requested = (
-            source.polish_force_balance if isinstance(source, VmecInput) else False
-        )
+        requested = False
     if requested is not False and requested is not True and requested != "auto":
         raise ValueError("polish_force_balance must be False, True, or 'auto'")
     return requested


### PR DESCRIPTION
Phase 1 of the plan: polishing becomes a normal, file-drivable VMEX feature, and execution metadata leaves the physics object.

## The problem

#192 stored `polish_force_balance` as a `VmecInput` dataclass field. That made execution policy part of the physics object: `to_indata` stamped a directive line on **every** written deck (including `.FALSE.`), and an input-file comment silently changed what `solve_multigrid(VmecInput.from_file(deck))` computes. The field has never shipped in a release — #192 merged after 0.7.1 — so it can die now without ever existing publicly.

## What this adds

**`vmex/core/run_options.py`** owns execution metadata. The canonical directive family, all VMEC-safe comments that VMEC2000 ignores:

```fortran
!@VMEX POLISH = AUTO
!@VMEX POLISH_TOL = 1.0E-8
!@VMEX POLISH_FAIL = ERROR
!@VMEX POLISH_DEGREE = 5
&INDATA
  ...
/
```

The original `! VMEX: POLISH_FORCE_BALANCE = .TRUE.` spelling still parses, and the two spellings are cross-checked for conflicts. Structured JSON carries the same keys in a reserved `_vmex` section, stripped before schema validation and validated separately, so the physics schema stays VMEC++ compatible. Unknown keys and invalid values fail with named errors — a typo never silently runs with defaults.

**`vmex.solve_file(path, polish="auto")`** runs a deck the way the CLI does: directives honored, `wout_<case>.nc` written from the polished state on success. **Precedence is exactly `CLI > Python keyword > file directive > default`**, with the resolved source recorded per field — the CLI prints which layer a polish request came from.

**CLI**: `--polish[=auto|true|false]`, `--no-polish`, `--polish-tol`, `--polish-fail {error,fallback,warn}`, `--polish-degree {3,5,7}`.

**Failure semantics without a second solve**: `fallback`/`warn` map onto the driver's own `return_unpolished`, so a failed polish arrives as an unconverged report rather than an exception; `warn` raises a `RuntimeWarning` naming the termination reason. Never a failure silently presented as polished. Free-boundary decks reject polish requests, naming which layer the request came from.

## `VmecInput` is physics-only again

- `from_file` ignores directives while preserving all physics (tested)
- `to_indata` writes physics only
- directive serialization moved to `run_options.format_indata_directives`
- the solver keywords `polish` / `polish_force_balance="auto"` are unchanged — #192's Python API survives intact

## Two bugs my own tests caught before review

- The directive regex used a greedy `\s*` before the optional trailing-comment group: it consumed the newline and let the first directive's comment **swallow the next directive line**. Character classes are now `[ \t]` and a multi-directive block is a test case.
- The free-boundary gate test deck omitted `MGRID_FILE` — and `readin.f` (and `VmecInput`) force `LFREEB=F` when it is `'NONE'`, silently rerouting the deck around the gate under test. The test now names a real mgrid path and a comment explains why.

## Tests

`tests/test_run_options.py` (22 tests): directive edge cases (inline comments, case-insensitivity, consistent repetition vs conflicts, conflicts *between* spellings, quoted `!` inside namelist strings), `_vmex` round trip and rejection cases, precedence with source maps, `PolishConfig` mapping with explicit-config priority, and three `solve_file` flows — including directive-activated polishing with the negative control that the same deck without the directive does not polish.

177 passed across `test_run_options` + `test_input_profiles` + manifest suites; ruff, mypy (75 files), `check_docs_prose`, `sphinx -W` clean. Manifest row added for the new module (`pr-parity-c3` primary lane).

Docs: README leads with `!@VMEX POLISH = AUTO` + `solve_file`; `docs/reference/cli.rst` documents the flags; `docs/reference/api/advanced.rst` documents ownership, precedence, and failure semantics.
