### PR TITLE
Stop identity-keyed recompilation in the implicit lane

### DIFF
--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -285,6 +285,59 @@ def _mask_bit_ident(a, b) -> bool:
                for f in im._STATE_FIELDS)
 
 
+def test_residual_lane_reuses_one_executable_across_trial_boundaries(solovev):
+    """Same-shape residuals from different frozen states share one program.
+
+    residual_fn used to return a fresh per-call ``@jax.jit`` closure that
+    baked ``frozen`` and the dof mask in as constants, so every trial
+    boundary of an optimization campaign recompiled it — five compilations
+    and more than half the wall time of a steady-state F7 campaign step in
+    the committed baseline. The lane is keyed on the (held) config and leaf
+    shapes only; new same-shape values must be cache hits.
+    """
+    import logging
+
+    _name, _inp, cfg, p0, x_star, _rt, mask = solovev
+    compiles: list[str] = []
+
+    class _Handler(logging.Handler):
+        def emit(self, record):
+            message = record.getMessage()
+            if (message.startswith("Compiling ")
+                    and "_preconditioned_residual_lane" in message):
+                compiles.append(message)
+
+    handler = _Handler()
+    logger = logging.getLogger("jax")
+    previous_level = logger.level
+    jax.config.update("jax_log_compiles", True)
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    try:
+        jax.clear_caches()
+        z = im._dof_projector(cfg, mask)(x_star)
+        base = jax.block_until_ready(
+            im.residual_fn(cfg, x_star, mask)(z, p0))
+        after_first = len(compiles)
+        # Additive: a multiplicative bump is inert on the zero blocks.
+        trial_frozen = jax.tree.map(lambda a: a + 1.0e-6, x_star)
+        trial = jax.block_until_ready(
+            im.residual_fn(cfg, trial_frozen, mask)(z, p0))
+    finally:
+        jax.config.update("jax_log_compiles", False)
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+
+    assert after_first == 1
+    assert len(compiles) == 1, "a new frozen state recompiled the residual"
+    for leaf in jax.tree.leaves(base) + jax.tree.leaves(trial):
+        assert np.all(np.isfinite(leaf))
+    # The frozen state genuinely flows as data, not as a baked-in constant.
+    assert any(
+        not np.array_equal(a, b)
+        for a, b in zip(jax.tree.leaves(base), jax.tree.leaves(trial)))
+
+
 def test_dof_mask_structural_invariance_and_cache(solovev):
     """The dof mask depends only on structure (resolution / lconm1 / ncurr),
     so ``_MASK_CACHE`` (keyed by ``_mask_cache_key``) reuses it across the

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -338,6 +338,20 @@ def test_residual_lane_reuses_one_executable_across_trial_boundaries(solovev):
         for a, b in zip(jax.tree.leaves(base), jax.tree.leaves(trial)))
 
 
+def test_content_token_distinguishes_each_supported_kind():
+    """Every branch of the config content key: arrays by bytes (numpy and
+    device arrays alike), sequences by element, devices and other
+    identity-like objects by repr."""
+    a = np.asarray([1.0, 2.0])
+    assert im._content_token(a) == im._content_token(a.copy())
+    assert im._content_token(a) != im._content_token(np.asarray([1.0, 3.0]))
+    assert im._content_token(jnp.asarray(a)) == im._content_token(a)
+    assert im._content_token((1, [2.0, "x"])) == ("tuple", (
+        1, ("list", (2.0, "x"))))
+    device = jax.devices()[0]
+    assert im._content_token(device) == ("repr", repr(device))
+
+
 def test_make_config_canonicalizes_equal_content(solovev):
     """Equal-content configs share one instance; distinct content does not.
 

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -338,6 +338,33 @@ def test_residual_lane_reuses_one_executable_across_trial_boundaries(solovev):
         for a, b in zip(jax.tree.leaves(base), jax.tree.leaves(trial)))
 
 
