### PR TITLE
Stop the implicit-adjoint backward pass recompiling on every gradient

### DIFF
--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -38,6 +38,7 @@ import jax.numpy as jnp
 from vmex.core import implicit as im
 from vmex.core import solver
 from vmex.core import stability as stab
+from vmex.core.errors import AdjointSolveError
 from vmex.core.input import VmecInput
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "examples" / "data"
@@ -136,6 +137,33 @@ def _tnorm(tree) -> float:
 def _tree_dot(left, right) -> float:
     return float(sum(jnp.vdot(a, b) for a, b in zip(
         jax.tree.leaves(left), jax.tree.leaves(right), strict=True)))
+
+
+def _compiles_during(fn) -> list[str]:
+    """Run ``fn`` under ``jax_log_compiles``; return the compile messages."""
+    import logging
+
+    compiles: list[str] = []
+
+    class _Handler(logging.Handler):
+        def emit(self, record):
+            message = record.getMessage()
+            if message.startswith("Compiling "):
+                compiles.append(message.split(" with global shapes")[0])
+
+    handler = _Handler()
+    logger = logging.getLogger("jax")
+    previous_level = logger.level
+    jax.config.update("jax_log_compiles", True)
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    try:
+        fn()
+    finally:
+        jax.config.update("jax_log_compiles", False)
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+    return compiles
 
 
 # ---------------------------------------------------------------------------
@@ -336,6 +364,73 @@ def test_residual_lane_reuses_one_executable_across_trial_boundaries(solovev):
     assert any(
         not np.array_equal(a, b)
         for a, b in zip(jax.tree.leaves(base), jax.tree.leaves(trial)))
+
+
+def test_repeated_same_shape_gradients_do_not_recompile(solovev):
+    """A warm un-jitted ``jax.grad`` repeat reuses every executable.
+
+    The host-eager backward used to hand ``solvax.gcrot`` a fresh closure
+    over each call's linearization residuals, so every repeat recompiled the
+    staged Krylov ``jit(while)`` — 5.4-6.5 s per repeat, most of the
+    measured F11 warm-gradient stage — and each ``run`` re-staged an
+    identity-keyed ``jit(pure_callback)``.  The adjoint solve is now one
+    module-level executable keyed on the canonical config
+    (``_adjoint_gcrot_core``) and the callback callable is memoized per
+    config, so a same-shape repeat must compile nothing.
+    """
+    _name, inp, cfg, p0, _x_star, _rt, _mask = solovev
+
+    def gradient():
+        jax.block_until_ready(jax.grad(
+            lambda p: im.run(inp, p, ftol=cfg.ftol,
+                             max_iterations=cfg.max_iterations).wb)(p0))
+
+    gradient()  # warm-up: the first evaluation may compile freely
+    compiles = _compiles_during(gradient)
+    assert compiles == [], f"warm gradient repeat recompiled: {compiles}"
+
+
+def test_enforce_adjoint_stats_typed_error_policy(solovev):
+    """The staged core's convergence certificate keeps the typed-error
+    contract: concrete unaccepted stats raise :class:`AdjointSolveError`
+    carrying the iteration/residual evidence (end-to-end with a starved
+    Krylov budget on the two-device rig in ``test_gpu_ci.py``), accepted
+    stats pass, and traced stats are a no-op — there the core has already
+    NaN-poisoned the returned lambda."""
+    _name, _inp, cfg, _p0, _x_star, _rt, _mask = solovev
+    bad = im._AdjointStats(
+        residual_norm=jnp.asarray(2.0e-3), iterations=jnp.asarray(7),
+        converged=jnp.asarray(False), tolerance=jnp.asarray(1.0e-9))
+    with pytest.raises(AdjointSolveError) as caught:
+        im._enforce_adjoint_stats(cfg, bad)
+    assert caught.value.iterations == 7
+    assert caught.value.residual_norm == 2.0e-3
+    assert caught.value.tolerance == 1.0e-9
+    im._enforce_adjoint_stats(cfg, bad._replace(converged=jnp.asarray(True)))
+    jax.jit(lambda stats: im._enforce_adjoint_stats(cfg, stats))(bad)
+
+
+def test_adjoint_debug_stages_on_default_device(monkeypatch, capfd, solovev):
+    """``VMEX_ADJOINT_DEBUG=1`` prints every reverse-pass stage line on the
+    ordinary single-device lane: the staged adjoint core keeps the eager
+    operator-application probe under the debug gate.  The two-device
+    placement variant lives in ``test_gpu_ci.py``."""
+    _name, inp, cfg, p0, _x_star, _rt, _mask = solovev
+    monkeypatch.setenv("VMEX_ADJOINT_DEBUG", "1")
+    gradient = jax.grad(
+        lambda p: im.run(inp, p, ftol=cfg.ftol,
+                         max_iterations=cfg.max_iterations).wb)(p0)
+    assert np.all(np.isfinite(np.asarray(gradient.rbc)))
+    err = capfd.readouterr().err
+    for stage in (
+        "backward entry",
+        "adjoint rhs P(gbar)",
+        "operator application (dF/dz)^T b",
+        "recovered lambda",
+        "implicit parameter contribution -lambda^T dF/dp",
+        "direct parameter contribution",
+    ):
+        assert f"[vmex adjoint] {stage}" in err, stage
 
 
 def test_content_token_distinguishes_each_supported_kind():
