### PR TITLE
fix: key the compilation cache to the jaxlib runtime, not its metadata

### DIFF
--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -11,6 +11,7 @@ Item I.8a dead-code prune — the core is JAX-only.
 from __future__ import annotations
 
 import re
+import sys
 import types
 
 import pytest
@@ -155,6 +156,58 @@ def test_cache_machine_fingerprint_changes_with_jaxlib(monkeypatch):
     selected["jaxlib"] = "0.10.1"
     new = _compat._cache_machine_fingerprint()
     assert old != new
+
+
+def test_cache_machine_fingerprint_tracks_runtime_jaxlib(monkeypatch):
+    """An in-place jaxlib downgrade must move the cache even when the
+    distribution metadata is stale.
+
+    Reproduced hazard: metadata kept reporting one version while the
+    jaxlib actually imported — whose AOT loader rejects the old entries'
+    CPU target features, then segfaults — changed underneath.  The
+    fingerprint must follow the runtime module, not the metadata.
+    """
+    jaxlib_version = pytest.importorskip("jaxlib.version")
+    real_version = _compat.importlib_metadata.version
+
+    def stale(name):
+        return "1.0.0" if name in ("jax", "jaxlib") else real_version(name)
+
+    monkeypatch.setattr(_compat.importlib_metadata, "version", stale)
+    monkeypatch.setattr(jaxlib_version, "__version__", "0.11.1")
+    old = _compat._cache_machine_fingerprint()
+    monkeypatch.setattr(jaxlib_version, "__version__", "0.9.2")
+    new = _compat._cache_machine_fingerprint()
+    assert old != new
+
+
+def test_jaxlib_backend_identity_tracks_native_extension(tmp_path, monkeypatch):
+    """The identity digest follows the native XLA extension's content."""
+    jaxlib = pytest.importorskip("jaxlib")
+    (tmp_path / "__init__.py").write_text("")
+    monkeypatch.setattr(jaxlib, "__file__", str(tmp_path / "__init__.py"))
+    ext = tmp_path / "_jax.so"
+
+    ext.write_bytes(b"one" * 100)
+    first = _compat._jaxlib_backend_identity()
+    ext.write_bytes(b"two" * 100)
+    second = _compat._jaxlib_backend_identity()
+
+    assert any(part.startswith("jaxlib-runtime=") for part in first)
+    assert any(part.startswith("jaxlib-ext=") for part in first)
+    assert first != second
+
+
+def test_jaxlib_backend_identity_degrades_gracefully(monkeypatch):
+    """Failures drop fingerprint parts; they never raise into the caller."""
+    jaxlib = pytest.importorskip("jaxlib")
+    # An unreadable package path drops only the extension digest.
+    monkeypatch.setattr(jaxlib, "__file__", None)
+    parts = _compat._jaxlib_backend_identity()
+    assert parts and all(part.startswith("jaxlib-runtime=") for part in parts)
+    # An unimportable jaxlib.version yields no parts at all.
+    monkeypatch.setitem(sys.modules, "jaxlib.version", None)
+    assert _compat._jaxlib_backend_identity() == []
 
 
 class _FakeConfig:

--- a/vmex/_compat.py
+++ b/vmex/_compat.py
@@ -27,7 +27,7 @@ import os
 import platform
 
 
-_CACHE_FORMAT_VERSION = "2"
+_CACHE_FORMAT_VERSION = "3"
 _CACHE_SIZE_FLOOR = 2 << 30          # 2 GiB
 _CACHE_SIZE_CEILING = 20 << 30       # 20 GiB
 _CACHE_DISK_FRACTION = 0.10
@@ -112,15 +112,59 @@ def _cache_deserialize_unsafe() -> bool:
     return version is None or version < _CACHE_DESERIALIZE_SAFE_JAXLIB
 
 