+def test_make_config_canonicalizes_equal_content(solovev):
+    """Equal-content configs share one instance; distinct content does not.
+
+    ``ImplicitConfig`` is ``eq=False``, so the residual lane's static
+    argument, ``_LAST_SOLVE``, and the template-runtime cache all key on
+    object identity. ``run``/``make_config`` mint a fresh config per
+    objective evaluation; without canonicalization the F4 baseline
+    recompiled the residual lane fourteen times per warm repeat of an
+    identical evaluation. The registry is a small LRU: eviction only costs
+    a later recompile, never correctness.
+    """
+    name, inp, _cfg, _p0, _x_star, _rt, _mask = solovev
+    cfg_a = im.make_config(inp, **CASES[name])
+    cfg_b = im.make_config(inp, **CASES[name])
+    assert cfg_a is cfg_b
+    cfg_c = im.make_config(inp, ftol=CASES[name]["ftol"] * 0.5,
+                           max_iterations=CASES[name]["max_iterations"])
+    assert cfg_c is not cfg_a
+    # The registry stays bounded: churning distinct contents evicts the
+    # oldest entries without breaking previously returned instances.
+    for extra in range(im._CONFIG_CANON_MAX + 3):
+        im.make_config(inp, ftol=1.0e-9 / (extra + 2),
+                       max_iterations=CASES[name]["max_iterations"])
+    assert len(im._CONFIG_CANON) <= im._CONFIG_CANON_MAX
+    assert im.make_config(inp, **CASES[name]).ftol == cfg_a.ftol
+
+
 def test_dof_mask_structural_invariance_and_cache(solovev):
     """The dof mask depends only on structure (resolution / lconm1 / ncurr),
     so ``_MASK_CACHE`` (keyed by ``_mask_cache_key``) reuses it across the
@@ -346,10 +373,15 @@ def test_dof_mask_structural_invariance_and_cache(solovev):
     across two fresh configs of the same structure."""
     name, inp, cfg, p0, x_star, rt, mask = solovev
 
