### PR TITLE
LASYM performance kernels: reverse-op reflections for symforce and alias

### DIFF
--- a/benchmarks/baselines/m4/F11_cache_reload.json
+++ b/benchmarks/baselines/m4/F11_cache_reload.json
@@ -1,26 +1,26 @@
 {
  "cache": {
-  "directory": "/private/tmp/claude-501/-Users-rogeriojorge-local/ba88a505-702b-41c6-a36d-3c58b0f50b6b/scratchpad/phase2wt/benchmarks/.profile_cache",
-  "entries_after": 23,
-  "entries_before": 23
+  "directory": "/private/tmp/claude-501/-Users-rogeriojorge-local/ba88a505-702b-41c6-a36d-3c58b0f50b6b/scratchpad/lasym-slice/m4-final-cache",
+  "entries_after": 31,
+  "entries_before": 31
  },
  "case_sha256": "9d1e58f23aea74f5ea8a29f0b75bb9c42f426dbb29e662943e6ac8a053a9950c",
- "commit": "8e6fdff4c79a8c500057482a3444bb52ad84cbaf",
+ "commit": "9f77fdbd5b4d083c3f7b402449a910c78e4030a3",
  "compile": {
   "lasym_gradient": {
    "cache_miss_reasons": [],
-   "compiles": 206,
-   "traces": 355
+   "compiles": 198,
+   "traces": 298
   },
   "lasym_value": {
    "cache_miss_reasons": [],
-   "compiles": 172,
-   "traces": 367
+   "compiles": 148,
+   "traces": 343
   },
   "symmetric_gradient": {
    "cache_miss_reasons": [],
-   "compiles": 393,
-   "traces": 678
+   "compiles": 386,
+   "traces": 646
   },
   "symmetric_value": {
    "cache_miss_reasons": [],
@@ -36,7 +36,7 @@
   "x64": true
  },
  "memory_bytes": {
-  "peak_host_rss": 4078436352
+  "peak_host_rss": 3997974528
  },
  "platform": {
   "machine": "arm64",
@@ -47,14 +47,14 @@
  "repo": "uwplasma/vmex",
  "schema": 1,
  "timing_s": {
-  "build": 0.1579514589975588,
-  "lasym_gradient": 17.4946502080129,
-  "lasym_value": 10.704148999997415,
-  "process_wall": 62.285252583009424,
-  "symmetric_gradient": 17.712726208992535,
-  "symmetric_value": 12.50561066600494
+  "build": 0.1852636249968782,
+  "lasym_gradient": 9.85478883300675,
+  "lasym_value": 10.086765290994663,
+  "process_wall": 48.845047915994655,
+  "symmetric_gradient": 11.907758457993623,
+  "symmetric_value": 13.836537708004471
  },
  "title": "symmetric versus LASYM value and gradient",
- "utc": "2026-08-30T17:51:14Z",
+ "utc": "2026-08-31T04:00:47Z",
  "workflow": "F11"
 }

--- a/benchmarks/baselines/m4/F11_cold.json
+++ b/benchmarks/baselines/m4/F11_cold.json
@@ -1,26 +1,26 @@
 {
  "cache": {
-  "directory": "/private/tmp/claude-501/-Users-rogeriojorge-local/ba88a505-702b-41c6-a36d-3c58b0f50b6b/scratchpad/phase2wt/benchmarks/.profile_cache",
-  "entries_after": 23,
+  "directory": "/private/tmp/claude-501/-Users-rogeriojorge-local/ba88a505-702b-41c6-a36d-3c58b0f50b6b/scratchpad/lasym-slice/m4-final-cache",
+  "entries_after": 31,
   "entries_before": 0
  },
  "case_sha256": "9d1e58f23aea74f5ea8a29f0b75bb9c42f426dbb29e662943e6ac8a053a9950c",
- "commit": "8e6fdff4c79a8c500057482a3444bb52ad84cbaf",
+ "commit": "9f77fdbd5b4d083c3f7b402449a910c78e4030a3",
  "compile": {
   "lasym_gradient": {
    "cache_miss_reasons": [],
-   "compiles": 206,
-   "traces": 355
+   "compiles": 198,
+   "traces": 298
   },
   "lasym_value": {
    "cache_miss_reasons": [],
-   "compiles": 172,
-   "traces": 367
+   "compiles": 148,
+   "traces": 343
   },
   "symmetric_gradient": {
    "cache_miss_reasons": [],
-   "compiles": 393,
-   "traces": 678
+   "compiles": 386,
+   "traces": 646
   },
   "symmetric_value": {
    "cache_miss_reasons": [],
@@ -36,7 +36,7 @@
   "x64": true
  },
  "memory_bytes": {
-  "peak_host_rss": 3638214656
+  "peak_host_rss": 2658418688
  },
  "platform": {
   "machine": "arm64",
@@ -47,14 +47,14 @@
  "repo": "uwplasma/vmex",
  "schema": 1,
  "timing_s": {
-  "build": 0.15069958299864084,
-  "lasym_gradient": 23.65132829200593,
-  "lasym_value": 15.220247457997175,
-  "process_wall": 79.85516387497773,
-  "symmetric_gradient": 22.02733591699507,
-  "symmetric_value": 15.221192042023176
+  "build": 0.11771820799913257,
+  "lasym_gradient": 17.543912624998484,
+  "lasym_value": 16.73148499999661,
+  "process_wall": 70.88455824999255,
+  "symmetric_gradient": 18.008602084009908,
+  "symmetric_value": 15.642576416023076
  },
  "title": "symmetric versus LASYM value and gradient",
- "utc": "2026-08-30T17:50:11Z",
+ "utc": "2026-08-31T03:59:59Z",
  "workflow": "F11"
 }

--- a/benchmarks/baselines/m4/F11_warm.json
+++ b/benchmarks/baselines/m4/F11_warm.json
@@ -1,31 +1,31 @@
 {
  "case_sha256": "9d1e58f23aea74f5ea8a29f0b75bb9c42f426dbb29e662943e6ac8a053a9950c",
- "commit": "8e6fdff4c79a8c500057482a3444bb52ad84cbaf",
+ "commit": "9f77fdbd5b4d083c3f7b402449a910c78e4030a3",
  "compile": {
   "lasym_gradient": {
    "cache_miss_reasons": [],
-   "compiles": 208,
-   "traces": 357
+   "compiles": 198,
+   "traces": 298
   },
   "lasym_value": {
    "cache_miss_reasons": [],
-   "compiles": 140,
-   "traces": 337
+   "compiles": 148,
+   "traces": 343
   },
   "symmetric_gradient": {
    "cache_miss_reasons": [],
-   "compiles": 246,
-   "traces": 645
+   "compiles": 386,
+   "traces": 646
   },
   "symmetric_value": {
    "cache_miss_reasons": [],
-   "compiles": 175,
-   "traces": 583
+   "compiles": 391,
+   "traces": 856
   },
   "warm": {
    "cache_miss_reasons": [],
-   "compiles": 24,
-   "traces": 99
+   "compiles": 3,
+   "traces": 3
   }
  },
  "dirty": false,
@@ -36,7 +36,7 @@
   "x64": true
  },
  "memory_bytes": {
-  "peak_host_rss": 16936681472
+  "peak_host_rss": 3405611008
  },
  "platform": {
   "machine": "arm64",
@@ -47,14 +47,14 @@
  "repo": "uwplasma/vmex",
  "schema": 1,
  "timing_s": {
-  "build": 0.003015541995409876,
-  "lasym_gradient": 34.38386775000254,
-  "lasym_value": 19.69494458398549,
-  "symmetric_gradient": 31.43966495798668,
-  "symmetric_value": 18.779236792004667,
-  "warm": 9.955269124999177
+  "build": 0.12683358299545944,
+  "lasym_gradient": 16.48325337501592,
+  "lasym_value": 17.821474790980574,
+  "symmetric_gradient": 16.530856249999488,
+  "symmetric_value": 16.417991791997338,
+  "warm": 0.043705624993890524
  },
  "title": "symmetric versus LASYM value and gradient",
- "utc": "2026-08-30T17:53:32Z",
+ "utc": "2026-08-31T04:01:58Z",
  "workflow": "F11"
 }

--- a/tests/test_forces_residuals.py
+++ b/tests/test_forces_residuals.py
@@ -214,3 +214,87 @@ def test_grad_of_fsqr_wrt_R_cos(case):
     assert grad_np.shape == np.asarray(case.state.R_cos).shape
     assert np.all(np.isfinite(grad_np))
     assert np.any(grad_np != 0.0)
+
+
+# ---------------------------------------------------------------------------
+# alias.f lasym path: reverse-op reflections == the index-map reference
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [(5, 0, 16, 1, 1), (6, 3, 18, 12, 3), (4, 2, 7, 5, 2)],
+    ids=["axisym", "nfp3", "odd-ntheta"],
+)
+def test_alias_lasym_gcon_matches_index_map_reference(shape):
+    """``alias_constraint_force(lasym=True)`` is BIT-identical to a reference
+    built with the explicit ``alias_par`` reflection index maps.
+
+    The production path now builds both reflections (``ztemp`` and the
+    second-half ``gcon`` fill) from slice/reverse/concatenate; this pins the
+    data movement to the index-map definition on random data.
+    """
+    from vmex.core.forces import alias_constraint_force, faccon
+    from vmex.core.fourier import Resolution, trig_tables
+
+    mpol, ntor, ntheta, nzeta, nfp = shape
+    res = Resolution(
+        mpol=mpol, ntor=ntor, ntheta=ntheta, nzeta=nzeta, nfp=nfp,
+        lasym=True, ns=7,
+    )
+    trig = trig_tables(res)
+    rng = np.random.default_rng(ntheta)
+    ztemp = jnp.asarray(rng.standard_normal((7, res.ntheta3, nzeta)))
+    tcon = jnp.asarray(rng.standard_normal((7,)) ** 2 + 0.1)
+    signgs = -1
+    got = np.asarray(alias_constraint_force(
+        ztemp, trig=trig, mpol=mpol, ntor=ntor, signgs=signgs,
+        tcon=tcon, lasym=True,
+    ))
+
+    from jax import lax
+
+    def ein(spec, *ops):
+        return np.asarray(jnp.einsum(
+            spec, *(jnp.asarray(o) for o in ops),
+            precision=lax.Precision.HIGHEST))
+
+    n_theta1, n_theta2 = res.ntheta1, res.ntheta2
+    i = np.arange(n_theta2)
+    i_reflected = np.where(i == 0, 0, n_theta1 - i)
+    k_reflected = (nzeta - np.arange(nzeta)) % nzeta
+    z = np.asarray(ztemp)
+    z_half = z[:, :n_theta2]
+    z_reflected = z[:, i_reflected, :][:, :, k_reflected]
+
+    fac = np.asarray(faccon(mpol, signgs))
+    cosmui = np.asarray(trig.cosmui[:n_theta2, :mpol])
+    sinmui = np.asarray(trig.sinmui[:n_theta2, :mpol])
+    cosmu_fac = np.asarray(trig.cosmu[:n_theta2, :mpol]) * fac[None, :]
+    sinmu_fac = np.asarray(trig.sinmu[:n_theta2, :mpol]) * fac[None, :]
+    cosnv = np.asarray(trig.cosnv[:, :ntor + 1])
+    sinnv = np.asarray(trig.sinnv[:, :ntor + 1])
+
+    w_cos = ein("sik,im->smk", z_half, cosmui)
+    w_sin = ein("sik,im->smk", z_half, sinmui)
+    w_cos_r = ein("sik,im->smk", z_reflected, cosmui)
+    w_sin_r = ein("sik,im->smk", z_reflected, sinmui)
+    half = 0.5 * np.asarray(tcon)[:, None, None]
+    gcs = half * ein("smk,kn->smn", w_cos - w_cos_r, sinnv)
+    gsc = half * ein("smk,kn->smn", w_sin - w_sin_r, cosnv)
+    gss = half * ein("smk,kn->smn", w_sin + w_sin_r, sinnv)
+    gcc = half * ein("smk,kn->smn", w_cos + w_cos_r, cosnv)
+    gcon_sym = (ein("smk,im->sik", ein("smn,kn->smk", gcs, sinnv), cosmu_fac)
+                + ein("smk,im->sik", ein("smn,kn->smk", gsc, cosnv), sinmu_fac))
+    gcon_asym = (ein("smk,im->sik", ein("smn,kn->smk", gcc, cosnv), cosmu_fac)
+                 + ein("smk,im->sik", ein("smn,kn->smk", gss, sinnv), sinmu_fac))
+
+    expected = np.zeros_like(z)
+    expected[:, :n_theta2] = gcon_sym + gcon_asym
+    i2 = np.arange(n_theta2, n_theta1)
+    i2_reflected = n_theta1 - i2
+    expected[:, n_theta2:] = (
+        -gcon_sym[:, i2_reflected][:, :, k_reflected]
+        + gcon_asym[:, i2_reflected][:, :, k_reflected]
+    )
+    np.testing.assert_array_equal(got, expected)

--- a/tests/test_fourier_transforms.py
+++ b/tests/test_fourier_transforms.py
@@ -321,3 +321,58 @@ def test_symforce_split_recovers_pure_parities():
         np.asarray(sym)[:, :n_theta2], field_odd[:, :n_theta2], rtol=RTOL, atol=1e-12
     )
     np.testing.assert_allclose(np.asarray(asym), 0.0, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [(5, 0, 16, 1, 1), (5, 2, 20, 18, 2), (4, 2, 7, 5, 2)],
+    ids=["axisym", "nfp2", "odd-ntheta"],
+)
+@pytest.mark.parametrize("reflect_even", [True, False], ids=["even", "odd"])
+def test_symforce_split_reflection_is_bitwise_exact(shape, reflect_even):
+    """The reverse-op reflection equals the index-map definition, bit for bit.
+
+    ``symforce_split`` builds ``a[(ntheta1 - i) % ntheta1, (nzeta - k) %
+    nzeta]`` from slice/reverse/concatenate (the gather it replaces lowered
+    to a scatter in the pullback that dominated the LASYM adjoint).  This
+    pins the data movement to the explicit index map on arbitrary data,
+    including the theta=0 / zeta=0 fixed points and an odd requested ntheta.
+    """
+    mpol, ntor, ntheta, nzeta, nfp = shape
+    res = Resolution(
+        mpol=mpol, ntor=ntor, ntheta=ntheta, nzeta=nzeta, nfp=nfp,
+        lasym=True, ns=NS,
+    )
+    trig = trig_tables(res)
+    rng = np.random.default_rng(ntheta)
+    a = rng.standard_normal((NS, res.ntheta3, nzeta))
+    n_theta1, n_theta2 = res.ntheta1, res.ntheta2
+    i = np.arange(n_theta2)
+    i_reflected = np.where(i == 0, 0, n_theta1 - i)
+    k_reflected = (nzeta - np.arange(nzeta)) % nzeta
+    a_reflected = a[:, i_reflected, :][:, :, k_reflected]
+    sign = 1.0 if reflect_even else -1.0
+    expected_sym = np.concatenate(
+        [0.5 * (a[:, :n_theta2] + sign * a_reflected), a[:, n_theta2:]], axis=1
+    )
+    expected_asym = np.concatenate(
+        [0.5 * (a[:, :n_theta2] - sign * a_reflected),
+         np.zeros_like(a[:, n_theta2:])], axis=1
+    )
+    sym, asym = symforce_split(
+        jnp.asarray(a), trig=trig, reflect_even=reflect_even
+    )
+    np.testing.assert_array_equal(np.asarray(sym), expected_sym)
+    np.testing.assert_array_equal(np.asarray(asym), expected_asym)
+
+
+def test_symforce_split_rejects_reduced_theta_grid():
+    """The reflection needs the full [0, 2*pi) grid; a reduced symmetric grid
+    (ntheta3 == ntheta2) has no second half-interval to reflect from."""
+    res = Resolution(
+        mpol=4, ntor=1, ntheta=16, nzeta=4, nfp=1, lasym=False, ns=NS
+    )
+    trig = trig_tables(res)
+    field = jnp.zeros((NS, res.ntheta3, 4))
+    with pytest.raises(ValueError, match="full lasym theta grid"):
+        symforce_split(field, trig=trig)

--- a/vmex/core/forces.py
+++ b/vmex/core/forces.py
@@ -60,6 +60,8 @@ from .geometry import HalfMeshJacobian, RealSpaceGeometry, sqrt_s_half_mesh
 from .transforms import (
     SpectralForce,
     _fourier_to_real_fft,
+    _reflect_stellarator,
+    _reflect_zeta,
     fourier_to_real,
     register_pytree_dataclass as _register,
     symforce_split,
@@ -555,10 +557,7 @@ def alias_constraint_force(
     n_theta1 = int(trig.ntheta1)
     if ntheta3 != n_theta1:
         raise ValueError("lasym=True requires ntheta3 == ntheta1")
-    i = np.arange(n_theta2, dtype=int)
-    i_reflected = np.where(i == 0, 0, n_theta1 - i)
-    k_reflected = (nzeta - np.arange(nzeta, dtype=int)) % nzeta
-    z_reflected = ztemp[:, i_reflected, :][:, :, k_reflected]
+    z_reflected = _reflect_stellarator(ztemp, n_theta2)
 
     w_cos_r = _einsum("sik,im->smk", z_reflected, cosmui)
     w_sin_r = _einsum("sik,im->smk", z_reflected, sinmui)
@@ -577,16 +576,17 @@ def alias_constraint_force(
     gcon_sym_half = _einsum("smk,im->sik", work_cs, cosmu_fac) + _einsum("smk,im->sik", work_sc, sinmu_fac)
     gcon_asym_half = _einsum("smk,im->sik", work_cc, cosmu_fac) + _einsum("smk,im->sik", work_ss, sinmu_fac)
 
-    gcon = jnp.zeros((ns, ntheta3, nzeta), dtype=ztemp.dtype)
-    gcon = gcon.at[:, :n_theta2, :].set(gcon_sym_half + gcon_asym_half)
-    n_second = n_theta1 - n_theta2
-    if n_second > 0:
-        i2 = np.arange(n_theta2, n_theta1, dtype=int)
-        i2_reflected = (n_theta1 - i2).astype(int)
-        gcon_sym_ref = gcon_sym_half[:, i2_reflected, :][:, :, k_reflected]
-        gcon_asym_ref = gcon_asym_half[:, i2_reflected, :][:, :, k_reflected]
-        gcon = gcon.at[:, n_theta2:, :].set(-gcon_sym_ref + gcon_asym_ref)
-    return gcon
+    front = gcon_sym_half + gcon_asym_half
+    # Second half-interval: gcon(2*pi - theta, -zeta) = -gcon_s + gcon_a.
+    # Rows i2 in [ntheta2, ntheta1) reflect to ntheta1 - i2 = the reversed
+    # rows [1, ntheta2 - 1) — reverse ops again instead of a gather.
+    gcon_sym_ref = _reflect_zeta(
+        jnp.flip(gcon_sym_half[:, 1:n_theta2 - 1, :], axis=1)
+    )
+    gcon_asym_ref = _reflect_zeta(
+        jnp.flip(gcon_asym_half[:, 1:n_theta2 - 1, :], axis=1)
+    )
+    return jnp.concatenate([front, -gcon_sym_ref + gcon_asym_ref], axis=1)
 
 
 def _internal_odd_channel(

--- a/vmex/core/transforms.py
+++ b/vmex/core/transforms.py
@@ -962,6 +962,30 @@ def tomnspa(
 # ---------------------------------------------------------------------------
 
 
+def _reflect_zeta(a: Array) -> Array:
+    """Map the last axis ``k -> (nzeta - k) % nzeta`` with reverse ops."""
+    return jnp.concatenate([a[..., :1], jnp.flip(a[..., 1:], axis=-1)], axis=-1)
+
+
+def _reflect_stellarator(a: Array, n_theta2: int) -> Array:
+    """Rows ``[0, n_theta2)`` of the full-grid ``a`` under ``(theta, zeta) ->
+    (2*pi - theta, -zeta)``: ``a[(ntheta1 - i) % ntheta1, (nzeta - k) % nzeta]``
+    with theta on the second-to-last axis.
+
+    The reflected theta rows are row 0 followed by the reversed tail rows
+    ``[n_theta2 - 1, ntheta1)``; zeta likewise keeps column 0 and reverses
+    the rest.  Built from slice/reverse/concatenate — bit-identical to the
+    equivalent index gather, but XLA lowers reverses to fast copies while the
+    gather's transposed scatter dominated the LASYM adjoint (measured in
+    context: the symforce pullback cost 2x more than the entire projection
+    pullback at production 3D resolution before this change).
+    """
+    theta_reflected = jnp.concatenate(
+        [a[..., :1, :], jnp.flip(a[..., n_theta2 - 1:, :], axis=-2)], axis=-2
+    )
+    return _reflect_zeta(theta_reflected)
+
+
 def symforce_split(
     field: Array,
     *,
@@ -1001,14 +1025,13 @@ def symforce_split(
     if int(trig.ntheta3) != int(n_theta3):
         raise ValueError("symforce_split: theta size mismatch with trig tables")
 
-    # Reflection maps (0-based): theta_i -> theta_{ntheta1 - i} (fixed point at
-    # i = 0) and zeta_k -> zeta_{nzeta - k mod nzeta}.
-    i = np.arange(n_theta2)
-    i_reflected = np.where(i == 0, 0, n_theta1 - i)
-    k_reflected = (nzeta - np.arange(nzeta)) % nzeta
+    if int(n_theta3) != int(n_theta1):
+        raise ValueError("symforce_split expects the full lasym theta grid")
 
+    # Reflection (0-based): theta_i -> theta_{(ntheta1 - i) % ntheta1} and
+    # zeta_k -> zeta_{(nzeta - k) % nzeta}, via reverse/roll ops (no gather).
     a_half = a[:, :n_theta2, :]
-    a_reflected = a[:, i_reflected, :][:, :, k_reflected]
+    a_reflected = _reflect_stellarator(a, n_theta2)
 
     if reflect_even:
         sym_half = 0.5 * (a_half + a_reflected)


### PR DESCRIPTION
Plan section 14 (Phase 7), PR-sequence item 10: the LASYM performance-kernel slice. Profiled first — the Phase 2 harness's F11 workflow (symmetric vs LASYM value+gradient at matched physical/mode resolution on `examples/data/input.up_down_asymmetric_tokamak`), `jax_log_compiles`, jaxpr-equation counts, and direct warm benchmarks of the LASYM force kernels at production 3D sizes — then fixed exactly what the profile showed. The flagship asymmetric-optimization campaign and downstream audit (item 11) are deliberately NOT here.

## What the profile showed

The LASYM lane's avoidable cost concentrates in the stellarator-reflection **data movement**, not in the transforms' arithmetic. `symforce.f`'s twenty per-kernel splits and `alias.f`'s `ztemp`/second-half reflections each lowered to an XLA gather; a gather's transpose is a scatter, and XLA-CPU scatters are serial. In a controlled single-process A/B at `mpol=12, ntor=12, ns=101` the twenty splits' pullback alone cost **more than the entire `tomnsps`+`tomnspa` projection pullback** — paid on every implicit-adjoint Krylov application and every optimization-campaign JVP.

## The fix

The reflection `(theta, zeta) -> (2*pi - theta, -zeta)` restricted to the reduced interval is row 0 plus the reversed theta tail rows, and column 0 plus the reversed zeta remainder. A shared `transforms._reflect_stellarator`/`_reflect_zeta` helper now builds it from slice/reverse/concatenate; `symforce_split`, `alias_constraint_force`'s `ztemp` reflection, and its second-half `gcon` fill all use it (the `gcon` zeros+scatter assembly became a concatenate too). Reverses lower to fast copies and their transposes are reverses.

Every changed line is pure data movement: **bit-identical values**, certified below.

## Measured before/after (gather -> reverse-op, same process, same data, jitted warm best-of-7, through the production `symforce_split` on all twenty kernels)

| device | size | pullback before | pullback after | forward before | forward after |
|---|---|---|---|---|---|
| CPU (36-core) | mpol=8, ns=51, 22x18 | 3404 us | **2994 us** (-12%) | 870 us | 783 us |
| CPU (36-core) | mpol=12, ns=101, 32x28 | 6561 us | **3154 us** (-52%) | 1621 us | 2587 us |
| GPU (RTX A4000) | mpol=8, ns=51, 22x18 | 291 us | **145 us** (-50%) | 208 us | 178 us |
| GPU (RTX A4000) | mpol=12, ns=101, 32x28 | 496 us | **364 us** (-27%) | 214 us | 190 us |

The one regression — CPU forward at the largest size (+1 ms per funct3d pass, a few percent of such a pass) — buys a 3.4 ms/matvec pullback saving in the adjoint that F11's gradient stages measure.

F11 harness records on the M4 (this PR refreshes `benchmarks/baselines/m4/F11_{cold,cache_reload,warm}.json`, previously recorded at 8e6fdff before the #199/#203 recompile fixes reached main; a same-session `origin/main` run on the same machine is the like-for-like "before"): with every solve now bit-identical to main, the F11 stage wall-times differ only by ambient load and per-repeat compile noise — the bit-identical symmetric control itself swings +-25% under the multi-agent load on that box — so no per-stage wall-clock claim is made from them; they are the refreshed instrument, not the evidence. The kernel table above is the evidence.

## Prototyped, measured, and rejected (evidence discipline)

Two 14.2 "batched contraction" candidates were implemented and benchmarked first, and both LOSE at production sizes on CPU, so they are not in this PR:

- a **stacked 20-kernel symforce split** (single reflection gather with a per-kernel sign): pullback 37x worse at `ns=101` (the big stacked gather's scatter);
- a **fused dual-parity `tomnsps`+`tomnspa`** (one batched theta/zeta stage for both families, bit-identical outputs): pullback 3x worse than the two separate transforms (whose VJP XLA already handles well); a channel-concatenated 5D variant lost as well.

The projection lane is therefore untouched and the split keeps its per-kernel structure.

## Correctness certification

- **Bit-identical solves, both parities**: force-pass `gc`+residual digests AND full jitted-solve state digests match a pinned `origin/main` (d2d5a011) worktree byte-for-byte for `solovev`, `li383_low_res`, the F11 symmetric twin, **and the F11 LASYM deck itself** — the LASYM trajectory is unchanged to the last bit.
- `tests/test_parity_breadth.py -k up_down_asymmetric_tokamak` (VMEC2000 golden: wb, iotaf, boundary/mid-surface and asymmetric harmonics, iteration count within 25%) passes on a **fresh** solve at this commit.
- New tests pin `symforce_split`'s reflection and the alias-lasym `gcon` to their explicit index-map references bit for bit, including the theta=0/zeta=0 fixed points and an odd requested `ntheta`.
- `python tools/preflight.py`: PASS (ruff, mypy, docs prose, guard tests, affected tests under coverage, changed-line bar).

## Measured, attributed, and deliberately left for later slices

- **Adjoint warm repeats recompile (14.6 acceptance; shared by BOTH parities)**: every un-jitted `jax.grad` repeat of an F11 gradient stage recompiles the adjoint GCROT `jit(while)` — 5.4-6.5 s per repeat on the M4, i.e. most of the warm-gradient stage — because the host-eager backward bakes each call's fresh linearization residuals into the loop as XLA constants (`vmex/core/implicit.py`: `_solve_implicit_bwd_impl` -> `_adjoint_solve_gcrot` -> `solvax.gcrot`), plus an identity-keyed `jit(pure_callback)` recompile per `im.run` call. Not a LASYM-vs-symmetric gap; fixing it means restructuring the host-eager adjoint without losing its typed `AdjointSolveError` contract and device-pinning behavior — core/JIT-lane work, prerequisite for closing 14.6's "no recompile" acceptance in the flagship PR.
- 14.3 accuracy matrix (VMEC2000 WOUT tables across fixed/free vacuum/finite-beta, Mercier/bootstrap/Boozer/virtual-casing, hot-restart/multigrid, polished LASYM once #192 certifies it).
- 14.4 flagship asymmetric optimization campaign (sine-mode continuation, gauge-invariant asymmetry norm, multi-seed basin evidence).
- 14.5 downstream audit (NEO_JAX LASYM adapter decision, ESSOS asymmetric readers, explicit capability tables).
- Remaining 14.2 candidates the profile did **not** show hot: a full-circle transform plan, long-double/validation separation, VJP family chunking — plus the two batched-contraction candidates measured and rejected above, recorded so they are not re-attempted without new evidence.
