### PR TITLE
Add scalar-adjoint QA/QH/QP/QI optimization examples

### DIFF
--- a/docs/reference/optimization.rst
+++ b/docs/reference/optimization.rst
@@ -120,6 +120,12 @@ steps. Their iterates, stopping tests, and possibly the local minimum reached
 can differ. Always compare final physical terms and held-out validation
 metrics, not iteration counts alone.
 
+Measured on the QA workflow at a matched evaluation budget, the least-squares
+driver reached roughly a 3x lower objective than the scalar lane; the scalar
+lane's gains are a cheaper cold start and lower peak memory (44.7 s to 32.2 s
+wall, 2965 to 2574 MiB peak RSS on an Apple M4), so it is the cold-start and
+low-memory option, not a replacement for the least-squares driver.
+
 Choose deliberately:
 
 * Keep the vector route when residual-level diagnostics, a least-squares trust

--- a/docs/reference/optimization.rst
+++ b/docs/reference/optimization.rst
@@ -42,6 +42,110 @@ profiles, and transforms (it is not elapsed run time). Use
 :meth:`~vmex.core.problem.FunctionProblem.from_functions` when the user already
 has decision-vector-level functions and derivatives.
 
+Vector least squares or one scalar adjoint
+-------------------------------------------
+
+The residual and scalar interfaces can represent the same mathematical cost
+while asking for different derivatives. Let ``z`` be the converged equilibrium,
+``x`` the boundary/current decision vector, and
+
+.. math::
+
+   g(z,x)=0, \qquad
+   \Phi(z,x)=\tfrac12 r(z,x)^T r(z,x).
+
+The residual/Jacobian route builds
+
+.. math::
+
+   J_r = \frac{d r}{d x}
+       = r_x-r_z g_z^{-1}g_x,
+   \qquad \nabla_x\Phi=J_r^T r.
+
+This is what ``VmecProblem.from_tuples`` plus SciPy ``least_squares`` needs.
+The optimizer receives every residual row and the complete
+``n_residuals``-by-``n_dofs`` Jacobian. It can form a Gauss--Newton trust-region
+model, report individual rows, and stop on residual/Jacobian criteria. VMEX
+uses its block response algorithm to amortize the equilibrium linear algebra,
+but the complete residual Jacobian is still computed and materialized.
+
+When the optimizer only needs a scalar value and gradient, form ``Phi`` before
+differentiating. The adjoint is
+
+.. math::
+
+   g_z^T\lambda=\Phi_z^T= r_z^T r,
+   \qquad
+   \nabla_x\Phi=\Phi_x-\lambda^T g_x.
+
+There is one equilibrium-adjoint right-hand side per scalar gradient,
+independent of the number of residual rows and decision variables. ``One``
+describes the number of adjoint solves; its cost still depends on equilibrium
+resolution, linear conditioning, and the work needed to evaluate the objective
+VJP. VMEX does not tape the nonlinear equilibrium iterations.
+
+The explicit scalar construction is:
+
+.. code-block:: python
+
+   def loss(state, runtime):
+       rows = opt.residuals_from_tuples(state, runtime, terms)
+       return 0.5 * jnp.vdot(rows, rows)
+
+   problem = opt.VmecProblem.from_loss(
+       inp, loss, max_mode=5, use_ess=True)
+   problem.compile_value_and_gradient()
+
+   result = scipy.optimize.minimize(
+       problem.value_and_grad, problem.x0,
+       jac=True, method="L-BFGS-B", bounds=problem.bounds)
+
+For a single tuple-defined stage, :func:`vmex.core.optimize.minimize` is the
+short form of the same route:
+
+.. code-block:: python
+
+   result = opt.minimize(
+       terms, inp, max_mode=5, method="L-BFGS-B",
+       options={"maxiter": 100})
+
+The longer ``from_loss`` form is useful when the scalar is not a sum of tuple
+rows, or when a script owns stage-specific scaled coordinates and monitoring.
+
+The two constructions use the same rows, targets, weights, and scalar cost.
+They do **not** use the same optimization algorithm. ``least_squares`` uses
+the explicit residual Jacobian and Gauss--Newton curvature; L-BFGS-B sees only
+``Phi`` and its gradient and builds limited-memory curvature from accepted
+steps. Their iterates, stopping tests, and possibly the local minimum reached
+can differ. Always compare final physical terms and held-out validation
+metrics, not iteration counts alone.
+
+Choose deliberately:
+
+* Keep the vector route when residual-level diagnostics, a least-squares trust
+  region, or Gauss--Newton curvature is valuable.
+* Prefer the scalar route when a large pointwise objective makes cold Jacobian
+  compilation or materialization the bottleneck and the optimizer only needs
+  ``(value, gradient)``.
+* A scalar loss must be fully JAX-traceable. Opaque WOUT/host callbacks require
+  a traceable implementation or the finite-difference derivative lane.
+* ``compile_value_and_gradient`` makes the first scalar compile explicit;
+  it does not turn a cold timing into a warm timing.
+
+The committed QA startup measurements make the tradeoff concrete for 6,723
+rows and 48 boundary degrees of freedom on one Apple CPU host. Cold startup
+dropped from 44.7 s and 2,965 MiB peak RSS for the residual Jacobian to 32.2 s
+and 2,574 MiB for the scalar adjoint. Warm value/gradient medians were 16.6 s
+and 17.4 s, respectively, so the scalar path did not improve warm throughput
+in that measurement. The raw records are
+``benchmarks/qa_optimization_startup_{least_squares,scalar}_m4.json``; neither
+record is a GPU or persistent-cache claim.
+
+The canonical ``QA_optimization.py`` remains the residual/Jacobian tutorial.
+The eight ``{QA,QH,QP,QI}_optimization[_finite_beta]_scalar.py`` companions
+show the scalar route in vacuum and at finite beta without replacing the
+least-squares examples.
+
 Callable contracts
 ------------------
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -77,6 +77,9 @@ All runnable examples live under this single `examples/` tree. Examples marked
   include radially weighted Mercier and resistive-interchange terms. The shared
   `_scalar_driver.py` contains only the optimizer wiring; each runnable file
   keeps its physical targets, resolution, save names, and validation visible.
