### PR TITLE
Make force-balance polishing strictly opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,90 +12,6 @@ VMEX is a JAX implementation of VMEC for stellarator and tokamak ideal-MHD equil
 
 ![VMEX equilibria and diagnostics](docs/_static/figures/readme_equilibrium_showcase.webp)
 
-## Force-balance polishing
-
-VMEC converges projected equations on a staggered radial mesh. A small
-`FSQR/FSQZ/FSQL` therefore does not guarantee a small continuum residual
-
-$$
-\mathbf F = \mathbf J \times \mathbf B - \nabla p , \qquad
-\epsilon_F = \frac{2 |\mathbf F|}{|\mathbf J \times \mathbf B| + |\nabla p| + F_{\mathrm{floor}}} .
-$$
-
-VMEX can polish a converged fixed-boundary state: it lifts the solution to
-axis-regular cubic B-splines, keeps the boundary and profiles fixed, and
-drives both physical force channels to zero on an overdetermined collocation
-grid with matrix-free SOLVAX Gauss–Newton steps. A result is accepted only if
-an independent volume L² force error stays below `1e-2`, radial refinement
-moves it by at most `1e-3`, and the signed Jacobian stays positive.
-
-The comparison below uses the same independent oracle for every code. Top
-row: the bundled finite-pressure shaped tokamak
-(`input.shaped_tokamak_pressure_polished`); VMEX is the polished result.
-Bottom row: the finite-beta two-field-period QA case, with DESC at
-`L=16, M=N=10`. Times are first runs from a fresh process with an empty JAX
-compilation cache - load, solve, and export included - with the VMEX rerun
-marked separately: the persistent cache is on by default, so a rerun of the
-3-D case takes `3.6 s` (first run `19.5 s`, versus `153 s` for DESC), and
-the polished tokamak reruns in `30 s` (first run `103 s`, dominated by
-one-time JIT compilation of the polishing step).
-
-![Finite-pressure tokamak and finite-beta stellarator force-balance comparisons](docs/_static/figures/readme_strong_force_comparison.webp)
-
-Enable polishing in a VMEC input without breaking VMEC2000:
-
-```fortran
-!@VMEX POLISH = AUTO
-&INDATA
-  ...
-/
-```
-
-VMEX reads the comment; VMEC2000 ignores it and performs its ordinary solve.
-Run the complete finite-beta stellarator example with either interface:
-
-```console
-vmex examples/data/input.finite_beta_stellarator_polished --plot
-python examples/force_balance_polishing.py
-```
-
-The Python flag overrides the input directive and works on both single-grid and
-multigrid solves:
-
-```python
-import vmex as vj
-
-result = vj.solve_file("input.my_case", polish="auto")  # honors !@VMEX lines
-print(result.polish_report.final_normalized_l2)
-
-inp = vj.VmecInput.from_file("input.my_case")           # physics only
-result = vj.solve_multigrid(inp, polish_force_balance=True)
-print(result.polish_report.initial_normalized_l2)
-print(result.polish_report.final_normalized_l2)
-
-# Continuous state for fields, Boozer, virtual casing, ESSOS, and derivatives.
-native = result.native_equilibrium
-# Sampled state used by the CLI's VMEC-compatible WOUT output.
-sampled = result.polished_state
-```
-
-`opt.solve_equilibrium(..., polish_force_balance=True)` exposes the same final
-step. Optimization examples leave it off during iteration and may enable it for
-the final saved equilibrium.
-
-The standard summary below is produced by the example before and after
-polishing. The independent continuum error drops from `1.361e-2` to `5.617e-3`;
-the fixed boundary and prescribed pressure/current profiles do not move. The
-summary's radial `equif` panel is the separate VMEC-grid diagnostic, so it need
-not decrease monotonically with the continuum objective.
-
-![Finite-beta stellarator summary before and after force-balance polishing](docs/_static/figures/readme_polish_summary.webp)
-
-The bundled benchmark artifact records all eight solver results, exact source
-revisions, DESC resolution, timing boundaries, and certificate refinements.
-The figure generator and raw data live in `benchmarks/`; the ordinary solve
-remains the default.
-
 ## Install
 
 ```console
@@ -132,6 +48,82 @@ vmex input.nearby --restart wout_circular_tokamak.nc
 ```
 
 VMEX uses the input file's `NS_ARRAY`, `FTOL_ARRAY`, and `NITER_ARRAY`. `verbose=True` prints the VMEC iteration table; typed errors distinguish invalid inputs, Jacobian failures, non-convergence, and numerical failures.
