### PR TITLE
Restore 0.3-class cold-start performance: jit the eager setup, export, and printout passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ concurrency:
 env:
   LC_ALL: C.UTF-8
   LANG: C.UTF-8
+  # Runners are ephemeral, so the persistent compilation cache can never pay
+  # for itself here — but it can hang the suite: the floor-0 default writes
+  # every compiled program, each write takes JAX's cross-process eviction
+  # lock, and pytest -n 4 workers on a 2-core runner serialize on it until
+  # the lane hits its timeout (every Fast API / physics / parity lane ran to
+  # exactly its timeout-minutes from 2026-08-31T21:00Z on, on every branch).
+  VMEX_COMPILATION_CACHE: disabled
 
 permissions:
   contents: read

--- a/vmex/core/bootstrap.py
+++ b/vmex/core/bootstrap.py
@@ -48,6 +48,7 @@ re-exports them for backward compatibility.
 from __future__ import annotations
 
 import dataclasses
+import functools
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -399,6 +400,24 @@ def _trapped_fraction_from_fields(
         )
         return tuple(x[:, 0] for x in result)
     return compute_trapped_fraction(modB, sqrtg, n_lambda=n_lambda)
+
+
+@functools.partial(jax.jit, static_argnames=("lasym", "n_lambda"))
+def _trapped_fraction_export_lane(
+    *, total_pressure, pressure, sqrt_g, s_full, lasym: bool, n_lambda: int
+):
+    """WOUT-export trapped fraction f_t(s) on the full mesh, one XLA program.
+
+    Module-level ``jax.jit``: eager, the interpolation + ``lax.map`` chain
+    dispatches ~150 single-op XLA programs per export (~2 s of every cold
+    CLI run that writes a WOUT file).  ``serial_surfaces=True`` keeps the
+    per-surface pitch-angle grid out of memory at once, as before.
+    """
+    return _trapped_fraction_from_fields(
+        total_pressure=total_pressure, pressure=pressure, sqrt_g=sqrt_g,
+        s_full=s_full, surfaces=s_full, lasym=lasym, n_lambda=n_lambda,
+        serial_surfaces=True,
+    )[-1]
 
 
 def _half_mesh_fields(state: SpectralState, rt: SolverRuntime) -> _HalfMeshFields:

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -35,6 +35,7 @@ host round-trips of traced values.
 from __future__ import annotations
 
 import gc
+import functools
 import threading
 from dataclasses import replace
 from typing import Any
