### PR TITLE
Summary figure: combined Gamma_c + epsilon_eff confinement panel

### DIFF
--- a/docs/howto/plot-diagnostics.md
+++ b/docs/howto/plot-diagnostics.md
@@ -46,8 +46,14 @@ version.
 ## The summary figure
 
 `*_summary.png` is a publication-style diagnostic set: rotational transform
-(full mesh), pressure and the parallel bootstrap current
-$\langle \mathbf{J}\cdot\mathbf{B} \rangle$ on one panel, the relative radial
+(full mesh) with the parallel bootstrap current
+$\langle \mathbf{J}\cdot\mathbf{B} \rangle$ on its right axis, a combined
+confinement panel — pressure on the left axis, with the effective ripple
+$\epsilon_{\rm eff}^{3/2}$ (NEO_JAX at the bounded
+{func}`~vmex.core.neoclassical.diagnostic_neo_config` resolution) and the
+fast-ion proxy $\Gamma_c$
+({func}`~vmex.core.gammac.gamma_c_from_wout` at a compact radial-trend
+sampling) sharing one dimensionless right axis — the relative radial
 force error
 $\epsilon_F=|(\mathbf J\times\mathbf B-\nabla p)_s|/(|(\mathbf J\times\mathbf B)_s|+|(\nabla p)_s|)$,
 Mercier `DMerc` and the Glasser
@@ -65,12 +71,20 @@ mismatch the curve is omitted with a panel note rather than drawn
 unvalidated. The force-error maximum in the scalar card uses the solved
 interior surfaces; WOUT's axis and boundary values are extrapolations. The
 same normalization is valid in vacuum, where the pressure term is zero.
-Use {func}`vmex.core.neoclassical.epsilon_effective_from_wout` with an explicit
-`neo_jax.NeoConfig` when an effective-ripple calculation is wanted.
-The WOUT adapter releases completed JAX executables before its first NEO
-compile, avoiding the large cold-start time and memory observed when VMEX and
-NEO executables coexist. This is appropriate for an end-of-run plot; pass
-`clear_jax_caches=False` when preserving warm executables for subsequent solves.
+The confinement panel's two right-axis profiles are radial *trends*, not
+transport numbers: both diagnostics run at bounded summary resolution, they
+share the summary's one in-process Boozer transform where the mathematics is
+common (NEO consumes it directly; $\Gamma_c$ keeps its validated real-space
+field-line route), and the computed profiles are cached per in-memory WOUT so
+repeated summary generation does not recompute or recompile them.  A
+diagnostic that is unavailable (NEO_JAX not installed, `lasym` Boozer
+tables, a failed evaluation) is dropped from the panel with the reason
+recorded — never drawn as zero.  Use
+{func}`vmex.core.neoclassical.epsilon_effective_from_wout` with an explicit
+`neo_jax.NeoConfig` when a publication effective-ripple calculation is
+wanted; the library default no longer clears process-wide JAX caches
+(`clear_jax_caches=False`) — the CLI releases the plot-only executables
+itself after all requested diagnostics.
 The two stability indices and $V''(s)$ use separate scales whose zero levels
 are aligned; $V''(s)<0$ denotes a magnetic well. Their legend sits below the
 panel so it cannot hide a curve.

--- a/tests/test_neoclassical.py
+++ b/tests/test_neoclassical.py
@@ -61,6 +61,19 @@ def test_epsilon_effective_rejects_lasym_before_importing_optional_backend():
         neoclassical.epsilon_effective_from_wout(SimpleNamespace(lasym=True))
 
 