+
+## Optional force-balance polishing
+
+Polishing is disabled by default. Ordinary `solve`, `solve_multigrid`,
+`solve_file`, CLI, and optimization calls run the established VMEC solve only.
+Enable the additional step explicitly when a smaller continuum force residual
+is needed.
+
+VMEC converges projected equations on a staggered radial mesh, so small
+`FSQR/FSQZ/FSQL` values do not by themselves guarantee a small continuum
+residual
+
+$$
+\mathbf F = \mathbf J \times \mathbf B - \nabla p , \qquad
+\epsilon_F = \frac{2 |\mathbf F|}{|\mathbf J \times \mathbf B| + |\nabla p| + F_{\mathrm{floor}}} .
+$$
+
+The optional step lifts a converged fixed-boundary state to axis-regular cubic
+B-splines, holds the boundary and profiles fixed, and reduces both physical
+force channels on an overdetermined collocation grid with matrix-free SOLVAX
+Gauss–Newton steps. VMEX accepts the result only after independent force,
+radial-refinement, and positive-Jacobian checks.
+
+Enable it in a VMEC-compatible input deck:
+
+```fortran
+!@VMEX POLISH = AUTO
+&INDATA
+  ...
+/
+```
+
+VMEX reads the comment; VMEC2000 ignores it. The same opt-in is available in
+Python:
+
+```python
+import vmex as vj
+
+# Reads the !@VMEX directive; no directive means no polishing.
+result = vj.solve_file("input.my_case")
+
+# VmecInput contains physics only, so direct solves use an explicit flag.
+inp = vj.VmecInput.from_file("input.my_case")
+result = vj.solve_multigrid(inp, polish_force_balance="auto")
+print(result.polish_report.initial_normalized_l2)
+print(result.polish_report.final_normalized_l2)
+```
+
+`opt.solve_equilibrium(..., polish_force_balance=True)` exposes the same final
+step. Leave it at its `False` default during ordinary optimization and enable it
+only for a final equilibrium if desired. The focused example shows the full
+before/after workflow:
+
+```console
+vmex examples/data/input.finite_beta_stellarator_polished --plot
+python examples/force_balance_polishing.py
+```
+
+The comparison below applies the same independent force oracle to VMEX,
+VMEC2000, VMEC++, and DESC. The top row is the bundled finite-pressure shaped
+tokamak; the bottom row is a finite-beta, two-field-period QA stellarator.
+Timings include load, solve, and export from a fresh process. Persistent-cache
+VMEX reruns are marked separately.
+
+![Finite-pressure tokamak and finite-beta stellarator force-balance comparisons](docs/_static/figures/readme_strong_force_comparison.webp)
+
+The standard VMEX summary before and after polishing makes the change visible
+without requiring the example to be run. The independent continuum error falls
+from `1.361e-2` to `5.617e-3`; the boundary and prescribed profiles do not move.
+The radial `equif` panel is a separate VMEC-grid diagnostic and need not decrease
+monotonically with the continuum objective.
+
+![Finite-beta stellarator summary before and after force-balance polishing](docs/_static/figures/readme_polish_summary.webp)
+
+The raw comparison data, source revisions, resolutions, timing boundaries, and
+certificate refinements are recorded in `benchmarks/`.
 
 ## Magnetic field and derivatives
 

--- a/docs/reference/api/advanced.rst
+++ b/docs/reference/api/advanced.rst
@@ -40,7 +40,8 @@ Both :func:`vmex.solve` and :func:`vmex.solve_multigrid` accept
 ``polish_force_balance=False`` (unchanged behavior), ``True`` (required
 correction), or ``"auto"`` (skip an already-certified state). The shorter
 ``polish`` keyword remains an alias on the single-grid call. A standard VMEC
-deck enables the same path with comment directives that VMEC2000 ignores::
+solve never polishes unless the caller explicitly requests it. A standard
+VMEC deck enables the same path with comment directives that VMEC2000 ignores::
 
    !@VMEX POLISH = AUTO
    !@VMEX POLISH_TOL = 1.0E-8
