### PR TITLE
Honor the loss= callable literally in the implicit scalar lane

### DIFF
--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -578,6 +578,37 @@ def test_scipy_bfgs_scalar_lane_completes_and_descends():
     np.testing.assert_array_equal(bad_gradient, np.zeros_like(problem.x0))
 
 
+def test_from_loss_honors_bound_scalar_method_literally():
+    """The ``loss=`` lane uses a bound scalar objective method exactly as passed.
+
+    ``QuasisymmetryRatioResidual.total_state`` is bound to an owner that also
+    exposes the vector ``residuals_state``; the scalar lane used to swap in
+    those rows through the objective-tuple substitution, which surfaced as a
+    confusing ``jax.lax.cond`` branch-shape error (``float64[N]`` vs
+    ``float64[]``) at the first ``fun`` evaluation.  The loss must be honored
+    literally, and vector or non-traceable losses must be rejected with
+    actionable errors before any optimizer sees them.
+    """
+    jax.config.update("jax_disable_jit", False)
+    inp = VmecInput.from_file(DATA_DIR / "input.solovev")
+    qs = opt.QuasisymmetryRatioResidual(SURFACES, 1, -1)
+
+    problem = opt.VmecProblem.from_loss(inp, qs.total_state, max_mode=1)
+    value = float(problem.fun(problem.x0))
+    assert np.isfinite(value)
+    eq = problem.equilibrium_from_x(problem.x0)
+    expected = float(jax.device_get(qs.total_state(eq.state, eq.runtime)))
+    # The problem evaluates the guarded-refinement fixed point; the
+    # materialized equilibrium is the host solve, so agreement is at the
+    # solver-refinement level, not machine precision.
+    np.testing.assert_allclose(value, expected, rtol=1e-5, atol=1e-10)
+
+    with pytest.raises(ValueError, match="must return a scalar"):
+        opt.VmecProblem.from_loss(inp, qs.residuals_state, max_mode=1)
+    with pytest.raises(ValueError, match=r"\(state, runtime\)"):
+        opt.VmecProblem.from_loss(inp, qs.J, max_mode=1)
+
+
 def test_certified_trial_guards_reject_stale_or_missing_memo(monkeypatch):
     """Certification refuses derivatives when the trial memo cannot vouch for x.
 

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -1470,6 +1470,16 @@ def _apply_current(inp: VmecInput, xc, k: int, ac_scale: float) -> VmecInput:
     return dataclasses.replace(inp, ac=values, curtor=float(xc[k]) * _CURTOR_SCALE)
 
 
+def _accepts_state_runtime(fun: Callable) -> bool:
+    """Whether ``fun`` takes two required positional ``(state, runtime)`` args."""
+    try:
+        params = [p for p in inspect.signature(fun).parameters.values()
+                  if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)]
+        return len(params) >= 2 and params[1].default is inspect.Parameter.empty
+    except (TypeError, ValueError):  # builtins / partials without signature
+        return False
+
+
 def _call_term(fun: Callable, eq: Equilibrium) -> np.ndarray:
     """Evaluate an objective callable against an :class:`Equilibrium`.
 