@@ -1003,6 +1098,27 @@ def test_lasym_wb_aspect_gradient_vs_fd(lasym):
         print(f"  d({out})/d({field}{idx}) h={h:.0e}: "
               f"AD={ad:+.10e} FD={fd:+.10e} rel={rel:.2e}")
         assert rel <= tol, f"{out}/{field}{idx}: rel {rel:.3e} > {tol:.0e}"
+
+
+def test_lasym_repeated_same_shape_gradients_do_not_recompile(lasym):
+    """Same-shape LASYM repeated evaluations do not recompile (plan 14.6).
+
+    The LASYM gradient runs the identical reverse lane as the symmetric one
+    (the per-config staged ``_adjoint_gcrot_core`` plus the memoized host
+    callback), so a warm value-and-gradient repeat of an asymmetric deck
+    must be compile-free too — the acceptance gate for the measured
+    per-repeat ``jit(while)`` GCROT recompile of the F11 profile.
+    """
+    _name, inp, cfg, p0, _x_star, _rt, _mask = lasym
+
+    def value_and_gradient():
+        jax.block_until_ready(jax.value_and_grad(
+            lambda p: im.run(inp, p, ftol=cfg.ftol,
+                             max_iterations=cfg.max_iterations).wb)(p0))
+
+    value_and_gradient()  # warm-up: the first evaluation may compile freely
+    compiles = _compiles_during(value_and_gradient)
+    assert compiles == [], f"warm LASYM repeat recompiled: {compiles}"
 
 
 @pytest.mark.full

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -11,7 +11,8 @@ coefficients).  :func:`solve_implicit` wraps the opaque host solver
     ``(dF/dx)^T lambda = g_x``
 
 matrix-free (one ``jax.vjp`` linearization of the residual, re-applied by a
-recycling GCROT(m, k) Krylov solve — see ``_adjoint_solve_gcrot``) and returns
+recycling GCROT(m, k) Krylov solve staged as one reusable per-config
+executable — see ``_adjoint_gcrot_core``) and returns
 ``g_p - lambda^T dF/dp`` with one more VJP — O(1) memory in the forward
 iteration count.  The adjoint solve executes host-eagerly on the caller's
 thread and is bound to the config's carried device on its own (see the
@@ -1582,6 +1583,28 @@ def _callback_sharding(cfg: ImplicitConfig):
     return jax.sharding.SingleDeviceSharding(cfg.device)
 
 
+@functools.lru_cache(maxsize=_CONFIG_CANON_MAX)
+def _host_callback(cfg: ImplicitConfig) -> Callable:
+    """Stable-identity host callback for :func:`_callback_solve`.
+
+    ``jax.pure_callback`` keys its staged computation partly on the callback
+    callable's identity (``functools.partial`` compares by identity), so the
+    previous per-call partial minted a fresh cache key and recompiled the
+    (small) callback program on every ``run``/``solve_implicit`` — one
+    measured ``jit(pure_callback)`` recompile per warm objective evaluation.
+    Memoized per canonical config identity, bounded like ``_CONFIG_CANON``
+    so entries expire together (eviction costs a recompile, never
+    correctness).
+    """
+    return functools.partial(_host_solve_and_mask, cfg)
+
+
+@functools.lru_cache(maxsize=_CONFIG_CANON_MAX)
+def _host_callback_status(cfg: ImplicitConfig) -> Callable:
+    """Stable-identity status host callback (see :func:`_host_callback`)."""
+    return functools.partial(_host_solve_and_mask_status, cfg)
+
+
 def _callback_solve(params: ImplicitParams, cfg: ImplicitConfig):
     """``pure_callback`` host solve returning ``(state, dof_mask)``.
 
@@ -1597,7 +1620,7 @@ def _callback_solve(params: ImplicitParams, cfg: ImplicitConfig):
     """
     try:
         return jax.pure_callback(
-            functools.partial(_host_solve_and_mask, cfg),
+            _host_callback(cfg),
             (_state_struct(cfg), _state_struct(cfg)), params,
             sharding=_callback_sharding(cfg),
         )