+  The scalar lane trades objective progress per evaluation (roughly 3x higher
+  objective at a matched budget on the QA workflow) for a cheaper cold start and
+  lower peak memory; `QA_optimization.py` remains the default.
   `single_stage_optimization.py` *(preview)* varies a prescribed boundary and
   coil Fourier coefficients; it does not call a free-boundary solve.
   `QA_optimization_bootstrap.py`, `QH_optimization_bootstrap.py` and

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,7 +59,24 @@ All runnable examples live under this single `examples/` tree. Examples marked
   - `vmex_fixed_free_boundary_comparison.py` *(preview)* — compare a parent
     free boundary with an `s=0.5` fixed-boundary solve and its exterior field.
 - `optimization/`: compact QA/QH/QP/QI scripts using `(function, target,
-  weight)` terms with SciPy least-squares, BFGS, or L-BFGS-B.
+  weight)` terms with SciPy least-squares, BFGS, or L-BFGS-B. The canonical
+  `QA_optimization.py` keeps the explicit residual/Jacobian workflow. Its
+  scalar companion forms the identical `0.5 * r.T @ r` objective before
+  implicit differentiation, so L-BFGS-B needs one equilibrium adjoint per
+  gradient rather than the complete residual Jacobian. The same comparison is
+  available for all four symmetry objectives:
+
+  | Family | Vacuum scalar example | Finite-beta scalar example |
+  | --- | --- | --- |
+  | QA | `QA_optimization_scalar.py` | `QA_optimization_finite_beta_scalar.py` |
+  | QH | `QH_optimization_scalar.py` | `QH_optimization_finite_beta_scalar.py` |
+  | QP | `QP_optimization_scalar.py` | `QP_optimization_finite_beta_scalar.py` |
+  | QI | `QI_optimization_scalar.py` | `QI_optimization_finite_beta_scalar.py` |
+
+  The finite-beta examples calibrate a prescribed linear pressure profile and
+  include radially weighted Mercier and resistive-interchange terms. The shared
+  `_scalar_driver.py` contains only the optimizer wiring; each runnable file
+  keeps its physical targets, resolution, save names, and validation visible.
   `single_stage_optimization.py` *(preview)* varies a prescribed boundary and
   coil Fourier coefficients; it does not call a free-boundary solve.
   `QA_optimization_bootstrap.py`, `QH_optimization_bootstrap.py` and

--- a/examples/optimization/QA_optimization.py
+++ b/examples/optimization/QA_optimization.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python
-"""Fast-start quasi-axisymmetric optimization with a magnetic well.
-
-The scalar objective uses one reverse implicit solve per gradient, avoiding
-the large pointwise residual Jacobian that made the former staged
-least-squares example spend minutes compiling before its first optimizer
-iteration.  The objective value and gradient are exactly the scalarization of
-the same weighted residual tuples.
-"""
+"""Quasi-axisymmetric boundary optimization with a magnetic well."""
 
 from dataclasses import replace
 import os
@@ -14,17 +7,19 @@ from pathlib import Path
 
 import jax.numpy as jnp
 import numpy as np
-from scipy.optimize import minimize
+from scipy.optimize import least_squares
 
 import vmex as vj
 from vmex import optimize as opt
 
 nfp = 2  # number of field periods
 SURFACES = np.linspace(0.1, 1.0, 10)
-MAX_MODE, MAXITER = 3, 30
+MAX_MODES, MAX_NFEV = [1, 2, 3], [10, 10, 15]
 MAGNETIC_WELL_TARGET = 0.01
 ASPECT_TARGET = 5.0
-# For a larger design space use MAX_MODE, MAXITER = 9, 60.
+# For a larger design space use:
+# MAX_MODES = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+# MAX_NFEV = [10, 10, 15, 20, 25, 40, 50, 60, 60]
 # MAGNETIC_WELL_TARGET = 0.07
 # ASPECT_TARGET = 3.5
 IOTA_FLOOR = 0.42
@@ -36,7 +31,7 @@ SEED_PERTURBATION = 0.05
 
 ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
 if ci_smoke:
-    MAX_MODE, MAXITER = 1, 4
+    MAX_MODES, MAX_NFEV = [1], [4]
 
 DATA = Path(__file__).resolve().parents[1] / "data" / f"input.minimal_seed_nfp{nfp}"
 inp = vj.VmecInput.from_file(DATA)
@@ -68,59 +63,41 @@ report = opt.EquilibriumReporter(
     ("mean iota", opt.mean_iota, ".4f"), ("magnetic well", opt.magnetic_well, ".4f"))
 monitor = opt.OptimizationMonitor(stream=None)
 
-# Scalarize the exact least-squares rows before differentiating. Reverse-mode
-# implicit differentiation then needs one adjoint regardless of boundary dof
-# count, instead of materializing the 6723 x 48 pointwise Jacobian.
-def loss(equilibrium_state, solver_context):
-    rows = opt.residuals_from_tuples(
-        equilibrium_state, solver_context, objective_function_terms)
-    return 0.5 * jnp.vdot(rows, rows)
-
-
-mpol = max(MAX_MODE + 2, MINIMUM_MPOL)
-inp = replace(inp, delt=0.5).change_resolution(
-    mpol=mpol, ntor=mpol, ntheta=2 * mpol + 6, nzeta=2 * mpol + 4)
-problem = opt.VmecProblem.from_loss(
-    inp, loss, max_mode=MAX_MODE, vary_major_radius=VARY_MAJOR_RADIUS,
-    use_ess=True, ess_alpha=ESS_ALPHA)
-print(f"dof_names = {problem.dof_names}")
-monitor.problem = problem
-problem.compile_value_and_gradient()
-
-x0 = problem.x0
-step = PARAMETER_STEP * problem.scales
-
-def x_from_y(y):
-    return x0 + step * y
-
-
-def value_and_gradient(y):
-    value, gradient = problem.value_and_grad(x_from_y(y))
-    evaluation_costs.append(float(value))
-    return value, step * gradient
-
-
-def monitor_y(intermediate_result):
-    x = x_from_y(intermediate_result.x)
-    monitor({"x": x, "fun": intermediate_result.fun,
-             "jac": value_and_gradient(intermediate_result.x)[1]})
-
-
-evaluation_costs = []
-result = minimize(
-    value_and_gradient, np.zeros_like(x0), jac=True, method="L-BFGS-B",
-    bounds=[(-MAX_PARAMETER_CHANGE, MAX_PARAMETER_CHANGE)] * x0.size,
-    callback=monitor_y,
-    options={"maxiter": MAXITER, "gtol": 1.0e-6, "ftol": 1.0e-12,
-             "maxls": 20, "maxcor": 20})
-print(
-    "optimizer scalar cost: "
-    f"{evaluation_costs[0]:.16e} -> {float(result.fun):.16e}"
-)
-result.x = x_from_y(result.x)
-inp = problem.input_from_x(result.x)
-equilibrium = problem.equilibrium_from_x(result.x)
-report(f"mode {MAX_MODE}", equilibrium)
+# The canonical example retains nonlinear least squares so users can inspect
+# individual residual rows and use SciPy's trust-region model. The companion
+# QA_optimization_scalar.py minimizes the identical aggregate cost with one
+# reverse equilibrium adjoint per gradient.
+equilibrium = opt.solve_equilibrium(inp)
+# If a RuntimeWarning reports uncertified Jacobian columns, it is expected
+# once the optimizer leaves the seed and needs no action: the shipped
+# jacobian_adjoint_tol=1e-4 and jacobian_adjoint_maxiter=10 are the measured
+# optimum, since ten times that budget moved the Jacobian by 2e-8 and
+# certified no extra column. Both are from_tuples arguments; pass
+# evaluation_progress=False to drop the per-evaluation timing lines.
+for max_mode, max_nfev in zip(MAX_MODES, MAX_NFEV):
+    print(f"\n===== QA stage, max_mode = {max_mode} =====")
+    mpol = max(max_mode + 2, MINIMUM_MPOL)
+    inp = replace(inp, delt=0.5).change_resolution(
+        mpol=mpol, ntor=mpol, ntheta=2 * mpol + 6, nzeta=2 * mpol + 4)
+    problem = opt.VmecProblem.from_tuples(
+        inp, objective_function_terms, max_mode=max_mode,
+        vary_major_radius=VARY_MAJOR_RADIUS, use_ess=True,
+        ess_alpha=ESS_ALPHA, restart_from=equilibrium)
+    print(f"dof_names = {problem.dof_names}")
+    monitor.problem = problem
+    if not ci_smoke:
+        problem.compile_residual_and_jacobian()
+    step = PARAMETER_STEP * problem.scales
+    result = least_squares(
+        problem.residual, problem.x0, jac=problem.residual_jac,
+        x_scale=step, max_nfev=max_nfev,
+        bounds=(problem.x0 - MAX_PARAMETER_CHANGE * step,
+                problem.x0 + MAX_PARAMETER_CHANGE * step),
+        ftol=1e-6, xtol=1e-10, verbose=2, callback=monitor)
+    inp = problem.input_from_x(result.x)
+    equilibrium = problem.equilibrium_from_x(result.x)
+    report(f"mode {max_mode}", equilibrium)
+    # inp.to_indata(f"input.QA_max_mode_{max_mode:03d}")
 
 # Print results
 final_input = replace(inp,

--- a/examples/optimization/QA_optimization_finite_beta_scalar.py
+++ b/examples/optimization/QA_optimization_finite_beta_scalar.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
-"""Finite-beta quasi-axisymmetric optimization with one scalar adjoint."""
+"""Finite-beta quasi-axisymmetric optimization with one scalar adjoint.
+
+The scalar lane trades objective progress per evaluation for a cheaper cold
+start and lower peak memory: at a matched evaluation budget the least-squares
+driver reached roughly a 3x lower objective on the same problem, so it remains
+the default for objective progress.
+"""
 
 from dataclasses import replace
 import os

--- a/examples/optimization/QA_optimization_finite_beta_scalar.py
+++ b/examples/optimization/QA_optimization_finite_beta_scalar.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""Finite-beta quasi-axisymmetric optimization with one scalar adjoint."""
+
+from dataclasses import replace
+import os
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+
+import vmex as vj
+from vmex import optimize as opt
+from _scalar_driver import run_scalar_stage
+
+nfp, TARGET_BETA = 2, 0.01
+SURFACES = np.linspace(0.1, 0.9, 8)
+MAX_MODES, MAXITER = [2, 4], [20, 45]
+ASPECT_TARGET, IOTA_FLOOR, MAGNETIC_WELL_TARGET = 5.0, 0.42, 0.01
+STABILITY_MIN_S, STABILITY_WEIGHT, EDGE_WEIGHT_FACTOR = 0.2, 1e-6, 10.0
+PARAMETER_STEP, MAX_PARAMETER_CHANGE = 0.01, 3.0
+ESS_ALPHA, MINIMUM_MPOL = 1.2, 5
+VARY_MAJOR_RADIUS = False
+SEED_PERTURBATION = 0.05
+POLISH_FORCE_BALANCE = False  # Set True to polish only the final saved state.
+
+ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
+if ci_smoke:
+    SURFACES = np.array([0.25, 0.6, 0.9])
+    MAX_MODES, MAXITER, MINIMUM_MPOL = [1], [2], 3
+
+DATA = Path(__file__).resolve().parents[1] / "data" / f"input.minimal_seed_nfp{nfp}"
+inp = vj.VmecInput.from_file(DATA)
+rbc, zbs = inp.rbc.copy(), inp.zbs.copy()
+rbc[inp.ntor - 1, 1], zbs[inp.ntor - 1, 1] = -SEED_PERTURBATION, SEED_PERTURBATION
+am = np.zeros(21)
+am[:2] = [1.0, -1.0]  # p(s) = PRES_SCALE * (1-s)
+inp = replace(inp, rbc=rbc, zbs=zbs, pmass_type="power_series", am=am,
+              pres_scale=100.0)
+calibration = opt.solve_equilibrium(inp)
+inp = replace(
+    inp, pres_scale=inp.pres_scale * TARGET_BETA / float(calibration.wout.betatotal))
+equilibrium = opt.solve_equilibrium(inp, initial_state=calibration.solution)
+
+stability_s = np.linspace(0.0, 1.0, int(inp.ns_array[-1]))[2:-1]
+stability_weights = np.where(
+    stability_s >= STABILITY_MIN_S,
+    STABILITY_WEIGHT * (1.0 + (EDGE_WEIGHT_FACTOR - 1.0) * stability_s**4), 0.0)
+
+
+def iota_floor(state, runtime):
+    return jnp.maximum(IOTA_FLOOR - opt.min_abs_iota(state, runtime), 0.0)
+
+
+qs = opt.QuasisymmetryRatioResidual(SURFACES, helicity_m=1, helicity_n=0)
+objective_terms = [
+    (qs, 0.0, 1.0), (opt.aspect_ratio, ASPECT_TARGET, 1.0),
+    (iota_floor, 0.0, 10.0),
+    (opt.magnetic_well, MAGNETIC_WELL_TARGET, 1.0),
+    (opt.volume_average_beta, TARGET_BETA, 1.0 / TARGET_BETA**2),
+    (opt.mercier_stability_residual, 0.0, stability_weights),
+    (opt.glasser_stability_residual, 0.0, stability_weights)]
+
+
+report = opt.EquilibriumReporter(
+    ("QS", qs.total, ".4e"), ("beta", opt.volume_average_beta, ".3%"),
+    ("aspect", opt.aspect_ratio, ".3f"),
+    ("min |iota|", opt.min_abs_iota, ".3f"))
+monitor = opt.OptimizationMonitor(stream=None)
+
+for max_mode, maxiter in zip(MAX_MODES, MAXITER):
+    inp, equilibrium = run_scalar_stage(
+        inp, equilibrium, objective_terms, label="finite-beta QA",
+        max_mode=max_mode, maxiter=maxiter,
+        parameter_step=PARAMETER_STEP,
+        max_parameter_change=MAX_PARAMETER_CHANGE,
+        minimum_mpol=MINIMUM_MPOL,
+        vary_major_radius=VARY_MAJOR_RADIUS,
+        ess_alpha=ESS_ALPHA, monitor=monitor, compile_first=not ci_smoke)
+    report(f"mode {max_mode}", equilibrium)
+
+final_input = replace(
+    inp, ns_array=np.array([31 if ci_smoke else 101]),
+    ftol_array=np.array([1e-10 if ci_smoke else 1e-14]),
+    niter_array=np.array([20000]))
+final_equilibrium = opt.solve_equilibrium(
+    final_input, initial_state=equilibrium.solution,
+    verbose=not ci_smoke, raise_on_max_iterations=True,
+    polish_force_balance=POLISH_FORCE_BALANCE)
+report("final", final_equilibrium)
+
+input_path = final_input.to_indata("input.QA_finite_beta_scalar_optimized")
+wout_path = vj.write_wout(
+    "wout_QA_finite_beta_scalar_optimized.nc", final_equilibrium.wout)
+print(f"wrote {input_path}\nwrote {wout_path}")
+monitor.save("QA_finite_beta_scalar_objectives.csv")
+monitor.plot("QA_finite_beta_scalar_objectives.png")
+for path in vj.plot_wout(wout_path, ".").values():
+    print(f"wrote {path}")

--- a/examples/optimization/QA_optimization_scalar.py
+++ b/examples/optimization/QA_optimization_scalar.py
@@ -5,6 +5,11 @@ This minimizes the same weighted sum of squared residuals as
 ``QA_optimization.py``.  The difference is algorithmic: residual rows are
 scalarized before implicit differentiation and SciPy L-BFGS-B receives a value
 and gradient instead of a residual vector and its full Jacobian.
+
+The scalar lane trades objective progress per evaluation for a cheaper cold
+start and lower peak memory: at a matched evaluation budget the least-squares
+driver reached roughly a 3x lower objective on the same problem, so it remains
+the default for objective progress.
 """
 
 from dataclasses import replace

--- a/examples/optimization/QA_optimization_scalar.py
+++ b/examples/optimization/QA_optimization_scalar.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+"""Quasi-axisymmetric optimization with one adjoint per scalar gradient.
+
+This minimizes the same weighted sum of squared residuals as
+``QA_optimization.py``.  The difference is algorithmic: residual rows are
+scalarized before implicit differentiation and SciPy L-BFGS-B receives a value
+and gradient instead of a residual vector and its full Jacobian.
+"""
+
+from dataclasses import replace
+import os
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+
+import vmex as vj
+from vmex import optimize as opt
+from _scalar_driver import run_scalar_stage
+
+nfp = 2
+SURFACES = np.linspace(0.1, 1.0, 10)
+MAX_MODES, MAXITER = [1, 2, 3], [10, 10, 15]
+MAGNETIC_WELL_TARGET, ASPECT_TARGET, IOTA_FLOOR = 0.01, 5.0, 0.42
+PARAMETER_STEP, MAX_PARAMETER_CHANGE = 0.02, 5.0
+ESS_ALPHA, MINIMUM_MPOL = 1.2, 5
+VARY_MAJOR_RADIUS = False
+SEED_PERTURBATION = 0.05
+POLISH_FORCE_BALANCE = False  # Set True to polish only the final saved state.
+
+ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
+if ci_smoke:
+    MAX_MODES, MAXITER = [1], [4]
+
+DATA = Path(__file__).resolve().parents[1] / "data" / f"input.minimal_seed_nfp{nfp}"
+inp = vj.VmecInput.from_file(DATA)
+rbc, zbs = inp.rbc.copy(), inp.zbs.copy()
+rbc[inp.ntor - 1, 1], zbs[inp.ntor - 1, 1] = -SEED_PERTURBATION, SEED_PERTURBATION
+inp = replace(inp, rbc=rbc, zbs=zbs)
+
+
+def iota_floor(state, runtime):
+    return jnp.maximum(IOTA_FLOOR - opt.min_abs_iota(state, runtime), 0.0)
+
+
+qs = opt.QuasisymmetryRatioResidual(SURFACES, helicity_m=1, helicity_n=0)
+objective_terms = [
+    (qs, 0.0, 1.0),
+    (opt.aspect_ratio, ASPECT_TARGET, 1.0),
+    (iota_floor, 0.0, 10.0),
+    (opt.magnetic_well, MAGNETIC_WELL_TARGET, 1.0),
+]
+
+
+report = opt.EquilibriumReporter(
+    ("QS total", qs.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
+    ("mean iota", opt.mean_iota, ".4f"),
+    ("magnetic well", opt.magnetic_well, ".4f"))
+monitor = opt.OptimizationMonitor(stream=None)
+equilibrium = opt.solve_equilibrium(inp)
+
+for max_mode, maxiter in zip(MAX_MODES, MAXITER):
+    inp, equilibrium = run_scalar_stage(
+        inp, equilibrium, objective_terms, label="QA",
+        max_mode=max_mode, maxiter=maxiter,
+        parameter_step=PARAMETER_STEP,
+        max_parameter_change=MAX_PARAMETER_CHANGE,
+        minimum_mpol=MINIMUM_MPOL,
+        vary_major_radius=VARY_MAJOR_RADIUS,
+        ess_alpha=ESS_ALPHA, monitor=monitor, compile_first=not ci_smoke)
+    report(f"mode {max_mode}", equilibrium)
+
+final_input = replace(
+    inp, ns_array=np.array([31 if ci_smoke else 101]),
+    ftol_array=np.array([1e-10 if ci_smoke else 1e-14]),
+    niter_array=np.array([8000]))
+final_equilibrium = opt.solve_equilibrium(
+    final_input, initial_state=equilibrium.solution,
+    verbose=not ci_smoke, raise_on_max_iterations=True,
+    polish_force_balance=POLISH_FORCE_BALANCE)
+report("final", final_equilibrium)
+
+input_path = final_input.to_indata("input.QA_scalar_optimized")
+wout_path = vj.write_wout("wout_QA_scalar_optimized.nc", final_equilibrium.wout)
+print(f"wrote {input_path}\nwrote {wout_path}")
+monitor.save("QA_scalar_optimization_objectives.csv")
+monitor.plot("QA_scalar_optimization_objectives.png")
+for path in vj.plot_wout(wout_path, ".").values():
+    print(f"wrote {path}")

--- a/examples/optimization/QH_optimization_finite_beta_scalar.py
+++ b/examples/optimization/QH_optimization_finite_beta_scalar.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+"""Finite-beta quasi-helical optimization with one scalar adjoint."""
+
+from dataclasses import replace
+import os
+from pathlib import Path
+
+import numpy as np
+
+import vmex as vj
+from vmex import optimize as opt
+from _scalar_driver import run_scalar_stage
+
+nfp, TARGET_BETA = 4, 0.01
+SURFACES = np.linspace(0.1, 0.9, 8)
+MAX_MODES, MAXITER = [2, 4], [20, 45]
+ASPECT_TARGET, IOTA_TARGET = 6.0, -1.1
+STABILITY_MIN_S, STABILITY_WEIGHT, EDGE_WEIGHT_FACTOR = 0.2, 1e-6, 10.0
+PARAMETER_STEP, MAX_PARAMETER_CHANGE = 0.01, 3.0
+ESS_ALPHA, MINIMUM_MPOL = 1.2, 5
+VARY_MAJOR_RADIUS = False
+SEED_PERTURBATION = 0.12
+POLISH_FORCE_BALANCE = False  # Set True to polish only the final saved state.
+
+ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
+if ci_smoke:
+    SURFACES = np.array([0.25, 0.6, 0.9])
+    MAX_MODES, MAXITER, MINIMUM_MPOL = [1], [2], 3
+
+DATA = Path(__file__).resolve().parents[1] / "data" / f"input.minimal_seed_nfp{nfp}"
+inp = vj.VmecInput.from_file(DATA)
+rbc, zbs = inp.rbc.copy(), inp.zbs.copy()
+rbc[inp.ntor - 1, 1], zbs[inp.ntor - 1, 1] = -SEED_PERTURBATION, SEED_PERTURBATION
+am = np.zeros(21)
+am[:2] = [1.0, -1.0]
+inp = replace(inp, rbc=rbc, zbs=zbs, pmass_type="power_series", am=am,
+              pres_scale=100.0)
+calibration = opt.solve_equilibrium(inp)
+inp = replace(
+    inp, pres_scale=inp.pres_scale * TARGET_BETA / float(calibration.wout.betatotal))
+equilibrium = opt.solve_equilibrium(inp, initial_state=calibration.solution)
+
+stability_s = np.linspace(0.0, 1.0, int(inp.ns_array[-1]))[2:-1]
+stability_weights = np.where(
+    stability_s >= STABILITY_MIN_S,
+    STABILITY_WEIGHT * (1.0 + (EDGE_WEIGHT_FACTOR - 1.0) * stability_s**4), 0.0)
+qs = opt.QuasisymmetryRatioResidual(SURFACES, helicity_m=1, helicity_n=-1)
+objective_terms = [
+    (qs, 0.0, 1.0), (opt.aspect_ratio, ASPECT_TARGET, 1.0),
+    (opt.mean_iota, IOTA_TARGET, 1.0),
+    (opt.volume_average_beta, TARGET_BETA, 1.0 / TARGET_BETA**2),
+    (opt.mercier_stability_residual, 0.0, stability_weights),
+    (opt.glasser_stability_residual, 0.0, stability_weights)]
+
+
+report = opt.EquilibriumReporter(
+    ("QS", qs.total, ".4e"), ("beta", opt.volume_average_beta, ".3%"),
+    ("aspect", opt.aspect_ratio, ".3f"),
+    ("mean iota", opt.mean_iota, ".3f"))
+monitor = opt.OptimizationMonitor(stream=None)
+
+for max_mode, maxiter in zip(MAX_MODES, MAXITER):
+    inp, equilibrium = run_scalar_stage(
+        inp, equilibrium, objective_terms, label="finite-beta QH",
+        max_mode=max_mode, maxiter=maxiter,
+        parameter_step=PARAMETER_STEP,
+        max_parameter_change=MAX_PARAMETER_CHANGE,
+        minimum_mpol=MINIMUM_MPOL,
+        vary_major_radius=VARY_MAJOR_RADIUS,
+        ess_alpha=ESS_ALPHA, monitor=monitor, compile_first=not ci_smoke)
+    report(f"mode {max_mode}", equilibrium)
+
+final_input = replace(
+    inp, ns_array=np.array([31 if ci_smoke else 101]),
+    ftol_array=np.array([1e-10 if ci_smoke else 1e-14]),
+    niter_array=np.array([20000]))
+final_equilibrium = opt.solve_equilibrium(
+    final_input, initial_state=equilibrium.solution,
+    verbose=not ci_smoke, raise_on_max_iterations=True,
+    polish_force_balance=POLISH_FORCE_BALANCE)
+report("final", final_equilibrium)
+
+input_path = final_input.to_indata("input.QH_finite_beta_scalar_optimized")
+wout_path = vj.write_wout(
+    "wout_QH_finite_beta_scalar_optimized.nc", final_equilibrium.wout)
+print(f"wrote {input_path}\nwrote {wout_path}")
+monitor.save("QH_finite_beta_scalar_objectives.csv")
+monitor.plot("QH_finite_beta_scalar_objectives.png")
+for path in vj.plot_wout(wout_path, ".").values():
+    print(f"wrote {path}")

--- a/examples/optimization/QH_optimization_finite_beta_scalar.py
+++ b/examples/optimization/QH_optimization_finite_beta_scalar.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
-"""Finite-beta quasi-helical optimization with one scalar adjoint."""
+"""Finite-beta quasi-helical optimization with one scalar adjoint.
+
+The scalar lane trades objective progress per evaluation for a cheaper cold
+start and lower peak memory: at a matched evaluation budget the least-squares
+driver reached roughly a 3x lower objective on the same problem, so it remains
+the default for objective progress.
+"""
 
 from dataclasses import replace
 import os

--- a/examples/optimization/QH_optimization_scalar.py
+++ b/examples/optimization/QH_optimization_scalar.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""Quasi-helical optimization with one adjoint per scalar gradient."""
+
+from dataclasses import replace
+import os
+from pathlib import Path
+
+import numpy as np
+
+import vmex as vj
+from vmex import optimize as opt
+from _scalar_driver import run_scalar_stage
+
+nfp = 4
+SURFACES = np.linspace(0.1, 1.0, 10)
+MAX_MODES, MAXITER = [2, 3], [15, 15]
+ASPECT_TARGET = 6.0
+TRIAL_BETA, USE_TRIAL_STABILITY = 0.025, False
+STABILITY_COST_PER_SURFACE, EDGE_WEIGHT_FACTOR = 1e-2, 10.0
+STABILITY_MIN_S, STABILITY_MARGIN = 0.2, 1e-3
+PARAMETER_STEP, MAX_PARAMETER_CHANGE = 0.02, 5.0
+ESS_ALPHA, MINIMUM_MPOL = 1.2, 5
+VARY_MAJOR_RADIUS = False
+SEED_PERTURBATION = 0.12
+POLISH_FORCE_BALANCE = False  # Set True to polish only the final saved state.
+
+ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
+if ci_smoke:
+    MAX_MODES, MAXITER = [1], [4]
+
+DATA = Path(__file__).resolve().parents[1] / "data" / f"input.minimal_seed_nfp{nfp}"
+inp = vj.VmecInput.from_file(DATA)
+rbc, zbs = inp.rbc.copy(), inp.zbs.copy()
+rbc[inp.ntor - 1, 1], zbs[inp.ntor - 1, 1] = -SEED_PERTURBATION, SEED_PERTURBATION
+inp = replace(inp, rbc=rbc, zbs=zbs)
+
+
+def trial_dmerc(state, runtime):
+    return opt.trial_pressure_mercier_stability_residual(
+        state, runtime, beta=TRIAL_BETA, margin=STABILITY_MARGIN)
+
+
+def trial_dr(state, runtime):
+    return opt.trial_pressure_glasser_stability_residual(
+        state, runtime, beta=TRIAL_BETA, margin=STABILITY_MARGIN)
+
+
+stability_s = np.linspace(0.0, 1.0, int(inp.ns_array[-1]))[2:-1]
+stability_shape = np.where(
+    stability_s >= STABILITY_MIN_S,
+    1.0 + (EDGE_WEIGHT_FACTOR - 1.0) * stability_s**4, 0.0)
+qs = opt.QuasisymmetryRatioResidual(SURFACES, helicity_m=1, helicity_n=-1)
+objective_terms = [(qs, 0.0, 1.0), (opt.aspect_ratio, ASPECT_TARGET, 1.0)]
+
+report = opt.EquilibriumReporter(
+    ("QS total", qs.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
+    ("mean iota", opt.mean_iota, ".4f"),
+    ("magnetic well", opt.magnetic_well, ".4f"))
+monitor = opt.OptimizationMonitor(stream=None)
+equilibrium = opt.solve_equilibrium(inp)
+
+for stage, (max_mode, maxiter) in enumerate(zip(MAX_MODES, MAXITER)):
+    stage_terms = objective_terms
+    if USE_TRIAL_STABILITY and stage > 0:
+        dmerc0 = np.asarray(trial_dmerc(equilibrium.solution, equilibrium.solver_context))
+        dr0 = np.asarray(trial_dr(equilibrium.solution, equilibrium.solver_context))
+        scale = np.maximum.reduce((np.abs(dmerc0), np.abs(dr0), np.ones_like(dmerc0)))
+        weights = STABILITY_COST_PER_SURFACE * stability_shape / scale**2
+        stage_terms = [*objective_terms,
+                       (trial_dmerc, 0.0, weights), (trial_dr, 0.0, weights)]
+
+    inp, equilibrium = run_scalar_stage(
+        inp, equilibrium, stage_terms, label="QH",
+        max_mode=max_mode, maxiter=maxiter,
+        parameter_step=PARAMETER_STEP,
+        max_parameter_change=MAX_PARAMETER_CHANGE,
+        minimum_mpol=MINIMUM_MPOL,
+        vary_major_radius=VARY_MAJOR_RADIUS,
+        ess_alpha=ESS_ALPHA, monitor=monitor, compile_first=not ci_smoke)
+    report(f"mode {max_mode}", equilibrium)
+
+final_input = replace(
+    inp, ns_array=np.array([31 if ci_smoke else 101]),
+    ftol_array=np.array([1e-10 if ci_smoke else 1e-14]),
+    niter_array=np.array([8000]))
+final_equilibrium = opt.solve_equilibrium(
+    final_input, initial_state=equilibrium.solution,
+    verbose=not ci_smoke, raise_on_max_iterations=True,
+    polish_force_balance=POLISH_FORCE_BALANCE)
+report("final", final_equilibrium)
+
+input_path = final_input.to_indata("input.QH_scalar_optimized")
+wout_path = vj.write_wout("wout_QH_scalar_optimized.nc", final_equilibrium.wout)
+print(f"wrote {input_path}\nwrote {wout_path}")
+monitor.save("QH_scalar_optimization_objectives.csv")
+monitor.plot("QH_scalar_optimization_objectives.png")
+for path in vj.plot_wout(wout_path, ".").values():
+    print(f"wrote {path}")

--- a/examples/optimization/QH_optimization_scalar.py
+++ b/examples/optimization/QH_optimization_scalar.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
-"""Quasi-helical optimization with one adjoint per scalar gradient."""
+"""Quasi-helical optimization with one adjoint per scalar gradient.
+
+The scalar lane trades objective progress per evaluation for a cheaper cold
+start and lower peak memory: at a matched evaluation budget the least-squares
+driver reached roughly a 3x lower objective on the same problem, so it remains
+the default for objective progress.
+"""
 
 from dataclasses import replace
 import os

--- a/examples/optimization/QI_optimization_finite_beta_scalar.py
+++ b/examples/optimization/QI_optimization_finite_beta_scalar.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+"""Finite-beta constructed-QI optimization with one scalar adjoint."""
+
+from dataclasses import replace
+import os
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+
+import vmex as vj
+from vmex import optimize as opt
+from vmex.core.qi import ConstructedQIResidual
+from _scalar_driver import run_scalar_stage
+
+nfp, TARGET_BETA = 2, 0.01
+SURFACES = np.linspace(0.1, 0.9, 6)
+MAX_MODES, MAXITER = [2, 3], [30, 60]
+ASPECT_TARGET, IOTA_FLOOR = 5.0, 0.51
+MIRROR_LIMIT, ELONGATION_LIMIT = 0.21, 8.0
+STABILITY_MIN_S, STABILITY_WEIGHT, EDGE_WEIGHT_FACTOR = 0.2, 1e-6, 10.0
+PARAMETER_STEP, MAX_PARAMETER_CHANGE = 0.01, 3.0
+ESS_ALPHA, MINIMUM_MPOL = 1.2, 5
+VARY_MAJOR_RADIUS = False
+SEED_PERTURBATION = 0.05
+POLISH_FORCE_BALANCE = False  # Set True to polish only the final saved state.
+qi_options = dict(mboz=12, nboz=12, nphi=61, nalpha=18, n_bounce=21)
+validation_options = dict(mboz=14, nboz=14, nphi=101, nalpha=29, n_bounce=31)
+
+ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
+if ci_smoke:
+    SURFACES = np.array([0.25, 0.6, 0.9])
+    MAX_MODES, MAXITER, MINIMUM_MPOL = [1], [2], 3
+    qi_options = dict(mboz=8, nboz=8, nphi=31, nalpha=7, n_bounce=7)
+    validation_options = qi_options
+
+DATA = Path(__file__).resolve().parents[1] / "data" / f"input.minimal_seed_nfp{nfp}"
+inp = vj.VmecInput.from_file(DATA)
+rbc, zbs = inp.rbc.copy(), inp.zbs.copy()
+rbc[inp.ntor - 1, 1], zbs[inp.ntor - 1, 1] = -SEED_PERTURBATION, SEED_PERTURBATION
+am = np.zeros(21)
+am[:2] = [1.0, -1.0]
+inp = replace(inp, rbc=rbc, zbs=zbs, pmass_type="power_series", am=am,
+              pres_scale=100.0)
+calibration = opt.solve_equilibrium(inp)
+inp = replace(
+    inp, pres_scale=inp.pres_scale * TARGET_BETA / float(calibration.wout.betatotal))
+equilibrium = opt.solve_equilibrium(inp, initial_state=calibration.solution)
+
+stability_s = np.linspace(0.0, 1.0, int(inp.ns_array[-1]))[2:-1]
+stability_weights = np.where(
+    stability_s >= STABILITY_MIN_S,
+    STABILITY_WEIGHT * (1.0 + (EDGE_WEIGHT_FACTOR - 1.0) * stability_s**4), 0.0)
+
+
+def iota_floor(state, runtime):
+    return jnp.maximum(IOTA_FLOOR - opt.min_abs_iota(state, runtime), 0.0)
+
+
+def mirror_excess(state, runtime):
+    return jnp.maximum(opt.mirror_ratio(state, runtime) - MIRROR_LIMIT, 0.0)
+
+
+def elongation_excess(state, runtime):
+    return jnp.maximum(opt.max_elongation(state, runtime) - ELONGATION_LIMIT, 0.0)
+
+
+qi = ConstructedQIResidual(SURFACES, **qi_options)
+objective_terms = [
+    (qi, 0.0, 10.0), (opt.aspect_ratio, ASPECT_TARGET, 0.005),
+    (iota_floor, 0.0, 10.0), (mirror_excess, 0.0, 10.0),
+    (elongation_excess, 0.0, 10.0),
+    (opt.volume_average_beta, TARGET_BETA, 1.0 / TARGET_BETA**2),
+    (opt.mercier_stability_residual, 0.0, stability_weights),
+    (opt.glasser_stability_residual, 0.0, stability_weights)]
+
+
+report = opt.EquilibriumReporter(
+    ("constructed QI", qi.total, ".4e"),
+    ("beta", opt.volume_average_beta, ".3%"),
+    ("aspect", opt.aspect_ratio, ".3f"),
+    ("min |iota|", opt.min_abs_iota, ".3f"),
+    ("mirror", opt.mirror_ratio, ".3f"))
+monitor = opt.OptimizationMonitor(stream=None)
+
+for max_mode, maxiter in zip(MAX_MODES, MAXITER):
+    inp, equilibrium = run_scalar_stage(
+        inp, equilibrium, objective_terms, label="finite-beta QI",
+        max_mode=max_mode, maxiter=maxiter,
+        parameter_step=PARAMETER_STEP,
+        max_parameter_change=MAX_PARAMETER_CHANGE,
+        minimum_mpol=MINIMUM_MPOL,
+        vary_major_radius=VARY_MAJOR_RADIUS,
+        ess_alpha=ESS_ALPHA, monitor=monitor, compile_first=not ci_smoke,
+        progress=not ci_smoke)
+    report(f"mode {max_mode}", equilibrium)
+
+final_input = replace(
+    inp, ns_array=np.array([31 if ci_smoke else 101]),
+    ftol_array=np.array([1e-10 if ci_smoke else 1e-14]),
+    niter_array=np.array([20000]))
+final_equilibrium = opt.solve_equilibrium(
+    final_input, initial_state=equilibrium.solution,
+    verbose=not ci_smoke, raise_on_max_iterations=True,
+    polish_force_balance=POLISH_FORCE_BALANCE)
+qi_final = report("final", final_equilibrium)["constructed QI"]
+qi_validation = ConstructedQIResidual(SURFACES, **validation_options)
+print(f"QI total {qi_final:.3e}; independent fine-grid validation "
+      f"{float(qi_validation.total(final_equilibrium)):.3e}")
+
+input_path = final_input.to_indata("input.QI_finite_beta_scalar_optimized")
+wout_path = vj.write_wout(
+    "wout_QI_finite_beta_scalar_optimized.nc", final_equilibrium.wout)
+print(f"wrote {input_path}\nwrote {wout_path}")
+monitor.save("QI_finite_beta_scalar_objectives.csv")
+monitor.plot("QI_finite_beta_scalar_objectives.png")
+for path in vj.plot_wout(wout_path, ".").values():
+    print(f"wrote {path}")

--- a/examples/optimization/QI_optimization_finite_beta_scalar.py
+++ b/examples/optimization/QI_optimization_finite_beta_scalar.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
-"""Finite-beta constructed-QI optimization with one scalar adjoint."""
+"""Finite-beta constructed-QI optimization with one scalar adjoint.
+
+The scalar lane trades objective progress per evaluation for a cheaper cold
+start and lower peak memory: at a matched evaluation budget the least-squares
+driver reached roughly a 3x lower objective on the same problem, so it remains
+the default for objective progress.
+"""
 
 from dataclasses import replace
 import os

--- a/examples/optimization/QI_optimization_scalar.py
+++ b/examples/optimization/QI_optimization_scalar.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""Constructed-QI optimization with one adjoint per scalar gradient."""
+
+from dataclasses import replace
+import os
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+
+import vmex as vj
+from vmex import optimize as opt
+from vmex.core.qi import ConstructedQIResidual
+from _scalar_driver import run_scalar_stage
+
+nfp = 2
+SURFACES = np.linspace(0.1, 1.0, 6)
+MAX_MODES, MAXITER = [3], [250]
+ASPECT_TARGET, IOTA_FLOOR = 5.0, 0.51
+MIRROR_LIMIT, ELONGATION_LIMIT = 0.21, 8.0
+PARAMETER_STEP, MAX_PARAMETER_CHANGE = 0.02, 5.0
+ESS_ALPHA, MINIMUM_MPOL = 1.2, 5
+VARY_MAJOR_RADIUS = False
+SEED_PERTURBATION = 0.05
+POLISH_FORCE_BALANCE = False  # Set True to polish only the final saved state.
+qi_options = dict(mboz=12, nboz=12, nphi=61, nalpha=18, n_bounce=21)
+validation_options = dict(mboz=14, nboz=14, nphi=101, nalpha=29, n_bounce=31)
+
+ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
+if ci_smoke:
+    qi_options = dict(mboz=8, nboz=8, nphi=31, nalpha=7, n_bounce=7)
+    validation_options = qi_options
+    MAX_MODES, MAXITER = [2], [5]
+
+DATA = Path(__file__).resolve().parents[1] / "data" / f"input.minimal_seed_nfp{nfp}"
+inp = vj.VmecInput.from_file(DATA)
+rbc, zbs = inp.rbc.copy(), inp.zbs.copy()
+rbc[inp.ntor - 1, 1], zbs[inp.ntor - 1, 1] = -SEED_PERTURBATION, SEED_PERTURBATION
+inp = replace(inp, rbc=rbc, zbs=zbs)
+
+
+def iota_floor(state, runtime):
+    return jnp.maximum(IOTA_FLOOR - opt.min_abs_iota(state, runtime), 0.0)
+
+
+def mirror_excess(state, runtime):
+    return jnp.maximum(opt.mirror_ratio(state, runtime) - MIRROR_LIMIT, 0.0)
+
+
+def elongation_excess(state, runtime):
+    return jnp.maximum(opt.max_elongation(state, runtime) - ELONGATION_LIMIT, 0.0)
+
+
+qi = ConstructedQIResidual(SURFACES, **qi_options)
+objective_terms = [
+    (qi, 0.0, 10.0), (opt.aspect_ratio, ASPECT_TARGET, 0.005),
+    (iota_floor, 0.0, 10.0), (mirror_excess, 0.0, 10.0),
+    (elongation_excess, 0.0, 10.0)]
+
+
+report = opt.EquilibriumReporter(
+    ("constructed QI", qi.total, ".6e"),
+    ("aspect", opt.aspect_ratio, ".4f"),
+    ("mean iota", opt.mean_iota, ".4f"),
+    ("mirror", opt.mirror_ratio, ".4f"),
+    ("elongation", opt.max_elongation, ".4f"))
+monitor = opt.OptimizationMonitor(stream=None)
+equilibrium = opt.solve_equilibrium(inp)
+
+for max_mode, maxiter in zip(MAX_MODES, MAXITER):
+    inp, equilibrium = run_scalar_stage(
+        inp, equilibrium, objective_terms, label="QI",
+        max_mode=max_mode, maxiter=maxiter,
+        parameter_step=PARAMETER_STEP,
+        max_parameter_change=MAX_PARAMETER_CHANGE,
+        minimum_mpol=MINIMUM_MPOL,
+        vary_major_radius=VARY_MAJOR_RADIUS,
+        ess_alpha=ESS_ALPHA, monitor=monitor, compile_first=not ci_smoke,
+        progress=not ci_smoke)
+    report(f"QI mode {max_mode}", equilibrium)
+
+final_input = replace(
+    inp, ns_array=np.array([31 if ci_smoke else 101]),
+    ftol_array=np.array([1e-10 if ci_smoke else 1e-14]),
+    niter_array=np.array([8000]))
+final_equilibrium = opt.solve_equilibrium(
+    final_input, initial_state=equilibrium.solution,
+    verbose=not ci_smoke, raise_on_max_iterations=True,
+    polish_force_balance=POLISH_FORCE_BALANCE)
+qi_final = report("final", final_equilibrium)["constructed QI"]
+qi_validation = ConstructedQIResidual(SURFACES, **validation_options)
+print(f"QI total {qi_final:.3e}; independent fine-grid validation "
+      f"{float(qi_validation.total(final_equilibrium)):.3e}")
+
+input_path = final_input.to_indata("input.QI_scalar_optimized")
+wout_path = vj.write_wout("wout_QI_scalar_optimized.nc", final_equilibrium.wout)
+print(f"wrote {input_path}\nwrote {wout_path}")
+monitor.save("QI_scalar_optimization_objectives.csv")
+monitor.plot("QI_scalar_optimization_objectives.png")
+for path in vj.plot_wout(wout_path, ".").values():
+    print(f"wrote {path}")

--- a/examples/optimization/QI_optimization_scalar.py
+++ b/examples/optimization/QI_optimization_scalar.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
-"""Constructed-QI optimization with one adjoint per scalar gradient."""
+"""Constructed-QI optimization with one adjoint per scalar gradient.
+
+The scalar lane trades objective progress per evaluation for a cheaper cold
+start and lower peak memory: at a matched evaluation budget the least-squares
+driver reached roughly a 3x lower objective on the same problem, so it remains
+the default for objective progress.
+"""
 
 from dataclasses import replace
 import os

--- a/examples/optimization/QP_optimization_finite_beta_scalar.py
+++ b/examples/optimization/QP_optimization_finite_beta_scalar.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+"""Finite-beta quasi-poloidal optimization with one scalar adjoint."""
+
+from dataclasses import replace
+import os
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+
+import vmex as vj
+from vmex import optimize as opt
+from _scalar_driver import run_scalar_stage
+
+nfp, TARGET_BETA = 2, 0.01
+SURFACES = np.array([0.5, 0.7, 0.9])
+MAX_MODES, MAXITER = [2, 4], [20, 45]
+ASPECT_TARGET, IOTA_FLOOR = 7.0, 0.51
+MIRROR_LIMIT, ELONGATION_LIMIT = 0.35, 12.0
+STABILITY_MIN_S, STABILITY_WEIGHT, EDGE_WEIGHT_FACTOR = 0.2, 1e-6, 10.0
+PARAMETER_STEP, MAX_PARAMETER_CHANGE = 0.01, 3.0
+ESS_ALPHA, MINIMUM_MPOL = 1.2, 5
+VARY_MAJOR_RADIUS = False
+SEED_PERTURBATION = 0.05
+POLISH_FORCE_BALANCE = False  # Set True to polish only the final saved state.
+
+ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
+if ci_smoke:
+    MAX_MODES, MAXITER, MINIMUM_MPOL = [1], [2], 3
+
+DATA = Path(__file__).resolve().parents[1] / "data" / f"input.minimal_seed_nfp{nfp}"
+inp = vj.VmecInput.from_file(DATA)
+rbc, zbs = inp.rbc.copy(), inp.zbs.copy()
+rbc[inp.ntor - 1, 1], zbs[inp.ntor - 1, 1] = -SEED_PERTURBATION, SEED_PERTURBATION
+am = np.zeros(21)
+am[:2] = [1.0, -1.0]
+inp = replace(inp, rbc=rbc, zbs=zbs, pmass_type="power_series", am=am,
+              pres_scale=100.0)
+calibration = opt.solve_equilibrium(inp)
+inp = replace(
+    inp, pres_scale=inp.pres_scale * TARGET_BETA / float(calibration.wout.betatotal))
+equilibrium = opt.solve_equilibrium(inp, initial_state=calibration.solution)
+
+stability_s = np.linspace(0.0, 1.0, int(inp.ns_array[-1]))[2:-1]
+stability_weights = np.where(
+    stability_s >= STABILITY_MIN_S,
+    STABILITY_WEIGHT * (1.0 + (EDGE_WEIGHT_FACTOR - 1.0) * stability_s**4), 0.0)
+
+
+def mirror_excess(state, runtime):
+    return jnp.maximum(opt.mirror_ratio(state, runtime) - MIRROR_LIMIT, 0.0)
+
+
+def iota_floor(state, runtime):
+    return jnp.maximum(IOTA_FLOOR - opt.min_abs_iota(state, runtime), 0.0)
+
+
+def elongation_excess(state, runtime):
+    return jnp.maximum(opt.max_elongation(state, runtime) - ELONGATION_LIMIT, 0.0)
+
+
+qs = opt.QuasisymmetryRatioResidual(SURFACES, helicity_m=0, helicity_n=1)
+objective_terms = [
+    (qs, 0.0, 1.0), (opt.aspect_ratio, ASPECT_TARGET, 1.0),
+    (iota_floor, 0.0, 100.0), (mirror_excess, 0.0, 10.0),
+    (elongation_excess, 0.0, 10.0),
+    (opt.volume_average_beta, TARGET_BETA, 1.0 / TARGET_BETA**2),
+    (opt.mercier_stability_residual, 0.0, stability_weights),
+    (opt.glasser_stability_residual, 0.0, stability_weights)]
+
+
+report = opt.EquilibriumReporter(
+    ("QS", qs.total, ".4e"), ("beta", opt.volume_average_beta, ".3%"),
+    ("aspect", opt.aspect_ratio, ".3f"),
+    ("min |iota|", opt.min_abs_iota, ".3f"),
+    ("mirror", opt.mirror_ratio, ".3f"))
+monitor = opt.OptimizationMonitor(stream=None)
+
+for max_mode, maxiter in zip(MAX_MODES, MAXITER):
+    inp, equilibrium = run_scalar_stage(
+        inp, equilibrium, objective_terms, label="finite-beta QP",
+        max_mode=max_mode, maxiter=maxiter,
+        parameter_step=PARAMETER_STEP,
+        max_parameter_change=MAX_PARAMETER_CHANGE,
+        minimum_mpol=MINIMUM_MPOL,
+        vary_major_radius=VARY_MAJOR_RADIUS,
+        ess_alpha=ESS_ALPHA, monitor=monitor, compile_first=not ci_smoke)
+    report(f"mode {max_mode}", equilibrium)
+
+final_input = replace(
+    inp, ns_array=np.array([31 if ci_smoke else 101]),
+    ftol_array=np.array([1e-10 if ci_smoke else 1e-14]),
+    niter_array=np.array([20000]))
+final_equilibrium = opt.solve_equilibrium(
+    final_input, initial_state=equilibrium.solution,
+    verbose=not ci_smoke, raise_on_max_iterations=True,
+    polish_force_balance=POLISH_FORCE_BALANCE)
+report("final", final_equilibrium)
+
+input_path = final_input.to_indata("input.QP_finite_beta_scalar_optimized")
+wout_path = vj.write_wout(
+    "wout_QP_finite_beta_scalar_optimized.nc", final_equilibrium.wout)
+print(f"wrote {input_path}\nwrote {wout_path}")
+monitor.save("QP_finite_beta_scalar_objectives.csv")
+monitor.plot("QP_finite_beta_scalar_objectives.png")
+for path in vj.plot_wout(wout_path, ".").values():
+    print(f"wrote {path}")

--- a/examples/optimization/QP_optimization_finite_beta_scalar.py
+++ b/examples/optimization/QP_optimization_finite_beta_scalar.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
-"""Finite-beta quasi-poloidal optimization with one scalar adjoint."""
+"""Finite-beta quasi-poloidal optimization with one scalar adjoint.
+
+The scalar lane trades objective progress per evaluation for a cheaper cold
+start and lower peak memory: at a matched evaluation budget the least-squares
+driver reached roughly a 3x lower objective on the same problem, so it remains
+the default for objective progress.
+"""
 
 from dataclasses import replace
 import os

--- a/examples/optimization/QP_optimization_scalar.py
+++ b/examples/optimization/QP_optimization_scalar.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+"""Quasi-poloidal optimization with one adjoint per scalar gradient."""
+
+from dataclasses import replace
+import os
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+
+import vmex as vj
+from vmex import optimize as opt
+from _scalar_driver import run_scalar_stage
+
+nfp = 2
+SURFACES = np.array([0.5, 0.7, 0.9])
+MAX_MODES, MAXITER = [3, 4, 5], [15, 15, 30]
+ASPECT_TARGET, IOTA_FLOOR = 7.0, 0.51
+MIRROR_LIMIT, ELONGATION_LIMIT = 0.35, 12.0
+PARAMETER_STEP, MAX_PARAMETER_CHANGE = 0.02, 5.0
+ESS_ALPHA, MINIMUM_MPOL = 1.2, 5
+VARY_MAJOR_RADIUS = False
+SEED_PERTURBATION = 0.05
+POLISH_FORCE_BALANCE = False  # Set True to polish only the final saved state.
+
+ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
+if ci_smoke:
+    MAX_MODES, MAXITER = [1], [4]
+
+DATA = Path(__file__).resolve().parents[1] / "data" / f"input.minimal_seed_nfp{nfp}"
+inp = vj.VmecInput.from_file(DATA)
+rbc, zbs = inp.rbc.copy(), inp.zbs.copy()
+rbc[inp.ntor - 1, 1], zbs[inp.ntor - 1, 1] = -SEED_PERTURBATION, SEED_PERTURBATION
+inp = replace(
+    inp, rbc=rbc, zbs=zbs, delt=0.5,
+    niter_array=np.array([300, 8000]),
+    ftol_array=np.array([1e-11, 1e-12]), ns_array=np.array([25, 35]))
+
+
+def mirror_excess(state, runtime):
+    return jnp.maximum(opt.mirror_ratio(state, runtime) - MIRROR_LIMIT, 0.0)
+
+
+def iota_floor(state, runtime):
+    return jnp.maximum(IOTA_FLOOR - opt.min_abs_iota(state, runtime), 0.0)
+
+
+def elongation_excess(state, runtime):
+    return jnp.maximum(opt.max_elongation(state, runtime) - ELONGATION_LIMIT, 0.0)
+
+
+qs = opt.QuasisymmetryRatioResidual(SURFACES, helicity_m=0, helicity_n=1)
+objective_terms = [
+    (qs, 0.0, 1.0), (opt.aspect_ratio, ASPECT_TARGET, 1.0),
+    (iota_floor, 0.0, 100.0), (mirror_excess, 0.0, 10.0),
+    (elongation_excess, 0.0, 10.0)]
+
+
+report = opt.EquilibriumReporter(
+    ("QS total", qs.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
+    ("mean iota", opt.mean_iota, ".4f"),
+    ("elongation", opt.max_elongation, ".4f"),
+    ("mirror", opt.mirror_ratio, ".4f"))
+monitor = opt.OptimizationMonitor(stream=None)
+equilibrium = opt.solve_equilibrium(inp)
+
+for max_mode, maxiter in zip(MAX_MODES, MAXITER):
+    inp, equilibrium = run_scalar_stage(
+        inp, equilibrium, objective_terms, label="QP",
+        max_mode=max_mode, maxiter=maxiter,
+        parameter_step=PARAMETER_STEP,
+        max_parameter_change=MAX_PARAMETER_CHANGE,
+        minimum_mpol=MINIMUM_MPOL,
+        vary_major_radius=VARY_MAJOR_RADIUS,
+        ess_alpha=ESS_ALPHA, monitor=monitor, compile_first=not ci_smoke)
+    report(f"mode {max_mode}", equilibrium)
+
+final_input = replace(
+    inp, ns_array=np.array([31 if ci_smoke else 101]),
+    ftol_array=np.array([1e-10 if ci_smoke else 1e-14]),
+    niter_array=np.array([35000]))
+final_equilibrium = opt.solve_equilibrium(
+    final_input, initial_state=equilibrium.solution,
+    verbose=not ci_smoke, raise_on_max_iterations=True,
+    polish_force_balance=POLISH_FORCE_BALANCE)
+report("final", final_equilibrium)
+
+input_path = final_input.to_indata("input.QP_scalar_optimized")
+wout_path = vj.write_wout("wout_QP_scalar_optimized.nc", final_equilibrium.wout)
+print(f"wrote {input_path}\nwrote {wout_path}")
+monitor.save("QP_scalar_optimization_objectives.csv")
+monitor.plot("QP_scalar_optimization_objectives.png")
+for path in vj.plot_wout(wout_path, ".").values():
+    print(f"wrote {path}")

--- a/examples/optimization/QP_optimization_scalar.py
+++ b/examples/optimization/QP_optimization_scalar.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
-"""Quasi-poloidal optimization with one adjoint per scalar gradient."""
+"""Quasi-poloidal optimization with one adjoint per scalar gradient.
+
+The scalar lane trades objective progress per evaluation for a cheaper cold
+start and lower peak memory: at a matched evaluation budget the least-squares
+driver reached roughly a 3x lower objective on the same problem, so it remains
+the default for objective progress.
+"""
 
 from dataclasses import replace
 import os

--- a/examples/optimization/_scalar_driver.py
+++ b/examples/optimization/_scalar_driver.py
@@ -1,0 +1,76 @@
+"""Shared scalar stage used by the eight optimization examples."""
+
+from dataclasses import replace
+
+import jax.numpy as jnp
+import numpy as np
+from scipy.optimize import minimize
+
+from vmex import optimize as opt
+
+
+def run_scalar_stage(
+    inp,
+    equilibrium,
+    objective_terms,
+    *,
+    label: str,
+    max_mode: int,
+    maxiter: int,
+    parameter_step: float,
+    max_parameter_change: float,
+    minimum_mpol: int,
+    vary_major_radius: bool,
+    ess_alpha: float,
+    monitor,
+    compile_first: bool,
+    progress: bool = False,
+):
+    """Minimize ``0.5 * r.T @ r`` with one reverse equilibrium adjoint."""
+    print(f"\n===== scalar {label} stage, max_mode = {max_mode} =====")
+    mpol = max(max_mode + 2, minimum_mpol)
+    inp = replace(inp, delt=0.5).change_resolution(
+        mpol=mpol, ntor=mpol, ntheta=2 * mpol + 6, nzeta=2 * mpol + 4)
+
+    def loss(state, runtime):
+        rows = opt.residuals_from_tuples(state, runtime, objective_terms)
+        return 0.5 * jnp.vdot(rows, rows)
+
+    problem = opt.VmecProblem.from_loss(
+        inp, loss, max_mode=max_mode,
+        vary_major_radius=vary_major_radius, use_ess=True,
+        ess_alpha=ess_alpha, restart_from=equilibrium,
+        progress=progress, evaluation_progress=progress)
+    print(f"dof_names = {problem.dof_names}")
+    monitor.problem = problem
+    if compile_first:
+        problem.compile_value_and_gradient()
+
+    x0 = problem.x0
+    step = parameter_step * problem.scales
+
+    def x_from_y(y):
+        return x0 + step * y
+
+    def value_and_gradient(y):
+        value, gradient = problem.value_and_grad(x_from_y(y))
+        return value, step * gradient
+
+    def monitor_y(intermediate_result):
+        x = x_from_y(intermediate_result.x)
+        value, gradient = problem.value_and_grad(x)
+        monitor({"x": x, "fun": value, "jac": gradient})
+
+    initial_value = float(value_and_gradient(np.zeros_like(x0))[0])
+    result = minimize(
+        value_and_gradient, np.zeros_like(x0), jac=True, method="L-BFGS-B",
+        bounds=[(-max_parameter_change, max_parameter_change)] * x0.size,
+        callback=monitor_y,
+        options={"maxiter": maxiter, "gtol": 1e-6, "ftol": 1e-12,
+                 "maxls": 20, "maxcor": 20})
+    result.x = x_from_y(result.x)
+    print(f"scalar cost: {initial_value:.12e} -> {float(result.fun):.12e}")
+    return (
+        problem.input_from_x(result.x),
+        problem.equilibrium_from_x(result.x),
+    )

--- a/examples/optimization/_scalar_driver.py
+++ b/examples/optimization/_scalar_driver.py
@@ -1,4 +1,10 @@
-"""Shared scalar stage used by the eight optimization examples."""
+"""Shared scalar stage used by the eight optimization examples.
+
+The scalar lane trades objective progress per evaluation for a cheaper cold
+start and lower peak memory: at a matched evaluation budget the least-squares
+driver reached roughly a 3x lower objective on the same problem, so it remains
+the default for objective progress.
+"""
 
 from dataclasses import replace
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -306,16 +306,41 @@ def test_global_optimization_example_exposes_optimizer_contract():
     assert "ess_alpha=ESS_ALPHA" in text
 
 
-def test_qa_optimization_uses_fast_scalar_adjoint_lane():
-    """The canonical QA example must not rebuild a pointwise Jacobian."""
-
+def test_qa_optimization_keeps_explicit_least_squares_lane():
+    """The canonical QA example keeps its residual/Jacobian tutorial."""
     text = (EXAMPLES / "optimization" / "QA_optimization.py").read_text()
-    assert "VmecProblem.from_loss" in text
-    assert "residuals_from_tuples" in text
-    assert "compile_value_and_gradient" in text
-    assert "compile_residual_and_jacobian" not in text
-    assert "minimize(" in text
+    assert "VmecProblem.from_tuples" in text
+    assert "compile_residual_and_jacobian" in text
+    assert "least_squares(" in text
+    assert "VmecProblem.from_loss" not in text
     assert "ess_alpha=ESS_ALPHA" in text
+
+
+@pytest.mark.parametrize("case", ["QA", "QH", "QP", "QI"])
+@pytest.mark.parametrize("finite_beta", [False, True])
+def test_scalar_optimization_examples_expose_one_adjoint_lane(case, finite_beta):
+    """All eight scalar examples share wiring but keep physics visible."""
+    suffix = "_finite_beta_scalar" if finite_beta else "_scalar"
+    text = (EXAMPLES / "optimization" / f"{case}_optimization{suffix}.py").read_text()
+    assert "from _scalar_driver import run_scalar_stage" in text
+    assert "objective_terms" in text
+    assert "run_scalar_stage(" in text
+    assert "POLISH_FORCE_BALANCE = False" in text
+    assert f"input.{case}_" in text and f"wout_{case}_" in text
+    if finite_beta:
+        assert "TARGET_BETA" in text
+        assert "opt.volume_average_beta" in text
+        assert "opt.mercier_stability_residual" in text
+        assert "opt.glasser_stability_residual" in text
+    else:
+        assert "TARGET_BETA" not in text
+
+    helper = (EXAMPLES / "optimization" / "_scalar_driver.py").read_text()
+    assert "VmecProblem.from_loss" in helper
+    assert "residuals_from_tuples" in helper
+    assert "0.5 * jnp.vdot(rows, rows)" in helper
+    assert "compile_value_and_gradient" in helper
+    assert 'method="L-BFGS-B"' in helper
 
 
 @pytest.mark.parametrize("case", ["QA", "QH", "QP", "QI"])
@@ -513,6 +538,32 @@ def test_qs_optimization_examples(case, tmp_path):
     assert (tmp_path / f"{case}_optimized_summary.png").exists()
     match = re.search(r"\[final\] QS total = ([0-9.eE+-]+)", out)
     assert match is not None and np.isfinite(float(match.group(1)))
+
+
+def test_qa_scalar_optimization_example(tmp_path):
+    """The vacuum scalar driver descends and writes distinct outputs."""
+    script = EXAMPLES / "optimization" / "QA_optimization_scalar.py"
+    out = _run_example(script, tmp_path)
+    match = re.search(r"scalar cost: ([0-9.eE+-]+) -> ([0-9.eE+-]+)", out)
+    assert match is not None and float(match.group(2)) < float(match.group(1))
+    assert "[final] QS total" in out
+    assert (tmp_path / "input.QA_scalar_optimized").exists()
+    assert (tmp_path / "wout_QA_scalar_optimized.nc").exists()
+    assert (tmp_path / "QA_scalar_optimized_summary.png").exists()
+
+
+@pytest.mark.full
+def test_qa_finite_beta_scalar_optimization_example(tmp_path):
+    """The finite-beta scalar driver includes pressure and stability rows."""
+    script = EXAMPLES / "optimization" / "QA_optimization_finite_beta_scalar.py"
+    out = _run_example(script, tmp_path)
+    match = re.search(r"scalar cost: ([0-9.eE+-]+) -> ([0-9.eE+-]+)", out)
+    assert match is not None and float(match.group(2)) < float(match.group(1))
+    beta = re.search(r"\[final\].*beta = ([0-9.]+)%", out)
+    assert beta is not None and 0.5 < float(beta.group(1)) < 2.0
+    assert (tmp_path / "input.QA_finite_beta_scalar_optimized").exists()
+    assert (tmp_path / "wout_QA_finite_beta_scalar_optimized.nc").exists()
+    assert (tmp_path / "QA_finite_beta_scalar_optimized_summary.png").exists()
 
 
 @pytest.mark.full  # nightly: shared Boozer + bounce-action Jacobian is cold-compile heavy


### PR DESCRIPTION
## Summary

- restore `examples/optimization/QA_optimization.py` to the staged SciPy `least_squares` residual/Jacobian workflow
- add separate scalar-adjoint QA, QH, QP, and QI drivers in both vacuum and finite-beta form
- document exactly why a scalar objective needs one equilibrium-adjoint solve per gradient, and when that is preferable to a residual Jacobian
- keep the implementation on a branch cut directly from `main`; this PR is independent of and does not modify #196

## One adjoint for one scalar gradient

Let `z` denote the converged equilibrium, `x` the design variables, and

```text
g(z, x) = 0,             Phi(z, x) = 1/2 r(z, x)^T r(z, x).
```

The explicit least-squares interface supplies every residual and the full residual Jacobian,

```text
J_r = d r / d x = r_x - r_z g_z^{-1} g_x,
grad_x Phi = J_r^T r.
```

This is useful because SciPy can build a Gauss-Newton trust-region model and retain residual-level diagnostics, but VMEX must compute and materialize the `n_residuals x n_dofs` Jacobian.

The scalar interface forms `Phi` before differentiating. Its implicit reverse rule solves

```text
g_z^T lambda = Phi_z^T = r_z^T r,
grad_x Phi = Phi_x - lambda^T g_x.
```

That is one equilibrium-adjoint right-hand side for each scalar gradient evaluation, independent of the residual-row and design-variable counts. It does not mean constant runtime: equilibrium resolution, linear conditioning, and the objective VJP still determine the work. The documentation also calls out that L-BFGS-B and nonlinear least squares have different curvature models, iterates, stopping rules, and potentially local basins.

## Example organization

The canonical QA file is again the explicit nonlinear least-squares tutorial. The new files are additive:

| Symmetry | Vacuum | Finite beta |
| --- | --- | --- |
| QA | `QA_optimization_scalar.py` | `QA_optimization_finite_beta_scalar.py` |
| QH | `QH_optimization_scalar.py` | `QH_optimization_finite_beta_scalar.py` |
| QP | `QP_optimization_scalar.py` | `QP_optimization_finite_beta_scalar.py` |
| QI | `QI_optimization_scalar.py` | `QI_optimization_finite_beta_scalar.py` |

Each runnable file keeps its physics, targets, continuation schedule, final solve, output names, and validation visible. A 76-line `_scalar_driver.py` centralizes only the repeated L-BFGS-B/scaled-coordinate wiring. The finite-beta cases calibrate a prescribed linear pressure profile and include radially weighted Mercier and resistive-interchange residuals. Final force-balance polishing remains an explicit, disabled-by-default option.

No VMEX source change was necessary: `VmecProblem.from_loss`, `residuals_from_tuples`, and `compile_value_and_gradient` already expose the required API.

## Performance evidence and limits

The reference page links the committed QA startup records rather than adding another benchmark variant. For 6,723 rows and 48 boundary degrees of freedom on the recorded Apple CPU host:

| Lane | Cold startup | Peak RSS | Warm value/gradient median |
| --- | ---: | ---: | ---: |
| residual Jacobian | 44.7 s | 2,965 MiB | 16.6 s |
| scalar adjoint | 32.2 s | 2,574 MiB | 17.4 s |

This supports the cold-start and memory motivation without claiming a universal warm-runtime win. Scalar objectives must be JAX-traceable; host-only callbacks still require a traceable implementation or finite differences.

## Validation

- `ruff check examples tests/test_examples.py`
- Python byte-compilation for all nine new modules
- `tools/check_docs_prose.py`
- Sphinx documentation build with warnings treated as errors (52 sources)
- focused scalar API and example-contract tests: 12 passed
- restored canonical QA end-to-end CI smoke: passed
- vacuum and finite-beta QA scalar pytest smoke tests: passed
- direct CI-smoke execution of all eight scalar examples: passed, with finite initial/final costs and distinct input, WOUT, monitor, and plot outputs

Observed CI-smoke scalar cost changes:

```text
QA vacuum       21.4488 -> 0.4908
QA finite beta  22.6159 -> 21.4269
QH vacuum        0.8144 -> 0.4523
QH finite beta   0.3506 -> 0.3325
QP vacuum       10.9987 -> 1.1926
QP finite beta  12.7535 -> 7.3061
QI vacuum        7.3408 -> 0.6868
QI finite beta   5.2069 -> 0.7267
```

## Review focus

1. Is retaining `least_squares` as the canonical QA tutorial while adding scalar companions the right API teaching split?
2. Are the optimizer differences and the meaning of “one adjoint” stated precisely enough?
3. Are the finite-beta objective weights suitable as concise starting examples rather than production configurations?