@@ -59,7 +60,8 @@ Python keywords override the file::
    result = vmex.solve_file("input.case", polish="auto")
 
 Precedence is exactly ``CLI option > Python keyword > file directive >
-package default``; the CLI prints which layer a polish request came from.
+package default``; the package default is false, and the CLI prints which
+layer a polish request came from.
 ``polish_fail`` selects the failure behavior: ``"error"`` raises,
 ``"fallback"`` returns the unpolished state, ``"warn"`` does the same with a
 :class:`RuntimeWarning` — never a failure silently presented as polished. A successful result retains the ordinary ``state`` and exposes

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -90,7 +90,8 @@ Options
    * - ``--polish [MODE]`` / ``--no-polish``
      - Force-balance polishing after the finest fixed-boundary stage:
        ``auto``, ``true`` (the bare flag), or ``false``. Overrides the
-       ``!@VMEX POLISH`` input directive; the default follows the file.
+       ``!@VMEX POLISH`` input directive. With no flag or directive,
+       polishing is disabled.
        Precedence is ``CLI > Python keyword > file directive > default``.
    * - ``--polish-tol VALUE``
      - Override the polish force tolerance

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,9 +21,9 @@ All runnable examples live under this single `examples/` tree. Examples marked
     state; warm restarts converge in ~1 iteration and recompile nothing.
   - `finite_beta_scan.py` — ramp the pressure (hot-restarted) and read beta,
     the Shafranov shift (magnetic-axis motion), and Mercier `DMerc` stability.
-  - `force_balance_polishing.py` — enable the VMEC-safe polishing directive,
-    inspect the independent certificate, and save/plot the VMEC-grid state
-    before and after the high-order correction.
+  - `force_balance_polishing.py` — explicitly enable the optional,
+    VMEC-safe polishing directive, inspect its independent certificate, and
+    save/plot the VMEC-grid state before and after the high-order correction.
   - `parallel_ensemble_scan.py` — solve an ensemble of independent equilibria
     concurrently on CPU (`vmex.parallel.solve_ensemble`); prints the measured
     strong-scaling curve and checks the results are bit-identical to serial.

--- a/examples/force_balance_polishing.py
+++ b/examples/force_balance_polishing.py
@@ -19,8 +19,10 @@ INPUT_FILE = (
 OUT_DIR = Path("output_force_balance_polishing")
 
 # --------------------------- solve -----------------------------------------
+# solve_file reads the VMEX-only directive in the input deck. VmecInput itself
+# contains physics only, so solve_multigrid requires an explicit Python flag.
 inp = vj.VmecInput.from_file(INPUT_FILE)
-result = vj.solve_multigrid(inp, verbose=True)
+result = vj.solve_file(INPUT_FILE, write_wout=False, verbose=True)
 if result.polished_state is None or result.polish_report is None:
     raise RuntimeError("the input deck did not request force-balance polishing")
 

--- a/examples/optimization/QA_optimization.py
+++ b/examples/optimization/QA_optimization.py
@@ -33,7 +33,6 @@ ESS_ALPHA = 1.2  # smaller values let high Fourier modes move more
 MINIMUM_MPOL = 5
 VARY_MAJOR_RADIUS = False  # set True to optimize RBC(0,0) instead of fixing it
 SEED_PERTURBATION = 0.05
-POLISH_FORCE_BALANCE = False  # Set True to polish the final saved equilibrium.
 
 ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
 if ci_smoke:
@@ -130,8 +129,7 @@ final_input = replace(inp,
     niter_array=np.array([8000]))
 final_equilibrium = opt.solve_equilibrium(
     final_input, initial_state=equilibrium.solution,
-    verbose=not ci_smoke, raise_on_max_iterations=True,
-    polish_force_balance=POLISH_FORCE_BALANCE)
+    verbose=not ci_smoke, raise_on_max_iterations=True)
 final_total = report("final", final_equilibrium)["QS total"]
 print(f"\nQS total {final_total:.3e}")
 

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -214,6 +214,7 @@ def test_solve_equilibrium_forwards_verbose(monkeypatch, solovev_eq):
     assert captured["initial_state"] is solovev_eq.state
     assert captured["raise_on_max_iterations"] is True
     assert captured["verbose"] is True