-    # fresh configs of the same structure share one hashable structural key,
-    # even though ImplicitConfig is eq=False (object-identity equality).
-    cfg_a = im.make_config(inp, **CASES[name])
-    cfg_b = im.make_config(inp, **CASES[name])
+    # Configs of the same structure but different content share one
+    # structural key while remaining distinct instances (equal content is
+    # canonicalized to one instance -- see
+    # test_make_config_canonicalizes_equal_content -- so different ftol is
+    # what "fresh configs" means now).
+    cfg_a = im.make_config(inp, ftol=CASES[name]["ftol"],
+                           max_iterations=CASES[name]["max_iterations"])
+    cfg_b = im.make_config(inp, ftol=CASES[name]["ftol"] * 0.5,
+                           max_iterations=CASES[name]["max_iterations"])
     assert cfg_a is not cfg_b and cfg_a != cfg_b
     key = im._mask_cache_key(cfg)
     assert im._mask_cache_key(cfg_a) == key == im._mask_cache_key(cfg_b)

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -1045,26 +1045,19 @@ def residual_fn(cfg: ImplicitConfig, frozen: SpectralState,
     rotated/zeroed) spectral force — same root, same gradients, but the
     adjoint GMRES then runs without preconditioning (diagnostic only).
     """
-    edge_mask = _edge_mask(cfg)
-    P = _dof_projector(cfg, dof_mask)
-
     if formulation == "preconditioned":
 
-        # jax.jit the residual so its linearization compiles as one reusable
-        # XLA sub-computation instead of being re-inlined into the enclosing
-        # jax.grad/jacrev program: the implicit-gradient memory peak is XLA
-        # *compile* working set, and this shrinks it bit-identically.
-        @jax.jit
         def F(z: SpectralState, params: ImplicitParams) -> SpectralState:
-            rt_p = runtime_from_params(params, cfg)
-            x = _assemble(z, rt_p, frozen, P, edge_mask)
-            gc, _, _ = evaluate_forces(x, rt_p)
-            return P(gc)
+            return _preconditioned_residual_lane(z, params, frozen,
+                                                 dof_mask, cfg)
 
         return F
 
     if formulation != "raw":
         raise ValueError(f"unknown formulation {formulation!r}")
+
+    edge_mask = _edge_mask(cfg)
+    P = _dof_projector(cfg, dof_mask)
 
     def F_raw(z: SpectralState, params: ImplicitParams) -> SpectralState:
         rt_p = runtime_from_params(params, cfg)
@@ -1072,6 +1065,28 @@ def residual_fn(cfg: ImplicitConfig, frozen: SpectralState,
         return P(_raw_force_state(x, rt_p))
 
     return F_raw
+
+
+# The residual stays under jax.jit so its linearization compiles as one
+# reusable XLA sub-computation instead of being re-inlined into the enclosing
+# jax.grad/jacrev program (the implicit-gradient memory peak is XLA *compile*
+# working set). Module scope with ``cfg`` static and the per-solve arrays as
+# arguments is what makes the executable REUSABLE: the previous per-call
+# ``@jax.jit`` closure was a fresh function object baking ``frozen`` and the
+# dof mask in as constants, so every trial boundary of an optimization
+# campaign recompiled it -- five compilations and several seconds of every
+# steady-state campaign step in the F7 baseline.
+@functools.partial(jax.jit, static_argnames=("cfg",))
+def _preconditioned_residual_lane(z: SpectralState, params: ImplicitParams,
+                                  frozen: SpectralState,
+                                  dof_mask: SpectralState,
+                                  cfg: ImplicitConfig) -> SpectralState:
+    edge_mask = _edge_mask(cfg)
+    P = _dof_projector(cfg, dof_mask)
+    rt_p = runtime_from_params(params, cfg)
+    x = _assemble(z, rt_p, frozen, P, edge_mask)
+    gc, _, _ = evaluate_forces(x, rt_p)
+    return P(gc)
 
 
 def _dof_mask(x_star: SpectralState, rt: SolverRuntime,

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -120,6 +120,7 @@ verified against :func:`~vmex.core.setup.run_setup` in
 
 from __future__ import annotations
 
+import collections
 import contextlib
 import dataclasses
 import functools
@@ -380,7 +381,7 @@ def make_config(
         max_iterations = int(np.asarray(inp.niter_array).ravel()[-1])
     if not np.isfinite(max_fsq_ratio) or max_fsq_ratio <= 0.0:
         raise ValueError("max_fsq_ratio must be finite and positive")
-    return ImplicitConfig(
+    return _canonical_config(ImplicitConfig(
         inp=inp, resolution=resolution, ftol=float(ftol),
         max_iterations=int(max_iterations), mode=str(mode),
         multigrid=bool(multigrid), lconm1=bool(lconm1),
@@ -393,7 +394,59 @@ def make_config(
         refine_tol=float(refine_tol),
         max_fsq_ratio=float(max_fsq_ratio),
         hot_restart=bool(hot_restart), device=device,
-    )
+    ))
+
+
+def _content_token(value: Any) -> Any:
+    """Deterministic hashable token of a config field's *content*."""
+    if value is None or isinstance(value, (bool, int, float, str, bytes)):
+        return value
+    if isinstance(value, np.ndarray):
+        return ("ndarray", value.shape, str(value.dtype), value.tobytes())
+    if isinstance(value, jax.Array):
+        host = np.asarray(value)
+        return ("ndarray", host.shape, str(host.dtype), host.tobytes())
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return (type(value).__qualname__, tuple(
+            (f.name, _content_token(getattr(value, f.name)))
+            for f in dataclasses.fields(value)))
+    if isinstance(value, (list, tuple)):
+        return (type(value).__name__, tuple(_content_token(v) for v in value))
+    # jax.Device and anything else identity-like: repr is stable in-process.
+    return ("repr", repr(value))
+
+
+#: Bounded: a canonical config is a strong reference, and the weak-keyed
+#: ``_LAST_SOLVE`` memo keeps one SolveResult alive per live config -- an
+#: unbounded registry would pin a solve per boundary variant in long
+#: parameter scans. Eviction only costs a later recompile, never
+#: correctness: an evicted instance keeps working, and equal content simply
+#: gets a fresh canonical identity afterwards.
+_CONFIG_CANON: "collections.OrderedDict[Any, ImplicitConfig]" =     collections.OrderedDict()
+_CONFIG_CANON_MAX = 16
+
+
+def _canonical_config(cfg: ImplicitConfig) -> ImplicitConfig:
+    """One shared instance per config *content* (``ImplicitConfig`` is
+    ``eq=False``, so every identity-keyed cache — the residual lane's static
+    argument, ``_LAST_SOLVE``, the template-runtime cache — would otherwise
+    miss across the fresh configs :func:`make_config`/:func:`run` mint on
+    every objective evaluation: the F4 baseline recompiled the residual lane
+    fourteen times per warm repeat on identical content). Equal content means
+    identical behaviour, so sharing is exact, and the registry stays small:
+    one entry per distinct deck/resolution/knob set per process. Callers
+    treat ``VmecInput`` arrays as frozen (the ``dataclasses.replace`` idiom
+    throughout); mutating them in place was already unsupported.
+    """
+    key = _content_token(cfg)
+    hit = _CONFIG_CANON.get(key)
+    if hit is not None:
+        _CONFIG_CANON.move_to_end(key)
+        return hit
+    _CONFIG_CANON[key] = cfg
+    while len(_CONFIG_CANON) > _CONFIG_CANON_MAX:
+        _CONFIG_CANON.popitem(last=False)
+    return cfg
 
 
 def _device_context(cfg: ImplicitConfig):
