### PR TITLE
Stop the polishing path recompiling on every solve

### DIFF
--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -463,7 +463,8 @@ def test_three_dimensional_m1_projector_transposes_without_scatter_failure():
     transfer = make_high_low_transfer(
         native,
         runtime,
-        low_project=implicit._dof_projector(config, mask),
+        project_config=config,
+        project_mask=mask,
     )
     high = _random_like(transfer.zeros_high(jnp.float64), 31)
     low_bar = _random_like(transfer.restrict(high), 32)
@@ -883,9 +884,30 @@ def test_strong_runtime_and_chart_pytree_roundtrip(small_strong_root):
         rebuilt = jax.tree.unflatten(structure, leaves)
         assert type(rebuilt) is type(original)
         np.testing.assert_allclose(rebuilt.coordinate_scale, original.coordinate_scale)
-    assert jax.tree.unflatten(
-        jax.tree.structure(small_strong_root), jax.tree.leaves(small_strong_root)
-    ).layout is small_strong_root.layout
+    # The layout is a child pytree now (its basis arrays are traced leaves,
+    # not baked metadata), so a round trip reconstructs an equivalent layout
+    # rather than preserving object identity.
+    rebuilt_layout = jax.tree.unflatten(
+        jax.tree.structure(small_strong_root),
+        jax.tree.leaves(small_strong_root),
+    ).layout
+    original_layout = small_strong_root.layout
+    assert rebuilt_layout.mnmax == original_layout.mnmax
+    assert rebuilt_layout.nbasis == original_layout.nbasis
+    assert len(rebuilt_layout.groups) == len(original_layout.groups)
+    for rebuilt_group, group in zip(rebuilt_layout.groups,
+                                    original_layout.groups):
+        np.testing.assert_array_equal(rebuilt_group.high_indices,
+                                      group.high_indices)
+        np.testing.assert_allclose(rebuilt_group.basis, group.basis)
+        assert (rebuilt_group.start, rebuilt_group.stop) == (
+            group.start, group.stop)
+    # What compile reuse actually needs: two flattens of one runtime share a
+    # treedef even though the layout and preconditioner are rebuilt objects.
+    assert jax.tree.structure(small_strong_root) == jax.tree.structure(
+        jax.tree.unflatten(
+            jax.tree.structure(small_strong_root),
+            jax.tree.leaves(small_strong_root)))
     assert jax.tree.unflatten(
         jax.tree.structure(chart), jax.tree.leaves(chart)
     ).gauge_rank == chart.gauge_rank

--- a/tests/test_radial_basis.py
+++ b/tests/test_radial_basis.py
@@ -233,3 +233,16 @@ def test_basis_operation_shape_topology_and_refinement_errors() -> None:
         periodic.refine_periodic_uniform(jnp.ones(periodic.size), 24)
     with pytest.raises(ValueError, match="coefficient axis"):
         periodic.refine_periodic_uniform(jnp.ones(periodic.size - 1), 16)
+
+
+def test_equality_and_hash_follow_content_not_identity() -> None:
+    """A basis rides in jit pytree metadata: two equal-content builds must be
+    one compilation-cache key, and different content must not collide."""
+    a = BSplineBasis.clamped(np.linspace(0.0, 1.0, 5))
+    b = BSplineBasis.clamped(np.linspace(0.0, 1.0, 5))
+    c = BSplineBasis.clamped(np.linspace(0.0, 1.0, 6))
+    assert a is not b
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a != c
+    assert a != object()

--- a/tests/test_strong_force.py
+++ b/tests/test_strong_force.py
@@ -441,3 +441,47 @@ def test_state_validation_and_empty_plot_errors():
         replace(state, pressure=jnp.zeros((state.radial_basis.size - 1,)))
     with pytest.raises(ValueError, match="at least one"):
         plot_strong_force_report({})