@@ -1612,7 +1635,7 @@ def _callback_solve_status(params: ImplicitParams, cfg: ImplicitConfig):
     status_struct = jax.ShapeDtypeStruct((), jnp.int32)
     scalar_struct = jax.ShapeDtypeStruct((), jnp.float64)
     return jax.pure_callback(
-        functools.partial(_host_solve_and_mask_status, cfg),
+        _host_callback_status(cfg),
         (_state_struct(cfg), _state_struct(cfg), status_struct, scalar_struct, scalar_struct),
         params,
         sharding=_callback_sharding(cfg),
@@ -1694,6 +1717,21 @@ def _solve_implicit_status_fwd(params, cfg):
 # ``jax.default_device`` context (steering eager fresh constants) —
 # independent of any caller-held context; cheap no-ops when no device is
 # carried.
+#
+# The scalar reverse rule itself no longer builds that Krylov loop eagerly:
+# ``_solve_implicit_bwd_impl`` calls :func:`_adjoint_gcrot_core`, a
+# module-level ``jax.jit`` keyed on the (canonical) static config that takes
+# the per-call linearization data — ``(params, z_star, frozen, dof_mask,
+# b)`` — as traced ARGUMENTS.  The previous eager path re-closed the loop
+# body over each call's fresh linearization residuals, so the ``jit(while)``
+# compile cache missed on every un-jitted ``jax.grad`` repeat (5.4-6.5 s per
+# warm F11 gradient).  Placement of the staged core follows its committed
+# inputs — exactly the explicit ``device_put`` pins ``_solve_implicit_bwd``
+# already applies at the boundary — so the hardware-verified device binding
+# is unchanged.  The eager pin+context binding below remains the execution
+# contract for the lanes that still call :func:`_adjoint_solve_gcrot` /
+# :func:`_adjoint_solve` directly (fixed-point refinement, multi-RHS rows,
+# Jacobian correctors, frozen-path FD, free-boundary traced branch).
 
 #: Environment gate for the off-by-default adjoint instrumentation: set
 #: ``VMEX_ADJOINT_DEBUG=1`` to print one ``[vmex adjoint]`` line per stage
@@ -1893,8 +1931,10 @@ def _adjoint_solve_gcrot(A, b, cfg: ImplicitConfig, *, precond=None,
                          rtol=None, max_restarts=None, enforce=True):
     """Adjoint linear solve ``(dF/dz)^T lambda = b`` via ``solvax.gcrot(m, k)``.
 
-    The reverse-pass default (:func:`_solve_implicit_bwd`,
-    :func:`implicit_state_pullback_multi_rhs`).  Same operator wrapping and
+    The eager Krylov lane (:func:`implicit_state_pullback_multi_rhs`, the
+    fixed-point refinement and the frozen-path FD; the scalar reverse rule
+    stages the same solve through :func:`_adjoint_gcrot_core` so warm
+    gradient repeats reuse one executable).  Same operator wrapping and
     *exactly the same tolerance* as :func:`_adjoint_solve` — GCROT keeps
     ``k`` recycled deflation directions across its FGMRES cycles, retaining
     the small eigendirections a truncated GMRES restart discards, and
@@ -2351,6 +2391,89 @@ def implicit_state_tangent_multi_rhs(
         return _device_pin(cfg, (state_batch, report))
 
 
+class _AdjointStats(NamedTuple):
+    """Concrete convergence certificate of one staged adjoint solve.
+
+    ``converged`` already folds in the residual-slack acceptance (like
+    :func:`_linear_response_report`); ``tolerance`` is the acceptance bound
+    the residual was measured against, ready for the typed error message.
+    """
+
+    residual_norm: Array
+    iterations: Array
+    converged: Array
+    tolerance: Array
+
+
+# The reverse-pass adjoint solve as ONE reusable executable per config.
+# Module scope with ``cfg`` static and the per-call linearization data as
+# traced arguments is what makes it reusable (exactly the residual-lane
+# argument, see ``_preconditioned_residual_lane``): the previous host-eager
+# path re-linearized ``F`` per call and handed ``solvax.gcrot`` a fresh
+# closure over that call's residuals, so the ``lax.while_loop`` it stages
+# missed the compile cache on every un-jitted ``jax.grad`` repeat — the
+# measured 5.4-6.5 s ``jit(while)`` recompile dominating the F11 warm
+# gradient stage, for symmetric and LASYM decks alike.
+@functools.partial(jax.jit, static_argnames=("cfg",))
+def _adjoint_gcrot_core(params: ImplicitParams, z_star: SpectralState,
+                        frozen: SpectralState, dof_mask: SpectralState,
+                        b: SpectralState, cfg: ImplicitConfig):
+    """Staged ``(dF/dz)^T lambda = b`` GCROT solve; returns ``(lam, stats)``.
+
+    Linearizes the preconditioned residual at ``(z_star, params)`` and runs
+    the same GCROT(m, k) solve as :func:`_adjoint_solve_gcrot` under one
+    ``jax.jit``.  Convergence enforcement is split across the staging
+    boundary: the returned ``lam`` is NaN-poisoned when the solve missed the
+    acceptance (the trace-time policy of :func:`_checked_adjoint_x`, so a
+    traced caller can never silently pass a finiteness check), while the
+    host-eager caller re-applies the typed-error policy on the CONCRETE
+    ``stats`` via :func:`_enforce_adjoint_stats`.  Placement follows the
+    committed arguments — the ``_device_pin`` at the ``_solve_implicit_bwd``
+    boundary — matching the eager lane's explicit RHS pin (execution-site
+    note above).
+    """
+    F = residual_fn(cfg, frozen, dof_mask)
+    _, vjp_z = jax.vjp(lambda z: F(z, params), z_star)
+    b_flat, unravel = ravel_pytree(b)
+    n = int(b_flat.shape[0])
+    m = min(int(cfg.adjoint_gcrot_m), n)
+    k = min(int(cfg.adjoint_gcrot_k), n)
+
+    def matvec(v):
+        return ravel_pytree(vjp_z(unravel(v))[0])[0]
+
+    sol = _solvax_gcrot(
+        matvec, b_flat, rtol=cfg.adjoint_tol, atol=0.0, m=m, k=k,
+        max_restarts=cfg.adjoint_maxiter,
+    )
+    tolerance = _adjoint_acceptance(cfg, jnp.linalg.norm(b_flat))
+    ok = jnp.logical_or(sol.converged, sol.residual_norm <= tolerance)
+    x = jnp.where(ok, sol.x, jnp.full_like(sol.x, jnp.nan))
+    return unravel(x), _AdjointStats(
+        residual_norm=sol.residual_norm, iterations=sol.iterations,
+        converged=ok, tolerance=tolerance,
+    )
+
+
+def _enforce_adjoint_stats(cfg: ImplicitConfig, stats: _AdjointStats) -> None:
+    """Typed-error half of the :func:`_adjoint_gcrot_core` convergence policy.
+
+    Host-eager (concrete stats — the default execution site) an unaccepted
+    solve raises :class:`~vmex.core.errors.AdjointSolveError` with the
+    iteration/residual evidence, exactly as :func:`_checked_adjoint_x` does
+    on the eager lane.  Under a trace the concrete check is impossible; the
+    core has already NaN-poisoned the returned ``lam`` there, so this is a
+    no-op and the gradient can never silently pass a finiteness check.
+    """
+    if any(isinstance(value, jax.core.Tracer) for value in stats):
+        return
+    if not bool(np.asarray(stats.converged)):
+        _raise_adjoint_unconverged(
+            cfg, iterations=int(np.asarray(stats.iterations)),
+            residual_norm=float(np.asarray(stats.residual_norm)),
+            tolerance=float(np.asarray(stats.tolerance)))
+
+
 def _solve_implicit_bwd(cfg, res, gbar):
     # The backward pass typically executes AFTER the caller's forward context
     # has exited (jax.grad pulls cotangents back later); re-enter the
@@ -2381,15 +2504,18 @@ def _solve_implicit_bwd_impl(cfg, res, gbar):
               f"{jax.config.jax_default_device} cfg.device={cfg.device}",
               file=sys.stderr)
 
-    # (dF/dz)^T lambda = P gbar, matrix-free (one linearization reused).
-    _, vjp_z = jax.vjp(lambda z: F(z, params), z_star)
+    # (dF/dz)^T lambda = P gbar, staged once per config (_adjoint_gcrot_core:
+    # the linearization happens INSIDE the jitted core so its residuals are
+    # traced arguments, not per-call closure constants).
     b = P(gbar)
     if debug:
         _debug_stage("adjoint rhs P(gbar)", b)
-        # One extra operator application, only under the debug gate: places
-        # the whole matvec chain (jitted-residual transpose included).
-        _debug_stage("operator application (dF/dz)^T b", vjp_z(b)[0])
-    lam, _ = _adjoint_solve_gcrot(lambda v: vjp_z(v)[0], b, cfg)
+        # One extra eager operator application, only under the debug gate:
+        # places the whole matvec chain (jitted-residual transpose included).
+        _, dbg_vjp_z = jax.vjp(lambda z: F(z, params), z_star)
+        _debug_stage("operator application (dF/dz)^T b", dbg_vjp_z(b)[0])
+    lam, stats = _adjoint_gcrot_core(params, z_star, frozen, dof_mask, b, cfg)
+    _enforce_adjoint_stats(cfg, stats)
     if debug:
         _debug_stage("recovered lambda", lam)
 


### PR DESCRIPTION
## Problem

Measured 2026-08-30 on the M4 (F11 workflow of `benchmarks/profile_workflows.py`): every un-jitted `jax.grad` repeat of an implicit gradient recompiled `jit(while)` — the GCROT Krylov loop — costing 5.4–6.5 s per repeat (most of the warm-gradient stage), plus a small identity-keyed `jit(pure_callback)` recompile per `vmex.core.implicit.run` call.

Mechanism: the host-eager backward (`_solve_implicit_bwd_impl` → `_adjoint_solve_gcrot` → `solvax.gcrot`) re-linearized the residual per call and handed the Krylov loop a fresh closure over that call's linearization residuals, so the staged `lax.while_loop` missed the compile cache on every repeat; the callback lane minted a fresh `functools.partial` per call, so `pure_callback`'s identity-keyed cache missed too.

## Fix

- `_adjoint_gcrot_core`: the reverse-pass adjoint solve as one module-level `jax.jit` keyed on the canonical static config, taking the per-call linearization data `(params, z_star, frozen, dof_mask, b)` as traced arguments — the same argument that made `_preconditioned_residual_lane` reusable.
- Convergence enforcement split across the staging boundary without weakening it: the core NaN-poisons the returned lambda when the solve misses the acceptance (the traced-caller policy of `_checked_adjoint_x`), and the host-eager wrapper re-applies the typed `AdjointSolveError` policy on the concrete stats (`_enforce_adjoint_stats`).
- `_host_callback` / `_host_callback_status`: the `pure_callback` callables memoized per canonical config, bounded like `_CONFIG_CANON`.
- Device binding unchanged: the staged core's placement follows the `_device_pin`-committed arguments at the `_solve_implicit_bwd` boundary; the eager pin+context contract remains for the refinement / multi-RHS / Jacobian-corrector / frozen-path-FD / free-boundary lanes that still call `_adjoint_solve_gcrot` directly. The `VMEX_ADJOINT_DEBUG=1` per-stage instrumentation is preserved (the operator-application probe stays eager under the gate).

## Measured

Solovev warm `jax.grad` repeat through `im.run`: 7.5–8.6 s and 6 recompiles (`jit(pure_callback)`, 4× `jit(F)`, `jit(while)`) before → 0.9–1.2 s and 0 recompiles after; gradient unchanged to ~1e-11 (within `adjoint_tol`). Cold gradient also drops (94 s / 1750 compiles → 78 s / 606 compiles).

## Certification

- New: `test_repeated_same_shape_gradients_do_not_recompile` (symmetric) and `test_lasym_repeated_same_shape_gradients_do_not_recompile` — the plan §14.6 "same-shape LASYM repeated evaluations do not recompile" acceptance item — via a `jax_log_compiles` counter; plus default-lane tests for the typed-error policy (`test_enforce_adjoint_stats_typed_error_policy`) and the debug stages (`test_adjoint_debug_stages_on_default_device`).
- Suites: `tests/test_implicit_grad.py` (33 passed), `tests/test_implicit_device.py` + `tests/test_implicit_multi_rhs.py` (14 passed), full preflight affected-test run (267 passed, 34 skipped), changed-line coverage 100%.
- An unconverged adjoint (starved Krylov budget) still raises the typed `AdjointSolveError` with iteration/residual evidence, verified end-to-end.

Note: `tools/preflight.py` reports two failures in `tests/test_performance_docs.py` (`test_solvax_polish_artifact_is_independently_certified`, `test_readme_strong_force_figure_matches_committed_sources`); both fail identically on pristine `origin/main` (444e2b99) — the committed `strong_force_*_m4.json` artifacts carry `null` for `solvax_source` / `summary_figure` — and are unrelated to this change.