+_EXT_DIGEST_CHUNK = 1 << 20
+
+
+def _jaxlib_backend_identity() -> list[str]:
+    """Fingerprint parts tied to the jaxlib build that will actually run.
+
+    Distribution metadata can survive an in-place up/downgrade stale or
+    broken — and that is exactly when reusing the old cache is most
+    dangerous: XLA:CPU AOT entries record the target features the compiling
+    backend chose (e.g. ``+prefer-no-gather``), and a different jaxlib's AOT
+    loader rejects them or segfaults.  Record the version constant of the
+    module Python will import, plus a bounded content digest (size, leading
+    and trailing :data:`_EXT_DIGEST_CHUNK` bytes) of the native XLA
+    extension, so any compiler/loader change lands in a fresh cache
+    directory.  ``jaxlib.version`` is pure Python; nothing here loads the
+    native extension.
+    """
+    parts: list[str] = []
+    try:
+        import jaxlib.version
+        parts.append(f"jaxlib-runtime={jaxlib.version.__version__}")
+    except Exception:
+        return parts
+    try:
+        ext_dir = os.path.dirname(jaxlib.__file__ or "")
+        digest = hashlib.sha256()
+        for name in sorted(os.listdir(ext_dir)):
+            if (name.split(".", 1)[0] in ("_jax", "xla_extension")
+                    and name.endswith((".so", ".pyd", ".dylib"))):
+                path = os.path.join(ext_dir, name)
+                size = os.path.getsize(path)
+                digest.update(f"{name}:{size}".encode())
+                with open(path, "rb") as fh:
+                    digest.update(fh.read(_EXT_DIGEST_CHUNK))
+                    fh.seek(max(size - _EXT_DIGEST_CHUNK, _EXT_DIGEST_CHUNK))
+                    digest.update(fh.read(_EXT_DIGEST_CHUNK))
+        parts.append(f"jaxlib-ext={digest.hexdigest()[:16]}")
+    except Exception:
+        pass
+    return parts
+
+
 def _cache_machine_fingerprint() -> str:
     """Return a short cache key for host-specific XLA CPU executables.
 
     XLA CPU persistent-cache entries are native executables.  On shared home
     directories, reusing an entry compiled on another CPU can trigger XLA AOT
     loader errors or even illegal-instruction failures.  The fingerprint keeps
-    vmex's default cache portable by separating entries by OS, machine, and
-    CPU-feature/model signature.  Users who deliberately want a shared cache can
-    still set ``VMEX_COMPILATION_CACHE_DIR`` or ``JAX_COMPILATION_CACHE_DIR``.
+    vmex's default cache portable by separating entries by OS, machine,
+    CPU-feature/model signature, and jaxlib compiler/loader identity
+    (:func:`_jaxlib_backend_identity`).  Users who deliberately want a shared
+    cache can still set ``VMEX_COMPILATION_CACHE_DIR`` or
+    ``JAX_COMPILATION_CACHE_DIR``.
     """
 
     parts = [
@@ -135,6 +179,7 @@ def _cache_machine_fingerprint() -> str:
             parts.append(f"{package}={importlib_metadata.version(package)}")
         except Exception:
             pass
+    parts.extend(_jaxlib_backend_identity())
     try:
         if os.path.exists("/proc/cpuinfo"):
             wanted = ("model name", "cpu family", "model", "stepping", "flags", "Features")


### PR DESCRIPTION
## Problem

A host whose venv had jaxlib 0.11.1, later downgraded in place to 0.9.2, kept serving persistent-cache AOT entries compiled with target features (`+prefer-no-gather`, `+prefer-no-scatter`) that the older runtime's target detection does not expect. Loading them first logged `cpu_aot_loader` machine-feature-mismatch errors and then died with SIGSEGV (reproduced with `python -m vmex ... --polish` on Linux).

The machine fingerprint behind `_default_compilation_cache_dir` already recorded the jax/jaxlib distribution versions — but only best-effort from importlib metadata, silently omitted on failure. Stale or broken dist metadata is exactly what an in-place reinstall can leave behind, and either failure mode collapses two incompatible runtimes into one cache directory.

## Fix

- New `_jaxlib_backend_identity()`, appended to the fingerprint content:
  - `jaxlib-runtime=<version>` from `jaxlib.version.__version__` — the module Python will actually import, immune to metadata staleness. Pure Python, ~1 ms, loads no native code (the fingerprint is computed before JAX initializes).
  - `jaxlib-ext=<digest>` — a bounded content digest (name, size, leading + trailing 1 MiB) of the native XLA extension (`_jax` / `xla_extension` `.so`/`.pyd`/`.dylib`), i.e. the binary that owns both codegen target-feature selection and the AOT loader. Any compiler/loader change lands in a fresh directory; reinstalling the identical wheel does not churn the cache.
- Cache format version bumped 2 → 3 so existing caches rotate once.
- Failures still degrade gracefully (fewer parts, never an exception into import).

## Tests

- `test_cache_machine_fingerprint_tracks_runtime_jaxlib`: pins dist metadata to a stale constant while the runtime module version changes — the fingerprint must still change (the reproduced hazard).
- `test_jaxlib_backend_identity_tracks_native_extension`: the digest follows the extension file's content, including a same-size rewrite.
- `test_jaxlib_backend_identity_degrades_gracefully`: both failure branches.

`tools/preflight.py`: ruff/mypy clean on the changed files, affected tests 32 passed, diff coverage 100%. (The three `test_performance_docs.py` guard failures preflight also reports are local-environment noise: two reproduce on a clean `main` checkout here, the third is tripped by untracked local example artifacts outside this change.)