+def test_epsilon_effective_default_is_library_safe():
+    """A diagnostic call must not clear process-wide JAX caches by default.
+
+    Cache release is memory *policy* and belongs to the caller (the CLI does
+    it after all requested diagnostics); a library default of ``True`` would
+    silently discard every warm executable of the surrounding program.
+    """
+    import inspect
+
+    signature = inspect.signature(neoclassical.epsilon_effective_from_wout)
+    assert signature.parameters["clear_jax_caches"].default is False
+
+
 def test_diagnostic_config_is_the_bounded_summary_resolution(monkeypatch):
     """Summary figures ask NEO for a radial trend, not a transport number.
 

--- a/tests/test_plot_summary.py
+++ b/tests/test_plot_summary.py
@@ -383,6 +383,53 @@ def test_confinement_one_valid_one_invalid_and_never_zero(
         plt.close(fig)
 
 
+def test_confinement_guards_report_failures_and_skip_cache(
+    solved_case, monkeypatch,
+):
+    """Every defensive branch reports its reason; no silent zeros anywhere.
+
+    NEO raising mid-evaluation, NEO returning nothing positive, an all-NaN
+    ``Gamma_c`` (iota ~ 0 poison on every surface), and a wout stand-in that
+    cannot be weak-referenced (computed uncached rather than crashing).
+    """
+    from vmex.core import gammac, neoclassical
+
+    _, wout = solved_case
+    booz = {"mboz": 4, "nboz": 4, "s_b": np.array([0.5]), "neo_booz": {}}
+    monkeypatch.setattr(neoclassical, "diagnostic_neo_config", lambda: None)
+
+    def _raises(_booz, *, config=None):
+        raise RuntimeError("synthetic NEO failure")
+
+    monkeypatch.setattr(neoclassical, "epsilon_effective_from_boozer", _raises)
+    plotting._CONFINEMENT_CACHE.clear()
+    conf = plotting.confinement_summary(wout, booz)
+    assert conf.notes["epsilon_effective"] == "NEO evaluation failed: RuntimeError"
+
+    monkeypatch.setattr(
+        neoclassical, "epsilon_effective_from_boozer",
+        lambda _booz, *, config=None: (np.array([0.5]), np.array([0.0])))
+    monkeypatch.setattr(
+        gammac, "gamma_c_from_wout",
+        lambda w, **kw: {"s": np.array([0.5]), "gamma_c": np.array([np.nan])})
+    plotting._CONFINEMENT_CACHE.clear()
+    conf = plotting.confinement_summary(wout, booz)
+    assert conf.notes["epsilon_effective"] == "NEO returned no finite positive values"
+    assert conf.notes["gamma_c"] == "no surface returned a finite Gamma_c"
+    assert not conf.validity["gamma_c"] and conf.gamma_c is None
+
+    class SlotsWout:
+        __slots__ = ("ns",)                   # no __weakref__: uncacheable
+
+    monkeypatch.setattr(
+        plotting, "_gamma_c_profile",
+        lambda w: (np.array([0.5]), np.array([1e-3]), ""))
+    plotting._CONFINEMENT_CACHE.clear()
+    conf = plotting.confinement_summary(SlotsWout(), booz)
+    assert conf.validity["gamma_c"]
+    assert len(plotting._CONFINEMENT_CACHE) == 0  # computed, not cached
+
+
 def test_confinement_panel_annotates_when_nothing_is_valid():
     """Both diagnostics invalid: an explicit note, no fabricated curves."""
     import matplotlib.pyplot as plt

--- a/tests/test_plot_summary.py
+++ b/tests/test_plot_summary.py
@@ -3,10 +3,14 @@
 One in-process solve of the bundled ``cth_like_fixed_bdy`` deck feeds every
 check, so the module needs no golden fixtures and stays network-free:
 
-- the summary figure carries the full required panel set (iota full-mesh,
-  combined pressure/``<J.B>``, relative radial force balance,
-  combined Mercier/Glasser/well profiles, 3-D LCFS,
+- the summary figure carries the full required panel set (iota full-mesh
+  with ``<J.B>`` on its right axis, pressure with the
+  ``eps_eff^(3/2)``/``Gamma_c`` confinement axis, relative radial force
+  balance, combined Mercier/Glasser/well profiles, 3-D LCFS,
   polar ``J(alpha, s)``, two Boozer ``|B|`` panels, scalar card);
+- the confinement bundle is cached per in-memory WOUT (bounded, weakly
+  keyed), reuses one Boozer transform and one ``Gamma_c`` executable, and
+  drops an unavailable diagnostic with a stated reason instead of a zero;
 - style invariants are pinned: every ``|B|`` contour set is non-filled and
   jet-mapped, the 3-D surface colormap constant is jet, all text is >= 11 pt,
   every drawn text artist stays inside the canvas, saved PNGs are >= 200 dpi;
@@ -18,6 +22,7 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -166,19 +171,58 @@ def test_summary_combines_stability_and_well(summary_figure):
         stability.get_window_extent(renderer).y0 + 2)
 
 
-def test_summary_combines_pressure_current_and_reports_force_error(
+def test_summary_combines_iota_current_and_confinement(
     solved_case, summary_figure,
 ):
-    """Top row carries both profiles, the force equation, and its scalar max."""
+    """iota carries <J.B> on its right axis; pressure carries confinement."""
     _, meta = summary_figure
-    profiles = meta["axes"]["profiles"]
+    iota = meta["axes"]["iota"]
     current = meta["current_axis"]
-    assert len(profiles.lines) == 1 and len(current.lines) == 1
-    assert "pressure and parallel current" in profiles.get_title()
-    labels = [text.get_text() for text in profiles.get_legend().get_texts()]
-    assert any(label == r"$p$" for label in labels)
+    assert len(iota.lines) == 1 and len(current.lines) == 1
+    assert "rotational transform and parallel current" in iota.get_title()
+    labels = [text.get_text() for text in iota.get_legend().get_texts()]
+    assert any(label == r"$\iota$" for label in labels)
     assert any(r"\mathbf{J}" in label for label in labels)
 
+    profiles = meta["axes"]["profiles"]
+    assert len(profiles.lines) == 1
+    assert "pressure and confinement" in profiles.get_title()
+    labels = [text.get_text() for text in profiles.get_legend().get_texts()]
+    assert any(label == r"$p$" for label in labels)
+
+
+def test_summary_confinement_axis_draws_only_valid_profiles(summary_figure):
+    """The right confinement axis carries exactly the valid diagnostics.
+
+    On this deck ``Gamma_c`` always evaluates; the effective ripple rides
+    along when NEO_JAX is installed and is dropped **with its reason
+    recorded** when not — an invalid diagnostic must never appear as a
+    plausible zero curve.
+    """
+    _, meta = summary_figure
+    conf = meta["confinement"]
+    axis = meta["confinement_axis"]
+    assert conf.validity["gamma_c"], conf.notes["gamma_c"]
+    labels = {line.get_label(): line for line in axis.lines}
+    assert r"$\Gamma_c$" in labels
+    gamma_line = labels[r"$\Gamma_c$"]
+    values = np.asarray(gamma_line.get_ydata(), dtype=float)
+    assert np.all(np.isfinite(values)) and np.all(values != 0.0)
+    np.testing.assert_allclose(values, conf.gamma_c)
+    assert conf.timing["gamma_c"] > 0.0
+    if conf.validity["epsilon_effective"]:
+        assert r"$\epsilon_{\mathrm{eff}}^{3/2}$" in labels
+    else:
+        assert conf.notes["epsilon_effective"]
+        assert r"$\epsilon_{\mathrm{eff}}^{3/2}$" not in labels
+    # distinct styles on the shared axis
+    styles = {(line.get_linestyle(), line.get_marker()) for line in axis.lines}
+    assert len(styles) == len(axis.lines)
+
+
+def test_summary_reports_force_error(solved_case, summary_figure):
+    """The force panel keeps its equation, log scale, and scalar-card max."""
+    _, meta = summary_figure
     force = meta["axes"]["force_balance"]
     assert force.get_yscale() == "log"
     assert r"\rho=\sqrt{s}" in force.get_xlabel()
@@ -214,6 +258,187 @@ def test_force_panel_reports_missing_data_deliberately():
         assert [text.get_text() for text in ax.texts] == ["force error unavailable"]
     finally:
         plt.close(fig)
+
+
+# ==========================================================================
+# Confinement summary: shared work, cache, and unavailability semantics
+# ==========================================================================
+
+def _fresh_conf(wout):
+    """confinement_summary through a cleared cache (fresh computation)."""
+    plotting._CONFINEMENT_CACHE.clear()
+    return plotting.confinement_summary(wout, None, booz_note="not sampled")
+
+
+def test_confinement_summary_is_cached_and_never_recompiles(solved_case):
+    """Same WOUT + settings: one computation, one XLA executable.
+
+    The second call must be a pure cache hit (same object, effectively
+    instant — the bounded runtime gate for repeated summary generation), and
+    a from-scratch recomputation for the same shapes must reuse the jitted
+    ``Gamma_c`` executable rather than compile a second one.
+    """
+    from vmex.core import gammac
+
+    _, wout = solved_case
+    plotting._CONFINEMENT_CACHE.clear()
+    first = plotting.confinement_summary(wout, None, booz_note="not sampled")
+    start = time.perf_counter()
+    again = plotting.confinement_summary(wout, None, booz_note="not sampled")
+    elapsed = time.perf_counter() - start
+    assert again is first
+    assert elapsed < 0.5
+    compiled = gammac._gamma_c_rows_from_tables._cache_size()
+    recomputed = _fresh_conf(wout)
+    assert recomputed is not first
+    np.testing.assert_allclose(recomputed.gamma_c, first.gamma_c)
+    assert gammac._gamma_c_rows_from_tables._cache_size() == compiled
+
+
+def test_confinement_cache_is_bounded_and_weakly_keyed(solved_case, monkeypatch):
+    """At most ``_CONFINEMENT_CACHE_SIZE`` entries; dead WOUTs are evicted."""
+    import dataclasses as dc
+
+    monkeypatch.setattr(
+        plotting, "_gamma_c_profile",
+        lambda wout: (np.array([0.5]), np.array([1.0e-3]), ""))
+    monkeypatch.setattr(
+        plotting, "_epsilon_effective_profile",
+        lambda booz, note: (None, None, "skipped"))
+    _, wout = solved_case
+    plotting._CONFINEMENT_CACHE.clear()
+    clones = [dc.replace(wout) for _ in range(plotting._CONFINEMENT_CACHE_SIZE + 2)]
+    for clone in clones:
+        plotting.confinement_summary(clone, None, booz_note="x")
+    assert len(plotting._CONFINEMENT_CACHE) == plotting._CONFINEMENT_CACHE_SIZE
+    del clones, clone
+    import gc
+
+    gc.collect()
+    plotting.confinement_summary(wout, None, booz_note="x")
+    assert len(plotting._CONFINEMENT_CACHE) == 1
+
+
+def test_confinement_missing_neo_and_lasym_notes(solved_case, monkeypatch):
+    """Missing NEO_JAX and symmetric-only Boozer tables give stated reasons."""
+    from vmex.core import neoclassical
+
+    _, wout = solved_case
+
+    def _no_neo():
+        raise ImportError("effective ripple requires NEO_JAX")
+
+    monkeypatch.setattr(neoclassical, "diagnostic_neo_config", _no_neo)
+    booz = {"mboz": 4, "nboz": 4, "s_b": np.array([0.5]), "neo_booz": {}}
+    plotting._CONFINEMENT_CACHE.clear()
+    conf = plotting.confinement_summary(wout, booz)
+    assert not conf.validity["epsilon_effective"]
+    assert "NEO_JAX" in conf.notes["epsilon_effective"]
+    assert conf.validity["gamma_c"]
+
+    plotting._CONFINEMENT_CACHE.clear()
+    conf = plotting.confinement_summary(wout, {**booz, "neo_booz": None})
+    assert not conf.validity["epsilon_effective"]
+    assert "symmetric-only" in conf.notes["epsilon_effective"]
+
+
+def test_confinement_one_valid_one_invalid_and_never_zero(
+    solved_case, monkeypatch,
+):
+    """A failing Gamma_c is dropped with a reason while eps still plots.
+
+    A failed or nonconverged diagnostic must never be drawn as zero: the
+    panel keeps only the valid curve and the note carries the cause.
+    """
+    import matplotlib.pyplot as plt
+
+    from vmex.core import gammac, neoclassical
+
+    _, wout = solved_case
+
+    def _fake_eps(booz, *, config=None):
+        return np.array([0.3, 0.6, 0.9]), np.array([1e-4, 2e-4, 4e-4])
+
+    def _broken_gamma(*args, **kwargs):
+        raise RuntimeError("synthetic gamma failure")
+
+    monkeypatch.setattr(neoclassical, "diagnostic_neo_config", lambda: None)
+    monkeypatch.setattr(
+        neoclassical, "epsilon_effective_from_boozer", _fake_eps)
+    monkeypatch.setattr(gammac, "gamma_c_from_wout", _broken_gamma)
+    plotting._CONFINEMENT_CACHE.clear()
+    booz = {"mboz": 4, "nboz": 4, "s_b": np.array([0.5]), "neo_booz": {}}
+    conf = plotting.confinement_summary(wout, booz)
+    assert conf.validity["epsilon_effective"]
+    assert not conf.validity["gamma_c"]
+    assert "RuntimeError" in conf.notes["gamma_c"]
+
+    fig, ax = plt.subplots()
+    try:
+        axis, lines = plotting._confinement_panel(ax, conf)
+        assert [line.get_label() for line in lines] == [
+            r"$\epsilon_{\mathrm{eff}}^{3/2}$"]
+        assert axis.get_yscale() == "linear"  # 4x dynamic range: no log
+    finally:
+        plt.close(fig)
+
+
+def test_confinement_panel_annotates_when_nothing_is_valid():
+    """Both diagnostics invalid: an explicit note, no fabricated curves."""
+    import matplotlib.pyplot as plt
+
+    conf = plotting.ConfinementSummary(
+        surfaces={}, epsilon_effective=None, gamma_c=None,
+        validity={"epsilon_effective": False, "gamma_c": False},
+        notes={"epsilon_effective": "a", "gamma_c": "b"}, timing={})
+    fig, ax = plt.subplots()
+    try:
+        axis, lines = plotting._confinement_panel(ax, conf)
+        assert lines == []
+        assert any(
+            "confinement diagnostics unavailable" in t.get_text()
+            for t in axis.texts)
+    finally:
+        plt.close(fig)
+
+
+def test_confinement_log_scale_needs_positive_wide_range():
+    """Log scale only for all-positive data spanning >= two decades."""
+    import matplotlib.pyplot as plt
+
+    base = dict(
+        epsilon_effective=None, gamma_c=np.array([1e-6, 5e-4, 2e-3]),
+        validity={"epsilon_effective": False, "gamma_c": True},
+        notes={"epsilon_effective": "no", "gamma_c": ""}, timing={})
+    wide = plotting.ConfinementSummary(
+        surfaces={"gamma_c": np.array([0.3, 0.6, 0.9])}, **base)
+    fig, (ax1, ax2) = plt.subplots(1, 2)
+    try:
+        axis, _ = plotting._confinement_panel(ax1, wide)
+        assert axis.get_yscale() == "log"
+        base["gamma_c"] = np.array([0.0, 5e-4, 2e-3])   # zero: no log
+        zero = plotting.ConfinementSummary(
+            surfaces={"gamma_c": np.array([0.3, 0.6, 0.9])}, **base)
+        axis, _ = plotting._confinement_panel(ax2, zero)
+        assert axis.get_yscale() == "linear"
+    finally:
+        plt.close(fig)
+
+
+def test_gamma_c_from_wout_matches_live_state(solved_case):
+    """The plot route reproduces the validated live-state Gamma_c exactly."""
+    from vmex.core import gammac
+
+    eq, wout = solved_case
+    kwargs = dict(surfaces=(0.3, 0.6), **plotting._GAMMA_C_DIAGNOSTIC)
+    live = gammac.gamma_c_state(eq.state, eq.runtime, **kwargs)
+    from_wout = gammac.gamma_c_from_wout(wout, **kwargs)
+    # measured on this deck: 2.8e-11 relative; the atol floor only covers
+    # exact-cancellation surfaces where Gamma_c is pure roundoff (~1e-28)
+    np.testing.assert_allclose(
+        np.asarray(from_wout["gamma_c"]), np.asarray(live["gamma_c"]),
+        rtol=1e-8, atol=1e-20)
+    assert from_wout["surface_rows"] == live["surface_rows"]
 
 
 def test_d_r_reconstruction_matches_traceable(solved_case):
@@ -285,11 +510,14 @@ def test_frozen_pressure_scan_guards(solved_case, tmp_path):
 
 
 def test_saved_summary_png_resolution(solved_case, tmp_path):
-    """plot_wout writes the summary PNG at >= 200 dpi pixel dimensions."""
+    """plot_wout writes the summary at >= 200 dpi and closes its figures."""
     import matplotlib.image as mpimg
+    import matplotlib.pyplot as plt
 
     _, wout = solved_case
+    open_before = set(plt.get_fignums())
     paths = plotting.plot_wout(wout, tmp_path, which=("summary",), name=DECK)
+    assert set(plt.get_fignums()) == open_before  # no leaked figures
     png = paths["summary"]
     assert png.exists()
     pixels = mpimg.imread(str(png))

--- a/vmex/__init__.py
+++ b/vmex/__init__.py
@@ -24,6 +24,8 @@ Public API (lazily imported; ``import vmex as vj``):
 - :func:`~vmex.core.boozer.run_booz_xform` — Boozer transform (booz_xform_jax)
 - :func:`~vmex.core.neoclassical.epsilon_effective_from_wout` — optional
   NEO_JAX effective-ripple profile
+- :func:`~vmex.core.gammac.gamma_c_from_wout` — fast-ion ``Gamma_c`` profile
+  from any compatible wout, without a solve
 - :func:`~vmex.core.tracing.essos_vmec_field` — hand a solved equilibrium to
   ESSOS as an ``essos.fields.Vmec`` (optional ESSOS dependency)
 - :func:`~vmex.core.tracing.trace_alphas` /
@@ -183,6 +185,7 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
         ".core.neoclassical", "epsilon_effective_from_boozer"),
     "epsilon_effective_from_wout": (
         ".core.neoclassical", "epsilon_effective_from_wout"),
+    "gamma_c_from_wout": (".core.gammac", "gamma_c_from_wout"),
     # alpha-particle tracing (ESSOS)
     "AlphaTracingResult": (".core.tracing", "AlphaTracingResult"),
     "essos_vmec_field": (".core.tracing", "essos_vmec_field"),

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -852,6 +852,15 @@ def _plot_wout_file(wout_path: Path, outdir: Path, *, emit, quiet: bool) -> None
     for key, path in plot_wout(wout_path, outdir=outdir).items():
         if not quiet:
             emit(f"   Saved {key}: {path}")
+    # Memory policy lives here, not in the diagnostic libraries: after every
+    # requested figure is on disk, release the plot-only executables (Boozer,
+    # NEO, Gamma_c field lines) that an end-of-run CLI process never reuses.
+    import gc
+
+    import jax
+
+    jax.clear_caches()
+    gc.collect()
 
 
 def _plot_mout_file(mout_path: Path, outdir: Path, *, emit, quiet: bool) -> None:

--- a/vmex/core/gammac.py
+++ b/vmex/core/gammac.py
@@ -71,6 +71,7 @@ field-line parameterization.
 from __future__ import annotations
 
 import functools
+from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 import numpy as np
@@ -90,6 +91,7 @@ Array = Any
 __all__ = [
     "GammaC",
     "gamma_c_from_fieldlines",
+    "gamma_c_from_wout",
     "gamma_c_state",
 ]
 
@@ -245,13 +247,8 @@ _ROW_FIELDS = ("gamma_c", "excluded_fraction", "overflow_fraction",
                "line_length", "pitch")
 
 
-@functools.partial(
-    jax.jit,
-    static_argnames=("rows", "nalpha", "num_transit", "points_per_transit",
-                     "num_pitch", "quadrature_order", "max_wells"))
-def _gamma_c_rows(
-    state: SpectralState,
-    rt: SolverRuntime,
+def _rows_from_context(
+    ctx: dict,
     zeta0: Array,
     *,
     rows: tuple[int, ...],
@@ -262,16 +259,15 @@ def _gamma_c_rows(
     quadrature_order: int,
     max_wells: int,
 ) -> dict[str, Array]:
-    """``Gamma_c`` of the full-mesh rows ``rows``, as one XLA executable.
+    """``Gamma_c`` of the full-mesh rows ``rows`` of one spectral context.
 
-    Module-level rather than a ``jax.jit`` at the call site, so every boundary
-    iterate of an optimization stage reuses one compilation instead of
-    re-tracing the spectral field-line machinery.  Measured on a three-surface
-    nfp = 2 case: 0.96 s eager against 0.03 s here, values bit-identical.
-    Everything that sets an array shape is static.
+    ``ctx`` is the shared field-line context of
+    :func:`vmex.core.stability._ballooning_context` — either from a live
+    ``(state, runtime)`` pair or normalized from a WOUT file — so the live
+    optimization path and the read-only plotting path run the identical
+    numerics.  Everything that sets an array shape is static in the jitted
+    wrappers below.
     """
