### PR TITLE
Release VMEX 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vmex"
-version = "0.7.1"
+version = "0.8.0"
 description = "JAX implementation of VMEC2000 with differentiable fixed-boundary and branch-local free-boundary research paths."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump for the 0.8.0 release: certified force-balance polishing (opt-in via CLI flag, `!@VMEX POLISH` input directives, or `solve_file(polish=...)`), execution metadata separated from physics (RunOptions, `_vmex` JSON, precedence CLI > keyword > directive > default), the workflow performance/compilation observability harness with committed Apple M4 baselines, and the implicit-lane compile-reuse fixes (campaign step 16.6 s -> 10.8 s, warm value+gradient repeat 28.8 s -> 3.0 s, bit-identical). Release notes accompany the tag.