### PR TITLE
Disable the persistent compilation cache on CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ concurrency:
 env:
   LC_ALL: C.UTF-8
   LANG: C.UTF-8
+  # Runners are ephemeral, so the persistent compilation cache can never pay
+  # for itself here — but it can hang the suite: the floor-0 default writes
+  # every compiled program, each write takes JAX's cross-process eviction
+  # lock, and pytest -n 4 workers on a 2-core runner serialize on it until
+  # the lane hits its timeout (every Fast API / physics / parity lane ran to
+  # exactly its timeout-minutes from 2026-08-31T21:00Z on, on every branch).
+  VMEX_COMPILATION_CACHE: disabled
 
 permissions:
   contents: read


### PR DESCRIPTION
Every CI lane on every branch has been running to exactly its `timeout-minutes` and getting reported as *cancelled* since 2026-08-31T21:28Z — Fast API at 8 min, physics lanes at 30, parity lanes at 45, on main, #226, and #227 alike. The same dependency versions (jax 0.11.1, solvax 0.20.0, numpy 2.5.2, equinox 0.13.8) pass locally in normal time, so it is not a release.

The onset coincides with the floor-0 persistent-cache default: with the floor at zero every compiled program is written to the bounded cache, each write takes JAX's cross-process eviction lock (the finite-bound/lock tradeoff is documented in `vmex/_compat.py`), and `pytest -n 4` workers on a 2-core ephemeral runner serialize on that lock until the lane times out (the stalled Fast API lane sat at 69% for 3+ minutes before the kill; its four workers were alive but idle at teardown).

Runners are ephemeral — the cache directory never survives a job — so the persistent cache cannot pay for itself on CI at all. This sets `VMEX_COMPILATION_CACHE: disabled` at the workflow level.

This PR's own run is the experiment: its lanes execute with the fix applied, so green lanes here are the confirmation.