+    assert captured["polish_force_balance"] is False
     assert solved.inp.ftol_array[-1] == 2.0e-11
     assert solved.inp.niter_array[-1] == 4321
     with pytest.raises(ValueError, match="cannot both"):

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -1373,6 +1373,7 @@ def test_public_solver_resolves_polish_keywords_only():
     inp = VmecInput.from_file(DATA / "input.solovev")
     assert solver._resolve_force_balance_polish(inp, None, None) is False
     assert solver._resolve_force_balance_polish(inp, True, None) is True
+    assert solver._resolve_force_balance_polish(inp, True, False) is True
     assert solver._resolve_force_balance_polish(inp, "auto", None) == "auto"
     with pytest.raises(ValueError, match="either polish or polish_force_balance"):
         solver._resolve_force_balance_polish(inp, False, True)

--- a/tests/test_run_options.py
+++ b/tests/test_run_options.py
@@ -169,6 +169,21 @@ def test_polish_config_mapping_and_explicit_config_priority():
     assert polish_config_from_options(options, base) is base
 
 
+def test_plain_run_options_do_not_import_polish_driver(monkeypatch):
+    """The default CLI path must not load the optional polishing stack."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name.endswith("polish_driver"):
+            raise AssertionError("plain run imported the polishing driver")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    assert polish_config_from_options(RunOptions()) is None
+
+
 # ---------------------------------------------------------------------------
 # solve_file
 # ---------------------------------------------------------------------------

--- a/tests/test_run_options.py
+++ b/tests/test_run_options.py
@@ -184,6 +184,22 @@ def test_plain_run_options_do_not_import_polish_driver(monkeypatch):
     assert polish_config_from_options(RunOptions()) is None
 
 
+def test_public_python_polish_defaults_are_explicitly_off():
+    import inspect
+
+    import vmex as vj
+    from vmex import optimize as opt
+
+    for function in (vj.solve, vj.solve_multigrid, opt.solve_equilibrium):
+        parameter = inspect.signature(function).parameters[
+            "polish_force_balance"
+        ]
+        assert parameter.default is False
+    # This file-oriented API alone needs a tri-state default: None means
+    # honor an explicit VMEX directive in the input deck.
+    assert inspect.signature(vj.solve_file).parameters["polish"].default is None
+
+
 # ---------------------------------------------------------------------------
 # solve_file
 # ---------------------------------------------------------------------------

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -258,7 +258,7 @@ def solve_multigrid(
     use_fft: bool | None = None,
     release_stage_cache: bool = False,
     prefetch_compile: bool = False,
-    polish_force_balance: bool | str | None = None,
+    polish_force_balance: bool | str = False,
     polish_config: Any = None,
 ) -> SolveResult:
     """Fixed-boundary multigrid solve over the ``NS_ARRAY`` ladder.
@@ -357,9 +357,10 @@ def solve_multigrid(
     ``ftol``, ``niter``) skip the prefetch because the previous rung's
     executable is reused directly.
 
-    ``polish_force_balance`` overrides the VMEX-only input directive. When
-    enabled, polishing runs once after the final radial stage; intermediate
-    stages remain the established VMEC continuation ladder.
+    ``polish_force_balance=False`` is the default and leaves the established
+    VMEC continuation solve unchanged. Set it to ``True`` or ``"auto"`` to
+    run polishing once after the final radial stage. Input-file directives
+    are handled by :func:`solve_file`, not by this physics-only API.
 
     Returns the final stage's :class:`~vmex.core.solver.SolveResult`.
     """

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -427,6 +427,7 @@ def solve_equilibrium(
     verbose: bool = False,
     forward_ftol: float | None = None,
     forward_max_iterations: int | None = None,
+    polish_force_balance: bool | str = False,
     **solve_kwargs,
 ) -> Equilibrium:
     """Converge ``inp`` with the core multigrid solver -> :class:`Equilibrium`.