+
+
+def test_state_treedefs_match_across_fresh_equal_bases():
+    """Two states over fresh equal-content bases share one jit pytree key.
+
+    The basis rides in the state's pytree metadata; identity equality there
+    recompiled the module-jitted evaluators on every polish call, since each
+    call rebuilds the basis.
+    """
+    from vmex.core.radial_basis import BSplineBasis
+    from vmex.core.strong_force import HighOrderEquilibriumState
+
+    def build():
+        basis = BSplineBasis.clamped(np.linspace(0.0, 1.0, 5))
+        m = np.asarray([0, 1])
+        table = jnp.zeros((2, basis.size))
+        profile = jnp.zeros((basis.size,))
+        return HighOrderEquilibriumState(
+            radial_basis=basis, m=m, n=np.asarray([0, 0]), nfp=1,
+            R_cos=table, R_sin=table, Z_cos=table, Z_sin=table,
+            L_cos=table, L_sin=table,
+            phipf=profile, chipf=profile, pressure=profile)
+
+    first = jax.tree_util.tree_structure(build())
+    second = jax.tree_util.tree_structure(build())
+    assert first == second
+
+
+def test_chart_metadata_excludes_the_build_timestamp():
+    """Charts differing only in build_seconds share one jit pytree key, and
+    a flatten round trip zeroes the wall-clock diagnostic."""
+    import dataclasses
+
+    from vmex.core.polish import StrongPhysicalChart
+
+    chart = StrongPhysicalChart(
+        coordinate_basis=jnp.eye(3), equation_basis=jnp.eye(3),
+        coordinate_scale=jnp.ones(3), equation_scale=jnp.ones(3),
+        gauge_rank=1, build_seconds=1.25)
+    rebuilt = dataclasses.replace(chart, build_seconds=9.75)
+    structure = jax.tree_util.tree_structure(chart)
+    assert structure == jax.tree_util.tree_structure(rebuilt)
+    leaves, treedef = jax.tree_util.tree_flatten(chart)
+    assert treedef.unflatten(leaves).build_seconds == 0.0

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -2181,6 +2181,45 @@ def _raw_block_solve(
     )
 
 