@@ -2737,7 +2790,9 @@ def run(
                 "omit device (or pass device=None) to run"
             )
         cfg_device = None
-    cfg = dataclasses.replace(cfg, device=cfg_device)
+    # replace() mints a fresh instance; re-canonicalize so identity-keyed
+    # caches (residual lane, _LAST_SOLVE, template runtime) keep hitting.
+    cfg = _canonical_config(dataclasses.replace(cfg, device=cfg_device))
     placement = jax.default_device(dev) if dev is not None else contextlib.nullcontext()
     with placement:
         if params is None:


### PR DESCRIPTION
## Summary

First measured Phase 3 fixes, driven directly by the Phase 2 baseline (#198): stop the implicit lane recompiling on every optimization trial. One defect class - identity-keyed compilation caches missing across equivalent objects - with two roots, fixed in two commits.

**Root 1 - per-call jitted closures.** `residual_fn` returned a fresh `@jax.jit` closure per call with the frozen state and dof mask baked in as XLA constants; every trial boundary produced a new function object, so the cache could never hit. The F7 baseline shows 400 compilations during a fully-warm 10-step campaign; instrumentation attributes 9.3 s of every 16.6 s steady-state step (56%) to XLA recompilation. The preconditioned residual now lives in one module-scope jitted lane (`_preconditioned_residual_lane`, config static, per-solve arrays as arguments); `residual_fn` still returns the same `F(z, params)` callable, so all seven call sites are unchanged, and the jit stays for its original reason (the linearization compiles as one reusable XLA sub-computation).

**Root 2 - per-call fresh configs.** `ImplicitConfig` is `eq=False`, and `run()`/`make_config` mint a fresh instance per objective evaluation, so every identity-keyed cache missed across equivalent configs: the residual lane's static argument recompiled (fourteen lane compilations per warm F4 repeat of an *identical* evaluation), the `_LAST_SOLVE` warm-start memo re-solved the same host problem, and the template-runtime cache rebuilt. `make_config` now interns configs in a small content-keyed LRU (arrays hashed by bytes; equal content means identical behaviour, so sharing is exact), bounded at sixteen entries because a canonical config strong-references one retained SolveResult via the weak-keyed memo - eviction only costs a later recompile, never correctness.

**Measured (Apple M4), bit-identical values and gradients in both cases:**

| workflow | metric | before | after |
|---|---|---|---|
| F7 steady campaign step | wall | 16.6 s | **10.8 s** |
| F7 steady campaign step | compiles | 8 | 3 |
| F4 warm value+gradient repeat | wall | 28.8 s | **3.0 s** |
| F4 warm value+gradient repeat | compiles | 21 | 3 |

## Not in this PR (documented follow-ups)

The remaining 3 compiles/step are the eager GCROT adjoint while-loops (~5 s): moving that solve under jit changes the adjoint's hardware-verified device-binding and typed-error semantics and needs GPU-lane validation.

## Test plan

- `test_residual_lane_reuses_one_executable_across_trial_boundaries`: counts JAX's own "Compiling" records across two same-shape residuals from different frozen states - exactly one compilation, and the frozen state demonstrably flows as data (the §10.1-prescribed regression).
- `test_make_config_canonicalizes_equal_content`: equal content shares one instance, distinct content does not, and the LRU stays bounded under churn without breaking evicted instances.
- The dof-mask invariance test builds its distinct instances from distinct content (different ftol) - what "fresh configs" means under canonicalization.
- Full implicit-lane certification locally: test_implicit_grad, test_implicit_multi_rhs, test_implicit_solve_kwargs, test_implicit_device, test_optimize_penalty, test_gammac (gradient-vs-FD included). ruff + mypy clean.