@@ -439,6 +440,8 @@ def solve_equilibrium(
     :func:`vmex.core.multigrid.solve_multigrid`. ``forward_ftol`` and
     ``forward_max_iterations`` replace the input ladder's final tolerance and
     iteration cap, using the same names as the optimization problem API.
+    Force-balance polishing is strictly opt-in: the default
+    ``polish_force_balance=False`` returns the ordinary converged VMEC state.
     """
     if forward_ftol is not None and "ftol_array" in solve_kwargs:
         raise ValueError("forward_ftol and ftol_array cannot both be supplied")
@@ -449,7 +452,8 @@ def solve_equilibrium(
     inp = _with_forward_controls(inp, forward_ftol, forward_max_iterations)
     result = solve_multigrid(
         inp, verbose=verbose, initial_state=initial_state,
-        raise_on_max_iterations=raise_on_max_iterations, **solve_kwargs,
+        raise_on_max_iterations=raise_on_max_iterations,
+        polish_force_balance=polish_force_balance, **solve_kwargs,
     )
     state = (
         result.polished_state

--- a/vmex/core/run_options.py
+++ b/vmex/core/run_options.py
@@ -279,8 +279,6 @@ def polish_config_from_options(options: RunOptions, base: Any = None) -> Any:
     """
     if base is not None:
         return base
-    from .polish_driver import PolishConfig
-
     updates: dict[str, Any] = {}
     if options.polish_tol is not None:
         updates["tolerance"] = options.polish_tol
@@ -290,4 +288,6 @@ def polish_config_from_options(options: RunOptions, base: Any = None) -> Any:
         updates["fail_policy"] = "return_unpolished"
     if not updates:
         return None
+    from .polish_driver import PolishConfig
+
     return PolishConfig(**updates)

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -2129,9 +2129,12 @@ def _resolve_force_balance_polish(
     """
 
     del source
-    if polish is not None and polish_force_balance is not None:
+    # ``polish_force_balance`` is the canonical spelling and has a public
+    # False default. A non-False value supplied with the compatibility alias
+    # is therefore the only unambiguous double specification.
+    if polish is not None and polish_force_balance not in (None, False):
         raise ValueError("pass either polish or polish_force_balance, not both")
-    requested = polish_force_balance if polish_force_balance is not None else polish
+    requested = polish if polish is not None else polish_force_balance
     if requested is None:
         requested = False
     if requested is not False and requested is not True and requested != "auto":
@@ -2190,7 +2193,7 @@ def solve(
     use_fft: bool | None = None,
     jacobian_retries: int = 2,
     polish: bool | str | None = None,
-    polish_force_balance: bool | str | None = None,
+    polish_force_balance: bool | str = False,
     polish_config: Any = None,
 ) -> SolveResult:
     """Single-grid fixed-boundary solve (VMEC2000 ``eqsolve.f``).


### PR DESCRIPTION
## Summary

Make the optional force-balance polishing stage visibly and mechanically opt-in across the direct, multigrid, and optimization Python APIs, while preserving input-file and CLI precedence.

- expose `polish_force_balance=False` in `solve`, `solve_multigrid`, and `opt.solve_equilibrium` signatures
- keep `solve_file(polish=None)` and the CLI tri-state so an explicit `!@VMEX POLISH` directive can still be honored
- return before importing the polishing driver on the ordinary no-option CLI path
- fix the dedicated polishing example to use `solve_file`, which actually reads the VMEX-only directive
- remove polishing controls from the ordinary QA optimization example
- move the polishing material after the basic solve workflow and state the opt-in contract consistently in the README, API reference, CLI reference, and examples index

## Motivation

A normal VMEX solve should remain simple and should not pay for or imply the higher-order correction. Polishing is useful when a user explicitly needs the independently certified continuum-force reduction, but it has substantial one-time compilation and solve cost. The public signatures, documentation order, and examples should make that distinction unambiguous.

`VmecInput.from_file` intentionally contains physics only and strips execution directives. The old dedicated example parsed the deck with that method and then called `solve_multigrid`, so its `!@VMEX POLISH` request was lost and the example raised its own "did not request" error. It now calls `solve_file(..., write_wout=False)`, the API that owns directive parsing.

## Compatibility

- No polishing request: ordinary solver result is unchanged; the polishing driver is not imported while resolving default run options.
- `!@VMEX POLISH = AUTO`: still honored by `solve_file` and the CLI; VMEC2000 ignores the comment.
- Explicit Python request: `polish_force_balance=True` or `"auto"` still works.
- Single-grid compatibility alias: `polish=` remains supported.

## Validation

- `python -m ruff check .`
- `git diff --check`
- focused default/API tests: 4 passed
- polishing/run-options regression selection: 23 passed before the long numerical subset was stopped after six minutes
- `python -m sphinx -W -b html docs <private-path>`
- fresh-process inspection confirms `vmex.core.polish_driver` is absent from `sys.modules` after importing VMEX and resolving default `RunOptions`