+def _pack_active(cfg: ImplicitConfig, tree: SpectralState) -> Array:
+    """Concatenate the active state fields (a pure function of ``cfg``)."""
+    return jnp.concatenate(
+        [getattr(tree, name) for name in _active_state_fields(cfg)], axis=1)
+
+
+def _unpack_active(cfg: ImplicitConfig, matrix: Array) -> SpectralState:
+    """Inverse of :func:`_pack_active` with zeros on inactive fields."""
+    names = _active_state_fields(cfg)
+    ns = int(cfg.resolution.ns)
+    mn = matrix.shape[1] // len(names)
+    parts = dict(zip(names, jnp.split(matrix, len(names), axis=1)))
+    return SpectralState(**{
+        name: parts.get(name, jnp.zeros((ns, mn), matrix.dtype))
+        for name in _STATE_FIELDS})
+
+
+def _block_inverse_apply(
+    factors: Any,
+    pack: Callable,
+    unpack: Callable,
+    project: Callable,
+    row_scale: Array,
+    column_scale: Array,
+    rhs: SpectralState,
+    *,
+    transpose: bool = False,
+) -> SpectralState:
+    """Apply one stored raw block inverse without rebuilding its factors."""
+    if factors is None:
+        raise ValueError("raw block factors were not requested")
+    packed = pack(project(rhs))
+    packed = packed * (column_scale if transpose else row_scale)
+    solution = block_thomas_solve(
+        factors, packed[..., None], transpose=transpose)[..., 0]
+    solution = solution * (row_scale if transpose else column_scale)
+    return project(unpack(solution))
+
+
 def _raw_block_apply(
     system: _RawBlockSystem,
     rhs: SpectralState,
@@ -2188,20 +2227,9 @@ def _raw_block_apply(
     transpose: bool = False,
 ) -> SpectralState:
     """Apply one stored raw block inverse without rebuilding its factors."""
-    if system.factors is None:
-        raise ValueError("raw block factors were not requested")
-    def solve(value):
-        packed = system.pack(system.project(value))
-        packed = packed * (system.column_scale if transpose
-                           else system.row_scale)
-        solution = block_thomas_solve(
-            system.factors, packed[..., None], transpose=transpose
-        )[..., 0]
-        solution = solution * (system.row_scale if transpose
-                               else system.column_scale)
-        return system.project(system.unpack(solution))
-
-    return solve(rhs)
+    return _block_inverse_apply(
+        system.factors, system.pack, system.unpack, system.project,
+        system.row_scale, system.column_scale, rhs, transpose=transpose)
 
 
 def _implicit_evolved_tangent_multi_rhs(

--- a/vmex/core/polish.py
+++ b/vmex/core/polish.py
@@ -50,6 +50,7 @@ jax.tree_util.register_dataclass(
 )
 
 
+@jax.tree_util.register_pytree_node_class
 @dataclass(frozen=True, eq=False)
 class HighLowTransfer:
     """Linear maps between regularized splines and legacy VMEX packing.
@@ -71,7 +72,45 @@ class HighLowTransfer:
     lthreed: bool
     lasym: bool
     lconm1: bool
-    low_project: Callable[[SpectralState], SpectralState]
+    #: Evolved-dof projection data; ``None`` means the identity. Stored as
+    #: (canonical config, mask pytree) rather than a per-call closure so the
+    #: transfer is a value-stable jit pytree - a baked callable made every
+    #: fresh transfer a new compilation-cache key.
+    project_config: Any = None
+    project_mask: SpectralState | None = None
+
+    def low_project(self, value: SpectralState) -> SpectralState:
+        if self.project_config is None:
+            return value
+        from .implicit import _dof_projector
+
+        return _dof_projector(self.project_config, self.project_mask)(value)
+
+    def tree_flatten(self):
+        children = (
+            self.evaluation, self.geometry_fit, self.lambda_fit,
+            self.mode_scale, self.phipf, self.lamscale, self.project_mask,
+        )
+        aux = (
+            tuple(int(v) for v in np.asarray(self.m)),
+            tuple(int(v) for v in np.asarray(self.n)),
+            bool(self.lthreed), bool(self.lasym), bool(self.lconm1),
+            self.project_config,
+        )
+        return children, aux
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        m, n, lthreed, lasym, lconm1, project_config = aux
+        (evaluation, geometry_fit, lambda_fit, mode_scale, phipf, lamscale,
+         project_mask) = children
+        return cls(
+            evaluation=evaluation, geometry_fit=geometry_fit,
+            lambda_fit=lambda_fit, mode_scale=mode_scale, phipf=phipf,
+            lamscale=lamscale, m=np.asarray(m, dtype=int),
+            n=np.asarray(n, dtype=int), lthreed=lthreed, lasym=lasym,
+            lconm1=lconm1, project_config=project_config,
+            project_mask=project_mask)
 
     @property
     def mnmax(self) -> int:
@@ -275,6 +314,7 @@ class PreconditionerRefreshDecision(NamedTuple):
     reasons: tuple[str, ...]
 
 
+@jax.tree_util.register_pytree_node_class
 @dataclass(frozen=True, eq=False)
 class StrongRootGroup:
     """One small independent ``(m, |n|)`` native-spline coordinate block."""
@@ -285,6 +325,20 @@ class StrongRootGroup:
     stop: int
     m: int
     abs_n: int
+
+    def tree_flatten(self):
+        return (self.basis,), (
+            tuple(int(v) for v in np.asarray(self.high_indices).ravel()),
+            np.asarray(self.high_indices).shape,
+            int(self.start), int(self.stop), int(self.m), int(self.abs_n))
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        indices, shape, start, stop, m, abs_n = aux
+        (basis,) = children
+        return cls(
+            high_indices=np.asarray(indices, dtype=int).reshape(shape),
+            basis=basis, start=start, stop=stop, m=m, abs_n=abs_n)
 
 
 def _flatten_high(correction: HighOrderCorrection) -> Array:
@@ -303,6 +357,7 @@ def _unflatten_high(vector: Array, mnmax: int, nbasis: int) -> HighOrderCorrecti
     return HighOrderCorrection(*values)
 
 
+@jax.tree_util.register_pytree_node_class
 @dataclass(frozen=True, eq=False)
 class StrongRootLayout:
     """Independent native-spline coordinates for the square strong root.
@@ -317,6 +372,15 @@ class StrongRootLayout:
     mnmax: int
     nbasis: int
     groups: tuple[StrongRootGroup, ...]
+
+    def tree_flatten(self):
+        return (self.groups,), (int(self.mnmax), int(self.nbasis))
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        mnmax, nbasis = aux
+        (groups,) = children
+        return cls(mnmax=mnmax, nbasis=nbasis, groups=tuple(groups))
 
     @property
     def size(self) -> int:
@@ -489,17 +553,20 @@ class StrongRootRuntime:
             self.strong_scale,
             self.operator_balance,
         )
-        metadata = (
-            self.transfer,
-            self.low_preconditioner,
-            self.layout,
-            float(self.force_floor),
-        )
+        # transfer, preconditioner, and layout are pytrees themselves; as
+        # children they carry their arrays as traced leaves, so runtimes of
+        # equal structure share compiled programs across polish calls (as
+        # hashable metadata their identity keyed every compile).
+        children = children + (
+            self.transfer, self.low_preconditioner, self.layout)
+        metadata = (float(self.force_floor),)
         return children, metadata
 
     @classmethod
     def tree_unflatten(cls, metadata, children):
-        transfer, low_preconditioner, layout, force_floor = metadata
+        (force_floor,) = metadata
+        *children, transfer, low_preconditioner, layout = children
+        children = tuple(children)
         (
             native,
             coordinate_scale,
@@ -606,38 +673,102 @@ class StrongModeBlockPreconditioner:
         return result
 
 
+@jax.tree_util.register_pytree_node_class
 @dataclass(frozen=True, eq=False)
 class LowOrderPreconditioner:
-    """Stored raw-force block inverse lifted to high-order coefficient space."""
+    """Stored raw-force block inverse lifted to high-order coefficient space.
+
+    A value-stable jit pytree: the raw-block callables live nowhere in the
+    stored state - packing, projection, and the legacy raw residual are
+    rebuilt on demand from the canonical config and the stored arrays, so
+    equal-structure preconditioners from different polish calls share
+    compiled programs. The factor build time is a wall-clock diagnostic and
+    is dropped to zero by a flatten round trip for the same reason the
+    chart's is.
+    """
 
     transfer: HighLowTransfer
-    system: Any
+    config: Any
+    params: Any
+    frozen_state: SpectralState
+    dof_mask: SpectralState
+    factors: Any
+    row_scale: Array
+    column_scale: Array
     legacy_coordinates: SpectralState
     legacy_defect: SpectralState
-    legacy_residual: Callable[[SpectralState], SpectralState]
     factor_build_seconds: float
+
+    def tree_flatten(self):
+        children = (
+            self.transfer, self.params, self.frozen_state, self.dof_mask,
+            self.factors, self.row_scale, self.column_scale,
+            self.legacy_coordinates, self.legacy_defect,
+        )
+        return children, (self.config,)
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        (config,) = aux
+        (transfer, params, frozen_state, dof_mask, factors, row_scale,
+         column_scale, legacy_coordinates, legacy_defect) = children
+        return cls(
+            transfer=transfer, config=config, params=params,
+            frozen_state=frozen_state, dof_mask=dof_mask, factors=factors,
+            row_scale=row_scale, column_scale=column_scale,
+            legacy_coordinates=legacy_coordinates,
+            legacy_defect=legacy_defect, factor_build_seconds=0.0)
+
+    def _project(self):
+        from .implicit import _dof_projector
+
+        return _dof_projector(self.config, self.dof_mask)
+
+    def _pack(self, tree: SpectralState) -> Array:
+        from .implicit import _pack_active
+
+        return _pack_active(self.config, tree)
+
+    def _unpack(self, matrix: Array) -> SpectralState:
+        from .implicit import _unpack_active
+
+        return _unpack_active(self.config, matrix)
+
+    def legacy_residual(self, coordinates: SpectralState) -> SpectralState:
+        """The frozen-state raw legacy residual (rebuilt, never stored)."""
+
+        from .implicit import residual_fn
+
+        raw = residual_fn(self.config, self.frozen_state, self.dof_mask,
+                          formulation="raw")
+        return raw(coordinates, self.params)
+
+    def _block_apply(self, rhs: SpectralState, *,
+                     transpose: bool = False) -> SpectralState:
+        from .implicit import _block_inverse_apply
+
+        return _block_inverse_apply(
+            self.factors, self._pack, self._unpack, self._project(),
+            self.row_scale, self.column_scale, rhs, transpose=transpose)
 
     def apply(self, rhs: HighOrderCorrection) -> HighOrderCorrection:
         """Apply ``prolong * A_low^-1 * restrict``."""
 
-        from .implicit import _raw_block_apply
-
         low_rhs = self.transfer.restrict(rhs)
-        return self.transfer.prolong(_raw_block_apply(self.system, low_rhs))
+        return self.transfer.prolong(self._block_apply(low_rhs))
 
     def apply_transpose(self, rhs: HighOrderCorrection) -> HighOrderCorrection:
         """Apply the algebraic transpose using the same stored factors."""
 
-        from .implicit import _raw_block_apply
-
         low_rhs = self.transfer.prolong_transpose(rhs)
-        low_solution = _raw_block_apply(self.system, low_rhs, transpose=True)
+        low_solution = self._block_apply(low_rhs, transpose=True)
         return self.transfer.restrict_transpose(low_solution)
 
     def residual(self, tangent: SpectralState) -> SpectralState:
         """Evaluate and row-scale the nonlinear legacy raw-force endpoint."""
 
-        candidate = self.system.project(
+        project = self._project()
+        candidate = project(
             jax.tree.map(jnp.add, self.legacy_coordinates, tangent)
         )
         force = jax.tree.map(
@@ -645,16 +776,14 @@ class LowOrderPreconditioner:
             self.legacy_residual(candidate),
             self.legacy_defect,
         )
-        scaled = self.system.pack(force) * jnp.asarray(self.system.row_scale)
-        return self.system.project(self.system.unpack(scaled))
+        scaled = self._pack(force) * jnp.asarray(self.row_scale)
+        return project(self._unpack(scaled))
 
     def solve_scaled(self, rhs: SpectralState) -> SpectralState:
         """Invert a row-scaled legacy residual with the stored raw factors."""
 
-        from .implicit import _raw_block_apply
-
-        raw_packed = self.system.pack(rhs) / jnp.asarray(self.system.row_scale)
-        return _raw_block_apply(self.system, self.system.unpack(raw_packed))
+        raw_packed = self._pack(rhs) / jnp.asarray(self.row_scale)
+        return self._block_apply(self._unpack(raw_packed))
 
     def solve_scaled_transpose(self, rhs: SpectralState) -> SpectralState:
         """Invert the transpose of the row-scaled legacy residual.
@@ -665,11 +794,9 @@ class LowOrderPreconditioner:
         forward :meth:`solve_scaled` path and is kept explicit here.
         """
 
-        from .implicit import _raw_block_apply
-
-        raw_solution = _raw_block_apply(self.system, rhs, transpose=True)
-        scaled = self.system.pack(raw_solution) / jnp.asarray(self.system.row_scale)
-        return self.system.project(self.system.unpack(scaled))
+        raw_solution = self._block_apply(rhs, transpose=True)
+        scaled = self._pack(raw_solution) / jnp.asarray(self.row_scale)
+        return self._project()(self._unpack(scaled))
 
 
 def _mode_table(m: np.ndarray, n: np.ndarray):
@@ -684,7 +811,8 @@ def make_high_low_transfer(
     native: HighOrderEquilibriumState,
     runtime: Any,
     *,
-    low_project: Callable[[SpectralState], SpectralState] | None = None,
+    project_config: Any = None,
+    project_mask: SpectralState | None = None,
 ) -> HighLowTransfer:
     """Build reusable high/low transfer matrices for one equilibrium layout."""
 
@@ -707,7 +835,6 @@ def make_high_low_transfer(
             evaluation[mode, :, :-1], rcond=1.0e-12
         )
         lambda_fit[mode] = np.linalg.pinv(evaluation[mode], rcond=1.0e-12)
-    project = (lambda value: value) if low_project is None else low_project
     return HighLowTransfer(
         evaluation=jnp.asarray(evaluation),
         geometry_fit=jnp.asarray(geometry_fit),
@@ -720,7 +847,8 @@ def make_high_low_transfer(
         lthreed=bool(runtime.setup.lthreed),
         lasym=bool(runtime.setup.lasym),
         lconm1=bool(runtime.setup.lconm1),
-        low_project=project,
+        project_config=project_config,
+        project_mask=project_mask,
     )
 
 
@@ -1862,19 +1990,13 @@ def build_low_order_preconditioner(
 
     runtime = implicit.runtime_from_params(params, config)
     project = implicit._dof_projector(config, dof_mask)
-    transfer = make_high_low_transfer(native, runtime, low_project=project)
+    transfer = make_high_low_transfer(
+        native, runtime, project_config=config, project_mask=dof_mask)
+    frozen_state = jax.lax.stop_gradient(legacy_state)
     legacy_coordinates = project(legacy_state)
     raw_residual = implicit.residual_fn(
-        config,
-        jax.lax.stop_gradient(legacy_state),
-        dof_mask,
-        formulation="raw",
-    )
-
-    def legacy_residual(coordinates: SpectralState) -> SpectralState:
-        return raw_residual(coordinates, params)
-
-    legacy_defect = legacy_residual(legacy_coordinates)
+        config, frozen_state, dof_mask, formulation="raw")
+    legacy_defect = raw_residual(legacy_coordinates, params)
 
     started = perf_counter()
     system = implicit._raw_block_system(
@@ -1886,13 +2008,20 @@ def build_low_order_preconditioner(
         int(probe_chunk_size),
     )
     elapsed = perf_counter() - started
+    # Only the factor and scale arrays survive: the system's closures would
+    # otherwise ride into jit metadata and defeat cross-call compile reuse.
     return LowOrderPreconditioner(
-        transfer,
-        system,
-        legacy_coordinates,
-        legacy_defect,
-        legacy_residual,
-        elapsed,
+        transfer=transfer,
+        config=config,
+        params=params,
+        frozen_state=frozen_state,
+        dof_mask=dof_mask,
+        factors=system.factors,
+        row_scale=system.row_scale,
+        column_scale=system.column_scale,
+        legacy_coordinates=legacy_coordinates,
+        legacy_defect=legacy_defect,
+        factor_build_seconds=elapsed,
     )
 
 

--- a/vmex/core/polish.py
+++ b/vmex/core/polish.py
@@ -362,7 +362,12 @@ class StrongPhysicalChart:
     build_seconds: float
 
     def tree_flatten(self):
-        """Keep dense numeric maps out of JIT static constants."""
+        """Keep dense numeric maps out of JIT static constants.
+
+        ``build_seconds`` is a wall-clock build diagnostic; in the hashable
+        metadata it made every chart a distinct compilation-cache key, so a
+        flatten/unflatten round trip drops it to zero instead.
+        """
 
         return (
             (
@@ -371,12 +376,13 @@ class StrongPhysicalChart:
                 self.coordinate_scale,
                 self.equation_scale,
             ),
-            (int(self.gauge_rank), float(self.build_seconds)),
+            (int(self.gauge_rank),),
         )
 
     @classmethod
     def tree_unflatten(cls, metadata, children):
-        gauge_rank, build_seconds = metadata
+        (gauge_rank,) = metadata
+        build_seconds = 0.0
         (
             coordinate_basis,
             equation_basis,

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -13,6 +13,8 @@ from inspect import signature
 from time import perf_counter
 from typing import Any, Literal, NamedTuple
 
+import functools
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -964,6 +966,30 @@ def polish_strong_root(
     )
 
 
+# The polish hot path used to jit fresh per-call lambdas closing over the
+# runtime and chart, baking every per-solve array in as XLA constants: each
+# polish call recompiled the residual, its linearization, and the whole
+# Gauss-Newton program, and the changed constants defeated the persistent
+# compilation cache as well (different constants, different HLO). These
+# module lanes take the pytrees as arguments, so equal-structure polish
+# calls share one compiled program in memory and on disk.
+@jax.jit
+def _scaled_collocation_lane(value, runtime, chart, collocation_scale):
+    return strong_collocation_residual(value, runtime, chart) / collocation_scale
+
+
+@functools.partial(jax.jit, static_argnames=("config",))
+def _gauss_newton_polish_lane(value, runtime, chart, variable_scale,
+                              collocation_scale, config):
+    from solvax import gauss_newton_least_squares
+
+    def residual(vector):
+        return strong_collocation_residual(
+            variable_scale * vector, runtime, chart) / collocation_scale
+
+    return gauss_newton_least_squares(residual, value, config=config)
+
+
 def _collocation_variable_scale(
     residual,
     zero: jax.Array,
@@ -1002,7 +1028,7 @@ def polish_collocation_least_squares(
     layout so it composes with the existing native-state utilities.
     """
 
-    from solvax import LeastSquaresConfig, gauss_newton_least_squares
+    from solvax import LeastSquaresConfig
 
     config = PolishConfig() if config is None else config
     chart = make_strong_structured_chart(runtime) if chart is None else chart
@@ -1018,11 +1044,12 @@ def polish_collocation_least_squares(
         / np.sqrt(float(initial_collocation.size)),
         1.0e-12,
     )
-    physical_residual = jax.jit(
-        lambda value: (
-            strong_collocation_residual(value, runtime, chart) / collocation_scale
-        )
-    )
+    collocation_scale_array = jnp.asarray(collocation_scale)
+
+    def physical_residual(value):
+        return _scaled_collocation_lane(
+            value, runtime, chart, collocation_scale_array)
+
     variable_scale = _collocation_variable_scale(
         physical_residual,
         zero,
@@ -1030,9 +1057,6 @@ def polish_collocation_least_squares(
         config.collocation_scale_probes,
     )
     variable_scale_array = jnp.asarray(variable_scale)
-    transformed_residual = jax.jit(
-        lambda value: physical_residual(variable_scale_array * value)
-    )
     least_squares_config = LeastSquaresConfig(
         rtol=config.tolerance,
         max_steps=config.max_nonlinear_iterations,
@@ -1044,13 +1068,9 @@ def polish_collocation_least_squares(
         ),
     )
     started = perf_counter()
-    solution = jax.jit(
-        lambda value: gauss_newton_least_squares(
-            transformed_residual,
-            value,
-            config=least_squares_config,
-        )
-    )(zero)
+    solution = _gauss_newton_polish_lane(
+        zero, runtime, chart, variable_scale_array,
+        collocation_scale_array, least_squares_config)
     jax.block_until_ready(solution)
     vector = variable_scale_array * solution.x
     state = _corrected_state(vector, runtime, chart)

--- a/vmex/core/radial_basis.py
+++ b/vmex/core/radial_basis.py
@@ -138,6 +138,32 @@ class BSplineBasis:
     quadrature_nodes: np.ndarray
     quadrature_weights: np.ndarray
 
+    # A basis rides in jit pytree metadata (HighOrderEquilibriumState and the
+    # mirror spline states), where identity equality made every freshly built
+    # basis a new compilation-cache key: the F3 baseline recompiled the
+    # module-jitted strong-force evaluators on every polish call over
+    # equal-content bases. Equality and hash follow the numeric content.
+
+    def _content(self) -> tuple:
+        return (
+            bool(self.periodic), int(self.degree), int(self.size),
+            self.knots.shape, self.knots.tobytes(),
+            self.breakpoints.tobytes(), self.collocation_nodes.tobytes(),
+            self.quadrature_nodes.tobytes(), self.quadrature_weights.tobytes(),
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, BSplineBasis):
+            return NotImplemented
+        return self is other or self._content() == other._content()
+
+    def __hash__(self) -> int:
+        cached = self.__dict__.get("_hash")
+        if cached is None:
+            cached = hash(self._content())
+            object.__setattr__(self, "_hash", cached)
+        return cached
+
     @classmethod
     def clamped(
         cls,


### PR DESCRIPTION
## Summary

The polishing path paid full XLA compilation on every solve - the direct cause of the README figure's 56.9 s tokamak row. Two commits, one defect class: per-solve values living inside compilation-cache keys.

**Commit 1 - type-level traps.** `BSplineBasis` is identity-compared and rides in jit pytree metadata, so every freshly built basis recompiled the module-jitted strong-force evaluators (8 recompiles per warm F3 repeat, measured); equality/hash now follow numeric content. `StrongPhysicalChart` carried its wall-clock **build time** in hashable metadata - a timestamp inside a compile-cache key - so equal charts never shared a program; dropped from the aux, zeroed by flatten round trips.

**Commit 2 - the hot path.** The driver jitted fresh per-call lambdas over the strong runtime/chart, and the runtime held its transfer, preconditioner, and layout in metadata as identity-keyed objects full of per-solve arrays, closures, and another timestamp. Every solve recompiled the residual, its linearization, and the entire Gauss-Newton program - and since baked constants change the HLO, the **persistent cache missed too** (cold F3 reload only recovered 20%). Now: transfer/preconditioner/layout are pytrees (arrays as traced leaves, structure-only metadata); the projection and frozen raw legacy residual are rebuilt on demand from the canonical config (#199's registry) instead of stored as closures; the raw-block inverse moved to a shared data-first helper; the driver's lambdas are two module-scope lanes with the SOLVAX config static.

**Measured** (F3, shaped tokamak polished, Apple M4):

| | before | after |
|---|---|---|
| warm repeat | 52.9 s | **22.8 s** |
| first call | 115 s | **80 s** |
| warm XLA recompilation | 26.9 s | 8.8 s |
| polish certificate | converged, same acceptance | unchanged |

Remaining warm compiles are the eager variable-scale probes and certificate scans (~5 s) - diminishing returns, left for the §11.4-style pass if profiles justify it.

## Test plan

- Full battery at CI's own parallelism: test_polish_preconditioner, test_strong_force, test_implicit_grad, test_implicit_multi_rhs, test_run_options, test_radial_basis - **168 passed** including the duality/certification and FD-parity tests; mypy + ruff clean.
- New regression tests: basis equality/hash follows content; state treedefs match across fresh equal bases; chart metadata excludes the timestamp; the runtime/chart roundtrip test now asserts treedef stability (the property compile reuse keys on) plus full numeric layout equivalence, instead of the object identity that metadata residence used to provide incidentally.
