### PR TITLE
Expose virtual-casing memory controls

### DIFF
--- a/docs/reference/optimization.rst
+++ b/docs/reference/optimization.rst
@@ -482,6 +482,9 @@ ESSOS update used by an optimization:
    )
 
 ``field.dof_names`` then lists VMEX variables followed by ESSOS variables.
+For unusually large surfaces or target arrays, ``chunk_size`` and
+``target_chunk_size`` cap virtual-casing batches; keep the default ``"auto"``
+unless memory measurements justify an override.
 The factored reverse pass differentiates the equilibrium and coil data once,
 rather than nesting the implicit equilibrium solve inside each Cartesian
 spatial derivative. Third spatial derivatives and their parameter VJPs remain

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -261,13 +261,15 @@ def test_vmec_problem_field_facades_validate_and_route(monkeypatch):
         problem.x0, external_parameters=np.array([2.0]),
         external_field_from_parameters=lambda p: p,
         external_dof_names=("coil current",), nphi=7, ntheta=9,
-        digits=4, levels=((7, 9),))
+        digits=4, levels=((7, 9),), chunk_size=11, target_chunk_size=3)
     interior = problem.interior_field(problem.x0, newton_iterations=6)
     assert exterior[0] == ("input", "state", {"runtime": "runtime", "nphi": 7, "ntheta": 9})
     np.testing.assert_array_equal(exterior[1], problem.x0)
     assert exterior[2]["dof_names"] == problem.dof_names
     np.testing.assert_array_equal(exterior[2]["external_parameters"], [2.0])
     assert exterior[2]["external_dof_names"] == ("coil current",)
+    assert exterior[2]["chunk_size"] == 11
+    assert exterior[2]["target_chunk_size"] == 3
     assert interior[0:2] == ("input", ("state", "runtime"))
     assert interior[3] == {"dof_names": problem.dof_names, "newton_iterations": 6}
 

--- a/tests/test_virtual_casing_physics.py
+++ b/tests/test_virtual_casing_physics.py
@@ -155,6 +155,8 @@ def test_finite_beta_extender_field_and_gradient_outside_lcfs(monkeypatch):
         external_field=coil_field,
         digits=3,
         levels=((13, 13), (26, 26)),
+        chunk_size=17,
+        target_chunk_size=1,
     )
     points = jnp.array([[1.8, 0.0, 0.1], [0.0, 1.9, -0.1]])
     assert field.uses_virtual_casing

--- a/vmex/core/extender.py
+++ b/vmex/core/extender.py
@@ -801,8 +801,15 @@ class VmecExtender(MagneticField):
         external_field: Any | None = None,
         digits: int = 6,
         levels: tuple[tuple[int, int], ...] | None = None,
+        chunk_size: int | str = "auto",
+        target_chunk_size: int | str = "auto",
     ) -> "VmecExtender":
-        """Construct the finite-beta path from traceable VMEX surface data."""
+        """Construct the finite-beta path from traceable VMEX surface data.
+
+        ``chunk_size`` bounds source points per virtual-casing batch;
+        ``target_chunk_size`` bounds evaluation points. ``"auto"`` delegates
+        both memory/performance choices to virtual-casing-jax.
+        """
         from . import virtual_casing as vc
 
         vc._require_vcj()
@@ -813,6 +820,8 @@ class VmecExtender(MagneticField):
             src_nphi=nphi,
             src_ntheta=ntheta,
             levels=schedule,
+            chunk_size=chunk_size,
+            target_chunk_size=target_chunk_size,
             branch="internal",
         )
         plasma_field = vc.VirtualCasingExteriorField(surface_data, config)
@@ -830,6 +839,8 @@ class VmecExtender(MagneticField):
         external_dof_names: tuple[str, ...] = (),
         digits: int = 6,
         levels: tuple[tuple[int, int], ...] | None = None,
