### PR TITLE
Add a safe differentiable state-quantity API

### DIFF
--- a/docs/reference/optimization.rst
+++ b/docs/reference/optimization.rst
@@ -75,6 +75,13 @@ The SciPy and JAX callables therefore return the same value and gradient.
 VMEX maintains one exact-key host cache to avoid repeated work when an
 optimizer requests the value and derivative separately.
 
+For a custom vector diagnostic, use
+:meth:`~vmex.core.problem.VmecProblem.jax_quantity_from_state`. It returns the
+floating-point quantity and the equilibrium status from one implicit solve;
+rejected trials return NaNs rather than a plausible value. Form only the
+contraction an algorithm needs with ``jax.vjp`` instead of materializing a
+full residual Jacobian.
+
 ``problem.dof_names`` is ordered exactly like ``problem.x0`` and every
 optimizer vector passed to the problem. For example,
 ``dict(zip(problem.dof_names, result.x))`` labels an optimized SciPy result.

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -193,6 +193,21 @@ def test_vmec_problem_state_objective_hides_failed_trial_branches():
     assert float(rejected_value) == 0.0
     np.testing.assert_array_equal(rejected_terms, [0.0, 0.0])
 
+    def quantity(problem, x):
+        return problem.jax_quantity_from_state(
+            x, lambda state, runtime: jnp.asarray([state[0], runtime[0]]))
+
+    value, status = quantity(accepted, jnp.asarray([2.0]))
+    np.testing.assert_allclose(value, [4.0, 3.0])
+    assert int(status) == 0
+    np.testing.assert_allclose(
+        jax.jacrev(lambda x: quantity(accepted, x)[0])(jnp.asarray([2.0])),
+        [[2.0], [1.0]],
+    )
+    value, status = quantity(rejected, jnp.asarray([2.0]))
+    assert np.isnan(value).all()
+    assert int(status) == 1
+
     with pytest.raises(ValueError, match="positive"):
         accepted.jax_objective_from_state(
             jnp.asarray([2.0]), lambda _state, _runtime: jnp.asarray([]),
@@ -220,6 +235,12 @@ def test_vmec_problem_state_objective_hides_failed_trial_branches():
         ordinary.jax_extra_costs_from_state(
             jnp.asarray([1.0]), lambda _state, _runtime: jnp.asarray([0.0]),
             n_extra_terms=1)
+    with pytest.raises(AttributeError, match="state quantities"):
+        ordinary.jax_quantity_from_state(
+            jnp.asarray([1.0]), lambda _state, _runtime: jnp.asarray([0.0]))
+    with pytest.raises(TypeError, match="floating-point"):
+        accepted.jax_quantity_from_state(
+            jnp.asarray([1.0]), lambda _state, _runtime: jnp.asarray([1]))
 
 
 def test_vmec_problem_field_facades_validate_and_route(monkeypatch):

--- a/vmex/core/problem.py
+++ b/vmex/core/problem.py
@@ -593,6 +593,31 @@ class VmecProblem(FunctionProblem):
             lambda _: (jnp.asarray(0.0), jnp.zeros(n_extra_terms)),
             operand=None)
 
+    def jax_quantity_from_state(
+        self,
+        x: Array,
+        quantity: Callable[[Array, Any], Array],
+    ) -> tuple[Array, Array]:
+        """Evaluate a differentiable floating-point quantity and solve status.
+
+        ``quantity(state, runtime)`` may return any fixed-shape JAX array.
+        Rejected equilibrium trials return an array of NaNs with that shape,
+        so an invalid state cannot look like a usable diagnostic. The scalar
+        status is zero only for an accepted equilibrium.
+        """
+        import jax.numpy as jnp
+
+        state_runtime_status = self.metadata.get("jax_state_runtime_status")
+        if state_runtime_status is None:
+            raise AttributeError(
+                "state quantities require an implicit VMEX problem")
+        state_runtime_status = cast(Callable[..., Any], state_runtime_status)
+        state, runtime, status = state_runtime_status(x)
+        value = jnp.asarray(quantity(state, runtime))
+        if not jnp.issubdtype(value.dtype, jnp.inexact):
+            raise TypeError("state quantities must have a floating-point dtype")
+        return jnp.where(status == 0, value, jnp.full_like(value, jnp.nan)), status
+
     def exterior_field(
         self,
         x: Array,


### PR DESCRIPTION
## Motivation

Optimization and coupled-physics callers sometimes need a vector quantity of the accepted implicit equilibrium, followed by one caller-chosen VJP. The existing scalar and additive-cost helpers do not expose that composition without reaching into VMEX metadata.

This extracts the state-quantity part of #213 as an independent API change.

## Design

- Add `VmecProblem.jax_quantity_from_state(x, quantity)`.
- Return the quantity and the solve status from the same implicit equilibrium evaluation.
- Return NaNs for rejected trials, so a placeholder state cannot be mistaken for a physical diagnostic.
- Require a floating-point result, which makes the rejection sentinel unambiguous.
- Document the intended `jax.vjp` use: contract only the quantity the algorithm needs instead of materializing a residual Jacobian.

## Verification

- Accepted value and exact Jacobian match the analytic toy map.
- Rejected trials return NaNs and preserve status.
- Ordinary non-implicit problems and non-floating quantities fail explicitly.
- `ruff check vmex tests`
- `mypy vmex`
- `pytest -q tests/test_problem.py`: 23 passed
- `sphinx -W -j auto -b html docs docs/_build/html`

This PR adds no benchmark scripts, data folders, or optimizer policy.
