### PR TITLE
Halve CI attempt wall time and add a preflight gate runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,31 +192,37 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_tests == 'true'
     runs-on: ubuntu-latest
-    # The primary-lane partition is the whole pull-request suite; these four
-    # jobs are the part no other job was running.  Measured on the runner at
-    # -n 2: 30m00s, 27m40s, 26m54s, 21m22s, which put total CI wall clock at
-    # 30 minutes against a ~14-minute budget before.  The four run in parallel
-    # with the nine physics jobs, so the fix is per-job width, not fewer tests.
-    # Measured at -n 4: c1 25m36s (from 27m40s), c2 15m07s (from 21m22s),
-    # misc 24m43s (from 26m54s) -- and lane a killed outright.  So the width
-    # is per-lane: a stays at -n 2, the rest keep the gain.
+    # The primary-lane partition is the whole pull-request suite; these
+    # jobs are the part no other job was running, and they define the CI
+    # attempt's wall clock, so the partition is rebalanced when a lane
+    # outgrows the others.  Lane c1 (then pr-parity-c1 + c3 + d) had grown
+    # to 44m36s -- double the next-longest job -- with almost all of the
+    # weight in the c3/d implicit-campaign modules (test_optimize.py alone
+    # carries ~31 minutes of call time), so those now run as their own
+    # job.  Lane a's 32m24s at -n 2 was the next ceiling; only the
+    # pr-parity-a1 selector carries the free-boundary modules whose
+    # concurrent solves exhaust the runner at -n 4 (killed mid-run at
+    # 32m10s, twice, on two different pull requests), so a1 keeps -n 2 by
+    # itself and a2+b run at -n 4.
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         include:
-          - lane: a
-            selector: pr-parity-a1 pr-parity-a2 pr-parity-b
-            # -n 2, not 4: this lane carries the free-boundary modules
-            # (test_freeboundary_implicit alone has two ~8-minute tests), and
-            # four concurrent free-boundary solves exhaust the runner.  At -n 4
-            # it was killed mid-run at 73% with no test failure -- "The
-            # operation was canceled" at 32m10s, twice, on two different pull
-            # requests.  The other three lanes keep -n 4, which measurably
-            # helps them.
+          - lane: a-free
+            selector: pr-parity-a1
+            # -n 2, not 4: this selector carries the free-boundary modules
+            # (test_freeboundary_implicit alone has two ~8-minute tests),
+            # and four concurrent free-boundary solves exhaust the runner.
             parallel: "-n 2"
+          - lane: a-core
+            selector: pr-parity-a2 pr-parity-b
+            parallel: "-n 4"
           - lane: c1
-            selector: pr-parity-c1 pr-parity-c3 pr-parity-d
+            selector: pr-parity-c1
+            parallel: "-n 4"
+          - lane: c3d
+            selector: pr-parity-c3 pr-parity-d
             parallel: "-n 4"
           - lane: c2
             selector: pr-parity-c2

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,6 +2,16 @@
 
 This directory contains developer-facing tools, not end-user examples.
 
