### PR TITLE
Combined epsilon/Gamma_c/maximum-J confinement optimization example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -83,6 +83,11 @@ All runnable examples live under this single `examples/` tree. Examples marked
 - `optimization/QA_maxJ_continuation.py` and `QI_maxJ_continuation.py` walk the
   constructed maximum-J target into the resolved certificate; the QA script
   states where maximum-J and quasisymmetry conflict near the axis.
+- `optimization/omnigenity_epsilon_gammac_maxj.py` refines the finite-beta QA
+  with one seed-normalized scalar objective — quasisymmetry ratio (effective
+  ripple proxy), the derivative-safe `GammaCSmooth` surrogate, and the
+  outer-volume maximum-J residual — then reports hard `Gamma_c` and NEO_JAX
+  `epsilon_eff^(3/2)` before and after.
 - `epsilon_effective.py` computes the NEO_JAX effective ripple from a solved
   equilibrium without writing a `boozmn` file; raise its `NeoConfig` controls
   for anything beyond a radial trend.

--- a/examples/optimization/omnigenity_epsilon_gammac_maxj.py
+++ b/examples/optimization/omnigenity_epsilon_gammac_maxj.py
@@ -39,7 +39,7 @@ MAXJ_SURFACES = np.array([0.6, 0.7, 0.8, 0.9])  # outer volume, where pressure h
 EPS_SURFACES = (0.25, 0.5, 0.75)            # hard NEO_JAX validation surfaces
 MAX_MODE, MAXITER = 2, 20
 W_EPS, W_GC, W_MAXJ = 1.0, 1.0, 1.0         # weights of the seed-normalized terms