-
-    ctx = _ballooning_context(state, rt)
     dtype = ctx["s"].dtype
     alpha = jnp.asarray(
         2.0 * np.pi * np.arange(int(nalpha)) / int(nalpha), dtype=dtype)
@@ -360,6 +356,99 @@ def _gamma_c_rows(
     return stacked
 
 
+_ROW_STATICS = ("rows", "nalpha", "num_transit", "points_per_transit",
+                "num_pitch", "quadrature_order", "max_wells")
+
+#: Traced context entries consumed by :func:`_rows_from_context`; the
+#: remaining `_ballooning_context` keys (normalizations, pressure) are unused
+#: here, and ``lasym`` is Python control flow, so it rides as a static.
+_CTX_KEYS = ("s", "hs", "psi_edge", "iotas", "phipf", "m", "xn",
+             "rmnc", "zmns", "lmns", "rmns", "zmnc", "lmnc")
+
+
+@functools.partial(jax.jit, static_argnames=_ROW_STATICS)
+def _gamma_c_rows(
+    state: SpectralState, rt: SolverRuntime, zeta0: Array, *,
+    rows, nalpha, num_transit, points_per_transit, num_pitch,
+    quadrature_order, max_wells,
+) -> dict[str, Array]:
+    """Live-state ``Gamma_c`` rows, as one XLA executable.
+
+    Module-level rather than a ``jax.jit`` at the call site, so every boundary
+    iterate of an optimization stage reuses one compilation instead of
+    re-tracing the spectral field-line machinery.  Measured on a three-surface
+    nfp = 2 case: 0.96 s eager against 0.03 s here, values bit-identical.
+    """
+    return _rows_from_context(
+        _ballooning_context(state, rt), zeta0, rows=rows, nalpha=nalpha,
+        num_transit=num_transit, points_per_transit=points_per_transit,
+        num_pitch=num_pitch, quadrature_order=quadrature_order,
+        max_wells=max_wells)
+
+
+@functools.partial(jax.jit, static_argnames=_ROW_STATICS + ("lasym",))
+def _gamma_c_rows_from_tables(
+    tables: dict, zeta0: Array, *, lasym: bool,
+    rows, nalpha, num_transit, points_per_transit, num_pitch,
+    quadrature_order, max_wells,
+) -> dict[str, Array]:
+    """WOUT-context ``Gamma_c`` rows; one executable per (shapes, settings)."""
+    return _rows_from_context(
+        dict(tables, lasym=lasym), zeta0, rows=rows, nalpha=nalpha,
+        num_transit=num_transit, points_per_transit=points_per_transit,
+        num_pitch=num_pitch, quadrature_order=quadrature_order,
+        max_wells=max_wells)
+
+
+def _validate_settings(nalpha, num_transit, points_per_transit, num_pitch):
+    if nalpha < 2:
+        raise ValueError("nalpha must be >= 2")
+    if num_transit < 1 or points_per_transit < 16:
+        raise ValueError("num_transit must be >= 1 and points_per_transit >= 16")
+    if num_pitch < 2:
+        raise ValueError("num_pitch must be >= 2")
+
+
+def gamma_c_from_wout(
+    wout,
+    *,
+    surfaces: Sequence[float] = (0.35, 0.6, 0.85),
+    nalpha: int = 9,
+    num_transit: int = 4,
+    points_per_transit: int = 64,
+    num_pitch: int = 32,
+    quadrature_order: int = 32,
+    max_wells: int | None = None,
+    zeta0: float = 0.0,
+) -> dict[str, Array]:
+    """Evaluate ``Gamma_c`` from a VMEC-compatible WOUT, without a solve.
+
+    ``wout`` is a :class:`~vmex.core.wout.WoutData` or a path accepted by
+    :func:`vmex.read_wout`.  The WOUT tables are normalized to the live-state
+    spectral context (the :mod:`vmex.core.turbulence` read-only route), so the
+    numerics — field lines, drift kernels, pitch quadrature — are identical to
+    :func:`gamma_c_state`; only the radial coefficient tables come from the
+    file instead of the solver state.  Same arguments and return contract as
+    :func:`gamma_c_state`.  Read-only: not the differentiable route.
+    """
+    from .turbulence import _wout_ballooning_context
+    from .wout import read_wout
+
+    if isinstance(wout, (str, Path)):
+        wout = read_wout(str(wout))
+    _validate_settings(nalpha, num_transit, points_per_transit, num_pitch)
+    ctx = _wout_ballooning_context(wout)
+    rows = _surface_rows(surfaces, int(ctx["ns"]))
+    out = _gamma_c_rows_from_tables(
+        {key: ctx[key] for key in _CTX_KEYS},
+        jnp.asarray(float(zeta0)), lasym=bool(ctx["lasym"]), rows=rows,
+        nalpha=int(nalpha), num_transit=int(num_transit),
+        points_per_transit=int(points_per_transit), num_pitch=int(num_pitch),
+        quadrature_order=int(quadrature_order),
+        max_wells=16 * int(num_transit) if max_wells is None else int(max_wells))
+    return {**out, "surface_rows": rows}
+
+
 def gamma_c_state(
     state: SpectralState,
     rt: SolverRuntime,
@@ -393,12 +482,7 @@ def gamma_c_state(
     number.  The numerics live in the jitted :func:`_gamma_c_rows`; only the
     validation and the row selection happen here, because those set shapes.
     """
-    if nalpha < 2:
-        raise ValueError("nalpha must be >= 2")
-    if num_transit < 1 or points_per_transit < 16:
-        raise ValueError("num_transit must be >= 1 and points_per_transit >= 16")
-    if num_pitch < 2:
-        raise ValueError("num_pitch must be >= 2")
+    _validate_settings(nalpha, num_transit, points_per_transit, num_pitch)
     rows = _surface_rows(surfaces, int(np.shape(rt.setup.s_full)[0]))
     out = _gamma_c_rows(
         state, rt, jnp.asarray(float(zeta0)), rows=rows, nalpha=int(nalpha),

--- a/vmex/core/neoclassical.py
+++ b/vmex/core/neoclassical.py
@@ -70,18 +70,19 @@ def epsilon_effective_from_wout(
     mboz: int = 16,
     nboz: int = 12,
     config=None,
-    clear_jax_caches: bool = True,
+    clear_jax_caches: bool = False,
 ):
     """Compute ``epsilon_eff**(3/2)`` directly from an in-memory VMEX wout.
 
     VMEX performs the Boozer transform in memory and passes its arrays to
     NEO_JAX; no ``boozmn`` file is required. NEO_JAX currently represents the
     stellarator-symmetric cosine/sine convention, so ``LASYM`` wouts are
-    rejected rather than silently dropping asymmetric harmonics. By default,
-    completed VMEX executables are released before compiling NEO; this keeps
-    end-of-run plotting responsive and memory-bounded. Set
-    ``clear_jax_caches=False`` when preserving other warm JAX executables
-    matters more than peak memory.
+    rejected rather than silently dropping asymmetric harmonics. The default
+    is library-safe: a diagnostic call never clears the process-wide JAX
+    executable caches behind its caller's back. Pass ``clear_jax_caches=True``
+    to release completed executables before compiling NEO when peak memory
+    matters more than warm executables — the CLI does this itself after all
+    requested diagnostics instead (:mod:`vmex.core.cli`).
     """
     if bool(getattr(wout, "lasym", False)):
         raise NotImplementedError(

--- a/vmex/core/plotting.py
+++ b/vmex/core/plotting.py
@@ -4,8 +4,11 @@ Self-contained matplotlib (Agg) figure set read from a ``wout_*.nc`` file
 (or an in-memory :class:`vmex.core.wout.WoutData`):
 
 - ``summary``   3x3 publication diagnostic set: rotational transform (full
-  mesh), pressure and parallel (bootstrap) current ``<J.B>``, relative radial
-  force error, Mercier ``DMerc``
+  mesh) with the parallel (bootstrap) current ``<J.B>`` on its right axis,
+  pressure with the confinement diagnostics ``eps_eff^(3/2)`` (NEO_JAX) and
+  ``Gamma_c`` sharing one right axis (bounded-resolution radial trends,
+  cached per in-memory WOUT — see :class:`ConfinementSummary`), relative
+  radial force error, Mercier ``DMerc``
   and Glasser ``D_R`` with ``V''(s)`` on the right axis, a 3-D LCFS,
   a Velasco-style polar second-adiabatic-invariant map ``J(alpha, s)``, ``|B|``
   in Boozer coordinates at mid radius and on the LCFS (line contours with a
@@ -39,12 +42,17 @@ plus the per-figure helpers each of those dispatches to.
 
 from __future__ import annotations
 
+import dataclasses
+import time
+import weakref
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 import numpy as np
 
 __all__ = [
+    "ConfinementSummary",
     "plot_wout",
     "plot_boozmn",
     "plot_bootstrap_current",
@@ -698,19 +706,243 @@ def _boozer_summary_data(
         if bmns_raw is not None and np.size(bmns_raw) else None
     )
     s_b = np.asarray(bx.s_b, dtype=float)
+    iota_b = np.asarray(bx.iota, dtype=float)[np.asarray(indices, dtype=int)]
+    # The same transform feeds NEO's effective ripple (the summary confinement
+    # panel), so the one Boozer run is shared instead of duplicated.  NEO's
+    # BoozerData contract is symmetric-only; ``pmns_b`` carries booz_xform's
+    # ``-numns`` sign convention (see ``epsilon_effective_from_wout``).
+    neo_booz = None
+    if bmns_b is None:
+        neo_booz = {
+            "nfp_b": int(bx.nfp), "ns_b": len(indices),
+            "ixm_b": np.asarray(bx.xm_b), "ixn_b": np.asarray(bx.xn_b),
+            "iota_b": iota_b,
+            "buco_b": np.asarray(bx.Boozer_I), "bvco_b": np.asarray(bx.Boozer_G),
+            "rmnc_b": np.asarray(bx.rmnc_b), "zmns_b": np.asarray(bx.zmns_b),
+            "pmns_b": -np.asarray(bx.numns_b), "bmnc_b": np.asarray(bx.bmnc_b),
+            "s_b": s_b,
+        }
     return {
         "bmnc_b": np.asarray(bx.bmnc_b, dtype=float).T,
         "bmns_b": bmns_b,
         "xm_b": np.asarray(bx.xm_b, dtype=int),
         "xn_b": np.asarray(bx.xn_b, dtype=int),
-        "iota_b": np.asarray(bx.iota, dtype=float)[np.asarray(indices, dtype=int)],
+        "iota_b": iota_b,
         "G_b": np.asarray(bx.Boozer_G, dtype=float),
         "I_b": np.asarray(bx.Boozer_I, dtype=float),
         "s_b": s_b,
         "nfp": int(bx.nfp),
         "index_mid": int(np.argmin(np.abs(s_b - 0.5))),
         "index_lcfs": int(s_b.size - 1),
+        "mboz": int(mboz),
+        "nboz": int(nboz),
+        "neo_booz": neo_booz,
     }
+
+
+# ==========================================================================
+# Confinement summary (effective ripple + Gamma_c) with a bounded cache
+# ==========================================================================
+
+#: Compact ``Gamma_c`` sampling for the summary trend panel — radial ordering
+#: quality, not publication numbers (the ``diagnostic_neo_config`` analogue;
+#: the value carries the resolution scatter documented in
+#: :func:`vmex.core.gammac.gamma_c_state`).
+_GAMMA_C_DIAGNOSTIC = dict(
+    nalpha=5, num_transit=3, points_per_transit=48, num_pitch=16,
+    quadrature_order=16)
+
+#: Radial targets of the summary ``Gamma_c`` profile (snapped to distinct
+#: interior full-mesh rows of the WOUT grid).
+_GAMMA_C_TARGETS = (0.25, 0.5, 0.7, 0.9)
+
+
+@dataclasses.dataclass(frozen=True)
+class ConfinementSummary:
+    """One bundle of the summary figure's confinement diagnostics.
+
+    ``surfaces`` maps each diagnostic name to its own radial grid (the two
+    diagnostics sample different native grids: NEO the Boozer half-mesh
+    surfaces of the shared summary transform, ``Gamma_c`` interior full-mesh
+    rows).  ``validity`` says whether each profile is usable; ``notes`` carries
+    the reason when it is not (never plot an invalid value as zero); ``timing``
+    records the wall seconds each diagnostic cost.
+    """
+
+    surfaces: dict[str, np.ndarray]
+    epsilon_effective: np.ndarray | None
+    gamma_c: np.ndarray | None
+    validity: dict[str, bool]
+    notes: dict[str, str]
+    timing: dict[str, float]
+
+
+#: Bounded cache of :func:`confinement_summary` results.  Keyed by WOUT
+#: identity — ``id`` for hashing plus a weak reference for liveness, so a
+#: cached entry never keeps a WOUT alive and a recycled ``id`` can never
+#: alias a collected one — plus every setting that feeds the numbers: Boozer
+#: resolution, NEO configuration, and the ``Gamma_c`` sampling.  Repeated
+#: summary generation for the same in-memory WOUT reuses the computed
+#: profiles instead of recompiling and re-running the diagnostics.
+_CONFINEMENT_CACHE: OrderedDict[
+    tuple, tuple[weakref.ref, ConfinementSummary]] = OrderedDict()
+_CONFINEMENT_CACHE_SIZE = 4
+
+
+def _confinement_cache_get(key: tuple, wout) -> ConfinementSummary | None:
+    for cached in [k for k, (ref, _) in _CONFINEMENT_CACHE.items() if ref() is None]:
+        del _CONFINEMENT_CACHE[cached]
+    hit = _CONFINEMENT_CACHE.get(key)
+    if hit is None or hit[0]() is not wout:
+        return None
+    _CONFINEMENT_CACHE.move_to_end(key)
+    return hit[1]
+
+
+def _confinement_cache_put(key: tuple, wout, value: ConfinementSummary) -> None:
+    _CONFINEMENT_CACHE[key] = (weakref.ref(wout), value)
+    while len(_CONFINEMENT_CACHE) > _CONFINEMENT_CACHE_SIZE:
+        _CONFINEMENT_CACHE.popitem(last=False)
+
+
+def _epsilon_effective_profile(booz: dict[str, Any] | None, note: str):
+    """``(s, eps_eff^{3/2}, note)`` from the shared summary Boozer result."""
+    if booz is None:
+        return None, None, note or "Boozer transform unavailable"
+    if booz.get("neo_booz") is None:
+        return None, None, "NEO_JAX's BoozerData contract is symmetric-only"
+    try:
+        from .neoclassical import diagnostic_neo_config, epsilon_effective_from_boozer
+
+        surfaces, values = epsilon_effective_from_boozer(
+            booz["neo_booz"], config=diagnostic_neo_config())
+    except ImportError:
+        return None, None, "effective ripple requires NEO_JAX (vmex[neoclassical])"
+    except Exception as exc:  # noqa: BLE001 - summary stays usable without NEO
+        return None, None, f"NEO evaluation failed: {type(exc).__name__}"
+    surfaces = np.asarray(surfaces, dtype=float)
+    values = np.asarray(values, dtype=float)
+    keep = np.isfinite(values) & (values > 0.0)
+    if not keep.any():
+        return None, None, "NEO returned no finite positive values"
+    return surfaces[keep], values[keep], ""
+
+
+def _gamma_c_profile(wout):
+    """``(s, Gamma_c, note)`` on distinct interior rows of the WOUT grid."""
+    ns = int(wout.ns)
+    rows = sorted({
+        min(max(int(round(target * (ns - 1))), 2), ns - 2)
+        for target in _GAMMA_C_TARGETS
+    })
+    try:
+        from .gammac import gamma_c_from_wout
+
+        out = gamma_c_from_wout(
+            wout, surfaces=tuple(row / (ns - 1) for row in rows),
+            **_GAMMA_C_DIAGNOSTIC)
+    except Exception as exc:  # noqa: BLE001 - summary stays usable without it
+        return None, None, f"Gamma_c evaluation failed: {type(exc).__name__}"
+    surfaces = np.asarray(out["s"], dtype=float)
+    values = np.asarray(out["gamma_c"], dtype=float)
+    # NaN rows are deliberate poison (iota ~ 0 field-line map): drop, never
+    # draw as zero.
+    keep = np.isfinite(values)
+    if not keep.any():
+        return None, None, "no surface returned a finite Gamma_c"
+    return surfaces[keep], values[keep], ""
+
+
+def confinement_summary(wout, booz: dict[str, Any] | None, *, booz_note: str = "") -> ConfinementSummary:
+    """Effective ripple + ``Gamma_c`` radial trends of one WOUT, cached.
+
+    ``booz`` is the shared :func:`_boozer_summary_data` result (or ``None``
+    with ``booz_note`` saying why), so the effective ripple rides the one
+    Boozer transform the summary figure already ran; ``Gamma_c`` uses its
+    validated real-space route (:func:`vmex.core.gammac.gamma_c_from_wout`)
+    since none of its ingredients live in Boozer coordinates.  Results are
+    cached per in-memory WOUT and settings (see ``_CONFINEMENT_CACHE``).
+    """
+    key = None
+    try:
+        weakref.ref(wout)
+        key = (
+            id(wout),
+            None if booz is None else (booz["mboz"], booz["nboz"], len(booz["s_b"])),
+            tuple(sorted(_GAMMA_C_DIAGNOSTIC.items())), _GAMMA_C_TARGETS,
+        )
+    except TypeError:
+        pass  # non-weakref-able stand-ins (tests): compute uncached
+    if key is not None:
+        hit = _confinement_cache_get(key, wout)
+        if hit is not None:
+            return hit
+
+    timing: dict[str, float] = {}
+    start = time.perf_counter()
+    eps_s, eps, eps_note = _epsilon_effective_profile(booz, booz_note)
+    timing["epsilon_effective"] = time.perf_counter() - start
+    start = time.perf_counter()
+    gamma_s, gamma, gamma_note = _gamma_c_profile(wout)
+    timing["gamma_c"] = time.perf_counter() - start
+
+    surfaces = {}
+    if eps is not None:
+        surfaces["epsilon_effective"] = eps_s
+    if gamma is not None:
+        surfaces["gamma_c"] = gamma_s
+    summary = ConfinementSummary(
+        surfaces=surfaces,
+        epsilon_effective=eps,
+        gamma_c=gamma,
+        validity={
+            "epsilon_effective": eps is not None, "gamma_c": gamma is not None},
+        notes={"epsilon_effective": eps_note, "gamma_c": gamma_note},
+        timing=timing,
+    )
+    if key is not None:
+        _confinement_cache_put(key, wout, summary)
+    return summary
+
+
+def _confinement_panel(ax, conf: ConfinementSummary):
+    """Overlay the confinement profiles on the pressure panel's right axis.
+
+    Returns the twin axis and its lines.  ``eps_eff^{3/2}`` and ``Gamma_c``
+    share one dimensionless right axis with distinct markers/linestyles; log
+    scale only when every plotted value is positive and the combined dynamic
+    range justifies it.  Unavailable diagnostics keep their reason in
+    ``conf.notes`` — the panel draws only what is valid.
+    """
+    axis = ax.twinx()
+    lines = []
+    curves = (
+        ("epsilon_effective", conf.epsilon_effective,
+         r"$\epsilon_{\mathrm{eff}}^{3/2}$", "o--", _LINE_COLORS[0]),
+        ("gamma_c", conf.gamma_c, r"$\Gamma_c$", "s-", _LINE_COLORS[3]),
+    )
+    values: list[np.ndarray] = []
+    for name, profile, label, style, color in curves:
+        if conf.validity[name]:
+            lines.append(axis.plot(
+                conf.surfaces[name], profile, style, color=color,
+                markersize=4.0, label=label)[0])
+            values.append(profile)
+    if lines:
+        stacked = np.concatenate(values)
+        if np.all(stacked > 0.0) and (
+                float(stacked.max()) > 100.0 * float(stacked.min())):
+            axis.set_yscale("log")
+        axis.set_ylabel(
+            r"$\epsilon_{\mathrm{eff}}^{3/2}$, $\Gamma_c$",
+            color=_LINE_COLORS[0])
+        axis.tick_params(axis="y", colors=_LINE_COLORS[0])
+    else:
+        axis.set_yticks([])
+        axis.text(
+            0.5, 0.5, "confinement diagnostics unavailable",
+            ha="center", va="center", transform=axis.transAxes, fontsize=11)
+    return axis, lines
 
 
 def _boozer_surface_modB(booz: dict[str, Any], k: int, theta: np.ndarray, zeta: np.ndarray) -> np.ndarray:
@@ -1086,20 +1318,23 @@ def _summary_figure(
                 projection = "3d" if (row, column) == (1, 1) else None
                 axes[row, column] = fig.add_subplot(grid[row, column], projection=projection)
 
-        # 1. rotational transform -- full mesh only.
+        # The one Boozer transform behind the J map, the |B| panels, and the
+        # effective ripple of the confinement panel — run once, up front.
+        booz_note = ""
+        try:
+            booz = _boozer_summary_data(wout)
+        except Exception as exc:  # noqa: BLE001 - summary stays usable without booz
+            booz = None
+            booz_note = f"Boozer transform unavailable:\n{type(exc).__name__}"
+
+        # 1. rotational transform and parallel current share radius.
         _profile_panel(
             axes[0, 0], s, np.asarray(wout.iotaf, dtype=float),
-            xlabel=_S_LABEL, ylabel=r"$\iota$", title="rotational transform (full mesh)",
+            xlabel=_S_LABEL, ylabel=r"$\iota$",
+            title="rotational transform and parallel current",
         )
-
-        # Pressure and parallel current share radius but retain their units.
-        _profile_panel(
-            axes[0, 1], s, 1.0e-3 * np.asarray(wout.presf, dtype=float),
-            xlabel=_S_LABEL, ylabel=r"$p$ [kPa]", title="pressure and parallel current",
-            color=_LINE_COLORS[1],
-        )
-        axes[0, 1].lines[0].set_label(r"$p$")
-        current_axis = axes[0, 1].twinx(); meta["current_axis"] = current_axis
+        axes[0, 0].lines[0].set_label(r"$\iota$")
+        current_axis = axes[0, 0].twinx(); meta["current_axis"] = current_axis
         current_line = current_axis.plot(
             s, 1.0e-3 * np.asarray(wout.jdotb, dtype=float), "-",
             color=_LINE_COLORS[2], label=r"$\langle\mathbf{J}\cdot\mathbf{B}\rangle$",
@@ -1109,9 +1344,27 @@ def _summary_figure(
             color=_LINE_COLORS[2],
         )
         current_axis.tick_params(axis="y", colors=_LINE_COLORS[2])
+        axes[0, 0].legend(
+            [axes[0, 0].lines[0], current_line],
+            [axes[0, 0].lines[0].get_label(), current_line.get_label()],
+            loc="best", fontsize=11,
+        )
+
+        # 2. pressure (left) with the confinement diagnostics eps_eff^{3/2}
+        # and Gamma_c sharing the dimensionless right axis.
+        _profile_panel(
+            axes[0, 1], s, 1.0e-3 * np.asarray(wout.presf, dtype=float),
+            xlabel=_S_LABEL, ylabel=r"$p$ [kPa]", title="pressure and confinement",
+            color=_LINE_COLORS[1],
+        )
+        axes[0, 1].lines[0].set_label(r"$p$")
+        conf = confinement_summary(wout, booz, booz_note=booz_note)
+        meta["confinement"] = conf
+        confinement_axis, conf_lines = _confinement_panel(axes[0, 1], conf)
+        meta["confinement_axis"] = confinement_axis
+        legend_lines = [axes[0, 1].lines[0], *conf_lines]
         axes[0, 1].legend(
-            [axes[0, 1].lines[0], current_line],
-            [axes[0, 1].lines[0].get_label(), current_line.get_label()],
+            legend_lines, [line.get_label() for line in legend_lines],
             loc="best", fontsize=11,
         )
 
@@ -1135,12 +1388,6 @@ def _summary_figure(
         )
 
         # 2 + 4. Boozer-based panels: J(alpha, s) map and |B| contours.
-        booz_note = ""
-        try:
-            booz = _boozer_summary_data(wout)
-        except Exception as exc:  # noqa: BLE001 - summary stays usable without booz
-            booz = None
-            booz_note = f"Boozer transform unavailable:\n{type(exc).__name__}"
         if booz is not None:
             try:
                 j_info = _j_invariant_map(booz, pitch=j_pitch)


### PR DESCRIPTION
Plan section 12 (PR-sequence item 7): the summary figure gains the requested combined confinement profile, sharing work instead of duplicating it.

## Panel semantics (12.1, 12.4)

- The top-left panel becomes **rotational transform + `<J.B>`** (right axis), freeing the top-middle panel.
- The top-middle panel becomes **pressure and confinement**: pressure stays on the left axis; `eps_eff^(3/2)` (NEO_JAX at the bounded `diagnostic_neo_config` resolution) and `Gamma_c` share one dimensionless right axis with distinct markers/linestyles and a combined legend.
- Log scale only when every plotted value is positive and the combined dynamic range exceeds two decades.
- An unavailable diagnostic (missing NEO_JAX, `lasym` Boozer tables, failed evaluation, all-NaN `Gamma_c`) is dropped from the panel with its reason recorded in `ConfinementSummary.notes` — **never drawn as zero**; when neither is available the axis says so explicitly.

## Shared work (12.2, 12.3)

- The one Boozer transform the summary already runs (`_boozer_summary_data`) now also carries the NEO `BoozerData` tables, so the effective ripple consumes it directly via `epsilon_effective_from_boozer` — no second transform.
- `Gamma_c` keeps its validated real-space field-line route, which shares no Boozer mathematics: `vmex.core.gammac` gains a read-only **`gamma_c_from_wout`** built by splitting `_gamma_c_rows` into a context body shared between the live jitted path and a WOUT-table jitted path (the `turbulence._wout_ballooning_context` normalization). Measured wout-vs-live parity on the bundled cth deck: relative difference ≤ 2.8e-11, bit-for-bit surface rows.
- **`ConfinementSummary`** (surfaces, epsilon_effective, gamma_c, validity, notes, timing) is cached per in-memory WOUT — `id` plus a weak reference for liveness, bounded LRU of 4 — keyed by Boozer resolution, NEO configuration, and the `Gamma_c` sampling. Repeated summary generation is a pure cache hit and never recompiles (`_cache_size()` pinned in the tests).
- `epsilon_effective_from_wout(clear_jax_caches=...)` now defaults to the library-safe `False`; the CLI releases the plot-only executables itself after all requested figures (memory policy lives in the caller, not the diagnostic library).

## Tests (12.5)

Panel inventory/labels for the new layout; valid-only curves with distinct styles; never-zero plotting; unavailability notes for missing NEO_JAX / symmetric-only tables / failed `Gamma_c`; both-invalid annotation; log-scale policy; cache hit under 0.5 s with identical values on recompute and a stable jit cache; bounded + weakly-keyed cache eviction; wout-vs-live `Gamma_c` parity; figure-closing hygiene; library-safe `clear_jax_caches` default.

Measured on the bundled cth deck: first summary figure 10.6 s (3.5 s of it the cold `Gamma_c` executable), repeated render 1.1 s with the confinement bundle served from cache.