+- `preflight.py`: runs CI's cheap gates (ruff, mypy, docs prose), the fast
+  guard tests, and the diff-affected test modules with the changed-line
+  coverage bar, all against `origin/main` — so the first CI attempt is the
+  only one. `--static` for the seconds-long subset, `--docs` to add
+  `sphinx -W`:
+
+  ```console
+  python tools/preflight.py
+  ```
+
 - `fetch_assets.py`: downloads optional validation assets and verifies their
   byte size and SHA-256 before extraction. `assets/manifest.json` records the
   release URL, provenance, license, generator revision, and installed paths.

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Run CI's cheap gates and the diff-affected tests before pushing.
+
+One CI attempt costs ~25-45 minutes of wall clock, so a failure that a
+local run would have caught in minutes costs a full extra attempt. This
+tool runs, against the diff to ``origin/main`` (or ``--base``):
+
+1. the static gates (ruff, mypy, docs prose) — the ``quality`` job's
+   cheap half;
+2. the guard tests — fast meta-tests that police the manifest, committed
+   reports (personal-path privacy), docs navigation, and packaging;
+3. the affected tests — changed test files plus every test module that
+   imports a changed vmex module — under coverage, followed by the same
+   changed-line bar CI enforces (``diff-cover --fail-under=95``) when
+   diff-cover is installed.
+
+The import scan is a local approximation (it overshoots harmlessly and
+cannot see dynamic imports), and the mirror-package coverage floor needs
+the full matrix, so CI remains the authority — preflight exists to make
+the first CI attempt the only one.
+
+Usage::
+
+    python tools/preflight.py            # gates + guards + affected tests
+    python tools/preflight.py --static   # gates + guards only (seconds)
+    python tools/preflight.py --docs     # also build sphinx -W
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+GUARD_TESTS = (
+    "tests/test_test_manifest.py",
+    "tests/test_performance_docs.py",
+    "tests/test_docs_nav.py",
+    "tests/test_capability_docs.py",
+    "tests/test_packaging_metadata.py",
+    "tests/test_coverage_margin.py",
+)
+
+
+def _run(title: str, command: list[str], **kwargs) -> bool:
+    print(f"\n== {title}: {' '.join(command)}", flush=True)
+    return subprocess.run(command, cwd=ROOT, **kwargs).returncode == 0
+
+
+def _changed_files(base: str) -> list[str]:
+    merge_base = subprocess.run(
+        ["git", "merge-base", base, "HEAD"], cwd=ROOT,
+        capture_output=True, text=True, check=True).stdout.strip()
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", merge_base], cwd=ROOT,
+        capture_output=True, text=True, check=True).stdout.split()
+    status = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=no"], cwd=ROOT,
+        capture_output=True, text=True, check=True).stdout
+    dirty = [line[3:].split(" -> ")[-1] for line in status.splitlines()]
+    return sorted(set(diff) | set(dirty))
+
+
+def _affected_tests(changed: list[str]) -> list[str]:
+    tests = {f for f in changed
+             if f.startswith("tests/") and f.endswith(".py")
+             and Path(ROOT, f).exists() and "/__" not in f}
+    modules = [f for f in changed
+               if f.startswith("vmex/") and f.endswith(".py")]
+    names = {Path(m).stem for m in modules} - {"__init__"}
+    if names:
+        pattern = re.compile(
+            r"^\s*(?:from\s+vmex[.\w]*\s+import\b.*\b({0})\b"
+            r"|import\s+vmex[.\w]*\b({0})\b"
+            r"|from\s+vmex[.\w]*\b({0})\s+import\b)".format(
+                "|".join(map(re.escape, sorted(names)))),
+            re.MULTILINE)
+        for path in sorted(ROOT.glob("tests/**/test_*.py")):
+            if pattern.search(path.read_text(errors="replace")):
+                tests.add(str(path.relative_to(ROOT)))
+    return sorted(tests)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--static", action="store_true",
+                        help="static gates and guard tests only")
+    parser.add_argument("--docs", action="store_true",
+                        help="also build the docs (sphinx -W)")
+    args = parser.parse_args(argv)
+
+    changed = _changed_files(args.base)
+    print("changed files vs", args.base)
+    for f in changed:
+        print("  ", f)
+
+    ok = True
+    ok &= _run("ruff", ["ruff", "check", "vmex", "tests", "examples",
+                        "benchmarks", "tools"])
+    ok &= _run("mypy", ["mypy", "vmex"])
+    ok &= _run("docs prose", [sys.executable, "tools/check_docs_prose.py"])
+    if args.docs:
+        ok &= _run("sphinx", [sys.executable, "-m", "sphinx", "-W", "-j",
+                              "auto", "-b", "html", "docs",
+                              "docs/_build/html"])
+
+    guards = [t for t in GUARD_TESTS if Path(ROOT, t).exists()]
+    ok &= _run("guard tests", [sys.executable, "-m", "pytest", "-q",
+                               "-m", "not full and not weekly", *guards])
+
+    if not args.static:
+        affected = _affected_tests(changed)
+        if affected:
+            print("\naffected test modules:")
+            for t in affected:
+                print("  ", t)
+            ok &= _run(
+                "affected tests", [
+                    sys.executable, "-m", "pytest", "-q", "-n", "auto",
+                    "-m", "not full and not weekly",
+                    "--cov=vmex", "--cov-report=xml", *affected])
+            if shutil.which("diff-cover"):
+                ok &= _run("changed-line coverage", [
+                    "diff-cover", "coverage.xml",
+                    f"--compare-branch={args.base}", "--fail-under=95"])
+            else:
+                print("\n== changed-line coverage: diff-cover not installed "
+                      "(pip install diff-cover); CI will enforce it")
+        else:
+            print("\nno affected test modules for this diff")
+
+    print("\npreflight:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

CI attempts were taking 3+ hours per PR in practice. Measured anatomy of the latest full run: runner queue time is ~zero and one attempt settles in ~45 min, gated entirely by lane c1 (44m36s; next-longest 32m24s) - the 3+ hours came from **serial attempts**, because every failure a local run could have caught in minutes (a stubbed CLI seam, the personal-path privacy guard, the changed-line coverage bar) restarted the whole matrix. This PR attacks both halves.

**Halve the attempt** - reshard the parity partition (same tests, same selectors, two more runners):
- c1 carried `pr-parity-c1 + c3 + d`, and nearly all its weight is the c3/d implicit-campaign modules (`test_optimize.py` alone: ~31 min of call time). `c3d` is now its own job; `c1` keeps the 25 light/medium modules.
- lane a (32m24s at `-n 2`) splits so only `pr-parity-a1` - the free-boundary modules whose concurrent solves killed the runner at `-n 4`, per the existing lane notes - pays the width cap; `a2+b` run at `-n 4`.
- Expected critical path after this: ~25 min, and the c3/d modules are exactly the implicit campaigns that #199's recompile fixes speed up, so it should drop further once that lands (worth re-measuring then).

**Kill repeat attempts** - `tools/preflight.py` runs, against the diff to `origin/main`: the static gates (ruff/mypy/docs prose), the fast guard tests (manifest parity, committed-report privacy, docs nav, packaging, coverage margin - 8 s total), and the diff-affected test modules (changed test files plus every test module importing a changed vmex module) under the same 95% changed-line coverage bar CI enforces. All three of today's CI-only failures reproduce locally under it in minutes. The import scan is a deliberate local approximation (overshoots harmlessly, cannot see dynamic imports); CI remains the authority.

## Test plan

- Verified the import scan against today's real failures: `vmex/core/run_options.py + tests/test_cli_device.py` selects exactly the three modules that broke #196's c1 lane; `vmex/core/implicit.py` selects the 17 implicit-consumer modules.
- `preflight --static` end-to-end on this branch: PASS in ~1 min (42 guard tests).
- Lane job ids (`parity`) and selectors are unchanged, so `changed-coverage`'s `needs` and the `PR gate` aggregation are untouched; only matrix entries were re-partitioned. This PR's own run demonstrates the new partition.