-IOTA_FLOOR, MAXJ_TARGET, TRAPPING_DEPTHS = 0.40, -0.01, (0.4, 0.8)
+IOTA_MARGIN, MAXJ_TARGET, TRAPPING_DEPTHS = 0.95, -0.01, (0.4, 0.8)
 PARAMETER_STEP, MAX_PARAMETER_CHANGE, ESS_ALPHA = 0.02, 5.0, 1.2
 GC_TEMPERATURE = 0.15
 gc_budget = dict(nalpha=7, num_transit=3, points_per_transit=64,
@@ -57,13 +57,14 @@ ACTION_MBOZ = 10
 ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
 if ci_smoke:
     MAX_MODE, MAXITER = 1, 2
-    QS_SURFACES, GC_SURFACES, TRAPPING_DEPTHS = np.linspace(0.2, 0.8, 4), (0.5,), (0.5,)
+    QS_SURFACES, GC_SURFACES = np.linspace(0.2, 0.8, 4), (0.5,)
     GC_TEMPERATURE = 0.2
     gc_budget = dict(nalpha=5, num_transit=2, points_per_transit=32,
                      num_pitch=12, quadrature_order=16)
-    action = dict(nalpha=5, points_per_period=24, num_periods=6,
-                  max_wells=16, quadrature_order=16)
-    ACTION_MBOZ = 8
+    # the bounce-action trace cannot be shortened further: a coarser plan
+    # loses the matched wells on the outer surfaces and returns NaN slopes
+    action = dict(nalpha=7, points_per_period=32, num_periods=8,
+                  max_wells=20, quadrature_order=16)
 
 # ---- seed equilibrium ------------------------------------------------------
 DATA = (Path(__file__).resolve().parents[1] / "data"
@@ -100,6 +101,9 @@ for name, scale in SCALES.items():
         raise RuntimeError(f"seed {name} total {scale} cannot normalize the objective")
 ASPECT0 = float(opt.aspect_ratio(state0, rt0))
 BETA0 = float(opt.volume_average_beta(state0, rt0))
+# Guard the seed's transform rather than push it: the floor sits just below
+# the seed minimum so the constraint activates only on degradation.
+IOTA_FLOOR = IOTA_MARGIN * float(opt.min_abs_iota(state0, rt0))
 
 
 def iota_floor(equilibrium_state, solver_context):
@@ -206,6 +210,12 @@ result = minimize(
     callback=monitor_y,
     options={"maxiter": MAXITER, "gtol": 1.0e-8, "ftol": 1.0e-12,
              "maxls": 20, "maxcor": 20})
+# The scalar cost is evaluated on the optimizer's internal jitted re-solve.
+# At a loose smoke-lane ftol that re-solve can sit on a different point of
+# the ftol ball than the seed solve, so this line need not start at exactly
+# W_EPS + W_GC + W_MAXJ; every quoted physics number below comes from the
+# materialized equilibria, whose before/after lineage is one hot-restart
+# chain from the seed.
 print(f"optimizer scalar cost: {evaluation_costs[0]:.16e} -> {float(result.fun):.16e}")
 
 x_final = x0 + step * result.x

--- a/examples/optimization/omnigenity_epsilon_gammac_maxj.py
+++ b/examples/optimization/omnigenity_epsilon_gammac_maxj.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python
+"""Combined effective-ripple / Gamma_c / maximum-J confinement optimization.
+
+Fast-ion refinement of the finite-beta Landreman--Buller--Drevlak QA: one
+scalar objective adds the quasisymmetry ratio residual (the differentiable
+proxy that controls effective ripple), the derivative-safe ``GammaCSmooth``
+surrogate, and the outer-volume maximum-J residual at fixed physical pitch.
+Each confinement term is normalized by its seed value so the weights are
+dimensionless preferences, one L-BFGS-B call drives the boundary through one
+reverse implicit adjoint per gradient, and force balance is a constraint by
+construction: every evaluation is a converged hot-restarted equilibrium.
+
+Policy: optimize the surrogate, report the hard values.  Hard ``Gamma_c``
+and NEO_JAX ``epsilon_eff^(3/2)`` are evaluated before and after at the
+shared optimization resolution.  Minimizing the surrogate does not promise
+zero prompt orbit losses -- certify a design with collisionless tracing
+(``examples/vmex_essos_workflow.py``) before quoting loss fractions.  The
+bootstrap-consistent current profile is frozen during this refinement; see
+``QA_maxJ_continuation.py`` for the self-consistent Redl loop.
+"""
+
+from dataclasses import replace
+import os
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+from scipy.optimize import minimize
+
+import vmex as vj
+from vmex import optimize as opt
+from vmex.core.gammac import GammaC, GammaCSmooth
+from vmex.core.maxj import MaximumJResidual, common_trapped_pitches_state
+
+# ---- user parameters -------------------------------------------------------
+QS_SURFACES = np.linspace(0.1, 0.9, 8)      # epsilon_eff proxy sampling
+GC_SURFACES = (0.35, 0.6, 0.85)             # Gamma_c surfaces (surrogate + hard)
+MAXJ_SURFACES = np.array([0.6, 0.7, 0.8, 0.9])  # outer volume, where pressure helps
+EPS_SURFACES = (0.25, 0.5, 0.75)            # hard NEO_JAX validation surfaces
+MAX_MODE, MAXITER = 2, 20
+W_EPS, W_GC, W_MAXJ = 1.0, 1.0, 1.0         # weights of the seed-normalized terms
+IOTA_FLOOR, MAXJ_TARGET, TRAPPING_DEPTHS = 0.40, -0.01, (0.4, 0.8)
+PARAMETER_STEP, MAX_PARAMETER_CHANGE, ESS_ALPHA = 0.02, 5.0, 1.2
+GC_TEMPERATURE = 0.15
+gc_budget = dict(nalpha=7, num_transit=3, points_per_transit=64,
+                 num_pitch=24, quadrature_order=32)
+action = dict(nalpha=7, points_per_period=32, num_periods=8,
+              max_wells=20, quadrature_order=24)
+ACTION_MBOZ = 10
+# Research resolution: MAX_MODE, MAXITER = 3, 40 with
+# gc_budget = dict(nalpha=9, num_transit=5, points_per_transit=128,
+#                  num_pitch=48, quadrature_order=32) and
+# action = dict(nalpha=9, points_per_period=48, num_periods=10,
+#               max_wells=24, quadrature_order=32); quote the budgets with
+# any number -- the hard Gamma_c carries 10-20% scatter at these resolutions.
+
+ci_smoke = os.environ.get("VMEX_EXAMPLES_CI") == "1"
+if ci_smoke:
+    MAX_MODE, MAXITER = 1, 2
+    QS_SURFACES, GC_SURFACES, TRAPPING_DEPTHS = np.linspace(0.2, 0.8, 4), (0.5,), (0.5,)
+    GC_TEMPERATURE = 0.2
+    gc_budget = dict(nalpha=5, num_transit=2, points_per_transit=32,
+                     num_pitch=12, quadrature_order=16)
+    action = dict(nalpha=5, points_per_period=24, num_periods=6,
+                  max_wells=16, quadrature_order=16)
+    ACTION_MBOZ = 8
+
+# ---- seed equilibrium ------------------------------------------------------
+DATA = (Path(__file__).resolve().parents[1] / "data"
+        / "input.LandremanPaul2021_QA_beta2p5_bootstrap")
+inp = vj.VmecInput.from_file(DATA)
+if ci_smoke:
+    inp = replace(inp, ns_array=np.array([13]), ftol_array=np.array([1e-9]),
+                  niter_array=np.array([3000]))
+equilibrium = opt.solve_equilibrium(inp)
+state0, rt0 = equilibrium.solution, equilibrium.solver_context
+
+# ---- shared field-line / pitch plan ----------------------------------------
+# One physical lambda must describe the same trapped particles on every
+# surface and field-line label; select it once at the seed and keep the
+# pitch grid static for the whole stage.
+pitch = np.asarray(common_trapped_pitches_state(
+    state0, rt0, MAXJ_SURFACES, TRAPPING_DEPTHS,
+    mboz=ACTION_MBOZ, nboz=ACTION_MBOZ, nalpha=action["nalpha"],
+    points_per_period=action["points_per_period"],
+    num_periods=action["num_periods"]))
+
+# ---- normalized objective terms --------------------------------------------
+qs = opt.QuasisymmetryRatioResidual(QS_SURFACES, helicity_m=1, helicity_n=0)
+gamma_c_smooth = GammaCSmooth(GC_SURFACES, temperature=GC_TEMPERATURE, **gc_budget)
+gamma_c_hard = GammaC(GC_SURFACES, **gc_budget)  # report-only, never differentiated
+maximum_j = MaximumJResidual(MAXJ_SURFACES, pitch, mboz=ACTION_MBOZ,
+                             nboz=ACTION_MBOZ, target=MAXJ_TARGET, **action)
+
+SCALES = {"QS": float(qs.total_state(state0, rt0)),
+          "GammaCSmooth": float(gamma_c_smooth.total_state(state0, rt0)),
+          "maxJ": float(maximum_j.total_state(state0, rt0))}
+for name, scale in SCALES.items():
+    if not np.isfinite(scale) or scale <= 0.0:
+        raise RuntimeError(f"seed {name} total {scale} cannot normalize the objective")
+ASPECT0 = float(opt.aspect_ratio(state0, rt0))
+BETA0 = float(opt.volume_average_beta(state0, rt0))
+
+
+def iota_floor(equilibrium_state, solver_context):
+    return jnp.maximum(
+        IOTA_FLOOR - opt.min_abs_iota(equilibrium_state, solver_context), 0.0)
+
+
+constraint_terms = [
+    (opt.aspect_ratio, ASPECT0, 1.0),
+    (iota_floor, 0.0, 10.0),
+    (opt.volume_average_beta, BETA0, 1.0 / BETA0**2),
+]
+
+
+def normalized_terms(equilibrium_state, solver_context):
+    return (qs.total_state(equilibrium_state, solver_context) / SCALES["QS"],
+            gamma_c_smooth.total_state(equilibrium_state, solver_context)
+            / SCALES["GammaCSmooth"],
+            maximum_j.total_state(equilibrium_state, solver_context) / SCALES["maxJ"])
+
+
+def loss(equilibrium_state, solver_context):
+    eps_proxy, gc_term, mj_term = normalized_terms(equilibrium_state, solver_context)
+    rows = opt.residuals_from_tuples(
+        equilibrium_state, solver_context, constraint_terms)
+    return (W_EPS * eps_proxy + W_GC * gc_term + W_MAXJ * mj_term
+            + 0.5 * jnp.vdot(rows, rows))
+
+
+def print_terms(label, eq):
+    eps_proxy, gc_term, mj_term = (
+        float(v) for v in normalized_terms(eq.solution, eq.solver_context))
+    rows = np.asarray(opt.residuals_from_tuples(
+        eq.solution, eq.solver_context, constraint_terms))
+    print(f"[{label}] w_eps*QS/QS0 = {W_EPS * eps_proxy:.4f}, "
+          f"w_gc*GammaCSmooth/G0 = {W_GC * gc_term:.4f}, "
+          f"w_maxj*maxJ/J0 = {W_MAXJ * mj_term:.4f}, "
+          f"constraints = {0.5 * float(rows @ rows):.4e}")
+
+
+def hard_confinement(eq):
+    """Hard validation metrics; the surrogate never appears in a quoted number."""
+    row = {"gamma_c": np.asarray(
+        gamma_c_hard.compute_state(eq.solution, eq.solver_context)["gamma_c"])}
+    maxj = maximum_j.compute_state(eq.solution, eq.solver_context)
+    row["maxj_total"] = float(maxj["total"])
+    row["maxj_fraction"] = float(maxj["maximum_j_fraction"])
+    row["qs_total"] = float(qs.total_state(eq.solution, eq.solver_context))
+    try:
+        from neo_jax import NeoConfig  # optional: pip install vmex[neoclassical]
+
+        config = NeoConfig(
+            theta_n=16 if ci_smoke else 24, phi_n=16 if ci_smoke else 24,
+            npart=8 if ci_smoke else 12, multra=1,
+            no_bins=12 if ci_smoke else 20, nstep_per=4 if ci_smoke else 6,
+            nstep_min=20 if ci_smoke else 30, nstep_max=40 if ci_smoke else 60,
+            acc_req=0.2 if ci_smoke else 0.1, max_rational_field_periods=100000)
+        row["eps32"] = np.asarray(vj.epsilon_effective_from_wout(
+            eq.wout, surfaces=EPS_SURFACES, config=config)[1])
+    except ImportError as error:  # state the reason; never report a zero
+        print(f"epsilon_eff unavailable: {error}")
+        row["eps32"] = None
+    return row
+
+
+report = opt.EquilibriumReporter(
+    ("QS", qs.total, ".4e"), ("GammaCSmooth", gamma_c_smooth.total, ".4e"),
+    ("maxJ", maximum_j.total, ".4e"), ("aspect", opt.aspect_ratio, ".3f"),
+    ("min |iota|", opt.min_abs_iota, ".3f"),
+    ("beta", opt.volume_average_beta, ".3%"))
+monitor = opt.OptimizationMonitor(stream=None)
+report("seed", equilibrium)
+print_terms("seed", equilibrium)
+before = hard_confinement(equilibrium)
+
+# ---- one optimizer call through the scalar adjoint --------------------------
+problem = opt.VmecProblem.from_loss(
+    inp, loss, max_mode=MAX_MODE, use_ess=True, ess_alpha=ESS_ALPHA,
+    restart_from=equilibrium,
+    forward_max_iterations=100 if ci_smoke else 3000)
+print(f"dof_names = {problem.dof_names}")
+monitor.problem = problem
+problem.compile_value_and_gradient()
+
+x0, step = problem.x0, PARAMETER_STEP * problem.scales
+
+
+def value_and_gradient(y):
+    value, gradient = problem.value_and_grad(x0 + step * y)
+    evaluation_costs.append(float(value))
+    return value, step * gradient
+
+
+def monitor_y(intermediate_result):
+    monitor({"x": x0 + step * intermediate_result.x,
+             "fun": intermediate_result.fun,
+             "jac": value_and_gradient(intermediate_result.x)[1]})
+
+
+evaluation_costs = []
+result = minimize(
+    value_and_gradient, np.zeros_like(x0), jac=True, method="L-BFGS-B",
+    bounds=[(-MAX_PARAMETER_CHANGE, MAX_PARAMETER_CHANGE)] * x0.size,
+    callback=monitor_y,
+    options={"maxiter": MAXITER, "gtol": 1.0e-8, "ftol": 1.0e-12,
+             "maxls": 20, "maxcor": 20})
+print(f"optimizer scalar cost: {evaluation_costs[0]:.16e} -> {float(result.fun):.16e}")
+
+x_final = x0 + step * result.x
+final_input = problem.input_from_x(x_final)
+final_equilibrium = problem.equilibrium_from_x(x_final)
+report("final", final_equilibrium)
+print_terms("final", final_equilibrium)
+
+# ---- hard before/after table (same radial and sampling resolution) ---------
+after = hard_confinement(final_equilibrium)
+gc_before, gc_after = before["gamma_c"].mean(), after["gamma_c"].mean()
+print(f"\nhard confinement, before -> after (s = {list(GC_SURFACES)}):")
+print(f"hard Gamma_c per surface = {np.array2string(before['gamma_c'], precision=4)} -> "
+      f"{np.array2string(after['gamma_c'], precision=4)}")
+print(f"hard Gamma_c mean = {gc_before:.4e} -> {gc_after:.4e}")
+if before["eps32"] is not None and after["eps32"] is not None:
+    print(f"epsilon_eff^(3/2) mean = {before['eps32'].mean():.4e} -> "
+          f"{after['eps32'].mean():.4e} (s = {list(EPS_SURFACES)})")
+print(f"maximum-J residual = {before['maxj_total']:.4e} -> {after['maxj_total']:.4e}, "
+      f"maximum-J fraction = {before['maxj_fraction']:.1%} -> {after['maxj_fraction']:.1%}")
+print(f"QS ratio total = {before['qs_total']:.4e} -> {after['qs_total']:.4e}")
+
+# ---- saved outputs ---------------------------------------------------------
+name = "QA_eps_gammac_maxJ"
+input_path = final_input.to_indata(f"input.{name}")
+wout_path = vj.write_wout(f"wout_{name}.nc", final_equilibrium.wout)
+print(f"wrote {input_path}\nwrote {wout_path}")
+monitor.save(f"{name}_objectives.csv")
+monitor.plot(f"{name}_objectives.png")
+for path in vj.plot_wout(wout_path, ".", j_pitch=float(pitch[0])).values():
+    print(f"wrote {path}")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -268,6 +268,17 @@ def test_qa_maxj_example_states_its_physical_scope():
     assert "opt.magnetic_well" in text
 
 
+def test_combined_confinement_example_states_the_surrogate_policy():
+    """Optimize GammaCSmooth, report hard values, promise no zero losses."""
+    text = (EXAMPLES / "optimization" / "omnigenity_epsilon_gammac_maxj.py").read_text()
+    assert "optimize the surrogate, report the hard values" in text
+    assert "GammaCSmooth(" in text and "GammaC(" in text
+    assert "does not promise" in text
+    assert "normalized by its seed value" in text
+    assert "VmecProblem.from_loss" in text  # one aggregate scalar adjoint
+    assert "epsilon_eff unavailable" in text  # optional NEO_JAX states its absence
+
+
 @pytest.mark.full  # one direct-coil free solve, coupled adjoint, and output solve (~2 min)
 def test_vacuum_free_boundary_single_stage_optimization(tmp_path):
     pytest.importorskip("essos")
@@ -451,6 +462,26 @@ def test_qi_maxj_continuation_example(tmp_path):
     assert (tmp_path / "input.QI_maxJ_optimized").exists()
     assert (tmp_path / "wout_QI_maxJ_optimized.nc").exists()
     assert (tmp_path / "QI_maxJ_optimized_summary.png").stat().st_size > 10_000
+
+
+@pytest.mark.full  # nightly: Gamma_c surrogate + Boozer action adjoint is cold-compile heavy
+def test_combined_confinement_objective_example(tmp_path):
+    """Reduced-budget epsilon/Gamma_c/maximum-J combined-objective smoke test."""
+    script = EXAMPLES / "optimization" / "omnigenity_epsilon_gammac_maxj.py"
+    out = _run_example(script, tmp_path, timeout=1800)
+    _assert_cost_decreased(out, "eps-gammac-maxJ")
+    hard = re.search(r"hard Gamma_c mean = ([0-9.eE+-]+) -> ([0-9.eE+-]+)", out)
+    assert hard is not None
+    assert all(np.isfinite(float(v)) and float(v) > 0.0 for v in hard.groups())
+    assert re.search(
+        r"maximum-J residual = ([0-9.eE+-]+) -> ([0-9.eE+-]+)", out)
+    # the hard ripple line appears when NEO_JAX is installed; its absence
+    # must be stated, never silently skipped
+    assert (re.search(r"epsilon_eff\^\(3/2\) mean = ([0-9.eE+-]+) -> ([0-9.eE+-]+)", out)
+            or "epsilon_eff unavailable" in out)
+    assert (tmp_path / "input.QA_eps_gammac_maxJ").exists()
+    assert (tmp_path / "wout_QA_eps_gammac_maxJ.nc").exists()
+    assert (tmp_path / "QA_eps_gammac_maxJ_summary.png").stat().st_size > 10_000
 
 
 @pytest.mark.full  # nightly: QI mode ladder + Boozer, subprocess cold-start heavy

--- a/tests/test_gammac.py
+++ b/tests/test_gammac.py
@@ -508,3 +508,11 @@ def test_gamma_c_respects_the_stellarator_reflection():
     assert physical > 1.0
     assert spurious / physical < 1.0e-8
 
+
+
+def test_optimize_reexports_the_gamma_c_family():
+    """``vmex.optimize`` lazily resolves the hard and smooth classes alike."""
+    assert opt.GammaC is gammac.GammaC
+    assert opt.GammaCSmooth is gammac.GammaCSmooth
+    assert opt.gamma_c_state is gammac.gamma_c_state
+    assert opt.gamma_c_smooth_state is gammac.gamma_c_smooth_state

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -180,7 +180,9 @@ __all__ = [
     "minimize",
     "RedlBootstrapMismatch",  # noqa: F822 - provided lazily by __getattr__ below
     "GammaC",  # noqa: F822 - provided lazily by __getattr__ below
+    "GammaCSmooth",  # noqa: F822 - provided lazily by __getattr__ below
     "gamma_c_state",  # noqa: F822 - provided lazily by __getattr__ below
+    "gamma_c_smooth_state",  # noqa: F822 - provided lazily by __getattr__ below
 ]
 
 Array = Any
@@ -194,7 +196,7 @@ def __getattr__(name: str):  # PEP 562 lazy re-export
         return RedlBootstrapMismatch
     # gammac.py sits on the stability/turbulence field-line lane; the lazy
     # re-export keeps the fast-ion proxy import-light like the f_boot term.
-    if name in ("GammaC", "gamma_c_state"):
+    if name in ("GammaC", "GammaCSmooth", "gamma_c_state", "gamma_c_smooth_state"):
         from . import gammac
         return getattr(gammac, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
Plan section 13.8 / PR-sequence item 9: the combined epsilon/Gamma_c/max-J example.

## What this adds

- `examples/optimization/omnigenity_epsilon_gammac_maxj.py` (the filename plan
  13.8 names) — refines the bundled finite-beta (2.5%, bootstrap-current)
  Landreman–Buller–Drevlak QA with **one scalar objective**: the quasisymmetry
  ratio residual (the differentiable proxy that controls effective ripple), the
  derivative-safe `GammaCSmooth` surrogate, and the outer-volume maximum-J
  residual at fixed physical pitch, each normalized by its seed value, plus
  aspect/iota/beta guards. One L-BFGS-B call drives the boundary through
  `VmecProblem.from_loss` — one reverse implicit adjoint per gradient; force
  balance holds by construction because every evaluation is a converged
  hot-restarted equilibrium.
- Policy stated and enforced by structure: **optimize the surrogate, report the
  hard values.** Hard `Gamma_c` (never differentiated) and NEO_JAX
  `epsilon_eff^(3/2)` are evaluated before and after at the shared resolution;
  a missing NEO_JAX states its absence instead of silently skipping.
- The field-line/pitch plan is selected once at the seed
  (`common_trapped_pitches_state`) and held static for the stage (plan 13.5);
  the iota floor sits just below the seed minimum so it guards rather than
  pushes.
- `vmex.optimize` now lazily re-exports `GammaCSmooth`/`gamma_c_smooth_state`
  beside `GammaC`/`gamma_c_state` (plan 13.1 discoverability), with a
  regression in `tests/test_gammac.py`.
- CI registration in `tests/test_examples.py`: a PR-lane surrogate-policy check
  plus a runtime smoke in the nightly `full-examples` lane beside
  `test_qi_maxj_continuation_example` (`VMEX_EXAMPLES_CI=1` finishes in
  ~3.5 min on an M-series CPU and writes every documented artifact).

## Measured before/after (default resolution: ns=31, max_mode=2, 20 L-BFGS iterations; office GPU, jax 0.9.2)

| quantity | before | after | change |
|---|---|---|---|
| hard Gamma_c mean (s = 0.35, 0.6, 0.85) | 1.5183e-03 | 9.0420e-04 | **-40%** |
| epsilon_eff^(3/2) mean (s = 0.25, 0.5, 0.75) | 6.4532e-07 | 5.3595e-07 | **-17%** |
| maximum-J residual (s = 0.6–0.9) | 3.6527e-02 | 2.5282e-02 | **-31%** |
| GammaCSmooth surrogate total | 1.3024e-08 | 7.8411e-09 | -40% |
| QS ratio total | 2.4596e-05 | 2.6751e-05 | +9% (accepted trade) |
| optimizer scalar cost | 3.0127 | 2.3368 | -22% |

Constraints held: aspect 6.000 → 5.989, beta 2.547% → 2.567%, min |iota|
0.211 → 0.210. The surrogate's -40% tracks the hard `Gamma_c`'s -40% — the
optimize-smooth/report-hard split earns its keep. Budgets belong with any
quoted number (hard `Gamma_c` carries 10–20% scatter at these resolutions),
and minimizing the surrogate does not promise zero prompt losses — ESSOS
tracing (`examples/vmex_essos_workflow.py`) is the certification lane.

## Preflight

- ruff / mypy / docs-prose: clean.
- Affected tests (24 modules, `-m "not full and not weekly"`): 345 passed,
  42 skipped. Changed-line coverage (diff-cover vs origin/main): 100%.
- Guard tests: the two `tests/test_performance_docs.py` strong-force metadata
  checks fail identically on pristine `origin/main` (committed
  `benchmarks/strong_force_comparison_m4.json` has `summary_figure: null` and
  `native.solvax_source: null`) — pre-existing, unrelated to this diff,
  flagged separately.

Smoke-lane note: the trace budget of the maximum-J term cannot be reduced
below the QA_maxJ CI plan — a coarser bounce-action trace loses the matched
outer-surface wells and returns NaN slopes; the example documents this inline.
