### PR TITLE
Hand the Boozer transform to booz_xform_jax for both parities

### DIFF
--- a/benchmarks/profile_workflows.py
+++ b/benchmarks/profile_workflows.py
@@ -306,7 +306,7 @@ def _wf_hot_restart_scan() -> tuple[dict, dict]:
 
 def _wf_boozer_one_surface() -> tuple[dict, dict]:
     from vmex.core import optimize as opt
-    from vmex.core.omnigenity import boozer_bmnc_state
+    from vmex.core.omnigenity import boozer_spectrum_state
 
     inp = _read_input("input.li383_low_res")
     held = {}
@@ -316,7 +316,7 @@ def _wf_boozer_one_surface() -> tuple[dict, dict]:
         return _block(held["eq"].state.R_cos)
 
     def transform():
-        held["bmnc"] = boozer_bmnc_state(
+        held["bmnc"] = boozer_spectrum_state(
             held["eq"].state, held["eq"].runtime, surfaces=(0.5,))
         return _block(next(iter(held["bmnc"].values())))
 
@@ -671,7 +671,7 @@ def _wf_hybrid_gk_geometry() -> tuple[dict, dict]:
 
 def _wf_boozer_many_surfaces() -> tuple[dict, dict]:
     from vmex.core import optimize as opt
-    from vmex.core.omnigenity import boozer_bmnc_state
+    from vmex.core.omnigenity import boozer_spectrum_state
 
     inp = _read_input("input.li383_low_res")
     surfaces = tuple(0.15 + 0.75 * i / 7.0 for i in range(8))
@@ -682,7 +682,7 @@ def _wf_boozer_many_surfaces() -> tuple[dict, dict]:
         return _block(held["eq"].state.R_cos)
 
     def transform():
-        held["bmnc"] = boozer_bmnc_state(
+        held["bmnc"] = boozer_spectrum_state(
             held["eq"].state, held["eq"].runtime, surfaces=surfaces)
         return _block(next(iter(held["bmnc"].values())))
 

--- a/docs/explanation/confinement.rst
+++ b/docs/explanation/confinement.rst
@@ -74,9 +74,8 @@ part :math:`w` of the Boozer generating potential, fixed by
    \frac{\partial w}{\partial\zeta}  = B_\zeta,
 
 with :math:`B_\theta,B_\zeta` the covariant components on the surface
-(:func:`~vmex.core.fields.magnetic_fields`). In
-:func:`~vmex.core.omnigenity.boozer_bmnc_state` this is inverted
-spectrally: after an FFT, the non-axisymmetric (:math:`m\ne 0`) harmonics of
+(:func:`~vmex.core.fields.magnetic_fields`). ``booz_xform_jax``'s kernel
+inverts this spectrally: the non-axisymmetric (:math:`m\ne 0`) harmonics of
 :math:`w` come from :math:`B_\theta` and the axisymmetric (:math:`m=0`)
 harmonics from :math:`B_\zeta`, matching the mode split of the Fortran
 ``booz_xform``. The coordinate shift is then
@@ -99,15 +98,19 @@ the angle bracket being the surface average over the original
 :math:`(\theta,\zeta)` grid. These are the ``bmnc_b`` coefficients (physical
 mode numbers ``xm_b``, ``xn_b``) consumed by every metric below.
 
-Two implementations share these equations. The host driver
-:func:`vmex.core.boozer.run_booz_xform` calls ``booz_xform_jax`` on a
-``wout_*.nc`` file and writes a standard ``boozmn_*.nc`` (used by ``vmec
---booz`` and by :func:`~vmex.core.optimize.quasi_isodynamic_residual_from_wout`).
-The traceable :func:`~vmex.core.omnigenity.boozer_bmnc_state` evaluates the
-*same* transform in pure ``jax.numpy`` directly from the solver's internal
-half-mesh field tables, so the Boozer spectrum — and any metric built on it —
-carries exact implicit gradients. The two agree to :math:`\sim10^{-6}` on the
-dominant modes.
+One transform implementation — ``booz_xform_jax``'s — executes these
+equations; vmex only feeds it. The host driver
+:func:`vmex.core.boozer.run_booz_xform` calls it on a ``wout_*.nc`` file and
+writes a standard ``boozmn_*.nc`` (used by ``vmec --booz`` and by
+:func:`~vmex.core.optimize.quasi_isodynamic_residual_from_wout`). The
+traceable :func:`~vmex.core.omnigenity.boozer_spectrum_state` calls the same
+jittable kernel in memory on wout-convention tables built from the solver's
+internal state (:func:`~vmex.core.boozer_tables.boozer_input_tables`), so
+the Boozer spectrum — and any metric built on it — carries exact implicit
+gradients. The two routes differ only through the table construction (the
+wout file stores half-mesh finite-difference averages of some families) and
+agree on the bundled QI deck to a measured :math:`1.7\times10^{-6}\,B_{00}`
+absolute and :math:`2\times10^{-5}` relative on the dominant modes.
 
 
 Quasisymmetry
@@ -283,8 +286,9 @@ line, a marginal or merged level, or more wells than ``max_wells`` returns NaN
 with a false ``valid_pitch`` flag. This makes a topology error visible instead
 of turning it into a favorable zero. The low-level Boozer-spectrum function
 accepts cosine and sine harmonics, and so does the equilibrium objective:
-:func:`~vmex.core.omnigenity.boozer_bmnc_state` dispatches ``lasym`` states to
-the full booz_xform transform and returns ``bmns_b`` alongside ``bmnc_b``,
+:func:`~vmex.core.omnigenity.boozer_spectrum_state` runs symmetric and
+``lasym`` states through the same booz_xform kernel and returns ``bmns_b``
+alongside ``bmnc_b`` (all-zero in the symmetric case),
 which every QI residual above passes through. On an up-down-asymmetric deck
 the traceable cosine and sine spectra are gated against the host
 booz_xform_jax reconstruction at ``2e-2`` and ``3e-2`` relative, and the QI

--- a/docs/reference/api/advanced.rst
+++ b/docs/reference/api/advanced.rst
@@ -110,7 +110,7 @@ one-field-period array view accepted by ESSOS, and
 :func:`vmex.surface_field_data_from_high_order` converts the same analytic
 geometry and edge field for ``virtual_casing_jax``.  Neither path writes a
 ``wout`` file or finite-differences a surface tangent.  Field-aligned
-objectives use :func:`vmex.boozer_bmnc_high_order`, which sends continuous
+objectives use :func:`vmex.boozer_spectrum_high_order`, which sends continuous
 geometry and field tables to BOOZ_XFORM_JAX without reconstructing a sampled
 radial mesh.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,13 @@ dependencies = [
   "packaging",
   # JAX's persistent compilation cache uses file locks across processes.
   "filelock",
-  "booz_xform_jax",
+  # 0.1.1 is the first release whose jittable kernel accepts the asymmetric
+  # families (rmns/zmnc/lmnc/bmns/bsubumns/bsubvmns) that the in-memory
+  # bridge passes for lasym states, and the first with guarded zero-mode
+  # denominators so the transform has finite tangents under jvp/grad.
+  # 0.1.0 raises TypeError on rmns/zmnc/lmnc.  (The BoozerConfig/
+  # BoozerPlan API on booz_xform_jax main is unreleased and NOT required.)
+  "booz_xform_jax>=0.1.1",
   # 0.20.0 adds the matrix-free least-squares APIs used by strong-force
   # polishing. 0.19.0 contains continuation but predates the least-squares PR.
   "solvax>=0.20.0",

--- a/tests/test_boozer_tables.py
+++ b/tests/test_boozer_tables.py
@@ -26,7 +26,7 @@ jax.config.update("jax_enable_x64", True)
 from vmex.core import solver
 from vmex.core.boozer_tables import boozer_input_tables, high_order_boozer_input_tables
 from vmex.core.input import VmecInput
-from vmex.core.omnigenity import boozer_bmnc_high_order, boozer_bmnc_state
+from vmex.core.omnigenity import boozer_spectrum_high_order, boozer_spectrum_state
 from vmex.core.strong_force import lift_high_order_state
 from vmex.core.wout import wout_from_state
 
@@ -362,7 +362,7 @@ def _boozer_range_matches_wout(eq, booz, tolerance=0.1):
 def test_boozer_transform_preserves_the_field_strength_range(symmetric_eq):
     """The Boozer map is a relabelling: |B| extrema on a surface are invariant.
 
-    Re-synthesizing ``|B|`` from ``boozer_bmnc_state`` on a fine Boozer grid
+    Re-synthesizing ``|B|`` from ``boozer_spectrum_state`` on a fine Boozer grid
     must recover the same surface minimum and maximum as the wout tables in
     VMEC angles (booz_xform, Sanchez et al. 2000: the transform changes the
     angle labels, not the field).  ``solovev`` is axisymmetric, so every
@@ -371,7 +371,7 @@ def test_boozer_transform_preserves_the_field_strength_range(symmetric_eq):
     from vmex.core import omnigenity as omn
 
     eq = symmetric_eq
-    booz = omn.boozer_bmnc_state(eq.state, eq.runtime, surfaces=[0.5],
+    booz = omn.boozer_spectrum_state(eq.state, eq.runtime, surfaces=[0.5],
                                  mboz=6, nboz=2)
     _boozer_range_matches_wout(eq, booz)
     # Axisymmetric deck: no toroidal harmonics, and no sine family at all.
@@ -384,7 +384,7 @@ def test_boozer_transform_preserves_the_field_strength_range(symmetric_eq):
 def test_lasym_boozer_transform_preserves_the_field_strength_range(lasym_solved):
     """``LASYM`` states keep the same invariant through the asymmetric route.
 
-    ``boozer_bmnc_state`` routes them through booz_xform_jax's asymmetric
+    ``boozer_spectrum_state`` routes them through booz_xform_jax's asymmetric
     transform, so the surface extrema must still match the wout tables and the
     sine family must carry the deck's actual asymmetry rather than vanish.
     """
@@ -392,7 +392,7 @@ def test_lasym_boozer_transform_preserves_the_field_strength_range(lasym_solved)
     from vmex.core import optimize as opt
 
     eq = lasym_solved
-    booz = omn.boozer_bmnc_state(eq.state, eq.runtime, surfaces=[0.5],
+    booz = omn.boozer_spectrum_state(eq.state, eq.runtime, surfaces=[0.5],
                                  mboz=6, nboz=6)
     row, span = _boozer_range_matches_wout(eq, booz)
     # The sine family is populated at the amplitude the wout engine reports;
@@ -462,8 +462,8 @@ def test_high_order_boozer_matches_live_state_without_file_io(symmetric_eq):
     with pytest.raises(ValueError, match="projection grids"):
         high_order_boozer_input_tables(native_state, np.sqrt(surface), ntheta=1)
     with pytest.raises(ValueError, match="0 < s <= 1"):
-        boozer_bmnc_high_order(native_state, surfaces=[0.0])
-    live = boozer_bmnc_state(
+        boozer_spectrum_high_order(native_state, surfaces=[0.0])
+    live = boozer_spectrum_state(
         eq.state,
         eq.runtime,
         surfaces=[surface],
@@ -471,7 +471,7 @@ def test_high_order_boozer_matches_live_state_without_file_io(symmetric_eq):
         nboz=2,
         oversample=1,
     )
-    native = boozer_bmnc_high_order(
+    native = boozer_spectrum_high_order(
         native_state,
         surfaces=[surface],
         mboz=8,
@@ -565,3 +565,47 @@ def test_refine_booz_grids_is_the_identity_at_oversample_one():
     same_constants, same_grids = _refine_booz_grids(constants, grids, 1, 3)
     assert same_constants is constants
     assert same_grids is grids
+
+
+@pytest.mark.parametrize("asym", [False, True])
+def test_refine_booz_grids_preserves_the_parity_grid_layout(asym):
+    """Refinement keeps booz_xform's own theta-domain convention.
+
+    The stellarator-symmetric quadrature spans theta in ``[0, pi]`` only
+    (``nu2_b`` rows; the kernel half-weights the boundary rows and reads its
+    normalization off ``nu2_b``), while the asymmetric quadrature spans the
+    full circle (``ntheta`` rows).  A refinement that rebuilt the full
+    circle for a symmetric run would hand the kernel twice the domain it
+    normalizes for and corrupt every spectrum, so pin the layout per parity.
+    """
+    pytest.importorskip("booz_xform_jax")
+    from booz_xform_jax.jax_api import prepare_booz_xform_constants
+
+    from vmex.core.omnigenity import _refine_booz_grids
+
+    nfp, mboz, nboz, factor = 3, 4, 3, 2
+    m = np.arange(5)
+    constants, grids = prepare_booz_xform_constants(
+        nfp=nfp, mboz=mboz, nboz=nboz, asym=asym, xm=m, xn=0 * m,
+        xm_nyq=m, xn_nyq=0 * m)
+    fine_c, fine_g = _refine_booz_grids(constants, grids, factor, nfp)
+
+    ntheta = factor * int(constants.ntheta)
+    nzeta = factor * int(constants.nzeta)
+    assert int(fine_c.ntheta) == ntheta
+    assert int(fine_c.nzeta) == nzeta
+    assert int(fine_c.nu2_b) == ntheta // 2 + 1
+    rows = ntheta if asym else ntheta // 2 + 1
+    theta = np.asarray(fine_g.theta_grid)
+    zeta = np.asarray(fine_g.zeta_grid)
+    assert theta.shape == zeta.shape == (rows * nzeta,)
+    # Same flattened layout and spacing the kernel's boundary-row indexing
+    # (idx_theta0/idx_thetapi) and Fourier normalization assume.
+    assert theta[-1] == pytest.approx(
+        2.0 * np.pi * (rows - 1) / ntheta)
+    assert np.max(theta) == pytest.approx(np.pi if not asym else
+                                          2.0 * np.pi * (ntheta - 1) / ntheta)
+    assert np.max(zeta) == pytest.approx(2.0 * np.pi * (nzeta - 1) / (nzeta * nfp))
+    coarse_rows = int(constants.ntheta) if asym else int(constants.nu2_b)
+    assert np.allclose(np.asarray(grids.theta_grid).reshape(coarse_rows, -1)[:, 0],
+                       theta.reshape(rows, -1)[::factor, 0][:coarse_rows])

--- a/tests/test_maxj.py
+++ b/tests/test_maxj.py
@@ -125,7 +125,7 @@ def test_constructed_class_matches_the_functional_form_and_guards_inputs(monkeyp
     booz = _boozer(0.98)
     options = dict(max_wells=2, quadrature_order=32,
                    qi_options={"nphi": 65, "nalpha": 5, "n_bounce": 7})
-    monkeypatch.setattr(maxj, "boozer_bmnc_state", lambda *args, **kwargs: booz)
+    monkeypatch.setattr(maxj, "boozer_spectrum_state", lambda *args, **kwargs: booz)
     term = maxj.ConstructedMaximumJResidual(
         [0.25, 0.75], [1.0 / 1.1], mboz=2, nboz=2, **options)
     eq = SimpleNamespace(state=object(), runtime=object())
@@ -232,7 +232,7 @@ def test_maximum_j_jit_and_ad_match_finite_difference():
 
 def test_maximum_j_composable_interface(monkeypatch):
     booz = _boozer(0.98)
-    monkeypatch.setattr(maxj, "boozer_bmnc_state", lambda *args, **kwargs: booz)
+    monkeypatch.setattr(maxj, "boozer_spectrum_state", lambda *args, **kwargs: booz)
     term = maxj.MaximumJResidual(
         [0.25, 0.75], [1.0 / 1.1], mboz=2, nboz=2, nalpha=5,
         points_per_period=64, num_periods=4, max_wells=6)
@@ -284,7 +284,7 @@ _LASYM_TERMS = {
 def test_bounce_objectives_consume_the_boozer_sine_spectrum(name, monkeypatch):
     """Every bounce objective must certify the field the equilibrium has.
 
-    ``boozer_bmnc_state`` returns ``bmns_b`` for LASYM states; a class that
+    ``boozer_spectrum_state`` returns ``bmns_b`` for LASYM states; a class that
     drops it silently evaluates the stellarator-symmetrized field, so its
     maximum-J or omnigenity certificate does not describe the asymmetric
     equilibrium being optimized. The symmetric limit must stay exact:
@@ -295,7 +295,7 @@ def test_bounce_objectives_consume_the_boozer_sine_spectrum(name, monkeypatch):
     eq = SimpleNamespace(state=object(), runtime=object())
 
     def rows(booz):
-        monkeypatch.setattr(module, "boozer_bmnc_state", lambda *a, **k: booz)
+        monkeypatch.setattr(module, "boozer_spectrum_state", lambda *a, **k: booz)
         return np.asarray(term(eq))
 
     symmetric = rows(_asymmetric_boozer(0.0))
@@ -343,7 +343,7 @@ def test_common_trapped_pitches_use_one_field_strength_on_all_lines():
 
 def test_common_trapped_pitches_state_samples_boozer_lines(monkeypatch):
     booz = _boozer(1.02)
-    monkeypatch.setattr(maxj, "boozer_bmnc_state", lambda *args, **kwargs: booz)
+    monkeypatch.setattr(maxj, "boozer_spectrum_state", lambda *args, **kwargs: booz)
     pitch = maxj.common_trapped_pitches_state(
         object(), object(), [0.25, 0.75], [0.5],
         nalpha=5, points_per_period=32, num_periods=2)

--- a/tests/test_omnigenity.py
+++ b/tests/test_omnigenity.py
@@ -1,7 +1,7 @@
 """Validation gates for the traceable omnigenity/QI objective (R26h.h2).
 
 - **Transform parity**: the traceable Boozer ``|B|`` spectrum
-  (:func:`vmex.core.omnigenity.boozer_bmnc_state`) matches the host
+  (:func:`vmex.core.omnigenity.boozer_spectrum_state`) matches the host
   booz_xform_jax route (:func:`vmex.core.optimize.boozer_modes_from_wout`)
   mode-by-mode on a converged 3D deck.
 - **Physics**: the residual is exactly zero on an analytic QI (pure-QP)
@@ -86,26 +86,47 @@ def test_half_mesh_midpoint_tie_selects_lower_surface(monkeypatch):
     with pytest.raises(ValueError, match="surfaces must be non-empty"):
         omn._nearest_half_mesh_rows(31, [])
 
-    class GeometryReached(RuntimeError):
+    class TablesReached(RuntimeError):
         pass
 
-    def stop_at_geometry(*_):
-        raise GeometryReached
+    def stop_at_tables(*_):
+        raise TablesReached
 
-    monkeypatch.setattr(omn, "_geometry", stop_at_geometry)
+    monkeypatch.setattr(omn, "boozer_input_tables", stop_at_tables)
     runtime = SimpleNamespace(
         setup=SimpleNamespace(lasym=False, s_full=np.linspace(0.0, 1.0, 31)),
         resolution=SimpleNamespace(nfp=2),
     )
-    with pytest.raises(GeometryReached):
-        omn.boozer_bmnc_state(object(), runtime, surfaces=[0.1])
+    with pytest.raises(TablesReached):
+        omn.boozer_spectrum_state(object(), runtime, surfaces=[0.1])
+
+
+def test_deprecated_transform_aliases_warn_and_dispatch(monkeypatch):
+    """The pre-handover names still work: one warning, then the canonical call."""
+    calls = []
+    monkeypatch.setattr(
+        omn, "boozer_spectrum_state",
+        lambda *a, **k: calls.append(("state", a, k)) or {"tag": "state"})
+    monkeypatch.setattr(
+        omn, "boozer_spectrum_high_order",
+        lambda *a, **k: calls.append(("high", a, k)) or {"tag": "high"})
+    with pytest.warns(DeprecationWarning, match="boozer_spectrum_state"):
+        out = omn.boozer_bmnc_state("st", "rt", surfaces=[0.5], mboz=4)
+    assert out == {"tag": "state"}
+    with pytest.warns(DeprecationWarning, match="boozer_spectrum_high_order"):
+        out = omn.boozer_bmnc_high_order("st", surfaces=[0.5], nboz=3)
+    assert out == {"tag": "high"}
+    assert calls == [
+        ("state", ("st", "rt"), {"surfaces": [0.5], "mboz": 4}),
+        ("high", ("st",), {"surfaces": [0.5], "nboz": 3}),
+    ]
 
 
 @pytest.mark.full
 def test_boozer_spectrum_matches_booz_xform(qi_eq):
     pytest.importorskip("booz_xform_jax")
     # 0.53 is not equidistant between half surfaces (0.5 is a snapping tie).
-    trace = omn.boozer_bmnc_state(qi_eq.state, qi_eq.runtime, surfaces=[0.53],
+    trace = omn.boozer_spectrum_state(qi_eq.state, qi_eq.runtime, surfaces=[0.53],
                                   mboz=10, nboz=10, oversample=2)
     host = opt.boozer_modes_from_wout(qi_eq, surfaces=[0.53], mboz=10, nboz=10)
     assert float(trace["iota_b"][0]) == pytest.approx(float(host["iota_b"][0]), rel=1e-8)
@@ -127,10 +148,14 @@ def test_boozer_spectrum_matches_booz_xform(qi_eq):
         bw = lookup.get((m, n))
         if bw is None:
             continue
-        # measured floor between the two discretizations: <= 6.3e-5 * b00
-        assert abs(bt[j] - bw) < 2e-4 * b00, (m, n)
+        # Both routes now run the same booz_xform_jax kernel, so the only
+        # difference left is the table construction (state-native half mesh
+        # vs the wout file's finite-difference averages).  Measured floor on
+        # this deck: 1.7e-6 * b00 absolute, 2.0e-5 relative on dominant
+        # modes; the gates keep ~10x margin.
+        assert abs(bt[j] - bw) < 2e-5 * b00, (m, n)
         if abs(bw) > 1e-2 * b00:  # dominant modes additionally match tightly
-            assert bt[j] == pytest.approx(bw, rel=5e-3), (m, n)
+            assert bt[j] == pytest.approx(bw, rel=3e-4), (m, n)
         checked += 1
     assert checked >= 50  # the comparison actually covered the spectrum
 
@@ -145,7 +170,7 @@ def test_lasym_boozer_spectra_and_qi_derivative(lasym_eq):
     # full Nyquist projection in boozer_input_tables the two routes agree to a
     # measured 1.06e-5 (bmnc_b) / 1.03e-4 (bmns_b) relative L2; the tolerances
     # below keep ~10x margin.
-    trace = omn.boozer_bmnc_state(
+    trace = omn.boozer_spectrum_state(
         lasym_eq.state, lasym_eq.runtime, surfaces=[0.53], mboz=6, nboz=6,
         oversample=1)
     for name, tolerance in (("bmnc_b", 1.1e-4), ("bmns_b", 1.1e-3)):

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -19,7 +19,7 @@ from vmex.core.errors import (
     StrongForceLinearSolveError,
 )
 from vmex.core.input import VmecInput
-from vmex.core.omnigenity import boozer_bmnc_high_order
+from vmex.core.omnigenity import boozer_spectrum_high_order
 from vmex.core.polish import (
     HighOrderCorrection,
     PreconditionerRefreshPolicy,
@@ -1234,7 +1234,7 @@ def test_collocation_polish_primal_and_derivatives(small_strong_root):
     )
 
     def boozer_objective(native):
-        spectrum = boozer_bmnc_high_order(
+        spectrum = boozer_spectrum_high_order(
             native,
             surfaces=[0.49],
             mboz=4,

--- a/tests/test_qi_maxj_composition.py
+++ b/tests/test_qi_maxj_composition.py
@@ -40,8 +40,8 @@ def _counting_boozer(monkeypatch):
         calls["count"] += 1
         return booz
 
-    monkeypatch.setattr(qi_mod, "boozer_bmnc_state", fake)
-    monkeypatch.setattr(maxj_mod, "boozer_bmnc_state", fake)
+    monkeypatch.setattr(qi_mod, "boozer_spectrum_state", fake)
+    monkeypatch.setattr(maxj_mod, "boozer_spectrum_state", fake)
     return calls
 
 

--- a/tests/test_qi_reference_oracle.py
+++ b/tests/test_qi_reference_oracle.py
@@ -268,7 +268,7 @@ def test_constructed_class_matches_functional_layer(monkeypatch):
     """ConstructedQIResidual is exactly the validated functional layer."""
     booz = dict(FIELD_QI, G_b=jnp.asarray([2.0]), I_b=jnp.asarray([0.0]),
                 s_b=jnp.asarray([0.5]))
-    monkeypatch.setattr(qi_mod, "boozer_bmnc_state", lambda *a, **k: booz)
+    monkeypatch.setattr(qi_mod, "boozer_spectrum_state", lambda *a, **k: booz)
     term = qi_mod.ConstructedQIResidual(
         [0.5], nphi=NPHI, nalpha=NALPHA, n_bounce=NBOUNCE)
     eq = SimpleNamespace(state=object(), runtime=object())

--- a/tests/test_qi_residuals.py
+++ b/tests/test_qi_residuals.py
@@ -89,7 +89,7 @@ def test_action_residual_ad_matches_finite_difference():
 
 def test_objective_terms_share_the_composable_interface(monkeypatch):
     booz = _boozer(0.04)
-    monkeypatch.setattr(qi, "boozer_bmnc_state", lambda *args, **kwargs: booz)
+    monkeypatch.setattr(qi, "boozer_spectrum_state", lambda *args, **kwargs: booz)
     eq = SimpleNamespace(state=object(), runtime=object())
 
     action = qi.JInvariantQIResidual(

--- a/tests/test_strong_force.py
+++ b/tests/test_strong_force.py
@@ -14,7 +14,7 @@ import pytest
 from vmex.core.fourier import Resolution
 from vmex.core.boozer_tables import high_order_boozer_input_tables
 from vmex.core.input import VmecInput
-from vmex.core.omnigenity import boozer_bmnc_high_order
+from vmex.core.omnigenity import boozer_spectrum_high_order
 from vmex.core.profiles import MU0
 from vmex.core.radial_basis import BSplineBasis
 from vmex.core.solver import _initial_state, prepare_runtime, resolution_from_input
@@ -217,7 +217,7 @@ def test_high_order_boozer_handoff_is_exact_and_differentiable():
 
     def objective(scale):
         candidate = replace(state, phipf=scale * state.phipf)
-        boozer = boozer_bmnc_high_order(
+        boozer = boozer_spectrum_high_order(
             candidate,
             surfaces=[0.49],
             mboz=4,

--- a/vmex/__init__.py
+++ b/vmex/__init__.py
@@ -166,6 +166,11 @@ _LAZY_ATTRS: dict[str, tuple[str, str | None]] = {
         ".core.strong_force", "evaluate_high_order_fields"),
     "evaluate_high_order_surface": (
         ".core.strong_force", "evaluate_high_order_surface"),
+    "boozer_spectrum_high_order": (
+        ".core.omnigenity", "boozer_spectrum_high_order"),
+    "boozer_spectrum_state": (
+        ".core.omnigenity", "boozer_spectrum_state"),
+    # deprecated alias (warns on call, dispatches to the canonical name)
     "boozer_bmnc_high_order": (
         ".core.omnigenity", "boozer_bmnc_high_order"),
     "evaluate_strong_force": (".core.strong_force", "evaluate_strong_force"),

--- a/vmex/core/maxj.py
+++ b/vmex/core/maxj.py
@@ -9,7 +9,7 @@ import numpy as np
 import jax.numpy as jnp
 
 from .bounce import bounce_action, bounce_action_from_boozer
-from .omnigenity import boozer_bmnc_state
+from .omnigenity import boozer_spectrum_state
 from .optimize import quasi_isodynamic_residual
 from .qi import j_invariant_qi_residual_from_boozer
 from .statephysics import _as_1d
@@ -168,7 +168,7 @@ def common_trapped_pitches_state(
     every surface and field-line label; this prevents radial maximum-J
     comparisons from silently changing the particle population.
     """
-    booz = boozer_bmnc_state(
+    booz = boozer_spectrum_state(
         state, rt, surfaces=surfaces, mboz=mboz, nboz=nboz)
     dtype = jnp.asarray(booz["bmnc_b"]).dtype
     alpha = jnp.asarray(2.0 * np.pi * np.arange(int(nalpha)) / int(nalpha), dtype=dtype)
@@ -370,7 +370,7 @@ def qi_and_maximum_j_from_boozer(
     """Evaluate the J-invariance and maximum-J residuals from one Boozer pass.
 
     :class:`~vmex.core.qi.JInvariantQIResidual` and :class:`MaximumJResidual`
-    each run their own :func:`~vmex.core.omnigenity.boozer_bmnc_state`
+    each run their own :func:`~vmex.core.omnigenity.boozer_spectrum_state`
     transform — the dominant cost when both objectives share the same
     surfaces and physical pitch (the usual campaign layout).  This helper
     runs the transform once and feeds both functional layers.
@@ -382,7 +382,7 @@ def qi_and_maximum_j_from_boozer(
     Returns ``{"boozer", "qi", "maximum_j"}``; the two residual entries are
     identical to the corresponding independent class evaluations.
     """
-    booz = boozer_bmnc_state(
+    booz = boozer_spectrum_state(
         state, rt, surfaces=surfaces, mboz=int(mboz), nboz=int(nboz),
         oversample=int(oversample))
     common = dict(
@@ -485,7 +485,7 @@ class ConstructedMaximumJResidual:
 
     def compute_state(self, state, rt):
         """Return constructed-field actions and radial-slope diagnostics."""
-        booz = boozer_bmnc_state(
+        booz = boozer_spectrum_state(
             state, rt, surfaces=self.surfaces, mboz=self.mboz,
             nboz=self.nboz, oversample=self.oversample)
         out = constructed_maximum_j_residual_from_boozer(
@@ -538,7 +538,7 @@ class MaximumJResidual:
 
     def compute_state(self, state, rt):
         """Return maximum-J residuals, actions, matches, and flux slopes."""
-        booz = boozer_bmnc_state(
+        booz = boozer_spectrum_state(
             state, rt, surfaces=self.surfaces, mboz=self.mboz,
             nboz=self.nboz, oversample=self.oversample)
         out = maximum_j_residual_from_boozer(

--- a/vmex/core/omnigenity.py
+++ b/vmex/core/omnigenity.py
@@ -165,6 +165,13 @@ def _boozer_kernel_state(state, rt, *, rows, s_half, mboz, nboz, oversample):
     stack = lambda name: jnp.stack([table[name] for table in tables])  # noqa: E731
     first = tables[0]
     xm, xn = np.asarray(first["xm"]), np.asarray(first["xn"])
+    # An axisymmetric state (no toroidal input harmonics) has exactly no
+    # n != 0 Boozer content -- the Boozer relabelling of an axisymmetric
+    # field is axisymmetric -- so drop the toroidal band outright.  This
+    # keeps the historical mode-list contract (tokamak decks return no
+    # toroidal harmonics) and skips the dead quadrature.
+    if not np.any(xn):
+        nboz = 0
     # booz_xform's convenience wrapper prepares shape constants with Python
     # integer conversions. Do that work at trace time, then call its fully
     # jittable kernel so the objectives remain differentiable under JVP.

--- a/vmex/core/omnigenity.py
+++ b/vmex/core/omnigenity.py
@@ -9,18 +9,17 @@ no host booz_xform round-trip.
 
 Two pieces:
 
-1. :func:`boozer_bmnc_state` — a minimal *traceable* Boozer ``|B|`` transform.
-   The classic BOOZ_XFORM construction (Hirshman's Fortran code; equation
-   numbers below follow Landreman's booz_xform documentation) is evaluated
-   in pure ``jax.numpy`` from the solver's internal half-mesh field tables:
-   the periodic part of the Boozer generating potential ``w`` is integrated
-   spectrally from the covariant field components (``dw/dtheta = B_theta``,
-   ``dw/dzeta = B_zeta``), then ``nu = (w - I*lambda) / (G + iota*I)`` gives
-   the Boozer angles ``theta_B = theta + lambda + iota*nu``,
-   ``zeta_B = zeta + nu``, and the Boozer ``|B|`` harmonics come from the
-   angle-transform quadrature ``bmnc_b = <|B| cos(m theta_B - n zeta_B) *
-   d(theta_B, zeta_B)/d(theta, zeta)>`` — the same equations booz_xform
-   solves, here end-to-end differentiable.
+1. :func:`boozer_spectrum_state` — a *traceable* Boozer ``|B|`` transform.
+   vmex owns only the equilibrium side: snapping requested surfaces to the
+   half mesh and building wout-convention single-surface spectral tables
+   from the live state (:func:`vmex.core.boozer_tables.boozer_input_tables`).
+   The Boozer transform itself — generating potential, Boozer angles, and
+   the angle-transform quadrature — executes in ``booz_xform_jax``'s
+   jittable kernel (``booz_xform_jax.jax_api.booz_xform_jax_impl``) for
+   symmetric and ``lasym`` states alike, so vmex carries no second
+   implementation of the transform and the whole chain stays end-to-end
+   differentiable.  (:func:`boozer_bmnc_state` remains as a deprecated
+   alias of the previous name.)
 
 2. :func:`omnigenity_residual` / :class:`QIResidual` — a smooth, lightweight
    surrogate for poloidally-closed-contour (``M = 0, N = 1``) omnigenity.
@@ -69,6 +68,7 @@ Scope notes
 from __future__ import annotations
 
 import dataclasses
+import warnings
 from typing import Any, Iterable
 
 import numpy as np
@@ -76,110 +76,20 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 
-from .fields import magnetic_fields, metric_elements, surface_currents
-from .geometry import half_mesh_jacobian
-from .solver import SolverRuntime, SpectralState, _geometry
-from .statephysics import _as_1d, _iotas_half_from_fields
-from .transforms import physical_to_internal_scale
+from .boozer_tables import boozer_input_tables, high_order_boozer_input_tables
+from .solver import SolverRuntime, SpectralState
+from .statephysics import _as_1d
 
 __all__ = [
     "boozer_bmnc_high_order",
     "boozer_bmnc_state",
+    "boozer_spectrum_high_order",
+    "boozer_spectrum_state",
     "omnigenity_residual",
     "QIResidual",
 ]
 
 Array = Any
-
-
-# ---------------------------------------------------------------------------
-# Small helpers
-# ---------------------------------------------------------------------------
-
-
-def _pad_spectrum_axis(hat: jnp.ndarray, axis: int, n_fine: int) -> jnp.ndarray:
-    """Zero-pad an FFT spectrum along ``axis`` (Nyquist split, real-safe).
-
-    Standard trigonometric interpolation: positive/negative frequency blocks
-    are copied, an even-length Nyquist coefficient is split half-and-half
-    onto ``+N/2`` and ``-N/2`` of the fine spectrum.  The caller rescales by
-    ``n_fine / n_coarse`` per padded axis (ifft normalization).
-    """
-    n = int(hat.shape[axis])
-    if n_fine == n:
-        return hat
-    if n_fine < n:
-        raise ValueError(f"padding target {n_fine} smaller than source {n}")
-
-    def take(sl):
-        index = [slice(None)] * hat.ndim
-        index[axis] = sl
-        return hat[tuple(index)]
-
-    n_pos = (n + 1) // 2                      # frequencies 0 .. ceil(n/2)-1
-    shape = list(hat.shape)
-    shape[axis] = n_fine
-    out = jnp.zeros(shape, dtype=hat.dtype)
-    index = [slice(None)] * hat.ndim
-    index[axis] = slice(0, n_pos)
-    out = out.at[tuple(index)].set(take(slice(0, n_pos)))
-    if n % 2 == 0:                            # split the Nyquist mode
-        nyq = 0.5 * take(slice(n // 2, n // 2 + 1))
-        index[axis] = slice(n // 2, n // 2 + 1)
-        out = out.at[tuple(index)].set(nyq)
-        index[axis] = slice(n_fine - n // 2, n_fine - n // 2 + 1)
-        out = out.at[tuple(index)].set(nyq)
-        n_neg = n // 2 - 1                    # strictly negative, non-Nyquist
-    else:
-        n_neg = n // 2
-    if n_neg > 0:
-        index[axis] = slice(n_fine - n_neg, n_fine)
-        out = out.at[tuple(index)].set(take(slice(n - n_neg, n)))
-    return out
-
-
-def _pad_spectrum(hat: jnp.ndarray, nt_fine: int, nz_fine: int) -> jnp.ndarray:
-    """Zero-pad a 2D FFT spectrum ``(..., ntheta, nzeta)`` with rescaling."""
-    nt, nz = int(hat.shape[-2]), int(hat.shape[-1])
-    out = _pad_spectrum_axis(hat, hat.ndim - 2, nt_fine)
-    out = _pad_spectrum_axis(out, hat.ndim - 1, nz_fine)
-    return out * (float(nt_fine * nz_fine) / float(nt * nz))
-
-
-def _mirror_maps(ntheta2: int, nzeta: int) -> tuple[int, np.ndarray, np.ndarray]:
-    """Stellarator-symmetry mirror of the reduced ``[0, pi]`` theta grid.
-
-    Same map as ``QuasisymmetryRatioResidual._pointwise_state``:
-    ``X(2 pi - theta, -zeta) = X(theta, zeta)`` for even (cos-series) fields.
-    """
-    ntheta1 = max(2 * (ntheta2 - 1), 1)
-    i_full = np.arange(ntheta1)
-    i_src = np.where(i_full < ntheta2, i_full, ntheta1 - i_full)
-    k = np.arange(nzeta)
-    k_src = np.where(i_full[:, None] < ntheta2, k[None, :], (nzeta - k[None, :]) % nzeta)
-    i_src = np.broadcast_to(i_src[:, None], (ntheta1, nzeta))
-    return ntheta1, i_src, k_src
-
-
-def _lambda_half_weights(ns: int) -> tuple[np.ndarray, np.ndarray]:
-    """Odd-m half-mesh interpolation weights ``(smw, spw)`` per half row.
-
-    ``lambda_wout_from_full_mesh`` (``wrout.f``) interpolates odd-m lambda
-    coefficients to half row ``js`` (between full ``js-1`` and ``js``) as
-    ``0.5 * (smw[js] * lam[js] + spw[js] * lam[js-1])`` with the
-    ``sqrt(s)``-representation weights below; even m uses plain averaging.
-    """
-    hs = 1.0 / (ns - 1)
-    js = np.arange(ns, dtype=float)
-    shalf = np.sqrt(hs * np.abs(js - 0.5))            # half surface js
-    sqrts = np.sqrt(hs * js)
-    smw = np.zeros(ns)
-    spw = np.zeros(ns)
-    smw[1:] = shalf[1:] / sqrts[1:]
-    spw[2:] = shalf[2:] / sqrts[1:-1]
-    if ns > 1:
-        spw[1] = smw[1]                               # wrout.f: sp(1) = sm(2)
-    return smw, spw
 
 
 # ---------------------------------------------------------------------------
@@ -214,45 +124,54 @@ def _refine_booz_grids(constants, grids, oversample, nfp):
     ``prepare_booz_xform_constants`` pins the angle-transform quadrature at
     ``2*(2*mboz+1)`` by ``2*(2*nboz+1)`` points, but the transform reads the
     counts back off ``constants`` for its Fourier normalization, so an integer
-    refinement of the flattened ``(theta, zeta)`` grid is a drop-in — the same
-    aliasing control the symmetric lane gets from its zero-padded FFT grid.
+    refinement of the flattened ``(theta, zeta)`` grid is a drop-in reduction
+    of the ``cos(m theta_B - n zeta_B)`` aliasing.
     """
     factor = int(oversample)
     if factor == 1:
         return constants, grids
     ntheta = factor * int(constants.ntheta)
     nzeta = factor * int(constants.nzeta) if int(constants.nzeta) > 1 else 1
-    theta = 2.0 * np.pi * np.arange(ntheta) / ntheta
+    nu2_b = ntheta // 2 + 1
+    # booz_xform's stellarator-symmetric grid spans theta in [0, pi] only
+    # (nu2_b rows, boundary rows half-weighted and the normalization read
+    # from nu2_b); the asymmetric grid spans the full circle (ntheta rows).
+    nu3_b = ntheta if bool(constants.asym) else nu2_b
+    theta = 2.0 * np.pi * np.arange(nu3_b) / ntheta
     zeta = 2.0 * np.pi * np.arange(nzeta) / (nzeta * int(nfp))
     return (
         dataclasses.replace(constants, ntheta=ntheta, nzeta=nzeta,
-                            nu2_b=ntheta // 2 + 1),
+                            nu2_b=nu2_b),
         dataclasses.replace(grids,
                             theta_grid=jnp.asarray(np.repeat(theta, nzeta)),
-                            zeta_grid=jnp.asarray(np.tile(zeta, ntheta))),
+                            zeta_grid=jnp.asarray(np.tile(zeta, nu3_b))),
     )
 
 
-def _boozer_lasym_state(state, rt, *, rows, s_half, mboz, nboz, oversample):
-    """LASYM state tables through booz_xform_jax's validated full transform."""
+def _boozer_kernel_state(state, rt, *, rows, s_half, mboz, nboz, oversample):
+    """State tables through booz_xform_jax's validated full transform.
+
+    One code path for both parities: symmetric states pass only the cosine
+    families (the kernel returns an all-zero ``bmns_b`` block), ``lasym``
+    states add the independent sine families.
+    """
     from booz_xform_jax.jax_api import (
         booz_xform_jax_impl,
         prepare_booz_xform_constants,
     )
 
-    from .boozer_tables import boozer_input_tables
-
+    lasym = bool(rt.setup.lasym)
     tables = [boozer_input_tables(state, rt, int(row)) for row in rows]
     stack = lambda name: jnp.stack([table[name] for table in tables])  # noqa: E731
     first = tables[0]
     xm, xn = np.asarray(first["xm"]), np.asarray(first["xn"])
     # booz_xform's convenience wrapper prepares shape constants with Python
     # integer conversions. Do that work at trace time, then call its fully
-    # jittable kernel so LASYM objectives remain differentiable under JVP.
+    # jittable kernel so the objectives remain differentiable under JVP.
     with jax.ensure_compile_time_eval():
         constants, grids = prepare_booz_xform_constants(
             nfp=int(rt.resolution.nfp), mboz=int(mboz), nboz=int(nboz),
-            asym=True, xm=xm, xn=xn, xm_nyq=xm, xn_nyq=xn)
+            asym=lasym, xm=xm, xn=xn, xm_nyq=xm, xn_nyq=xn)
         constants, grids = _refine_booz_grids(
             constants, grids, oversample, rt.resolution.nfp)
         xm_b = np.asarray(grids.xm_b, dtype=float)
@@ -263,9 +182,9 @@ def _boozer_lasym_state(state, rt, *, rows, s_half, mboz, nboz, oversample):
         bsubvmnc=stack("bsubvmnc"), iota=stack("iota"),
         xm=jnp.asarray(xm), xn=jnp.asarray(xn), xm_nyq=jnp.asarray(xm),
         xn_nyq=jnp.asarray(xn), constants=constants, grids=grids,
-        rmns=stack("rmns"), zmnc=stack("zmnc"), lmnc=stack("lmnc"),
-        bmns=stack("bmns"), bsubumns=stack("bsubumns"),
-        bsubvmns=stack("bsubvmns"),
+        **(dict(rmns=stack("rmns"), zmnc=stack("zmnc"), lmnc=stack("lmnc"),
+                bmns=stack("bmns"), bsubumns=stack("bsubumns"),
+                bsubvmns=stack("bsubvmns")) if lasym else {}),
     )
     setup = rt.setup
     return {
@@ -279,7 +198,7 @@ def _boozer_lasym_state(state, rt, *, rows, s_half, mboz, nboz, oversample):
     }
 
 
-def boozer_bmnc_high_order(
+def boozer_spectrum_high_order(
     state,
     *,
     surfaces,
@@ -295,8 +214,6 @@ def boozer_bmnc_high_order(
         booz_xform_jax_impl,
         prepare_booz_xform_constants,
     )
-
-    from .boozer_tables import high_order_boozer_input_tables
 
     surface_values = np.atleast_1d(np.asarray(surfaces, dtype=float))
     if np.any((surface_values <= 0.0) | (surface_values > 1.0)):
@@ -356,7 +273,7 @@ def boozer_bmnc_high_order(
     }
 
 
-def boozer_bmnc_state(
+def boozer_spectrum_state(
     state: SpectralState,
     rt: SolverRuntime,
     *,
@@ -365,30 +282,28 @@ def boozer_bmnc_state(
     nboz: int = 16,
     oversample: int = 2,
 ) -> dict[str, Array]:
-    """Boozer ``|B|`` cosine spectrum of selected surfaces, fully traceable.
+    """Boozer ``|B|`` spectrum of selected surfaces, fully traceable.
 
     The jnp analogue of :func:`vmex.core.optimize.boozer_modes_from_wout`
-    (booz_xform algorithm, module docstring) evaluated from the solver's
-    internal tables: ``|B|``, the covariant components ``B_theta``/``B_zeta``
-    and the Boozer profile averages ``I``/``G`` live on the half-mesh
-    ``(theta, zeta)`` grid (mirrored to the full theta circle), lambda comes
-    from the state's spectral coefficients with the exact wout half-mesh
-    rescale, and the generating potential ``w`` is integrated spectrally
-    (FFT) — ``m != 0`` modes from ``B_theta``, ``m = 0`` modes from
-    ``B_zeta``, the booz_xform mode split.
+    evaluated without a wout file: vmex snaps the requested surfaces and
+    builds the wout-convention single-surface spectral tables from the
+    solver's internal state (:func:`vmex.core.boozer_tables
+    .boozer_input_tables`), then ``booz_xform_jax``'s jittable kernel runs
+    the Boozer construction itself — generating potential, Boozer angles,
+    and the angle-transform quadrature — for symmetric and ``lasym`` states
+    through the same code path.
 
     ``surfaces`` are normalized-flux values snapped to the nearest half-mesh
     surfaces (one Boozer construction per requested value, duplicates kept so
-    outputs align with ``surfaces``).  ``oversample`` refines the quadrature
-    grid by trigonometric (FFT zero-pad) interpolation before the Boozer
+    outputs align with ``surfaces``).  ``oversample`` refines booz_xform's
+    pinned ``(theta, zeta)`` quadrature grid by an integer factor before the
     angle transform, reducing the aliasing of ``cos(m theta_B - n zeta_B)``
-    products; ``mboz``/``nboz`` are capped at the fine grid's Nyquist.  LASYM
-    states run through booz_xform_jax's full transform, where the same factor
-    refines that code's own ``(theta, zeta)`` quadrature grid.
+    products.
 
-    Returns ``{bmnc_b (nsurf, nmodes), xm_b, xn_b (physical), iota_b, G_b,
-    I_b, nfp, s_b, psi_b, psi_edge}``; ``psi_b`` and ``psi_edge`` are the
-    signed toroidal flux divided by ``2*pi``.
+    Returns ``{bmnc_b (nsurf, nmodes), bmns_b, xm_b, xn_b (physical),
+    iota_b, G_b, I_b, nfp, s_b, psi_b, psi_edge}``; ``bmns_b`` is the
+    all-zero cosine partner for symmetric states, and ``psi_b``/``psi_edge``
+    are the signed toroidal flux divided by ``2*pi``.
     ``bmnc_b/xm_b/xn_b/iota_b/G_b/I_b/nfp`` are the inputs of
     :func:`omnigenity_residual` and of
     :func:`vmex.core.optimize.quasi_isodynamic_residual`.
@@ -399,172 +314,37 @@ def boozer_bmnc_state(
     s = jnp.asarray(setup.s_full)
     ns = int(s.shape[0])
     if ns < 3:
-        raise ValueError(f"boozer_bmnc_state needs ns >= 3, got ns = {ns}")
-    nfp = int(rt.resolution.nfp)
-    dtype = s.dtype
+        raise ValueError(f"boozer_spectrum_state needs ns >= 3, got ns = {ns}")
 
     # -- surface selection: nearest half-mesh rows (static, shape-only) -----
     s_half_np, rows = _nearest_half_mesh_rows(ns, surfaces)
-    if bool(setup.lasym):
-        return _boozer_lasym_state(
-            state, rt, rows=rows, s_half=s_half_np, mboz=mboz, nboz=nboz,
-            oversample=oversample)
+    return _boozer_kernel_state(
+        state, rt, rows=rows, s_half=s_half_np, mboz=mboz, nboz=nboz,
+        oversample=oversample)
 
-    # -- half-mesh field tables (the QS-residual field chain) ----------------
-    _, geometry = _geometry(state, rt)
-    jacobian = half_mesh_jacobian(geometry, s=s)
-    metrics = metric_elements(geometry, s=s)
-    fields = magnetic_fields(
-        geometry=geometry, jacobian=jacobian, metrics=metrics, trig=rt.trig,
-        s=s, phips=setup.phips, phipf=setup.phipf, chips=setup.chips,
-        signgs=setup.signgs, gamma=rt.gamma, mass=setup.mass,
-        ncurr=setup.ncurr, enclosed_current=setup.icurv,
-    )
-    iota_prof = _iotas_half_from_fields(setup, fields)
-    cur = surface_currents(bsubu=fields.bsubu, bsubv=fields.bsubv,
-                           trig=rt.trig, s=s, signgs=setup.signgs)
-    G_prof, I_prof = jnp.asarray(cur.bvco), jnp.asarray(cur.buco)
 
-    # |B| on the half mesh (bcovar.f: bsq = |B|^2/2 + p).
-    bsq2 = 2.0 * (jnp.asarray(fields.total_pressure)
-                  - jnp.asarray(fields.pressure)[:, None, None])
-    tiny = jnp.asarray(jnp.finfo(dtype).tiny, dtype=dtype)
+def boozer_bmnc_state(*args, **kwargs) -> dict[str, Array]:
+    """Deprecated alias of :func:`boozer_spectrum_state`.
 
-    # -- select rows, mirror the reduced theta grid to the full circle -------
-    ntheta2 = int(np.shape(fields.total_pressure)[1])
-    nzeta = int(np.shape(fields.total_pressure)[2])
-    # Asymmetric states returned through _boozer_lasym_state above, so only
-    # the reduced [0, pi] grid reaches here and always needs mirroring.
-    ntheta1, i_src, k_src = _mirror_maps(ntheta2, nzeta)
+    Same signature and return contract (including the ``bmns_b`` block).
+    The name changed when the in-repo symmetric FFT transform was retired in
+    favor of booz_xform_jax's kernel for both parities.
+    """
+    warnings.warn(
+        "vmex.core.omnigenity.boozer_bmnc_state is deprecated; call "
+        "boozer_spectrum_state (identical signature and return contract)",
+        DeprecationWarning, stacklevel=2)
+    return boozer_spectrum_state(*args, **kwargs)
 
-    def full(a):
-        return jnp.asarray(a)[rows][:, i_src, k_src]
 
-    bmag = jnp.sqrt(jnp.maximum(full(bsq2), tiny))          # (nsurf, nt1, nz)
-    bsubu = full(fields.bsubu)
-    bsubv = full(fields.bsubv)
-    iota = iota_prof[rows]
-    G = G_prof[rows]
-    I = I_prof[rows]  # noqa: E741 - Boozer I
-
-    # -- physical lambda modes on the selected half surfaces ------------------
-    # wrout.f / lambda_wout_from_full_mesh: internal full-mesh L_sin ->
-    # wout-normalized modes, lamscale/phipf rescale, parity-weighted half-mesh
-    # interpolation (plain average for even m, sqrt(s)-representation weights
-    # for odd m).
-    m_modes = np.asarray(rt.modes.m, dtype=int)
-    xn_modes = np.asarray(rt.modes.n, dtype=float) * float(nfp)
-    mode_scale = jnp.asarray(1.0 / physical_to_internal_scale(rt.modes, rt.trig))
-    phipf = jnp.asarray(setup.phipf)
-    safe_phipf = jnp.where(phipf != 0.0, phipf, 1.0)
-    lambda_scale = mode_scale[None, :] * (
-        jnp.asarray(setup.lamscale) / safe_phipf)[:, None]
-    lam_sin_full = jnp.asarray(state.L_sin) * lambda_scale
-    lam_cos_full = jnp.asarray(state.L_cos) * lambda_scale
-    smw_np, spw_np = _lambda_half_weights(ns)
-    even = (m_modes % 2 == 0)
-    hi_w = np.where(even[None, :], 1.0, smw_np[rows][:, None])
-    lo_w = np.where(even[None, :], 1.0, spw_np[rows][:, None])
-    def half_lambda(table):
-        return 0.5 * (jnp.asarray(hi_w) * table[rows]
-                      + jnp.asarray(lo_w) * table[rows - 1])
-
-    lam_sin_mn = half_lambda(lam_sin_full)
-    lam_cos_mn = half_lambda(lam_cos_full) if bool(setup.lasym) else jnp.zeros_like(lam_sin_mn)
-
-    # -- generating potential w (periodic part) by spectral integration ------
-    # dw/dtheta = B_theta, dw/dzeta = B_zeta (physical toroidal angle; the
-    # grid spans one field period, so the zeta wavenumbers carry nfp).
-    kt_c = np.fft.fftfreq(ntheta1) * ntheta1
-    kz_c = np.fft.fftfreq(nzeta) * nzeta * nfp
-    bu_hat = jnp.fft.fft2(bsubu, axes=(1, 2))
-    bv_hat = jnp.fft.fft2(bsubv, axes=(1, 2))
-    kt2 = jnp.asarray(kt_c)[None, :, None]
-    kz2 = jnp.asarray(kz_c)[None, None, :]
-    w_hat = jnp.where(
-        kt2 != 0.0, bu_hat / jnp.where(kt2 != 0.0, 1j * kt2, 1.0),
-        jnp.where(kz2 != 0.0, bv_hat / jnp.where(kz2 != 0.0, 1j * kz2, 1.0), 0.0))
-
-    # -- fine quadrature grid (trigonometric interpolation) ------------------
-    nt_f = int(oversample) * ntheta1
-    nz_f = int(oversample) * nzeta if nzeta > 1 else 1
-    kt_f = jnp.asarray(np.fft.fftfreq(nt_f) * nt_f)[None, :, None]
-    kz_f = jnp.asarray(np.fft.fftfreq(nz_f) * nz_f * nfp)[None, None, :]
-    w_hat_f = _pad_spectrum(w_hat, nt_f, nz_f)
-    w = jnp.real(jnp.fft.ifft2(w_hat_f, axes=(1, 2)))
-    dw_dth = jnp.real(jnp.fft.ifft2(1j * kt_f * w_hat_f, axes=(1, 2)))
-    dw_dze = jnp.real(jnp.fft.ifft2(1j * kz_f * w_hat_f, axes=(1, 2)))
-    bmod = jnp.real(jnp.fft.ifft2(
-        _pad_spectrum(jnp.fft.fft2(bmag, axes=(1, 2)), nt_f, nz_f), axes=(1, 2)))
-
-    theta_f = jnp.asarray(2.0 * np.pi * np.arange(nt_f) / nt_f, dtype=dtype)
-    zeta_f = jnp.asarray(2.0 * np.pi * np.arange(nz_f) / (nz_f * nfp), dtype=dtype)
-    ang = (theta_f[:, None, None] * jnp.asarray(m_modes, dtype=dtype)
-           - zeta_f[None, :, None] * jnp.asarray(xn_modes, dtype=dtype))
-    sin_tab, cos_tab = jnp.sin(ang), jnp.cos(ang)           # (nt_f, nz_f, mn)
-    m_arr = jnp.asarray(m_modes, dtype=dtype)
-    n_arr = jnp.asarray(xn_modes, dtype=dtype)
-    lam = (jnp.einsum("sm,tzm->stz", lam_sin_mn, sin_tab)
-           + jnp.einsum("sm,tzm->stz", lam_cos_mn, cos_tab))
-    dlam_dth = (jnp.einsum("sm,tzm->stz", lam_sin_mn * m_arr, cos_tab)
-                  - jnp.einsum("sm,tzm->stz", lam_cos_mn * m_arr, sin_tab))
-    dlam_dze = (-jnp.einsum("sm,tzm->stz", lam_sin_mn * n_arr, cos_tab)
-                 + jnp.einsum("sm,tzm->stz", lam_cos_mn * n_arr, sin_tab))
-
-    # -- Boozer angles + transform Jacobian (booz_xform eqs. (3), (10), (12))
-    GI = G + iota * I
-    GI_safe = jnp.where(GI != 0.0, GI, 1.0)
-    one_over_GI = (1.0 / GI_safe)[:, None, None]
-    nu = one_over_GI * (w - I[:, None, None] * lam)
-    dnu_dth = one_over_GI * (dw_dth - I[:, None, None] * dlam_dth)
-    dnu_dze = one_over_GI * (dw_dze - I[:, None, None] * dlam_dze)
-    theta_B = theta_f[None, :, None] + lam + iota[:, None, None] * nu
-    zeta_B = zeta_f[None, None, :] + nu
-    jac_fac = ((1.0 + dlam_dth) * (1.0 + dnu_dze)
-               + (iota[:, None, None] - dlam_dze) * dnu_dth)
-
-    # -- Boozer mode list + separable Fourier quadrature ----------------------
-    mboz = int(min(mboz, max(nt_f // 2 - 1, 0)))
-    nboz = int(min(nboz, max((nz_f - 1) // 2, 0)))
-    m_list = [0] * (nboz + 1) + [m for m in range(1, mboz + 1) for _ in range(2 * nboz + 1)]
-    n_list = list(range(nboz + 1)) + [n for _ in range(1, mboz + 1)
-                                      for n in range(-nboz, nboz + 1)]
-    xm_b = np.asarray(m_list, dtype=float)
-    xn_b = np.asarray(n_list, dtype=float) * float(nfp)
-
-    marr = jnp.asarray(np.arange(mboz + 1), dtype=dtype)
-    karr = jnp.asarray(np.arange(nboz + 1), dtype=dtype) * float(nfp)
-    cosm = jnp.cos(theta_B[..., None] * marr)               # (nsurf, nt, nz, mb+1)
-    sinm = jnp.sin(theta_B[..., None] * marr)
-    cosn = jnp.cos(zeta_B[..., None] * karr)                # (nsurf, nt, nz, nb+1)
-    sinn = jnp.sin(zeta_B[..., None] * karr)
-    F = bmod * jac_fac
-    Xc = jnp.einsum("stzm,stz,stzk->smk", cosm, F, cosn)
-    Xs = jnp.einsum("stzm,stz,stzk->smk", sinm, F, sinn)
-    Ys = jnp.einsum("stzm,stz,stzk->smk", sinm, F, cosn)
-    Yc = jnp.einsum("stzm,stz,stzk->smk", cosm, F, sinn)
-    m_idx = np.asarray(m_list, dtype=int)
-    k_idx = np.abs(np.asarray(n_list, dtype=int))
-    sgn = jnp.asarray(np.where(np.asarray(n_list) < 0, -1.0, 1.0), dtype=dtype)
-    ff = np.full(len(m_list), 2.0 / (nt_f * nz_f))
-    ff[0] = 1.0 / (nt_f * nz_f)                             # the (0, 0) mode
-    # cos(m th_B - n ze_B) = cos(m th_B) cos(|n| ze_B) + sgn(n) sin(m th_B) sin(|n| ze_B)
-    bmnc_b = jnp.asarray(ff) * (Xc[:, m_idx, k_idx] + sgn[None, :] * Xs[:, m_idx, k_idx])
-    bmns_b = jnp.asarray(ff) * (Ys[:, m_idx, k_idx] - sgn[None, :] * Yc[:, m_idx, k_idx])
-
-    return {
-        "bmnc_b": bmnc_b,
-        "bmns_b": bmns_b,
-        "xm_b": xm_b,
-        "xn_b": xn_b,
-        "iota_b": iota,
-        "G_b": G,
-        "I_b": I,
-        "nfp": nfp,
-        "s_b": jnp.asarray(s_half_np, dtype=dtype)[rows - 1],
-        "psi_b": jnp.asarray(setup.psi_half)[rows],
-        "psi_edge": jnp.asarray(setup.psi_edge),
-    }
+def boozer_bmnc_high_order(*args, **kwargs) -> dict[str, Array]:
+    """Deprecated alias of :func:`boozer_spectrum_high_order`."""
+    warnings.warn(
+        "vmex.core.omnigenity.boozer_bmnc_high_order is deprecated; call "
+        "boozer_spectrum_high_order (identical signature and return "
+        "contract)",
+        DeprecationWarning, stacklevel=2)
+    return boozer_spectrum_high_order(*args, **kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -701,7 +481,7 @@ def omnigenity_residual(
 class QIResidual:
     """Traceable smooth quasi-isodynamic surrogate (module docstring).
 
-    Composition of :func:`boozer_bmnc_state` (traceable Boozer ``|B|``
+    Composition of :func:`boozer_spectrum_state` (traceable Boozer ``|B|``
     spectrum on the requested surfaces) and :func:`omnigenity_residual`
     (a smooth level-set surrogate for the Goodman construction).  The
     interface mirrors
@@ -757,7 +537,7 @@ class QIResidual:
 
     def compute_state(self, state: SpectralState, rt: SolverRuntime) -> dict[str, Array]:
         """Full diagnostics dict (Boozer spectrum + residual pieces)."""
-        booz = boozer_bmnc_state(
+        booz = boozer_spectrum_state(
             state, rt, surfaces=self.surfaces, mboz=self.mboz, nboz=self.nboz,
             oversample=self.oversample)
         out = omnigenity_residual(

--- a/vmex/core/qi.py
+++ b/vmex/core/qi.py
@@ -9,7 +9,7 @@ import numpy as np
 import jax.numpy as jnp
 
 from .bounce import bounce_action_from_boozer
-from .omnigenity import boozer_bmnc_state
+from .omnigenity import boozer_spectrum_state
 from .optimize import quasi_isodynamic_residual
 from .statephysics import _as_1d
 
@@ -131,7 +131,7 @@ class ConstructedQIResidual(_QIResidualTerm):
 
     def compute_state(self, state, rt):
         """Return the constructed-QI residual and Boozer diagnostics."""
-        booz = boozer_bmnc_state(
+        booz = boozer_spectrum_state(
             state, rt, surfaces=self.surfaces, mboz=self.mboz,
             nboz=self.nboz, oversample=self.oversample)
         out = quasi_isodynamic_residual(
@@ -170,7 +170,7 @@ class JInvariantQIResidual(_QIResidualTerm):
 
     def compute_state(self, state, rt):
         """Return action-invariance residuals and topology diagnostics."""
-        booz = boozer_bmnc_state(
+        booz = boozer_spectrum_state(
             state, rt, surfaces=self.surfaces, mboz=self.mboz,
             nboz=self.nboz, oversample=self.oversample)
         out = j_invariant_qi_residual_from_boozer(


### PR DESCRIPTION
# Boozer ownership: one transform implementation, owned by booz_xform_jax

vmex carried two Boozer transforms: booz_xform_jax's kernel (already used for
`lasym` states and the high-order route) and an in-repo ~150-line FFT
reimplementation for symmetric states inside `boozer_bmnc_state`. This PR
retires the in-repo transform and routes both parities through the same
`booz_xform_jax.jax_api.booz_xform_jax_impl` call, so vmex owns only the
equilibrium side of the handoff: surface snapping and the wout-convention
input tables (`vmex/core/boozer_tables.py`).

## Ownership audit

| Site | Role | Disposition |
| --- | --- | --- |
| `omnigenity.py` symmetric lane of `boozer_bmnc_state` | in-repo FFT reimplementation of the Boozer transform | **removed**; both parities call the kernel via `_boozer_kernel_state` |
| `omnigenity.py::_pad_spectrum_axis/_pad_spectrum/_mirror_maps/_lambda_half_weights` | FFT-lane-only helpers, no external users | **removed** |
| `omnigenity.py::_boozer_lasym_state` | kernel route, lasym-only | **generalized** to `_boozer_kernel_state` (both parities) |
| `omnigenity.py::_nearest_half_mesh_rows`, `_refine_booz_grids` | surface snap; quadrature refinement of booz's constants/grids | **kept** (vmex-side bridge); refinement made parity-aware, see below |
| `boozer_tables.py` | state -> wout-convention input tables | **kept** (vmex owns the input side) |
| `optimize.py::boozer_modes_from_wout` | host object-API adapter (wout -> spectra dict) | kept as-is |
| `boozer.py::run_booz_xform` | file driver (`wout_*.nc` -> `boozmn_*.nc`; writer lives upstream) | kept as-is |
| `plotting.py::_boozer_summary_data`, `_load_boozmn` | object-API adapters (summary panels; boozmn reader) | kept as-is |
| `neoclassical.py::epsilon_effective_from_wout` | object-API adapter + NEO `BoozerData` layout (`pmns_b = -numns_b`) | kept: upstream's object API exposes only `numns_b`; the sign flip is the NEO contract, one line per site |
| `qi.py`, `maxj.py`, `bounce.py`, plotting consumers; `vmex/mirror` | consume spectra dicts only (mirror: none) | call sites renamed, no behavior change |

Spotted in passing, not changed here: `boozer_modes_from_wout` still
documents booz_xform_jax as an optional soft import while `pyproject.toml`
lists it as a core dependency; upstream's `__version__` string is stale
(reports 0.1.0 for the 0.1.1 release — pip metadata is correct, so never
gate on the attribute).

## The two behavior findings the handover surfaced

1. **Quadrature refinement vs parity.** booz_xform's stellarator-symmetric
   quadrature spans theta in `[0, pi]` only (`nu2_b` rows; boundary rows
   half-weighted, normalization read off `nu2_b`), while the asymmetric grid
   spans the full circle. `_refine_booz_grids` was written for the lasym lane
   and rebuilt a full-circle theta grid; extending it unchanged to symmetric
   states corrupted every spectrum (dominant-mode errors of order one, caught
   by the evidence harness before any push). The refinement now preserves the
   per-parity layout, pinned by the new
   `test_refine_booz_grids_preserves_the_parity_grid_layout` (both parities).
2. **Axisymmetric mode-list contract.** The retired FFT lane capped `nboz` at
   the state grid's Nyquist, so axisymmetric decks returned no toroidal
   harmonics; the kernel builds its own quadrature and would return a dead
   `n != 0` band. The band is now dropped when the input tables carry no
   toroidal harmonics (the Boozer relabelling of an axisymmetric field is
   axisymmetric), preserving the contract pinned by
   `test_boozer_transform_preserves_the_field_strength_range`.

## API: canonical names + thin deprecation aliases

- `boozer_spectrum_state` / `boozer_spectrum_high_order` are the canonical
  entry points (identical signatures and return contracts; symmetric states
  get the all-zero `bmns_b` block from the kernel).
- `boozer_bmnc_state` / `boozer_bmnc_high_order` remain as thin aliases that
  emit `DeprecationWarning` and dispatch
  (`test_deprecated_transform_aliases_warn_and_dispatch`).
- Top-level lazy exports: `vmex.boozer_spectrum_state` and
  `vmex.boozer_spectrum_high_order` added; `vmex.boozer_bmnc_high_order`
  still resolves (to the warning alias).

## Pin re-anchored: `booz_xform_jax` -> `booz_xform_jax>=0.1.1`

- PyPI ships 0.1.0 and 0.1.1 only; **0.1.1 is the floor vmex needs**: first
  release whose `booz_xform_jax_impl` accepts the asymmetric families
  (`rmns`/`zmnc`/`lmnc` — 0.1.0 raises `TypeError` on them) and first with
  guarded zero-mode denominators, required for finite `jvp`/`grad` through
  the objectives (v0.1.0..v0.1.1 diff).
- The `BoozerConfig`/`BoozerPlan`/separable-contraction API on upstream main
  (uwplasma/booz_xform_jax PRs #5/#6) is **unreleased and not used**; a
  `>=0.2.0` pin would make vmex uninstallable today. Move the pin when
  upstream cuts that release.
- Rounding-level evidence: the identical stacked input tables (bundled QI
  deck, 3 surfaces, `mboz=nboz=10`) replayed through the released 0.1.1
  kernel and through upstream main (2db7456) give
  `max|d(bmnc_b)| = 3.5e-16` (4.0e-16 relative) — the release the pin names
  reproduces the canonical kernel at rounding level for vmex's inputs.

## Numerical evidence (bundled QI deck, surfaces 0.25/0.53/0.75, mboz=nboz=10, oversample=2)

- Old in-repo FFT lane vs new kernel route: `max|d(bmnc_b)| = 6.6e-5`
  (`7.7e-5 * B00`) over the 200 shared modes — exactly the two quadratures'
  previously measured aliasing floor (the old cross-check test documented
  `<= 6.3e-5 * b00`), i.e. the handover moves nothing beyond discretization.
- New route vs host `boozer_modes_from_wout`: `1.7e-6 * B00` absolute,
  `2.0e-5` max relative on dominant modes — ~100x tighter than the FFT lane
  because both routes now share one kernel; only the table construction
  differs. `test_boozer_spectrum_matches_booz_xform` gates tightened
  accordingly (2e-5*b00 abs / 3e-4 rel dominant, ~10x margin).
- iota delta 0.0; `G_b` vs `wout.bvco` 1.6e-7.
- Cost (jitted, best of 5, arm64 CPU): eval 1.6 -> 7.9 ms, grad
  3.8 -> 19.5 ms (~5x). The released kernel is the pre-#6 dense projection;
  upstream's separable contraction should recover most of this when
  released. Accepted as the price of a single owned implementation.

## Preflight

- `ruff check vmex tests examples benchmarks tools`: clean
- `mypy vmex`: clean (75 files)
- `python tools/check_docs_prose.py`: clean
- `python -m sphinx -W`: clean
- Suites (RUN_FULL=1, JAX_ENABLE_X64=1, single run on the final HEAD):
  test_boozer_tables, test_omnigenity, test_qi_residuals, test_maxj,
  test_qi_maxj_composition, test_qi_reference_oracle, plus the renamed
  call-site tests in test_strong_force / test_polish_preconditioner:
  **61 passed** (5:51, `-n 2`). An earlier sweep of the first commit also
  ran on the office 36-core box and caught the axisymmetric mode-list
  regression fixed in the second commit (its other failure there was a GPU
  OOM from the box's busy devices, not reproducible on CPU).
- Pre-existing failures on clean main (asset-bundle-dependent, unrelated):
  `test_solvax_polish_artifact_is_independently_certified`,
  `test_readme_strong_force_figure_matches_committed_sources`.
