### PR TITLE
Export polished WOUTs on a certifiable radial mesh

### DIFF
--- a/docs/reference/api/advanced.rst
+++ b/docs/reference/api/advanced.rst
@@ -63,10 +63,14 @@ package default``; the CLI prints which layer a polish request came from.
 ``polish_fail`` selects the failure behavior: ``"error"`` raises,
 ``"fallback"`` returns the unpolished state, ``"warn"`` does the same with a
 :class:`RuntimeWarning` — never a failure silently presented as polished. A successful result retains the ordinary ``state`` and exposes
-the VMEC-grid projection as ``polished_state``. CLI WOUT files and an
-:class:`vmex.core.optimize.Equilibrium` requested with polishing use that
+the VMEC-grid projection as ``polished_state``; an
+:class:`vmex.core.optimize.Equilibrium` requested with polishing uses that
 projected state, while the continuous solution remains in
-``native_equilibrium``.
+``native_equilibrium``.  CLI WOUT files instead sample
+``native_equilibrium`` on a denser radial mesh
+(:func:`vmex.core.polish_driver.polished_wout_ns`): on the solve mesh the
+stable wout reconstruction cannot resolve the between-node correction, so a
+solve-resolution export would silently discard most of the certified gain.
 
 The public primal path solves the overdetermined physical collocation residual
 with SOLVAX Gauss--Newton and accepts it only after independent force,

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -35,6 +35,7 @@ from vmex.core.polish import (
     make_strong_root_runtime,
     preconditioner_quality,
     preconditioner_refresh_decision,
+    sample_high_order_state,
     _strong_residual_unscaled,
     _streaming_ruiz_scales,
     _physical_coordinate_blocks,
@@ -63,6 +64,7 @@ from vmex.core.polish_driver import (
     _supports_keyword,
     polish_collocation_least_squares,
     polish_strong_root,
+    polished_wout_ns,
 )
 from vmex.core.polish_implicit import (
     PolishLinearConfig,
@@ -363,20 +365,24 @@ def _random_like(value, seed: int):
     )
 
 
-@pytest.fixture(scope="module")
-def small_adapter():
+def _small_solovev_input():
     inp = VmecInput.from_file(DATA / "input.solovev").change_resolution(
         mpol=3,
         ntor=0,
         ntheta=12,
         nzeta=4,
     )
-    inp = dataclasses.replace(
+    return dataclasses.replace(
         inp,
         ns_array=np.asarray([5]),
         ftol_array=np.asarray([1.0e-10]),
         niter_array=np.asarray([1000]),
     )
+
+
+@pytest.fixture(scope="module")
+def small_adapter():
+    inp = _small_solovev_input()
     config = implicit.make_config(inp, ftol=1.0e-10, max_iterations=1000)
     params = implicit.params_from_input(inp)
     state, mask = implicit.solve_implicit_with_aux(params, config)
@@ -1400,3 +1406,101 @@ def test_public_solver_auto_attaches_an_already_certified_native_state():
     assert result.polished_state.R_cos.shape == result.state.R_cos.shape
     assert np.all(np.isfinite(result.polished_state.R_cos))
     assert result.native_equilibrium.R_cos.shape == (3, 4)
+
+
+def test_sample_high_order_state_inverts_the_lift_on_any_mesh(small_adapter):
+    native, _, state, _, _ = small_adapter
+    inp = _small_solovev_input()
+    for ns in (5, 11):
+        runtime = solver.prepare_runtime(
+            inp, solver.resolution_from_input(inp, ns=ns)
+        )
+        sampled = sample_high_order_state(native, runtime)
+        assert np.shape(np.asarray(sampled.R_cos)) == (ns, native.m.size)
+        relift = lift_high_order_state(
+            sampled, runtime, radial_basis=native.radial_basis, degree=3
+        )
+        for name in ("R_cos", "R_sin", "Z_cos", "Z_sin", "L_cos", "L_sin"):
+            np.testing.assert_allclose(
+                np.asarray(getattr(relift, name)),
+                np.asarray(getattr(native, name)),
+                rtol=0.0,
+                atol=1.0e-11,
+            )
+    # The solve-mesh sample reproduces the fixed boundary row exactly: the
+    # lift pinned the edge spline coefficients to the legacy edge values.
+    solve_mesh = solver.prepare_runtime(
+        inp, solver.resolution_from_input(inp, ns=5)
+    )
+    sampled = sample_high_order_state(native, solve_mesh)
+    np.testing.assert_allclose(
+        np.asarray(sampled.R_cos[-1]), np.asarray(state.R_cos[-1]),
+        rtol=0.0, atol=1.0e-13,
+    )
+    np.testing.assert_allclose(
+        np.asarray(sampled.Z_sin[-1]), np.asarray(state.Z_sin[-1]),
+        rtol=0.0, atol=1.0e-13,
+    )
+
+
+def test_sample_high_order_state_requires_matching_mode_tables(small_adapter):
+    native, *_ = small_adapter
+    other = VmecInput.from_file(DATA / "input.solovev").change_resolution(
+        mpol=4, ntor=0, ntheta=12, nzeta=4
+    )
+    runtime = solver.prepare_runtime(
+        other, solver.resolution_from_input(other, ns=5)
+    )
+    with pytest.raises(ValueError, match="mode tables"):
+        sample_high_order_state(native, runtime)
+
+
+def test_polished_wout_ns_covers_reconstruction_and_the_native_basis():
+    native = SimpleNamespace(radial_basis=SimpleNamespace(size=17))
+    # The stable wout lift caps at 32 spans; four samples per capped span.
+    assert polished_wout_ns(native, solve_ns=31) == 129
+    # A finer solve mesh is never coarsened.
+    assert polished_wout_ns(native, solve_ns=201) == 201
+    # A native basis beyond the cap still stays fully determined.
+    wide = SimpleNamespace(radial_basis=SimpleNamespace(size=90))
+    assert polished_wout_ns(wide, solve_ns=31) == 181
+
+
+def test_polished_wout_export_certifies_near_the_native_state(tmp_path):
+    pytest.importorskip("netCDF4")
+    import vmex as vj
+    from vmex.core.strong_force import (
+        certify_strong_force,
+        high_order_state_from_wout,
+    )
+    from vmex.core.wout import read_wout
+
+    inp = _small_solovev_input()
+    physics = inp.to_indata(tmp_path / "input.polished_export")
+    source = tmp_path / "input.polished_export_directive"
+    source.write_text(
+        "!@VMEX POLISH = .TRUE.\n" + physics.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    config = PolishConfig(radial_degree=3, validation_tolerance=3.0)
+    result = vj.solve_file(source, outdir=tmp_path, polish_config=config)
+    assert bool(result.polish_report.converged)
+    # The in-memory API contract is untouched: polished_state still matches
+    # the solve mesh.  Only the exported file gets the certifiable mesh.
+    assert result.polished_state.R_cos.shape == result.state.R_cos.shape
+
+    wout_path = tmp_path / "wout_polished_export_directive.nc"
+    solve_ns = int(np.shape(np.asarray(result.state.R_cos))[0])
+    exported_ns = int(read_wout(wout_path).ns)
+    assert exported_ns == polished_wout_ns(
+        result.native_equilibrium, solve_ns=solve_ns
+    )
+    assert exported_ns > solve_ns
+
+    native_l2 = float(np.asarray(result.strong_force.normalized_l2))
+    exported = high_order_state_from_wout(wout_path, inp=inp, degree=5)
+    exported_l2 = float(np.asarray(certify_strong_force(exported).normalized_l2))
+    # The export is the only carrier of the polish gain for downstream wout
+    # consumers: the stable default reconstruction of the file must
+    # re-certify within 10% of the native continuous certificate.
+    assert exported_l2 <= 1.1 * native_l2

--- a/tests/test_run_options.py
+++ b/tests/test_run_options.py
@@ -189,6 +189,41 @@ def test_solve_file_runs_and_writes_wout(tmp_path):
     assert int(read_wout(wout_path).ier_flag) == 0
 
 
+def test_unpolished_wout_stays_bit_identical_to_the_plain_state_write(tmp_path):
+    """The polished-export lane must not touch unpolished runs at all."""
+    import dataclasses
+
+    import vmex as vj
+    from vmex.core.wout import wout_from_state, write_wout
+
+    inp = VmecInput.from_file(DATA / "input.solovev").change_resolution(
+        mpol=3, ntor=0, ntheta=12, nzeta=4)
+    inp = dataclasses.replace(
+        inp, ns_array=np.asarray([5]), ftol_array=np.asarray([1.0e-10]),
+        niter_array=np.asarray([1000]))
+    source = inp.to_indata(tmp_path / "input.unpolished_case")
+    result = vj.solve_file(source, polish=False, outdir=tmp_path)
+    assert result.polished_state is None
+    assert result.native_equilibrium is None
+    written = tmp_path / "wout_unpolished_case.nc"
+    assert written.exists()
+
+    # Reference: the direct state write with the CLI's own metadata,
+    # bypassing every polish-aware branch in the writer.
+    history = np.asarray(result.fsq_history, dtype=float)
+    total = history[:, 0] + history[:, 1]
+    stride = total.size // 100 + 1
+    fsqt = total[stride - 1 :: stride][:100]
+    reference = tmp_path / "wout_reference.nc"
+    reparsed = read_input_request(source).input  # what solve_file solved
+    write_wout(reference, wout_from_state(
+        inp=reparsed, state=result.state, fsqr=float(result.fsqr),
+        fsqz=float(result.fsqz), fsql=float(result.fsql), fsqt=fsqt,
+        niter=int(result.iterations), converged=bool(result.converged),
+        input_extension="unpolished_case", vacuum_output=result.vacuum))
+    assert written.read_bytes() == reference.read_bytes()
+
+
 def test_solve_file_rejects_polish_on_a_free_boundary_deck(tmp_path):
     source = tmp_path / "input.freeb"
     # MGRID_FILE must name something: readin.f (and VmecInput) force

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -686,13 +686,30 @@ def _write_wout_from_result(inp, input_path: Path, result, wout_path: Path,
             nextcur=freeb_plan.nextcur, extcur=freeb_plan.extcur,
             mgrid_mode=freeb_plan.mgrid_mode, curlabel=freeb_plan.curlabel,
         )
+    state = (
+        result.polished_state
+        if result.polished_state is not None
+        else result.state
+    )
+    if (
+        result.native_equilibrium is not None
+        and result.polish_report is not None
+        and bool(result.polish_report.converged)
+    ):
+        # A certified polish lives between the solve-mesh nodes; sampled at
+        # the solve resolution the stable wout reconstruction cannot recover
+        # it (see polished_wout_state).  Export the native state on the
+        # denser certifiable mesh instead.  Unpolished results (and failed
+        # polishes) take the unchanged path above.
+        from .polish_driver import polished_wout_state
+
+        state = polished_wout_state(
+            result.native_equilibrium, inp,
+            solve_ns=int(np.shape(np.asarray(result.state.R_cos))[0]),
+        )
     wout = wout_from_state(
         inp=inp,
-        state=(
-            result.polished_state
-            if result.polished_state is not None
-            else result.state
-        ),
+        state=state,
         fsqr=float(result.fsqr), fsqz=float(result.fsqz), fsql=float(result.fsql),
         fsqt=fsqt,
         niter=int(result.iterations),

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -977,8 +977,9 @@ def solve_file(
     ``polish_config`` wins over the scalar overrides entirely.
 
     ``write_wout=True`` writes ``wout_<case>.nc`` beside the input (or into
-    ``outdir``), sampled from the polished state when polishing succeeded —
-    the same output contract as ``vmex <input>``.  Free-boundary decks solve
+    ``outdir``) — the same output contract as ``vmex <input>``.  When
+    polishing succeeded the file samples the certified native state on the
+    denser :func:`~vmex.core.polish_driver.polished_wout_ns` export mesh.  Free-boundary decks solve
     through the free-boundary ladder and reject polish requests, matching the
     fixed-boundary-only scope of the polishing lane.
 

--- a/vmex/core/polish.py
+++ b/vmex/core/polish.py
@@ -852,6 +852,70 @@ def make_high_low_transfer(
     )
 
 
+def sample_high_order_state(
+    native: HighOrderEquilibriumState,
+    runtime: Any,
+) -> SpectralState:
+    """Evaluate a continuous native state on ``runtime``'s legacy full mesh.
+
+    The exact inverse of the representation changes performed by
+    :func:`~vmex.core.strong_force.lift_high_order_state`: clamped-spline
+    evaluation with the ``rho**abs(m)`` regularity factor, VMEX Fourier
+    normalization, the m=1 constrained variables, and the internal
+    ``phipf/lamscale`` lambda scaling.  Unlike :meth:`HighLowTransfer.restrict`
+    this samples a full equilibrium rather than a correction, so the boundary
+    row and the non-evolved degrees of freedom are kept, not zeroed.  The
+    target mesh is whatever ``runtime`` was prepared with — it does not have
+    to match the mesh the native state was lifted from.
+    """
+
+    modes = runtime.modes
+    m = np.asarray(modes.m, dtype=int)
+    n = np.asarray(modes.n, dtype=int)
+    if not np.array_equal(m, np.asarray(native.m)) or not np.array_equal(
+        n, np.asarray(native.n)
+    ):
+        raise ValueError("native and legacy mode tables must match")
+    setup = runtime.setup
+    s = np.asarray(setup.s_full, dtype=float)
+    rho = np.sqrt(np.maximum(s, 0.0))
+    basis_values = np.asarray(native.radial_basis.basis_matrix(s), dtype=float)
+    evaluation = jnp.asarray(
+        rho[None, :, None] ** np.abs(m)[:, None, None] * basis_values[None]
+    )
+
+    def sample(coefficients: Array) -> Array:
+        return jnp.einsum(
+            "msk,mk->sm",
+            evaluation,
+            jnp.asarray(coefficients),
+            precision=jax.lax.Precision.HIGHEST,
+        )
+
+    scale = jnp.asarray(physical_to_internal_scale(modes, runtime.trig))[None, :]
+    R_cos, Z_sin, R_sin, Z_cos = m1_physical_to_constrained(
+        sample(native.R_cos) * scale,
+        sample(native.Z_sin) * scale,
+        sample(native.R_sin) * scale,
+        sample(native.Z_cos) * scale,
+        modes=_mode_table(m, n),
+        lthreed=bool(setup.lthreed),
+        lasym=bool(setup.lasym),
+        lconm1=bool(setup.lconm1),
+    )
+    lambda_scale = (
+        scale * jnp.asarray(setup.phipf)[:, None] / jnp.asarray(setup.lamscale)
+    )
+    return SpectralState(
+        R_cos=R_cos,
+        R_sin=R_sin,
+        Z_cos=Z_cos,
+        Z_sin=Z_sin,
+        L_cos=sample(native.L_cos) * lambda_scale,
+        L_sin=sample(native.L_sin) * lambda_scale,
+    )
+
+
 def make_strong_root_layout(
     dof_mask: SpectralState,
     native: HighOrderEquilibriumState,
@@ -2102,6 +2166,7 @@ __all__ = [
     "make_strong_root_runtime",
     "preconditioner_quality",
     "preconditioner_refresh_decision",
+    "sample_high_order_state",
     "strong_collocation_residual",
     "strong_collocation_residual_at_native",
     "strong_root_rank",

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -251,6 +251,52 @@ def polished_compatibility_state(legacy_state, result: PolishResult):
     return jax.tree.map(jnp.add, legacy_state, low)
 
 
+#: Minimum radial surfaces for a polished WOUT export.  The stable wout
+#: reconstruction (:func:`~vmex.core.strong_force.lift_high_order_state`'s
+#: default) fits ``min(32, (ns - degree + 1) // 2)`` uniform spans, which
+#: locks every pre-cap mesh to ~2 samples per span — a near-interpolatory
+#: fit whose curvature ringing swamps the polish correction.  Only beyond
+#: the 32-span cap do additional samples turn that fit into an
+#: overdetermined L2 projection, so the export mesh provides four samples
+#: per capped span: ``4 * 32 + 1``.
+_POLISHED_WOUT_MIN_NS = 129
+
+
+def polished_wout_ns(
+    native: HighOrderEquilibriumState, *, solve_ns: int
+) -> int:
+    """Radial export mesh on which sampling ``native`` stays certifiable."""
+
+    determined = 2 * int(native.radial_basis.size) + 1
+    return max(int(solve_ns), _POLISHED_WOUT_MIN_NS, determined)
+
+
+def polished_wout_state(
+    native: HighOrderEquilibriumState, source, *, solve_ns: int
+):
+    """Sample the certified native state on the WOUT export mesh.
+
+    ``polished_state`` keeps its API contract of matching the solve mesh;
+    this is the file-export companion.  The WOUT is the only carrier of the
+    polish gain for downstream consumers, and on a coarse solve mesh the
+    stable reconstruction cannot resolve the between-node correction: on the
+    bundled shaped tokamak (``ns = 31``) the native certificate is 1.8e-3
+    while the solve-mesh export certifies at 3.3e-2 — worse than an
+    unrefined VMEC2000 wout — even though the samples still determine the
+    native state exactly.  Sampling on :func:`polished_wout_ns` surfaces
+    instead certifies within a few percent of the dense-sampling floor of
+    the default reconstruction (1.9e-3 at ``ns = 129`` against a 1.88e-3
+    floor measured at ``ns = 401``).
+    """
+
+    from .polish import sample_high_order_state
+    from .solver import prepare_runtime, resolution_from_input
+
+    ns = polished_wout_ns(native, solve_ns=solve_ns)
+    runtime = prepare_runtime(source, resolution_from_input(source, ns=ns))
+    return sample_high_order_state(native, runtime)
+
+
 @dataclass(frozen=True)
 class _IdentityPreconditioner:
     """Explicit identity action used to benchmark unpreconditioned JFNK."""
@@ -1256,5 +1302,7 @@ __all__ = [
     "polish_collocation_least_squares",
     "polish_legacy_solution",
     "polished_compatibility_state",
+    "polished_wout_ns",
+    "polished_wout_state",
     "polish_strong_root",
 ]

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -2265,7 +2265,9 @@ def solve(
     driver to return immediately when the independent certificate already
     passes.  Polishing
     requires a :class:`VmecInput` source. ``polished_state`` is the native
-    correction projected onto the sampled VMEC mesh for WOUT compatibility;
+    correction projected onto the sampled VMEC solve mesh (the in-memory
+    VMEC-grid view; WOUT export instead samples the certified native state
+    on the denser :func:`~vmex.core.polish_driver.polished_wout_ns` mesh);
     ``native_equilibrium``, ``strong_force``, ``polish_report``, and
     ``polish_context`` carry the certified high-order result and its frozen
     derivative chart. ``polish`` remains a backward-compatible alias.


### PR DESCRIPTION
Force-balance polishing certifies the native continuous state at a volume-L2 force residual of 1.81e-3 on the bundled shaped tokamak, but the WOUT the CLI exported re-certified at 3.34e-2 — worse than VMEC2000's own wout on the same case. Downstream wout consumers received almost none of the polish gain. This PR makes the exported file certify within 6% of the native state, at the measured floor of what wout sampling can deliver to the default reconstruction.

## Measured certificates (bundled `input.shaped_tokamak_pressure_polished`, deck resolution ns=31/mpol=5)

`benchmarks/strong_certificate.py` default invocation, `JAX_ENABLE_X64=1`:

| equilibrium | normalized volume-L2 |
| --- | --- |
| native continuous state (`strong_polish` reference command, deg 3 / 14 spans) | **1.794e-3** |
| native continuous state of the CLI run itself (deck-directive polish) | 1.811e-3 |
| polished wout — before (ns = 31) | 3.337e-2 |
| polished wout — **after** (ns = 129) | **1.914e-3** |
| unpolished wout (`--no-polish`, ns = 31) | 5.052e-2 |
| VMEC2000 wout, same case | 1.71e-2 |

(The CLI-run native certificate, 1.811e-3, is the export's apples-to-apples baseline; the benchmark command's explicit flags land marginally lower at 1.794e-3.)

Before: exporting kept a 1.5x improvement of the 27.9x native gain over the unpolished wout, and shipped a file worse than VMEC2000's. After: the exported file re-certifies 26.4x better than the unpolished export and ~9x better than VMEC2000.

## Root cause

The correction the polish certifies lives *between* the solve-mesh nodes. The exported ns=31 file was actually information-complete — lifting it in the polish's own basis (degree 3, 14 spans) reproduces the native certificate to four digits (1.811e-3) — but no wout consumer knows that basis. The stable default reconstruction (`lift_high_order_state`, used by `strong_certificate.py` and any wout import) deliberately fits an overdetermined `min(32, (ns - degree + 1) // 2)`-span spline to avoid amplifying legacy mesh noise, which locks every pre-cap mesh to ~2 samples per span: 13 spans at ns=31, fewer than the 14 the correction needs, and near-interpolatory, so its curvature ringing swamps the correction (density before the cap even *hurts*: ns=61 → 28 spans certifies at 4.2e-2). The wout writer/reader round trip itself is exact — ns=31 and ns=129 round trips reproduce their in-memory certificates to 12 digits, including the half-mesh lambda inversion — so the loss was purely export sampling density.

## Fix

`_write_wout_from_result` (shared by the CLI and `solve_file`) now samples `result.native_equilibrium` — the certified continuous state — on `polished_wout_ns` = `max(solve_ns, 129, 2*nbasis + 1)` surfaces, via the new `sample_high_order_state`, the exact inverse of the legacy lift's representation changes (spline evaluation with the `rho**|m|` factor, Fourier normalization, m=1 constrained variables, `phipf/lamscale` lambda scaling). 129 = 4 samples per capped 32-span reconstruction + 1; `2*nbasis + 1` keeps a wider-than-cap native basis fully determined.

## Theoretical floor

For any export density the default reconstruction converges (as ns → ∞) to the L2 projection of the native state onto its capped 32-span quintic space; the certificate of that projection is the floor no export can beat without the consumer choosing a finer basis. Measured on this case: 1.880e-3 at ns=401 (1.877e-3 at ns=201). The shipped ns=129 export certifies at 1.914e-3 — within 2% of that floor and 5.7% above the native certificate. The information-theoretic floor (a consumer fitting the native basis) is the native 1.811e-3, and the exported file still supports it exactly.

## No behavior change for unpolished runs

- Unpolished and failed-polish results keep writing `result.state` through the identical code path; the `--no-polish` wout on the bundled case is byte-identical before/after this change, and `test_unpolished_wout_stays_bit_identical_to_the_plain_state_write` locks the writer to the plain state write.
- `result.polished_state` keeps its solve-mesh API contract (in-memory consumers, e.g. `optimize.Equilibrium`, unchanged).
- Regression: `test_polished_wout_export_certifies_near_the_native_state` asserts the exported wout's default-reconstruction certificate is within 10% of the native certificate on a small case, and that the export mesh follows `polished_wout_ns`.
- Round trip: `test_sample_high_order_state_inverts_the_lift_on_any_mesh` checks `sample_high_order_state` inverts the lift to 1e-11 on solve-density and denser meshes and preserves the fixed boundary row exactly.

Cost on the bundled case: wout write 0.7 s → 5.4 s, file 45 KB → 140 KB. Global scalars (volume, aspect, beta, B0) agree with the ns=31 export to ≤ 3e-5 relative.

## Reproduce

```
JAX_ENABLE_X64=1 python -m vmex examples/data/input.shaped_tokamak_pressure_polished --outdir out
JAX_ENABLE_X64=1 python benchmarks/strong_certificate.py \
  --input examples/data/input.shaped_tokamak_pressure_polished \
  --wout out/wout_shaped_tokamak_pressure_polished.nc
```

## Verification

`tools/preflight.py`: ruff, mypy, docs prose, and guard tests clean; 781 affected tests passed; changed-line coverage 100% (31/31, bar 95%). The single local failure, `test_optimize.py::test_qi_regression_pin_and_jit`, fails identically (same 0.134997 vs pinned 0.136266) on pristine origin/main in the same environment — a locally built `booz_xform_jax` in the shared venv, unrelated to this change.