+        chunk_size: int | str = "auto",
+        target_chunk_size: int | str = "auto",
         dof_names: tuple[str, ...] = (),
     ) -> "VmecExtender":
         """Construct a virtual-casing field with VJPs in ``parameters``.
@@ -891,11 +902,13 @@ class VmecExtender(MagneticField):
             live_external_field = make_external(external_dofs)
             return cls.from_surface_data(
                 data, external_field=live_external_field, digits=digits,
-                levels=levels).B(points)
+                levels=levels, chunk_size=chunk_size,
+                target_chunk_size=target_chunk_size).B(points)
 
         field = cls.from_surface_data(
             initial_surface_data, external_field=initial_external_field,
-            digits=digits, levels=levels)
+            digits=digits, levels=levels, chunk_size=chunk_size,
+            target_chunk_size=target_chunk_size)
         field._parameters = all_parameters
         field._parameter_data_fn = differentiable_surface_data
         field._B_from_data = B_from_surface_arrays
@@ -913,6 +926,8 @@ class VmecExtender(MagneticField):
         ntheta: int = 32,
         digits: int = 6,
         levels: tuple[tuple[int, int], ...] | None = None,
+        chunk_size: int | str = "auto",
+        target_chunk_size: int | str = "auto",
         base_dir: str | Path | None = None,
     ) -> "VmecExtender":
         """Construct an exterior field from a wout-like object."""
@@ -938,6 +953,8 @@ class VmecExtender(MagneticField):
                 external_field=external_field,
                 digits=digits,
                 levels=levels,
+                chunk_size=chunk_size,
+                target_chunk_size=target_chunk_size,
             )
 
         if external_field is None and plasma_field is None:
@@ -965,6 +982,8 @@ class VmecExtender(MagneticField):
         ntheta: int = 32,
         digits: int = 6,
         levels: tuple[tuple[int, int], ...] | None = None,
+        chunk_size: int | str = "auto",
+        target_chunk_size: int | str = "auto",
     ) -> "VmecExtender":
         """Construct the differentiable finite-beta path from a live VMEX state."""
         from . import virtual_casing as vc
@@ -977,6 +996,8 @@ class VmecExtender(MagneticField):
             external_field=external_field,
             digits=digits,
             levels=levels,
+            chunk_size=chunk_size,
+            target_chunk_size=target_chunk_size,
         )
 
     @classmethod

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -3218,6 +3218,8 @@ def _least_squares_implicit(
                 "external_field_from_parameters", None)
             external_dof_names = tuple(kwargs.pop("external_dof_names", ()))
             digits = int(kwargs.pop("digits", 6)); levels = kwargs.pop("levels", None)
+            chunk_size = kwargs.pop("chunk_size", "auto")
+            target_chunk_size = kwargs.pop("target_chunk_size", "auto")
             plasma = kwargs.pop("plasma", "auto")
             if plasma not in ("auto", "include", "vacuum"):
                 raise ValueError("plasma must be 'auto', 'include', or 'vacuum'")
@@ -3237,7 +3239,8 @@ def _least_squares_implicit(
                 external_parameters=external_parameters,
                 external_field_from_parameters=external_field_from_parameters,
                 external_dof_names=external_dof_names,
-                digits=digits, levels=levels, dof_names=tuple(names))
+                digits=digits, levels=levels, chunk_size=chunk_size,
+                target_chunk_size=target_chunk_size, dof_names=tuple(names))
 
         return Equilibrium(
             inp=result_input,

--- a/vmex/core/problem.py
+++ b/vmex/core/problem.py
@@ -605,12 +605,16 @@ class VmecProblem(FunctionProblem):
         ntheta: int = 32,
         digits: int = 6,
         levels: tuple[tuple[int, int], ...] | None = None,
+        chunk_size: int | str = "auto",
+        target_chunk_size: int | str = "auto",
     ) -> Any:
         """Return the exterior field and exact VJPs in this problem's DOFs.
 
         Query points must lie outside the last closed flux surface and away
         from coil filaments.  The returned field follows the stored-point API:
         ``field.set_points(xyz); field.B(); field.B_vjp(cotangent)``.
+        Set the source and target chunk sizes only to cap virtual-casing
+        memory; ``"auto"`` is the tuned default.
         """
         state_runtime = self.metadata.get("jax_state_runtime")
         inp = self.metadata.get("input")
@@ -632,7 +636,8 @@ class VmecProblem(FunctionProblem):
             external_parameters=external_parameters,
             external_field_from_parameters=external_field_from_parameters,
             external_dof_names=external_dof_names,
-            digits=digits, levels=levels, dof_names=self.dof_names)
+            digits=digits, levels=levels, chunk_size=chunk_size,
+            target_chunk_size=target_chunk_size, dof_names=self.dof_names)
 
     def interior_field(
         self, x: Array, *, newton_iterations: int = 10


### PR DESCRIPTION
## Motivation

Large virtual-casing source grids or target arrays sometimes need an explicit memory bound. virtual-casing-jax already provides independent source and target chunk controls, but VMEX's field constructors hid them.

This extracts the virtual-casing part of #213 as an independent, backward-compatible API change.

## Design

- Thread `chunk_size` and `target_chunk_size` through `VmecExtender` construction from surface data, parameterized surface data, WOUTs, live states, and optimization equilibria.
- Thread the same controls through `VmecProblem.exterior_field`.
- Keep `"auto"` as the default so ordinary users retain virtual-casing-jax's tuned policy.
- Document these as measured memory controls, not generic tuning knobs.

No virtual-casing mathematics, quadrature schedule, field convention, or default changes.

## Physics and numerical verification

- The finite-beta exterior-field test now executes the real virtual-casing operator with deliberately small source and target chunks.
- It verifies the composed coil-plus-plasma field, Cartesian field Jacobian, and directional finite difference exactly as before; chunking therefore changes batching, not the field or derivative.
- Public routing tests verify both controls reach the parameterized field constructor.

## Verification

- `ruff check vmex tests`
- `mypy vmex`
- Focused problem, extender, and finite-beta virtual-casing suite: 25 passed
- `sphinx -W -j auto -b html docs docs/_build/html`

This PR adds no benchmark script, data artifact, folder, or new dependency. It supersedes only the virtual-casing chunk-control portion of #213.