@@ -1478,13 +1488,8 @@ def _call_term(fun: Callable, eq: Equilibrium) -> np.ndarray:
     callables receive the :class:`Equilibrium` (e.g.
     ``QuasisymmetryRatioResidual.J`` or user lambdas).
     """
-    try:
-        params = [p for p in inspect.signature(fun).parameters.values()
-                  if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)]
-        two_positional = len(params) >= 2 and params[1].default is inspect.Parameter.empty
-    except (TypeError, ValueError):  # builtins / partials without signature
-        two_positional = False
-    value = fun(eq.state, eq.runtime) if two_positional else fun(eq)
+    value = (fun(eq.state, eq.runtime) if _accepts_state_runtime(fun)
+             else fun(eq))
     return np.atleast_1d(np.asarray(jax.device_get(value), dtype=float)).ravel()
 
 
@@ -2326,13 +2331,7 @@ def _traceable_term(fun: Callable) -> Callable:
     owner = getattr(fun, "__self__", fun)
     if hasattr(owner, "residuals_state"):
         return owner.residuals_state
-    try:
-        params = [p for p in inspect.signature(fun).parameters.values()
-                  if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)]
-        two_positional = len(params) >= 2 and params[1].default is inspect.Parameter.empty
-    except (TypeError, ValueError):
-        two_positional = False
-    if two_positional:
+    if _accepts_state_runtime(fun):
         return fun
     raise ValueError(
         f"objective term {fun!r} is not implicit-differentiable: jac='implicit' "
@@ -2341,6 +2340,25 @@ def _traceable_term(fun: Callable) -> Callable:
         "host NumPy — use jac=None (finite differences) for those, or the "
         "traceable d_merc_state / mercier_stability_residual and "
         "l_grad_b_state alternatives.")
+
+
+def _traceable_scalar_loss(fun: Callable) -> Callable:
+    """Scalar ``loss`` callable -> the same callable, validated as traceable.
+
+    The ``loss=`` lane honors the passed callable literally: a bound scalar
+    method such as ``QuasisymmetryRatioResidual.total_state`` is used exactly
+    as given, never swapped for its owner's vector ``residuals_state`` — that
+    substitution belongs to the objective-tuple lane of
+    :func:`_traceable_term`, where residual rows are the desired shape.
+    """
+    if _accepts_state_runtime(fun):
+        return fun
+    raise ValueError(
+        f"loss {fun!r} is not implicit-differentiable: loss= needs a traceable "
+        "(state, runtime) -> scalar callable, e.g. an objective's total_state "
+        "method or a lambda composing such callables. Wout-engine callables "
+        "(J, residuals, d_merc, ...) run on host NumPy — use "
+        "derivative_method='finite_difference' for those.")
 
 
 def residuals_from_tuples(
@@ -2464,7 +2482,8 @@ def _least_squares_implicit(
         weight = _least_squares_weight(w, weight_semantics)
         terms.append((_traceable_term(f), float(t), jnp.asarray(weight)))
     traceable_scalar = (
-        None if scalar_objective is None else _traceable_term(scalar_objective)
+        None if scalar_objective is None
+        else _traceable_scalar_loss(scalar_objective)
     )
     modes = _dof_modes(inp, max_mode)
     nm = len(modes)
@@ -2567,6 +2586,13 @@ def _least_squares_implicit(
     if initial_rows.size == 0 or not np.all(np.isfinite(initial_rows)):
         raise FloatingPointError("non-finite or empty objective at the initial point")
     residual_size = int(initial_rows.size)
+    if traceable_scalar is not None and residual_size != 1:
+        raise ValueError(
+            f"loss returned {residual_size} values at the initial point; "
+            "loss= must return a scalar. Vector residual rows (e.g. a "
+            "residuals_state method) belong in objective_terms / "
+            "least_squares, or reduce them: "
+            "lambda state, runtime: jnp.sum(term.residuals_state(state, runtime)**2).")
     if traceable_scalar is None:
         sizes = [int(np.asarray(jax.device_get(
             jnp.atleast_1d(w * (jnp.asarray(f(state0, runtime0)) - t)).ravel()


### PR DESCRIPTION
## Problem

`opt.VmecProblem.from_loss(inp, term.total_state, ...)` crashed with a confusing `jax.lax.cond` branch-shape error (`true_fun has type float64[N] but false_fun float64[]`) whenever `term` is an objective exposing `residuals_state` (e.g. `opt.QuasisymmetryRatioResidual`). The loss lane reused the objective-tuple routing of `_traceable_term`, which substitutes the owner's vector `residuals_state` for any bound method whose `__self__` exposes one — silently discarding the scalar `total_state` the user passed and feeding N residual rows into the scalar lane's `lax.cond`.

Reproduce with any converged input:

```python
qs = opt.QuasisymmetryRatioResidual([0.25, 0.5, 0.75, 1.0], 1, 0)
problem = opt.VmecProblem.from_loss(inp, qs.total_state, max_mode=1)
problem.fun(problem.x0)  # TypeError from jax.lax.cond
```

## Fix

- The `loss=` lane now validates the callable with a new `_traceable_scalar_loss` and uses it exactly as passed — the `residuals_state` substitution stays confined to the objective-tuple lane, where residual rows are the desired shape.
- Non-traceable callables (wout-engine methods like `qs.J`) get an actionable `ValueError` pointing at the `(state, runtime) -> scalar` contract and the finite-difference alternative, raised eagerly before any solve.
- A seed-time guard rejects any loss returning more than one value (e.g. `qs.residuals_state` passed directly) with a clear message and a suggested reduction, so a shape mismatch can never reach the `lax.cond`.
- The duplicated two-positional signature check is consolidated into `_accepts_state_runtime`, shared with `_call_term` and `_traceable_term`; tuple-lane behavior is unchanged.

All existing `from_loss` call sites (tests, examples, benchmarks) pass plain `(state, runtime)` functions and are unaffected.

## Test plan

- New regression test `test_from_loss_honors_bound_scalar_method_literally`: builds `from_loss(inp, qs.total_state)` on solovev, asserts `fun(x0)` is finite and matches `total_state` evaluated on the materialized equilibrium, and pins both new error paths.
- Full `tests/test_optimize.py`: 34 passed.
- ruff clean.