### PR TITLE
Jit the remaining eager field-chain passes

### DIFF
--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -414,6 +414,19 @@ def _jacobian_ok(state: SpectralState, rt: SolverRuntime,
     )
 
 
+@jax.jit
+def _carried_edge_radius_lane(state: SpectralState, rt: SolverRuntime) -> Array:
+    """Boundary-row ``R = R_even(ns) + R_odd(ns)`` (``sqrts(ns) = 1``).
+
+    The carried-rbsq edge conversion at a radial transition needs only this
+    angular array; eager, the full ``_geometry`` synthesis it sits on
+    dispatches ~1e2 single-op XLA programs per transition.  Module-level
+    ``jax.jit`` lane keyed structurally on ``rt`` (``solver._while_lane``).
+    """
+    _, geometry = _geometry(state, rt)
+    return geometry.R_even[-1] + geometry.R_odd[-1]
+
+
 @functools.partial(jax.jit, static_argnames=("use_fft",))
 def _iter_lane(carry, rt: SolverRuntime, *, use_fft: bool = False):
     """One jitted eqsolve iteration (shared traced body; per-``rt`` lane)."""
@@ -1705,11 +1718,9 @@ def _solve_free_boundary_stage(
     # free boundary must do it *before* constructing the fused axis-current
     # filament, otherwise a recoverable bad axis can fail the static-topology
     # guard before iteration 1.
-    _, _initial_geometry = _geometry(_init_state, rt)
-    _initial_jacobian = half_mesh_jacobian(_initial_geometry, s=rt.setup.s_full)
     if (
         allow_initial_axis_reguess
-        and bool(_initial_jacobian.jacobian_sign_changed)
+        and not bool(_jacobian_ok(_init_state, rt))
         and ns >= 3
     ):
         if verbose:
@@ -1723,9 +1734,7 @@ def _solve_free_boundary_stage(
                 zaxis_cc=_axis[2] if resolution.lasym else None,
             ), end="")
         _initial_ijacob = 1
-        _, _retry_geometry = _geometry(_init_state, rt)
-        _retry_jacobian = half_mesh_jacobian(_retry_geometry, s=rt.setup.s_full)
-        if bool(_retry_jacobian.jacobian_sign_changed):
+        if not bool(_jacobian_ok(_init_state, rt)):
             # Preserve the normal typed solver failure and its remedy hint;
             # do not let the later axis-filament topology guard obscure it.
             from .errors import BAD_JACOBIAN_FLAG, VmecJacobianError, WERROR_MESSAGES
