### PR TITLE
Reuse guarded implicit refinement corrections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [changes, fast, physics, parity, device]
+    permissions:
+      contents: read
+      id-token: write
     if: >-
       always() &&
       needs.changes.outputs.run_coverage == 'true' &&
@@ -333,6 +336,12 @@ jobs:
           coverage combine coverage.device coverage.fast coverage.physics-* coverage.parity-*
           coverage report --include='*/vmex/mirror/*' --fail-under=90
           coverage xml
+      - name: Publish combined coverage
+        uses: codecov/codecov-action@v5.5.5
+        with:
+          fail_ci_if_error: true
+          files: coverage.xml
+          use_oidc: true
       - name: Enforce changed-line coverage
         if: github.event_name == 'pull_request'
         run: diff-cover coverage.xml --compare-branch="origin/${GITHUB_BASE_REF}" --fail-under=95

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://github.com/uwplasma/vmex/blob/main/pyproject.toml)
 [![License](https://img.shields.io/github/license/uwplasma/vmex)](https://github.com/uwplasma/vmex/blob/main/LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/uwplasma/vmex/ci.yml?branch=main&label=ci)](https://github.com/uwplasma/vmex/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/uwplasma/vmex/branch/main/graph/badge.svg)](https://codecov.io/gh/uwplasma/vmex)
 [![Docs](https://img.shields.io/readthedocs/vmex/latest?label=docs)](https://vmex.readthedocs.io/en/latest/)
 
 > **Rename note:** `vmec_jax` is now `vmex`; the deprecated `import vmec_jax` compatibility shim still ships with VMEX 0.5.

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
         threshold: 0.1%
     patch:
       default:
-        target: 90%
-        threshold: 1%
+        target: 95%
+        threshold: 0.1%
 
 comment: false

--- a/docs/explanation/adjoint-gradients.md
+++ b/docs/explanation/adjoint-gradients.md
@@ -84,6 +84,13 @@ gradient agrees with that reference to rel 5.4e-07 when they do, against
 4.2e-03 at the host stopping point and 5.7e-03 with the linearization alone
 refined.
 
+Nearby optimization trials reuse the previous Newton displacement as a guess.
+VMEX evaluates the new frozen residual before accepting that guess; if it does
+not reach `refine_tol`, VMEX discards it and replays the original refinement.
+This changes work, not the accepted numerical path. Public optimization
+factories expose the same `refine_tol`; keep 1e-10 for production gradients
+and use `numpy.inf` only for an explicit legacy comparison.
+
 ## The six SOLVAX solve classes
 
 Every linear solve in the gradient stack goes through SOLVAX. The complete

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -1202,6 +1202,46 @@ def test_lasym_3d_state_is_anchored_at_the_frozen_root(lasym_3d):
     assert r_anchored <= cfg.refine_tol
 
 
+def test_nearby_refinement_seed_is_guarded_and_conservative(monkeypatch):
+    """A reused Newton displacement must improve F or replay the old path."""
+    class Config:
+        refine_tol = 0.1
+
+    cfg = Config()
+    state = jnp.asarray([10.0])
+    params = jnp.asarray([0.0])
+    monkeypatch.setattr(im, "_dof_projector", lambda *_: lambda value: value)
+    monkeypatch.setattr(im, "residual_fn", lambda *_: lambda z, _params: z)
+    monkeypatch.setattr(im, "_REFINE_MAX_STEPS", 1)
+
+    calls = []
+
+    def incomplete_step(_operator, rhs, _config, **_kwargs):
+        calls.append(float(rhs[0]))
+        # Both paths improve, but neither reaches the requested tolerance.
+        delta = 1.0 if float(rhs[0]) < 7.0 else 2.0
+        return jnp.asarray([delta]), None
+
+    monkeypatch.setattr(im, "_adjoint_solve_gcrot", incomplete_step)
+    legacy = im._refined_state(cfg, params, state, state)
+    warm = im._refined_state(
+        cfg, params, state, state, initial_correction=jnp.asarray([-5.0]))
+    np.testing.assert_array_equal(legacy, [8.0])
+    np.testing.assert_array_equal(warm, legacy)
+    assert calls == [10.0, 5.0, 10.0]
+
+    calls.clear()
+    exact = im._refined_state(
+        cfg, params, state, state, initial_correction=jnp.asarray([-10.0]))
+    np.testing.assert_array_equal(exact, [0.0])
+    assert calls == []
+
+    worse = im._refined_state(
+        cfg, params, state, state, initial_correction=jnp.asarray([1.0]))
+    np.testing.assert_array_equal(worse, legacy)
+    assert calls == [10.0]
+
+
 @pytest.mark.full
 def test_lasym_3d_stability_gradients_vs_frozen_path_fd(lasym_3d):
     """LASYM Mercier/Glasser derivatives include the RBS/ZBC families."""

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1170,6 +1170,8 @@ def test_public_problem_factory_validation():
         opt.make_problem(inp, objective_terms=term, jacobian_batch_size=0)
     with pytest.raises(ValueError, match="max_fsq_ratio"):
         opt.make_problem(inp, objective_terms=term, max_fsq_ratio=0.0)
+    with pytest.raises(ValueError, match="refine_tol"):
+        opt.make_problem(inp, objective_terms=term, refine_tol=np.nan)
     with pytest.raises(ValueError, match="forward_ftol"):
         opt.make_problem(inp, objective_terms=term, forward_ftol=0.0)
     with pytest.raises(ValueError, match="forward_max_iterations"):

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -381,6 +381,9 @@ def make_config(
         max_iterations = int(np.asarray(inp.niter_array).ravel()[-1])
     if not np.isfinite(max_fsq_ratio) or max_fsq_ratio <= 0.0:
         raise ValueError("max_fsq_ratio must be finite and positive")
+    refine_tol = float(refine_tol)
+    if not refine_tol > 0.0:
+        raise ValueError("refine_tol must be positive or numpy.inf")
     return _canonical_config(ImplicitConfig(
         inp=inp, resolution=resolution, ftol=float(ftol),
         max_iterations=int(max_iterations), mode=str(mode),
@@ -391,7 +394,7 @@ def make_config(
         adjoint_restart=int(adjoint_restart),
         adjoint_maxiter=int(adjoint_maxiter),
         adjoint_gcrot_m=int(adjoint_gcrot_m), adjoint_gcrot_k=int(adjoint_gcrot_k),
-        refine_tol=float(refine_tol),
+        refine_tol=refine_tol,
         max_fsq_ratio=float(max_fsq_ratio),
         hot_restart=bool(hot_restart), device=device,
     ))
@@ -1282,6 +1285,12 @@ _LAST_STATUS_ERROR: weakref.WeakKeyDictionary[ImplicitConfig, Exception] = \
 _LAST_REFINED: weakref.WeakKeyDictionary[
     ImplicitConfig, tuple[bytes, SpectralState]] = weakref.WeakKeyDictionary()
 
+# Last accepted refinement displacement. At a nearby parameter point it is
+# only an initial guess: an exact residual check guards its use, and failure
+# to reach the requested tolerance replays the established path from scratch.
+_LAST_REFINEMENT_CORRECTION: weakref.WeakKeyDictionary[
+    ImplicitConfig, SpectralState] = weakref.WeakKeyDictionary()
+
 
 def _params_key(params: ImplicitParams) -> bytes:
     return b"".join(np.asarray(leaf, dtype=np.float64).tobytes()
@@ -1326,6 +1335,7 @@ def _host_solve(cfg: ImplicitConfig, params: ImplicitParams) -> SolveResult:
             break
         except VmecError:
             if k == len(attempts) - 1:
+                _LAST_REFINEMENT_CORRECTION.pop(cfg, None)
                 raise
     if cfg.hot_restart and bool(result.converged):
         _HOT_CACHE[cfg] = result.state
@@ -1362,14 +1372,26 @@ def _refine_fixed_point(cfg: ImplicitConfig, params: ImplicitParams,
     key = _params_key(params)
     hit = _LAST_REFINED.get(cfg)
     if hit is None or hit[0] != key:
-        hit = (key, _refined_state(cfg, params, state, dof_mask))
+        refined = _refined_state(
+            cfg, params, state, dof_mask,
+            initial_correction=_LAST_REFINEMENT_CORRECTION.get(cfg),
+        )
+        correction = jax.tree.map(jnp.subtract, refined, state)
+        correction_norm = float(_tree_norm(correction))
+        if np.isfinite(correction_norm) and correction_norm > 0.0:
+            _LAST_REFINEMENT_CORRECTION[cfg] = correction
+        else:
+            _LAST_REFINEMENT_CORRECTION.pop(cfg, None)
+        hit = (key, refined)
         _LAST_REFINED[cfg] = hit
     return hit[1]
 
 
 def _refined_state(cfg: ImplicitConfig, params: ImplicitParams,
                    state: SpectralState,
-                   dof_mask: SpectralState) -> SpectralState:
+                   dof_mask: SpectralState,
+                   *, initial_correction: SpectralState | None = None,
+                   ) -> SpectralState:
     """Newton-refine ``state`` onto the root of the frozen residual ``F``.
 
     The implicit function theorem defines the derivative of the equilibrium
@@ -1394,31 +1416,50 @@ def _refined_state(cfg: ImplicitConfig, params: ImplicitParams,
     P = _dof_projector(cfg, dof_mask)
     F = residual_fn(cfg, state, dof_mask)
     z0 = P(state)
-    z, fz = z0, F(z0, params)
+    fz = F(z0, params)
     base = float(_tree_norm(fz))
     if not np.isfinite(base) or base <= tol:
         return state
-    best_z, best = z0, base
-    for _ in range(_REFINE_MAX_STEPS):
-        _, jvp = jax.linearize(lambda t: F(t, params), z)
-        # Best-effort by contract: GCROT, not the plain restarted GMRES of
-        # _adjoint_solve, because a truncated cycle stagnates on exactly the
-        # small eigendirection this refinement exists to walk down.
-        delta, _ = _adjoint_solve_gcrot(
-            jvp, fz, cfg, rtol=_REFINE_FORCING, enforce=False,
-            max_restarts=_REFINE_MAX_RESTARTS)
-        z = jax.tree.map(lambda a, b: a - b, z, delta)
-        fz = F(z, params)
-        residual = float(_tree_norm(fz))
-        if not np.isfinite(residual):
-            break
-        # Newton is not monotone here (one deck rises 1.3e-07 -> 4.4e-07
-        # before falling to 3.9e-13), so iterate from the latest point but
-        # return the best one seen.
-        if residual < best:
-            best_z, best = z, residual
-        if best <= tol:
-            break
+    def refine_from(z, fz, residual):
+        best_z, best = z, residual
+        for _ in range(_REFINE_MAX_STEPS):
+            _, jvp = jax.linearize(lambda t: F(t, params), z)
+            # GCROT avoids the small-eigenvalue stagnation seen with ordinary
+            # restarted GMRES on this fixed-point solve.
+            delta, _ = _adjoint_solve_gcrot(
+                jvp, fz, cfg, rtol=_REFINE_FORCING, enforce=False,
+                max_restarts=_REFINE_MAX_RESTARTS)
+            z = jax.tree.map(lambda a, b: a - b, z, delta)
+            fz = F(z, params)
+            residual = float(_tree_norm(fz))
+            if not np.isfinite(residual):
+                break
+            # Newton need not be monotone: iterate from the latest point but
+            # retain the best state seen.
+            if residual < best:
+                best_z, best = z, residual
+            if best <= tol:
+                break
+        return best_z, best
+
+    if initial_correction is not None:
+        candidate = jax.tree.map(jnp.add, z0, P(initial_correction))
+        candidate_f = F(candidate, params)
+        candidate_residual = float(_tree_norm(candidate_f))
+        if np.isfinite(candidate_residual) and candidate_residual < base:
+            if candidate_residual <= tol:
+                correction = P(jax.tree.map(
+                    lambda a, b: a - b, candidate, z0))
+                return jax.tree.map(jnp.add, state, correction)
+            warm_z, warm = refine_from(candidate, candidate_f, candidate_residual)
+            if warm <= tol:
+                correction = P(jax.tree.map(
+                    lambda a, b: a - b, warm_z, z0))
+                return jax.tree.map(jnp.add, state, correction)
+
+    # A warm guess that misses the tolerance cannot alter numerical results:
+    # replay the original refinement from the host-solver state.
+    best_z, best = refine_from(z0, fz, base)
     if best >= base:
         return state
     correction = P(jax.tree.map(lambda a, b: a - b, best_z, z0))
@@ -1538,6 +1579,7 @@ def _host_solve_and_mask_status(cfg: ImplicitConfig, params_np) -> tuple:
         if error is not None:
             _HOST_ERROR.clear()
             _LAST_STATUS_ERROR[cfg] = error
+            _LAST_REFINEMENT_CORRECTION.pop(cfg, None)
             params = _device_pin(cfg, jax.tree.map(jnp.asarray, params_np))
             runtime = runtime_from_params(params, cfg)
             state = _initial_state(runtime.setup)
@@ -1555,6 +1597,7 @@ def _host_solve_and_mask_status(cfg: ImplicitConfig, params_np) -> tuple:
             _LAST_STATUS_ERROR[cfg] = RuntimeError(
                 "equilibrium solve completed without a certification memo"
             )
+            _LAST_REFINEMENT_CORRECTION.pop(cfg, None)
             return (
                 state, mask, np.int32(1), np.float64(np.inf), np.float64(np.inf)
             )
@@ -1562,6 +1605,8 @@ def _host_solve_and_mask_status(cfg: ImplicitConfig, params_np) -> tuple:
         fsq = float(result.fsqr) + float(result.fsqz) + float(result.fsql)
         ratio = fsq / cfg.ftol
         status = 0 if bool(result.converged) or ratio <= cfg.max_fsq_ratio else 2
+        if status != 0:
+            _LAST_REFINEMENT_CORRECTION.pop(cfg, None)
         return state, mask, np.int32(status), np.float64(fsq), np.float64(ratio)
 
 

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -1781,6 +1781,7 @@ def make_problem(
     jacobian_adjoint_maxiter: int = 10,
     adjoint_maxiter: int = 300,
     max_fsq_ratio: float = 1.0e6,
+    refine_tol: float = 1.0e-10,
     forward_ftol: float | None = None,
     forward_max_iterations: int | None = None,
     hot_restart: bool = True,
@@ -1849,6 +1850,10 @@ def make_problem(
 
     ``adjoint_tol`` is a relative Krylov tolerance with a certified true
     residual check; ``adjoint_maxiter`` is the restart budget.
+
+    ``refine_tol`` is the frozen fixed-point residual required before
+    implicit differentiation. The default preserves strict gradients;
+    ``numpy.inf`` explicitly disables refinement for legacy comparisons.
 
     ``restart_from`` seeds the first equilibrium from a previous WOUT,
     :class:`Equilibrium`, or solver result.  This is useful when a continuation
@@ -1938,6 +1943,7 @@ def make_problem(
             jacobian_adjoint_maxiter=jacobian_adjoint_maxiter,
             adjoint_maxiter=adjoint_maxiter,
             max_fsq_ratio=max_fsq_ratio,
+            refine_tol=refine_tol,
             warm_start=(warm_start if hot_restart else None),
             solve_kwargs=dict(solve_kwargs or {}),
             initial_state=initial_state,
@@ -1969,6 +1975,7 @@ def make_problem(
     problem.metadata["forward_ftol"] = float(np.asarray(inp.ftol_array).ravel()[-1])
     problem.metadata["forward_max_iterations"] = int(np.asarray(inp.niter_array).ravel()[-1])
     problem.metadata["max_fsq_ratio"] = float(max_fsq_ratio)
+    problem.metadata["refine_tol"] = float(refine_tol)
     return problem
 
 
@@ -1988,6 +1995,7 @@ def least_squares(
     jacobian_adjoint_maxiter: int = 10,
     adjoint_maxiter: int = 300,
     max_fsq_ratio: float = 1.0e6,
+    refine_tol: float = 1.0e-10,
     forward_ftol: float | None = None,
     forward_max_iterations: int | None = None,
     hot_restart: bool = True,
@@ -2128,7 +2136,8 @@ def least_squares(
                 current_dofs=current_dofs, jac=jac,
                 jac_chunk_size=jac_chunk_size, jac_solver=jac_solver,
                 adjoint_tol=adjoint_tol, adjoint_maxiter=adjoint_maxiter,
-                max_fsq_ratio=max_fsq_ratio, hot_restart=hot_restart,
+                max_fsq_ratio=max_fsq_ratio, refine_tol=refine_tol,
+                hot_restart=hot_restart,
                 warm_start=warm_start, use_ess=use_ess,
                 ess_alpha=ess_alpha, device=device, solve_kwargs=solve_kwargs,
                 verbose=verbose, **scipy_kwargs)
@@ -2156,7 +2165,7 @@ def least_squares(
             current_dofs=current_dofs,
             jac_chunk_size=jac_chunk_size, jac_solver=jac_solver,
             adjoint_tol=adjoint_tol, adjoint_maxiter=adjoint_maxiter,
-            max_fsq_ratio=max_fsq_ratio,
+            max_fsq_ratio=max_fsq_ratio, refine_tol=refine_tol,
             warm_start=(warm_start if hot_restart else None),
             solve_kwargs=dict(solve_kwargs or {}),
             device=device, verbose=verbose, **scipy_kwargs)
@@ -2236,6 +2245,7 @@ def minimize(
     adjoint_tol: float = 1e-6,
     adjoint_maxiter: int = 300,
     max_fsq_ratio: float = 1.0e6,
+    refine_tol: float = 1.0e-10,
     forward_ftol: float | None = None,
     forward_max_iterations: int | None = None,
     **scipy_kwargs,
@@ -2279,6 +2289,7 @@ def minimize(
                 device=device, solve_kwargs=solve_kwargs, verbose=verbose,
                 method=method, adjoint_tol=adjoint_tol,
                 adjoint_maxiter=adjoint_maxiter, max_fsq_ratio=max_fsq_ratio,
+                refine_tol=refine_tol,
                 **scipy_kwargs)
             stage_results.append(result)
             current = result.input
@@ -2290,7 +2301,7 @@ def minimize(
         current_dofs=current_dofs, jac_solver="reverse",
         warm_start=("state" if hot_restart else None),
         adjoint_tol=adjoint_tol, adjoint_maxiter=adjoint_maxiter,
-        max_fsq_ratio=max_fsq_ratio,
+        max_fsq_ratio=max_fsq_ratio, refine_tol=refine_tol,
         solve_kwargs=dict(solve_kwargs or {}), device=device, verbose=verbose,
         minimize_method=method, **scipy_kwargs)
 
@@ -2378,6 +2389,7 @@ def _least_squares_implicit(
     jacobian_adjoint_maxiter: int = 10,
     adjoint_maxiter: int = 300,
     max_fsq_ratio: float = 1.0e6,
+    refine_tol: float = 1.0e-10,
     warm_start: str | None = "perturbation",
     solve_kwargs: dict,
     device: Any = AUTO,
@@ -2484,6 +2496,7 @@ def _least_squares_implicit(
         jacobian_adjoint_maxiter=jacobian_adjoint_maxiter,
         adjoint_maxiter=adjoint_maxiter,
         max_fsq_ratio=max_fsq_ratio,
+        refine_tol=refine_tol,
     )
     # Pin the residual/Jacobian graphs to the fastest device for this
     # launch-bound path (CPU by default; explicit device= honored; None


### PR DESCRIPTION
## Motivation

VMEX Newton-refines the host equilibrium before implicit differentiation because the theorem applies at the frozen residual root, not merely at the host solver's sum-of-squares stopping point. Nearby optimization trials repeatedly solve almost the same refinement problem. #213 demonstrated useful warm-runtime savings, but mixed this algorithm with two public APIs, private instrumentation, and twelve benchmark scripts.

This PR keeps only the refinement algorithm and its user-facing accuracy control.

## Algorithm and numerical guard

For a nearby parameter point, VMEX proposes the preceding accepted refinement displacement as the Newton initial guess. It evaluates the new frozen residual exactly before using it. A candidate is used only when it lowers that residual. If the warm path does not reach `refine_tol`, VMEX discards it and replays the original path from the host-solver state. Rejected equilibrium trials invalidate the correction.

Thus the optimization changes work, not the accepted fallback result. The strict default remains `refine_tol=1e-10`; `numpy.inf` is an explicit legacy-comparison switch. Nonpositive, NaN, and negative-infinite tolerances are rejected.

## Measured evidence

The pre-split review reproduced #213 on CPU with 48 active boundary degrees of freedom and 41,475 residual rows. Against the legacy refinement path:

| evaluation | legacy | guarded reuse | change |
|---|---:|---:|---:|
| residual, plus perturbation | 12.30 s | 7.56 s | -39% |
| residual, minus perturbation | 4.48 s | 2.45 s | -45% |
| scalar value + gradient, plus | 17.58 s | 12.97 s | -26% |
| scalar value + gradient, minus | 9.64 s | 7.11 s | -26% |

Cold problem construction was unchanged (23.01 vs 23.06 s), as expected: this targets repeated nearby refinement. Objective differences were below 3.3e-12; gradient relative L2 difference was at most 1.04e-8; both paths reached `refine_tol=1e-10`. Reverse-order measurements retained an overall improvement but showed the expected compilation/order noise at one point.

## Coverage and repository hygiene

- Remove the instrumentation and all twelve Phase 0-5 benchmark/summarizer files proposed in #213; no new benchmark file or folder is added.
- Test the residual-improvement guard, exact warm acceptance, and legacy fallback in one focused numerical test; retain the existing real LASYM fixed-root and frozen-path FD tests as the physics anchors.
- Publish the already-combined CI coverage XML to Codecov with OIDC.
- Set both project and patch Codecov targets to 95% and add the coverage badge to the README. The existing local diff-coverage gate remains 95%.

## Verification

- `ruff check vmex tests`
- `mypy vmex`
- Focused refinement and public-factory tests: 2 passed
- `sphinx -W -j auto -b html docs docs/_build/html`
- Earlier full implicit-gradient campaign on the submitted algorithm: 6 full physics tests passed, including the real 3-D LASYM fixed-root and frozen-path gradient checks.

Supersedes the refinement/tolerance portion of #213; independent of its state-quantity and virtual-casing API portions.