@@ -175,8 +176,23 @@ def interpolate_state(
     ns_state = int(jnp.shape(state_coarse.R_cos)[0])
     if ns_coarse is not None and int(ns_coarse) != ns_state:
         raise ValueError(f"ns_coarse={ns_coarse} does not match state ns={ns_state}")
-    m = np.asarray(modes.m, dtype=np.int64)
-    interp = lambda x: interpolate_coefficients(x, m=m, ns_fine=int(ns_fine))  # noqa: E731
+    return _interpolate_state_lane(
+        state_coarse, m=tuple(int(v) for v in modes.m), ns_fine=int(ns_fine)
+    )
+
+
+@functools.partial(jax.jit, static_argnames=("m", "ns_fine"))
+def _interpolate_state_lane(
+    state_coarse: SpectralState, *, m: tuple, ns_fine: int
+) -> SpectralState:
+    """All six coefficient interpolations as one XLA program.
+
+    Module-level ``jax.jit``: eager, each stage transition dispatches
+    ~120 single-op XLA programs (six fields x ~20 ops).  ``m`` is a tuple
+    so the static key hashes by value across freshly built mode tables.
+    """
+    m_arr = np.asarray(m, dtype=np.int64)
+    interp = lambda x: interpolate_coefficients(x, m=m_arr, ns_fine=ns_fine)  # noqa: E731
     return SpectralState(
         R_cos=interp(state_coarse.R_cos), R_sin=interp(state_coarse.R_sin),
         Z_cos=interp(state_coarse.Z_cos), Z_sin=interp(state_coarse.Z_sin),

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -765,10 +765,18 @@ def runtime_with_baselines(
     return replace(rt, rcon0=rcon0, zcon0=zcon0)
 
 
+@functools.partial(jax.jit, static_argnames="use_fft")
 def _constraint_baselines(
     state: SpectralState, rt: SolverRuntime, *, use_fft: bool = False
 ):
-    """One-time ``rcon0/zcon0 = s * rcon(ns)`` (funct3d.f, iter2 == iter1)."""
+    """One-time ``rcon0/zcon0 = s * rcon(ns)`` (funct3d.f, iter2 == iter1).
+
+    Module-level ``jax.jit`` lane, keyed structurally on ``rt`` exactly like
+    :func:`_while_lane`: eager, this geometry + constraint-force pass
+    dispatches hundreds of single-op XLA programs per multigrid stage (twice
+    per stage — :func:`prepare_runtime` and the ``iter2 == iter1`` rebind),
+    a measurable share of every cold CLI start.
+    """
     (R_cos, R_sin, Z_cos, Z_sin), geometry = _geometry(
         state, rt, use_fft=use_fft
     )

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -1952,7 +1952,9 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
             AXIS_REGUESS_FLAG, BAD_JACOBIAN_FLAG,
         )
         if verbose and not retry_transfer:
-            trajectory = np.asarray(carry.trajectory[:max(upto, 0)])
+            # Transfer, then slice: slicing on device compiles one XLA
+            # program per distinct ``upto`` (~190 over a QA_lowres ladder).
+            trajectory = np.asarray(carry.trajectory)[:max(upto, 0)]
             _emit_lines(rt, trajectory, upto, printed, done, emit)
         if done:
             break

--- a/vmex/core/wout.py
+++ b/vmex/core/wout.py
@@ -629,7 +629,7 @@ def wout_from_state(
     import jax
 
     from . import nyquist as _nyq
-    from .bootstrap import _trapped_fraction_from_fields
+    from .bootstrap import _trapped_fraction_export_lane
     from .fields import energies_and_force_norms, magnetic_fields, metric_elements
     from .fourier import Resolution, mode_table, trig_tables
     from .geometry import (
@@ -686,16 +686,14 @@ def wout_from_state(
         jacobian=jacobian, metrics=metrics, fields=fields, trig=trig,
         s=grids.s_full, signgs=signgs,
     )
-    trapped_fraction = _trapped_fraction_from_fields(
+    trapped_fraction = _trapped_fraction_export_lane(
         total_pressure=fields.total_pressure,
         pressure=fields.pressure,
         sqrt_g=jacobian.sqrt_g,
         s_full=grids.s_full,
-        surfaces=grids.s_full,
         lasym=lasym,
         n_lambda=64,
-        serial_surfaces=True,
-    )[-1]
+    )
     (geometry, jacobian, metrics, fields, norms, R_cos_p, Z_sin_p, R_sin_p,
      Z_cos_p, trapped_fraction) = jax.device_get(
         (geometry, jacobian, metrics, fields, norms, R_cos_p, Z_sin_p,


### PR DESCRIPTION
## Problem

Users report VMEX became much slower since ~0.7 for cold runs. Measured locally (M4, CPU, jax 0.11.1 for **both** versions, caches cleared, full iteration budgets, the decks users actually run): 0.8.0 is 1.4-1.5x slower than 0.3.0 on every deck.

| deck (cold CLI, 2 reps) | 0.3.0 | 0.8.0 | this branch |
|---|---|---|---|
| input.LandremanPaul2021_QA_lowres | 16.4 / 18.0 s | 22.3 / 23.3 s | **17.9 / 18.6 s** |
| input.li383_low_res | 9.4 / 5.6 s | 13.1 / 9.3 s | **7.1 / 7.0 s** |
| input.solovev | 4.8 / 4.9 s | 7.3 / 7.3 s | **5.6 / 5.5 s** |

Per-iteration execution never regressed (identical solve times at fixed budgets). The whole gap was cold-start compilation: at QA_lowres the 0.8.0 CLI compiled **773 XLA programs vs 523** on 0.3.0 — the extra ~250 all being single-op eager dispatches (compile-name census + cProfile caller attribution + HLO dumps in the PR discussion protocol below).

## Fixes (all module-level jit lanes, the `_while_lane` idiom)

- `_constraint_baselines` ran the geometry + constraint-force chain **eagerly** twice per multigrid stage (`prepare_runtime` + the `iter2 == iter1` rebind) — hundreds of single-op programs per stage.
- The WOUT trapped-fraction export (new in 0.8.0) ran its interpolation + `lax.map` chain eagerly: ~150 single-op programs, ~2 s per export. Now `_trapped_fraction_export_lane` — one program.
- `interpolate_state` dispatched ~120 eager programs per stage transition. Now `_interpolate_state_lane` (mode numbers passed as a tuple so the static key hashes by value).
- `_run_loop` sliced `carry.trajectory[:upto]` **on device with a different bound every block pass** — one compiled slice program per distinct `upto` (~190 over a QA ladder). Now transfer once, slice in numpy.

Post-fix census at QA_lowres: **376 programs / 10.8 s** compile vs 0.3.0's 523 / 10.7 s. The residual ~1 s vs 0.3.0 is deliberate body growth since 0.3 (the `_evaluation_is_finite` NaN-containment guard and the in-lane axis-reguess branch), which this PR does not weaken.

## Verification

- Focused suites over the changed modules (bootstrap, multigrid interp/ladder, CLI, wout-golden, nonfinite-failfast, solver end-to-end, restart, step-control): **126 passed, 11 skipped, 2 xfailed**.
- Changed-line coverage: **100%** (diff-cover vs origin/main).
- WOUT equivalence patched vs unpatched, solovev + li383: every variable **bit-identical** except `vmex_trapped_fraction` at 1-4 ULP (jit fusion reordering in the new lane).
- Measurement protocol: fresh process + `rm -rf ~/.cache/vmex ~/.cache/jax` before every cold run; compile census via a `logging` handler on jax compile records; HLO attribution via `--xla_dump_to` with `--xla_dump_hlo_module_re`.

The four guard tests failing on this branch (`test_performance_docs` x3, `test_packaging_metadata`) fail identically on pristine main and are repaired by #226.