@@ -1751,8 +1760,7 @@ def _solve_free_boundary_stage(
             # funct3d skips IVAC0, so forces.f consumes the coarse-stage rbsq
             # verbatim.  Express that product as an equivalent bsqvac on the
             # new geometry for the shared force seam.
-            _, carried_geometry = _geometry(_init_state, rt)
-            r_edge = carried_geometry.R_even[-1] + carried_geometry.R_odd[-1]
+            r_edge = _carried_edge_radius_lane(_init_state, rt)
             pres_ns = _vacuum_scalars(_init_state, rt)[5]
             rbsq = jnp.asarray(vacuum_continuation.rbsq, dtype=dtype)
             carried_edge = jnp.where(
@@ -1919,10 +1927,7 @@ def _solve_free_boundary_stage(
             if (vacuum_continuation is not None
                     and vacuum_continuation.turned_on):
                 if vacuum_continuation.rbsq is not None:
-                    _, carried_geometry = _geometry(_init_state, rt)
-                    r_edge = (
-                        carried_geometry.R_even[-1] + carried_geometry.R_odd[-1]
-                    )
+                    r_edge = _carried_edge_radius_lane(_init_state, rt)
                     pres_ns = _vacuum_scalars(_init_state, rt)[5]
                     rbsq = jnp.asarray(vacuum_continuation.rbsq, dtype=dtype)
                     carried_edge = jnp.where(

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -590,6 +590,21 @@ def _geometry(
     return (R_cos, R_sin, Z_cos, Z_sin), geometry
 
 
+@functools.partial(jax.jit, static_argnames="use_fft")
+def _geometry_lane(
+    state: SpectralState, rt: SolverRuntime, *, use_fft: bool = False
+):
+    """:func:`_geometry` as a module-level lane (``freeboundary._jacobian_ok``'s
+    twin), for host-stepped one-shot callers.
+
+    Eager, one synthesis dispatches ~1e2 single-op XLA programs; the axis
+    retry (:func:`reguess_initial_axis`) needs the real-space geometry itself
+    for the ``guess_axis.f`` host scan, which the boolean-only Jacobian gate
+    cannot supply.
+    """
+    return _geometry(state, rt, use_fft=use_fft)
+
+
 def _resolve_prec2d(
     source: VmecInput | RunSetup,
     prec2d: Prec2DConfig | None,
@@ -1339,7 +1354,7 @@ def reguess_initial_axis(
     (``funct3d.f: iter2 == iter1``).
     """
     setup = rt.setup
-    _, geometry = _geometry(state, rt, use_fft=use_fft)
+    _, geometry = _geometry_lane(state, rt, use_fft=use_fft)
     axis = guess_axis(
         geometry, s=setup.s_full, trig=rt.trig, signgs=setup.signgs
     )

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -1298,6 +1298,23 @@ def _evaluate(
     )
 
 
+@functools.partial(jax.jit, static_argnames="collect_health")
+def _evaluate_lane(
+    state: SpectralState, cache: PreconditionerCache, iteration: Array,
+    iter_last_reset: Array, fsqz_previous: Array, rt: SolverRuntime,
+    *, collect_health: bool = False,
+) -> _EvalResult:
+    """One public funct3d pass as one XLA program (:func:`evaluate_forces`).
+
+    Module-level ``jax.jit`` keyed structurally on ``rt`` exactly like
+    :func:`_while_lane`: eager, every :func:`evaluate_forces` call dispatched
+    the whole funct3d chain op-by-op (the implicit/free-boundary drivers call
+    it once per outer step).
+    """
+    return _evaluate(state, cache, iteration, iter_last_reset, fsqz_previous,
+                     rt, collect_health=collect_health)
+
+
 def evaluate_forces(
     state: SpectralState,
     runtime: SolverRuntime,
@@ -1317,7 +1334,7 @@ def evaluate_forces(
     if cache is None:
         cache = _zero_cache(runtime)
         iter_last_reset = iteration  # force refresh
-    result = _evaluate(
+    result = _evaluate_lane(
         state, cache, jnp.asarray(iteration), jnp.asarray(iter_last_reset),
         jnp.asarray(fsqz_previous), runtime, collect_health=True,
     )

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -1782,7 +1782,7 @@ def _emit_lines(rt: SolverRuntime, trajectory: np.ndarray, upto: int,
         printed.add(it)
 
 
-@jax.jit
+@functools.partial(jax.jit, donate_argnums=(0,))
 def _while_lane(carry: _LoopCarry, rt: SolverRuntime) -> _LoopCarry:
     """Whole-solve ``lax.while_loop`` lane, keyed structurally on ``rt``.
 
@@ -1790,6 +1790,11 @@ def _while_lane(carry: _LoopCarry, rt: SolverRuntime) -> _LoopCarry:
     two DIFFERENT runtimes with equal structure (same meta, same leaf
     shapes/dtypes) — e.g. two boundaries at one :class:`Resolution`, hot
     restarts, optimization iterates — share one XLA executable.
+
+    ``donate_argnums=(0,)``: the sole caller (:func:`_run_loop`,
+    ``mode="jit"``) copies the initial carry to distinct buffers first, so
+    the input carry is dead at the call and XLA aliases the loop carry onto
+    it — same rationale as :func:`_block_lane`, numerically identical.
     """
     body = _make_body(rt)
     return lax.while_loop(lambda c: jnp.logical_not(c.done), body, carry)
@@ -1810,9 +1815,9 @@ def _block_lane(carry: _LoopCarry, rt: SolverRuntime) -> _LoopCarry:
     return lax.scan(lambda cc, _: (body(cc), None), carry, None, length=BLOCK_SIZE)[0]
 
 
-@jax.jit
+@functools.partial(jax.jit, donate_argnums=(0,))
 def _while_lane_fft(carry: _LoopCarry, rt: SolverRuntime) -> _LoopCarry:
-    """Whole-solve lane using separable Fourier synthesis."""
+    """Whole-solve lane using separable Fourier synthesis (donated carry)."""
     body = _make_body(rt, use_fft=True)
     return lax.while_loop(lambda c: jnp.logical_not(c.done), body, carry)
 
@@ -1935,6 +1940,11 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
     )
 
     if mode == "jit":
+        # The while lanes donate the carry; _initial_carry aliases some leaves
+        # (xstore=state, shared cache zeros), so copy to distinct buffers —
+        # same rationale as the CLI-lane copy below, values bit-for-bit
+        # unchanged.
+        carry = jax.tree.map(jnp.array, carry)
         return (_while_lane_fft if use_fft else _while_lane)(carry, rt)
 
     if mode != "cli":

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -791,6 +791,35 @@ def _constraint_baselines(
     return rcon0, zcon0
 
 
+@jax.jit
+def _field_chain_lane(state: SpectralState, rt: SolverRuntime):
+    """Geometry -> Jacobian -> metrics -> fields -> energies, one XLA program.
+
+    The shared state -> field-state evaluation chain behind
+    :func:`_result_from_carry`'s ncurr=1 iota reconstruction and every
+    :mod:`~vmex.core.statephysics` derived quantity.  Module-level ``jax.jit``
+    keyed structurally on ``rt`` exactly like :func:`_while_lane`: eager,
+    each pass dispatches hundreds of single-op XLA programs (once per solved
+    result, and repeatedly under the objective modules).
+    """
+    setup = rt.setup
+    s = setup.s_full
+    _, geometry = _geometry(state, rt)
+    jacobian = half_mesh_jacobian(geometry, s=s)
+    metrics = metric_elements(geometry, s=s)
+    fields = magnetic_fields(
+        geometry=geometry, jacobian=jacobian, metrics=metrics, trig=rt.trig,
+        s=s, phips=setup.phips, phipf=setup.phipf, chips=setup.chips,
+        signgs=setup.signgs, gamma=rt.gamma, mass=setup.mass,
+        ncurr=setup.ncurr, enclosed_current=setup.icurv,
+    )
+    energies = energies_and_force_norms(
+        jacobian=jacobian, metrics=metrics, fields=fields, trig=rt.trig,
+        s=s, signgs=setup.signgs,
+    )
+    return geometry, jacobian, metrics, fields, energies
+
+
 def _zero_cache(rt: SolverRuntime) -> PreconditionerCache:
     """Zero-filled cache (shapes only; iteration 1 always refreshes it)."""
     res = rt.resolution
@@ -1686,15 +1715,7 @@ def _result_from_carry(carry: _LoopCarry, rt: SolverRuntime) -> SolveResult:
     # iotaf (add_fluxes.f90): prescribed profile for ncurr = 0; reconstructed
     # from the converged current-constrained chips for ncurr = 1.
     if int(setup.ncurr) == 1:
-        _, geometry = _geometry(carry.state, rt)
-        jacobian = half_mesh_jacobian(geometry, s=setup.s_full)
-        metrics = metric_elements(geometry, s=setup.s_full)
-        fields = magnetic_fields(
-            geometry=geometry, jacobian=jacobian, metrics=metrics, trig=rt.trig,
-            s=setup.s_full, phips=setup.phips, phipf=setup.phipf,
-            chips=setup.chips, signgs=setup.signgs, gamma=rt.gamma,
-            mass=setup.mass, ncurr=setup.ncurr, enclosed_current=setup.icurv,
-        )
+        _, _, _, fields, _ = _field_chain_lane(carry.state, rt)
         chips = np.asarray(fields.chips)
         phips = np.asarray(setup.phips)
         iotas = np.divide(chips, phips, out=np.zeros_like(chips), where=phips != 0.0)

--- a/vmex/core/statephysics.py
+++ b/vmex/core/statephysics.py
@@ -49,11 +49,9 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 
-from .fields import energies_and_force_norms, magnetic_fields, metric_elements
 from .fourier import Resolution, mode_table, trig_tables
-from .geometry import half_mesh_jacobian
 from .residuals import m1_constrained_to_physical
-from .solver import SolverRuntime, SpectralState, _geometry
+from .solver import SolverRuntime, SpectralState, _field_chain_lane
 from .transforms import physical_to_internal_scale
 
 Array = Any
@@ -112,23 +110,14 @@ def _mode_matrix(wout, name: str, *, ns: int, mn: int, optional: bool = False) -
 
 
 def _field_chain(state: SpectralState, rt: SolverRuntime):
-    """Geometry -> Jacobian -> metric -> fields -> energies of a core state."""
-    setup = rt.setup
-    s = setup.s_full
-    _, geometry = _geometry(state, rt)
-    jacobian = half_mesh_jacobian(geometry, s=s)
-    metrics = metric_elements(geometry, s=s)
-    fields = magnetic_fields(
-        geometry=geometry, jacobian=jacobian, metrics=metrics, trig=rt.trig,
-        s=s, phips=setup.phips, phipf=setup.phipf, chips=setup.chips,
-        signgs=setup.signgs, gamma=rt.gamma, mass=setup.mass,
-        ncurr=setup.ncurr, enclosed_current=setup.icurv,
-    )
-    energies = energies_and_force_norms(
-        jacobian=jacobian, metrics=metrics, fields=fields, trig=rt.trig,
-        s=s, signgs=setup.signgs,
-    )
-    return geometry, jacobian, metrics, fields, energies
+    """Geometry -> Jacobian -> metric -> fields -> energies of a core state.
+
+    Delegates to the module-level jitted :func:`vmex.core.solver.
+    _field_chain_lane` (one XLA program instead of hundreds of eager
+    dispatches); jit is AD-transparent, so traced/differentiated callers see
+    the same chain.
+    """
+    return _field_chain_lane(state, rt)
 
 
 def _iotas_half_from_fields(setup, fields) -> jnp.ndarray:

--- a/vmex/core/wout.py
+++ b/vmex/core/wout.py
@@ -43,8 +43,18 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+import jax
+
 from . import postprocess as _pp
 from ._netcdf import assign_array
+from .fields import energies_and_force_norms, magnetic_fields, metric_elements
+from .fourier import Resolution, mode_table, trig_tables
+from .geometry import (
+    apply_lambda_axis_closure,
+    half_mesh_jacobian,
+    real_space_geometry,
+)
+from .residuals import m1_constrained_to_physical
 
 if TYPE_CHECKING:
     from .solver import VacuumOutput
@@ -565,6 +575,64 @@ def _ftolv_from_input(inp) -> float:
     return float(ftol_arr[min(idx, ftol_arr.size - 1)])
 
 
+@functools.partial(jax.jit, static_argnames=("res", "signgs", "gamma", "ncurr"))
+def _wout_field_state_lane(state, s_full, phips, phipf, chips, mass, icurv,
+                           *, res, signgs: int, gamma: float, ncurr: int):
+    """The export's state -> field-state re-evaluation as ONE XLA program.
+
+    Module-level ``jax.jit`` (the ``solver._while_lane`` idiom): eager, this
+    totzsps/jacobian/bcovar chain on the Nyquist-extended trig tables
+    dispatches hundreds of single-op XLA programs — the largest remaining
+    eager block (~1-3 s) of every cold CLI run that writes a WOUT file.
+    ``res`` is the solver :class:`~vmex.core.fourier.Resolution` (hashable
+    static key); the mode table and the grid-Nyquist trig extension are
+    rebuilt from it at trace time as NumPy constants, identical to the host
+    tables ``wout_from_state`` keeps for the numpy postprocessing downstream
+    of the returned (device_get) arrays.
+    """
+    from .bootstrap import _trapped_fraction_export_lane  # circular at import
+
+    mpol, ntor, lasym = int(res.mpol), int(res.ntor), bool(res.lasym)
+    modes = mode_table(mpol, ntor)
+    mnyq_grid = max(res.ntheta1 // 2, mpol - 1)
+    nnyq_grid = max(int(res.nzeta) // 2, ntor)
+    trig = trig_tables(Resolution(
+        mpol=mnyq_grid + 1, ntor=nnyq_grid, ntheta=int(res.ntheta),
+        nzeta=int(res.nzeta), nfp=int(res.nfp), lasym=lasym, ns=int(res.ns)))
+
+    R_cos_p, Z_sin_p, R_sin_p, Z_cos_p = m1_constrained_to_physical(
+        state.R_cos, state.Z_sin, state.R_sin, state.Z_cos,
+        modes=modes, lthreed=bool(res.lthreed), lasym=lasym, lconm1=True,
+    )
+    lambda_sin = apply_lambda_axis_closure(state.L_sin, modes=modes, ntor=ntor)
+    geometry = real_space_geometry(
+        R_cos=R_cos_p, R_sin=R_sin_p, Z_cos=Z_cos_p, Z_sin=Z_sin_p,
+        lambda_cos=state.L_cos, lambda_sin=lambda_sin,
+        modes=modes, trig=trig, s=s_full,
+    )
+    jacobian = half_mesh_jacobian(geometry, s=s_full)
+    metrics = metric_elements(geometry, s=s_full)
+    fields = magnetic_fields(
+        geometry=geometry, jacobian=jacobian, metrics=metrics, trig=trig,
+        s=s_full, phips=phips, phipf=phipf, chips=chips, signgs=signgs,
+        gamma=gamma, mass=mass, ncurr=ncurr, enclosed_current=icurv,
+    )
+    norms = energies_and_force_norms(
+        jacobian=jacobian, metrics=metrics, fields=fields, trig=trig,
+        s=s_full, signgs=signgs,
+    )
+    trapped_fraction = _trapped_fraction_export_lane(
+        total_pressure=fields.total_pressure,
+        pressure=fields.pressure,
+        sqrt_g=jacobian.sqrt_g,
+        s_full=s_full,
+        lasym=lasym,
+        n_lambda=64,
+    )
+    return (geometry, jacobian, metrics, fields, norms, R_cos_p, Z_sin_p,
+            R_sin_p, Z_cos_p, trapped_fraction)
+
+
 def _on_state_device(fun):
     """Run postprocessing where the committed equilibrium state lives."""
     @functools.wraps(fun)
@@ -626,18 +694,7 @@ def wout_from_state(
     NESTOR ``potsin``/``xmpot``/``xnpot`` and ``*_sur`` tables.  LASYM runs
     additionally populate ``potcos`` and the four sine ``*_sur`` partners.
     """
-    import jax
-
     from . import nyquist as _nyq
-    from .bootstrap import _trapped_fraction_export_lane
-    from .fields import energies_and_force_norms, magnetic_fields, metric_elements
-    from .fourier import Resolution, mode_table, trig_tables
-    from .geometry import (
-        apply_lambda_axis_closure,
-        half_mesh_jacobian,
-        real_space_geometry,
-    )
-    from .residuals import m1_constrained_to_physical
     from .setup import boundary_from_input, flux_profiles, radial_grids
     from .solver import resolution_from_input
     from .transforms import physical_to_internal_scale
@@ -664,40 +721,11 @@ def wout_from_state(
                          lflip=boundary.lflip)
 
     # -- geometry + half-mesh field state (totzsps/jacobian/bcovar) ---------
-    R_cos_p, Z_sin_p, R_sin_p, Z_cos_p = m1_constrained_to_physical(
-        state.R_cos, state.Z_sin, state.R_sin, state.Z_cos,
-        modes=modes, lthreed=bool(res.lthreed), lasym=lasym, lconm1=True,
-    )
-    lambda_sin = apply_lambda_axis_closure(state.L_sin, modes=modes, ntor=ntor)
-    geometry = real_space_geometry(
-        R_cos=R_cos_p, R_sin=R_sin_p, Z_cos=Z_cos_p, Z_sin=Z_sin_p,
-        lambda_cos=state.L_cos, lambda_sin=lambda_sin,
-        modes=modes, trig=trig, s=grids.s_full,
-    )
-    jacobian = half_mesh_jacobian(geometry, s=grids.s_full)
-    metrics = metric_elements(geometry, s=grids.s_full)
-    fields = magnetic_fields(
-        geometry=geometry, jacobian=jacobian, metrics=metrics, trig=trig,
-        s=grids.s_full, phips=prof["phips"], phipf=prof["phipf"],
-        chips=prof["chips"], signgs=signgs, gamma=gamma, mass=prof["mass"],
-        ncurr=ncurr, enclosed_current=prof["icurv"],
-    )
-    norms = energies_and_force_norms(
-        jacobian=jacobian, metrics=metrics, fields=fields, trig=trig,
-        s=grids.s_full, signgs=signgs,
-    )
-    trapped_fraction = _trapped_fraction_export_lane(
-        total_pressure=fields.total_pressure,
-        pressure=fields.pressure,
-        sqrt_g=jacobian.sqrt_g,
-        s_full=grids.s_full,
-        lasym=lasym,
-        n_lambda=64,
-    )
     (geometry, jacobian, metrics, fields, norms, R_cos_p, Z_sin_p, R_sin_p,
-     Z_cos_p, trapped_fraction) = jax.device_get(
-        (geometry, jacobian, metrics, fields, norms, R_cos_p, Z_sin_p,
-         R_sin_p, Z_cos_p, trapped_fraction))
+     Z_cos_p, trapped_fraction) = jax.device_get(_wout_field_state_lane(
+        state, grids.s_full, prof["phips"], prof["phipf"], prof["chips"],
+        prof["mass"], prof["icurv"],
+        res=res, signgs=signgs, gamma=gamma, ncurr=ncurr))
 
     # -- 1D profiles in file conventions ------------------------------------
     vp = np.asarray(norms.vp, dtype=float).copy()


### PR DESCRIPTION
Second wave of the cold-start campaign, sibling to the iteration-body PR. Converts the remaining eager (unjitted) computation paths to module-scope jit lanes, from cProfile/compile-census attribution of cold CLI runs:

- **WOUT export field chain** (`_wout_field_state_lane`): the whole m1→geometry→jacobian→metrics→fields→energies→trapped-fraction chain on the Nyquist-extended tables as one XLA program (was the largest remaining eager block; the WOUT write dropped 25.8 → 9.4 s on the verification box).
- **Shared field chain** (`_field_chain_lane`) reused by `_result_from_carry`'s ncurr==1 branch and `statephysics._field_chain`.
- `reguess_initial_axis` synthesizes through the jitted `_geometry_lane` (guess_axis itself stays host-side).
- free-boundary: the initial/reguess Jacobian checks reuse the already-jitted `_jacobian_ok`; the carried-rbsq edge conversions get `_carried_edge_radius_lane`.
- **While-lane donation**: `donate_argnums=(0,)` on `_while_lane`/`_while_lane_fft` plus the alias-breaking copy in `_run_loop` — removes the 2×-carry transient for every python-API/implicit/optimize forward solve.
- Public `evaluate_forces` routed through a module-level jitted `_evaluate_lane` (collect_health static).

Verification: li383 cold CLI wout comparison branch-vs-base — everything the solver itself produces is bit-identical (rmnc/zmns/lmns, histories, residuals, niter); 38 derived postprocessing variables differ at reassociation level (1–4 ULP typical). wout-golden (12), solver end-to-end (9), freeboundary-multigrid (8) all pass; ruff clean.