### PR TITLE
Stop recompiling lanes for print cadence, initial delt, and ftol

### DIFF
--- a/tests/test_freeboundary.py
+++ b/tests/test_freeboundary.py
@@ -391,7 +391,8 @@ def test_vacuum_lane_never_consumes_a_sign_changed_state():
     assert not np.all(np.isfinite(np.asarray(poisoned["bsqvac"])))
 
     int64 = lambda v: jnp.asarray(v, dtype=jnp.int64)  # noqa: E731
-    carry = FB._initial_carry(bad, rt_freeb, ijacob=0,
+    delt0, _ = FB._loop_driver_config(inp)
+    carry = FB._initial_carry(bad, rt_freeb, ijacob=0, time_step0=delt0,
                               residuals=(1.0e-4, 1.0e-4, 1.0e-4))
     # A steady-state pass: mid-run iteration, best state stored at xstore;
     # max_iterations=5 bounds the lane to this single pass.

--- a/tests/test_runtime_recompile_keys.py
+++ b/tests/test_runtime_recompile_keys.py
@@ -1,0 +1,84 @@
+"""Lane recompile keys of :class:`vmex.core.solver.SolverRuntime`.
+
+Pins the perf contract that host loop-driver configuration never keys a lane
+recompile (lower-only — no solves are run here):
+
+- ``nstep`` (print cadence) and ``time_step0`` (initial DELT) are call
+  arguments of ``_run_loop``/``_initial_carry``, NOT runtime fields — as
+  static pytree meta they forced a full lane recompile for a changed print
+  cadence or initial time step;
+- ``ftol`` is a traced data scalar (read inside the trace only in exact
+  comparisons), so two runtimes differing only in tolerance share one
+  structural key and one lowering, bit-exactly.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import numpy as np
+
+from vmex.core import solver
+from vmex.core.input import VmecInput
+
+DECK = Path(__file__).resolve().parents[1] / "examples" / "data" / "input.solovev"
+
+
+def _small_runtime(ftol: float = 1e-10) -> solver.SolverRuntime:
+    inp = VmecInput.from_file(str(DECK))
+    resolution = solver.resolution_from_input(inp, ns=5)
+    return solver.prepare_runtime(inp, resolution, ftol=ftol, max_iterations=6)
+
+
+def test_loop_driver_scalars_are_not_runtime_fields() -> None:
+    """nstep/time_step0 are host loop-driver config, not solver context."""
+    names = {f.name for f in dataclasses.fields(solver.SolverRuntime)}
+    assert "nstep" not in names
+    assert "time_step0" not in names
+
+
+def test_initial_delt_does_not_change_lane_structure() -> None:
+    """Two initial carries differing only in DELT share one lane key.
+
+    The structural key (treedef + leaf avals) is exactly what selects a
+    compiled lane executable, so equality here IS executable reuse.
+    """
+    rt = _small_runtime()
+    state = solver._initial_state(rt.setup)
+    carry_a = solver._initial_carry(state, rt, ijacob=0, time_step0=0.9)
+    carry_b = solver._initial_carry(state, rt, ijacob=0, time_step0=0.45)
+    key_a = solver._lane_signature("block", carry_a, rt)
+    key_b = solver._lane_signature("block", carry_b, rt)
+    assert key_a == key_b
+    # ... and the DELT value itself still reaches the carry.
+    assert float(carry_a.time_step) != float(carry_b.time_step)
+
+
+def test_ftol_variants_share_one_structural_key_and_lowering() -> None:
+    """Runtimes differing only in ftol lower to the identical program."""
+    import jax
+
+    rt_a = _small_runtime(1e-10)
+    rt_b = _small_runtime(1e-8)
+    assert float(rt_a.ftol) != float(rt_b.ftol)
+
+    leaves_a, tree_a = jax.tree_util.tree_flatten(rt_a)
+    leaves_b, tree_b = jax.tree_util.tree_flatten(rt_b)
+    assert tree_a == tree_b
+    assert len(leaves_a) == len(leaves_b)
+
+    state = solver._initial_state(rt_a.setup)
+    carry_a = solver._initial_carry(state, rt_a, ijacob=0, time_step0=0.9)
+    carry_b = solver._initial_carry(state, rt_b, ijacob=0, time_step0=0.9)
+    key_a = solver._lane_signature("block", carry_a, rt_a)
+    key_b = solver._lane_signature("block", carry_b, rt_b)
+    assert key_a == key_b
+
+    # Lower-only executable-identity pin: the ftol scalar is an ARGUMENT of
+    # the lowered program, never a baked constant, so the lowered text is
+    # byte-identical across tolerance variants (one compile serves both).
+    text_a = solver._block_lane.lower(carry_a, rt_a).as_text()
+    text_b = solver._block_lane.lower(carry_b, rt_b).as_text()
+    assert text_a == text_b
+    assert not np.array_equal(float(rt_a.ftol), float(rt_b.ftol))

--- a/tests/test_step_control.py
+++ b/tests/test_step_control.py
@@ -183,7 +183,11 @@ def test_apply_restart(kind, dt_factor):
 
 
 def _recovery_runtime():
-    """Small real runtime (solovev, ns=5) for the structural recovery tests."""
+    """Small real runtime (solovev, ns=5) for the structural recovery tests.
+
+    Returns ``(runtime, time_step0, nstep)`` — the loop-driver scalars are
+    call-signature config (solver._loop_driver_config), not runtime fields.
+    """
     from pathlib import Path
 
     from vmex.core import solver
@@ -192,7 +196,8 @@ def _recovery_runtime():
     deck = Path(__file__).resolve().parents[1] / "examples" / "data" / "input.solovev"
     inp = VmecInput.from_file(str(deck))
     resolution = solver.resolution_from_input(inp, ns=5)
-    return solver.prepare_runtime(inp, resolution, max_iterations=8)
+    time_step0, nstep = solver._loop_driver_config(inp)
+    return solver.prepare_runtime(inp, resolution, max_iterations=8), time_step0, nstep
 
 
 def _install_fake_loop(monkeypatch, rt, calls, *, failures: int):
@@ -212,6 +217,7 @@ def _install_fake_loop(monkeypatch, rt, calls, *, failures: int):
     from vmex.core.errors import JAC75_FLAG, SUCCESSFUL_TERM_FLAG
 
     def fake_run_loop(state0, loop_rt, *, mode, ijacob, verbose, emit,
+                      time_step0, nstep,
                       use_fft=False, emit_banner=True, emit_legend=True,
                       initial_xcdot=None, initial_residuals=None):
         n = len(calls)
@@ -221,11 +227,12 @@ def _install_fake_loop(monkeypatch, rt, calls, *, failures: int):
                 for name in ("R_cos", "Z_sin", "L_sin")
             },
             lmove_axis=bool(loop_rt.lmove_axis),
-            delt0=float(loop_rt.time_step0),
+            delt0=float(time_step0),
             residuals=None if initial_residuals is None else tuple(
                 float(v) for v in initial_residuals),
         ))
-        carry = solver._initial_carry(state0, loop_rt, ijacob=ijacob)
+        carry = solver._initial_carry(
+            state0, loop_rt, ijacob=ijacob, time_step0=time_step0)
         if n < failures:
             checkpoint = jax.tree.map(
                 lambda x: x + 1e-3 * (n + 1), state0)
@@ -263,7 +270,7 @@ def test_consecutive_jac75_retries_restore_checkpoints_and_reduce_delt(
     from vmex.core import solver
     from vmex.core.errors import SUCCESSFUL_TERM_FLAG
 
-    rt = _recovery_runtime()
+    rt, delt0_in, nstep_in = _recovery_runtime()
     calls: list[dict] = []
     _install_fake_loop(monkeypatch, rt, calls, failures=2)
 
@@ -271,6 +278,7 @@ def test_consecutive_jac75_retries_restore_checkpoints_and_reduce_delt(
     carry = solver._solve_stage(
         rt, None, mode="cli", verbose=True,
         emit=lambda value="", end="\n": lines.append(str(value)),
+        time_step0=delt0_in, nstep=nstep_in,
         jacobian_retries=2,
     )
 
@@ -284,7 +292,7 @@ def test_consecutive_jac75_retries_restore_checkpoints_and_reduce_delt(
     interior = calls[0]["state"]
     # attempt 1: fresh interior guess, axis transfer allowed, input DELT
     assert calls[0]["lmove_axis"] is True
-    assert calls[0]["delt0"] == pytest.approx(float(rt.time_step0))
+    assert calls[0]["delt0"] == pytest.approx(delt0_in)
 
     # each retry restarts the PREVIOUS attempt's recorded best checkpoint
     for attempt in (1, 2):
@@ -308,7 +316,7 @@ def test_consecutive_jac75_retries_restore_checkpoints_and_reduce_delt(
             (0.5 + attempt - 1, 0.25 + attempt - 1, 0.125 + attempt - 1))
 
     # DELT reduced BEFORE the next update: min(0.5, 0.5 * previous)
-    d0 = float(rt.time_step0)
+    d0 = delt0_in
     assert calls[1]["delt0"] == pytest.approx(min(0.5, 0.5 * d0))
     assert calls[2]["delt0"] == pytest.approx(min(0.5, 0.5 * calls[1]["delt0"]))
     assert calls[0]["delt0"] > calls[1]["delt0"] > calls[2]["delt0"]
@@ -329,12 +337,13 @@ def test_jac75_chain_exhausts_retries_with_typed_error(monkeypatch) -> None:
     from vmex.core import solver
     from vmex.core.errors import JAC75_FLAG, VmecJacobianError
 
-    rt = _recovery_runtime()
+    rt, delt0_in, nstep_in = _recovery_runtime()
     calls: list[dict] = []
     _install_fake_loop(monkeypatch, rt, calls, failures=99)
 
     carry = solver._solve_stage(
         rt, None, mode="cli", verbose=False, emit=lambda *a, **k: None,
+        time_step0=delt0_in, nstep=nstep_in,
         jacobian_retries=2,
     )
     assert int(carry.ier) == JAC75_FLAG

--- a/tools/force_oracle.py
+++ b/tools/force_oracle.py
@@ -292,15 +292,15 @@ def replay(inp, *, ns: int | None = None, niter: int = 30,
     )
 
     resolution = solver.resolution_from_input(inp, ns=ns)
-    rt = solver.prepare_runtime(
-        inp, resolution, max_iterations=niter, time_step=time_step,
-    )
+    rt = solver.prepare_runtime(inp, resolution, max_iterations=niter)
+    delt0, _ = solver._loop_driver_config(inp, time_step=time_step)
     state = solver._initial_state(rt.setup)
     wanted = set(int(i) for i in iterations)
 
     def attempt(rt, state, *, ijacob, xcdot, residuals):
         carry = solver._initial_carry(
-            state, rt, ijacob=ijacob, xcdot=xcdot, residuals=residuals,
+            state, rt, ijacob=ijacob, time_step0=delt0,
+            xcdot=xcdot, residuals=residuals,
         )
         body = solver._make_body(rt)
         records: dict[int, dict] = {}

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -79,7 +79,7 @@ from .solver import (
     SolveResult, SolverRuntime, SpectralState, VacuumOutput,
     _LANE_EXECUTABLES, _USED_LANE_KEYS,
     _finalize, _geometry, _initial_carry, _initial_state, _leaf_signature,
-    _make_body,
+    _loop_driver_config, _make_body,
     _result_from_carry, _zero_cache, prepare_runtime, resolution_from_input,
     reguess_initial_axis, runtime_with_baselines,
     _resolve_use_fft,
@@ -1252,10 +1252,11 @@ def _prefetch_stage_lane_set(
     to on-demand compilation.
     """
     resolution = free_boundary_resolution(inp, external_field, ns=int(ns))
+    time_step0, _ = _loop_driver_config(inp, time_step=time_step, nstep=nstep)
     with device_context(device, resolution):
         rt = prepare_runtime(
             inp, resolution, ftol=ftol, max_iterations=max_iterations,
-            time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
+            tcon0=tcon0, gamma=gamma,
             lconm1=lconm1, precon_type=precon_type,
             prec2d_threshold=prec2d_threshold, prec2d=prec2d, use_fft=use_fft,
         )
@@ -1279,8 +1280,10 @@ def _prefetch_stage_lane_set(
             presf_ns_scale=jnp.asarray(
                 _presf_ns_scale(inp, ns_i), dtype=dtype),
         )
-        carry_fixed = _initial_carry(state, rt_fixed, ijacob=0)
-        carry_freeb = _initial_carry(state, rt_freeb, ijacob=0)
+        carry_fixed = _initial_carry(
+            state, rt_fixed, ijacob=0, time_step0=time_step0)
+        carry_freeb = _initial_carry(
+            state, rt_freeb, ijacob=0, time_step0=time_step0)
         out = jax.eval_shape(fused.full, state, rt_freeb, external_field)
         z = lambda sd: jnp.zeros(sd.shape, dtype=sd.dtype)  # noqa: E731
         int_dtype = carry_freeb.iteration.dtype
@@ -1659,9 +1662,14 @@ def _solve_free_boundary_stage(
                 hint="use free_boundary_resolution(), NZETA = 0, or a "
                      "divisor of the mgrid plane count",
             )
+    # Host loop-driver scalars (initial DELT, NSTEP cadence): call-signature
+    # config, never runtime pytree structure (solver._loop_driver_config).
+    time_step0, nstep_cadence = _loop_driver_config(
+        inp, time_step=time_step, nstep=nstep
+    )
     rt = prepare_runtime(
         inp, resolution, ftol=ftol, max_iterations=max_iterations,
-        time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
+        tcon0=tcon0, gamma=gamma,
         lconm1=lconm1, precon_type=precon_type,
         prec2d_threshold=prec2d_threshold, prec2d=prec2d,
         use_fft=use_fft,
@@ -1821,8 +1829,8 @@ def _solve_free_boundary_stage(
         prefetch = _launch_free_lane_prefetch(
             inp, external_field=external_field, ns=ns, ftol=float(rt.ftol),
             max_iterations=int(rt.max_iterations),
-            time_step=float(rt.time_step0), tcon0=float(rt.tcon0),
-            gamma=float(rt.gamma), nstep=int(rt.nstep), lconm1=lconm1,
+            time_step=time_step0, tcon0=float(rt.tcon0),
+            gamma=float(rt.gamma), nstep=nstep_cadence, lconm1=lconm1,
             precon_type=precon_type, prec2d_threshold=prec2d_threshold,
             prec2d=prec2d, use_fft=use_fft, device=prefetch_device,
             lmove_axis=bool(rt.lmove_axis), vacuum_on=bool(vacuum_active),
@@ -1837,7 +1845,7 @@ def _solve_free_boundary_stage(
 
     try:
         if verbose:
-            emit(stage_banner(ns, resolution.mnmax, rt.ftol, rt.max_iterations), end="")
+            emit(stage_banner(ns, resolution.mnmax, float(rt.ftol), rt.max_iterations), end="")
             # runvmec.f prints the residual legend once per run; later radial
             # rungs of a ladder keep only the NS banner and the column header.
             if emit_legend:
@@ -1851,6 +1859,7 @@ def _solve_free_boundary_stage(
             _init_state,
             rt_initial,
             ijacob=_initial_ijacob,
+            time_step0=time_step0,
             residuals=residual_continuation,
         )
         printed: set[int] = set()
@@ -1865,7 +1874,7 @@ def _solve_free_boundary_stage(
             upto = int(carry.iteration) if bool(carry.done) or final else int(carry.iteration) - 1
             trajectory = np.asarray(carry.trajectory[: max(upto, 0)])
             for it_p in range(1, upto + 1):
-                due = (it_p == 1) or (it_p % rt.nstep == 0) or (final and it_p == upto)
+                due = (it_p == 1) or (it_p % nstep_cadence == 0) or (final and it_p == upto)
                 if not due or it_p in printed:
                     continue
                 row = trajectory[it_p - 1]
@@ -1953,6 +1962,7 @@ def _solve_free_boundary_stage(
             retry_xcdot = carry.xcdot
             carry = _initial_carry(
                 _init_state, rt_initial, ijacob=_initial_ijacob,
+                time_step0=time_step0,
                 xcdot=retry_xcdot,
                 residuals=(carry.fsqr, carry.fsqz, carry.fsql),
             )
@@ -2125,15 +2135,17 @@ def _solve_free_boundary_stage(
         _emit_due(final=True)
         ier = int(carry.ier)
         if ier == JAC75_FLAG and int(jacobian_retries) > 0:
-            retry_step = min(0.5, 0.5 * float(rt.time_step0))
+            retry_step = min(0.5, 0.5 * time_step0)
             if verbose:
                 emit(
                     " JACOBIAN RECOVERY RETRY: RESTARTING BEST FINITE "
                     f"STATE WITH DELT = {retry_step:.6g}"
                 )
-            # Retire this stage's prefetch before recursing: the retry's
-            # halved DELT is static meta, so none of the pending lanes match
-            # its structures (the finally below re-joins harmlessly).
+            # Retire this stage's prefetch before recursing: DELT is host
+            # loop-driver config (not meta), so the retry's lane structures
+            # match and any already-compiled executables are reused; the
+            # recursed stage relaunches its own worker for the remainder
+            # (the finally below re-joins harmlessly).
             if prefetch is not None:
                 prefetch[1].set()
                 prefetch[0].join()

--- a/vmex/core/freeboundary.py
+++ b/vmex/core/freeboundary.py
@@ -78,6 +78,7 @@ from .printing import (
 from .solver import (
     SolveResult, SolverRuntime, SpectralState, VacuumOutput,
     _LANE_EXECUTABLES, _USED_LANE_KEYS,
+    _due_rows_pending,
     _finalize, _geometry, _initial_carry, _initial_state, _leaf_signature,
     _loop_driver_config, _make_body,
     _result_from_carry, _zero_cache, prepare_runtime, resolution_from_input,
@@ -1863,22 +1864,38 @@ def _solve_free_boundary_stage(
             residuals=residual_continuation,
         )
         printed: set[int] = set()
+        emit_start = 1
         #: per-iteration DEL-BSQ recorded by the batched steady-state lane; rows
         #: not covered (pre-activation, turn-on pass) fall back to ``fb.delbsq``
         #: exactly as the per-pass driver printed them.
         delbsq_rows: dict[int, float] = {}
 
         def _emit_due(final: bool) -> None:
+            # Resume-index scan + transfer gate (solver._emit_lines twin):
+            # rows below ``emit_start`` are printed or permanently non-due,
+            # and a pass with no due row in range transfers nothing.  A due
+            # row whose slot is not yet written pins the resume index, so a
+            # later pass prints it exactly as the full rescan did — with the
+            # then-current DEL-BSQ fallback, as before.
+            nonlocal emit_start
             if not verbose:
                 return
             upto = int(carry.iteration) if bool(carry.done) or final else int(carry.iteration) - 1
+            if not _due_rows_pending(
+                    emit_start, upto, nstep=nstep_cadence, final=final):
+                return
             trajectory = np.asarray(carry.trajectory[: max(upto, 0)])
-            for it_p in range(1, upto + 1):
+            advancing = True
+            resume = max(1, emit_start)
+            for it_p in range(resume, upto + 1):
                 due = (it_p == 1) or (it_p % nstep_cadence == 0) or (final and it_p == upto)
                 if not due or it_p in printed:
+                    if advancing:
+                        resume = it_p + 1
                     continue
                 row = trajectory[it_p - 1]
                 if int(row[0]) != it_p:
+                    advancing = False
                     continue
                 emit(screen_line(
                     it_p, float(row[1]), float(row[2]), float(row[3]),
@@ -1887,6 +1904,14 @@ def _solve_free_boundary_stage(
                     del_bsq=delbsq_rows.get(it_p, float(fb.delbsq)),
                 ), end="")
                 printed.add(it_p)
+                if advancing:
+                    resume = it_p + 1
+            if bool(carry.done) and not final:
+                # A done carry keeps this ``upto`` for the terminating
+                # _emit_due(final=True) call, where row ``upto`` becomes
+                # unconditionally due — never resume past it.
+                resume = min(resume, max(upto, 1))
+            emit_start = resume
 
         # VMEC2000's LMOVE_AXIS path is triggered by the *first force pass*, not
         # only by a bad Jacobian.  Run that pass explicitly before entering the

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -55,7 +55,8 @@ from .preconditioner_2d import Prec2DConfig
 from .printing import emit_flushed
 from .restart import restart_state, skip_ladder_rungs
 from .solver import (
-    SolveResult, SpectralState, _finalize, _prefetch_block_lane,
+    SolveResult, SpectralState, _finalize, _loop_driver_config,
+    _prefetch_block_lane,
     _polish_solve_result, _release_used_lane_executables, _result_from_carry,
     _resolve_force_balance_polish, _solve_stage, _resolve_use_fft,
     hot_restart_state, prepare_runtime, resolution_from_input,
@@ -231,16 +232,21 @@ def _launch_lane_prefetch(
     def worker() -> None:
         try:
             resolution = resolution_from_input(inp, ns=ns_next)
+            time_step0, _ = _loop_driver_config(
+                inp, time_step=time_step, nstep=nstep
+            )
             with device_context(device, resolution):
                 rt = prepare_runtime(
                     inp, resolution, ftol=float(ftol_next),
                     max_iterations=int(niter_next), lconm1=lconm1,
-                    time_step=time_step, tcon0=tcon0, gamma=gamma,
-                    nstep=nstep, precon_type=precon_type,
+                    tcon0=tcon0, gamma=gamma,
+                    precon_type=precon_type,
                     prec2d_threshold=prec2d_threshold, prec2d=prec2d,
                     use_fft=use_fft,
                 )
-                _prefetch_block_lane(rt, use_fft=use_fft)
+                _prefetch_block_lane(
+                    rt, use_fft=use_fft, time_step0=time_step0
+                )
         except Exception:      # silent fallback: on-demand compilation
             pass
 
@@ -336,7 +342,8 @@ def solve_multigrid(
 
     Executable reuse: stage runtimes are structural pytrees (solver.py), so
     one XLA executable is compiled per distinct stage structure ``(ns,
-    ftol, niter, ...)`` per session, and repeated ladders (parameter scans,
+    niter, ...)`` per session (``ftol`` is pytree data, so tolerance-only
+    rung changes share it), and repeated ladders (parameter scans,
     hot restarts) recompile nothing.  Full radial padding to
     ``max(ns_array)`` — ONE executable for all stages — would need masked
     radial reductions through geometry/fields/forces/preconditioner and is
@@ -369,9 +376,9 @@ def solve_multigrid(
     *before* the ``release_stage_cache`` point, and the prefetched
     executable is held as a standalone object, so releasing rung k's caches
     cannot evict rung k+1's just-built executable.  Only the ``mode="cli"``
-    block lane is prefetched, and equal-structure reruns (same ``ns``,
-    ``ftol``, ``niter``) skip the prefetch because the previous rung's
-    executable is reused directly.
+    block lane is prefetched, and equal-structure reruns (same ``ns`` and
+    ``niter``; ``ftol`` is data) skip the prefetch because the previous
+    rung's executable is reused directly.
 
     ``polish_force_balance=False`` is the default and leaves the established
     VMEC continuation solve unchanged. Set it to ``True`` or ``"auto"`` to
@@ -419,6 +426,11 @@ def solve_multigrid(
     residual_continuation = None
     carry = rt = None
     prefetch_thread: threading.Thread | None = None
+    # runvmec.f resets DELT to the input value at every stage; the loop-driver
+    # scalars are host config shared by all rungs (never pytree structure).
+    time_step0, nstep_cadence = _loop_driver_config(
+        inp, time_step=time_step, nstep=nstep
+    )
     for igrid in range(n_stages):
         nsval = int(ns_arr[igrid])
         resolution = resolution_from_input(inp, ns=nsval)
@@ -427,7 +439,7 @@ def solve_multigrid(
             rt = prepare_runtime(
                 inp, resolution, ftol=float(ftol_arr[igrid]),
                 max_iterations=int(niter_arr[igrid]), lconm1=lconm1,
-                time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
+                tcon0=tcon0, gamma=gamma,
                 precon_type=precon_type, prec2d_threshold=prec2d_threshold,
                 prec2d=prec2d, use_fft=stage_use_fft,
             )
@@ -446,7 +458,8 @@ def solve_multigrid(
         # Overlapped compilation (see the docstring): start building rung
         # igrid+1's executable now, so it is (mostly) ready when this rung's
         # iterations finish.  Equal-structure next rungs reuse this rung's
-        # executable directly, so nothing needs prefetching.
+        # executable directly, so nothing needs prefetching (ftol is pytree
+        # DATA — a tolerance-only change is not a new structure).
         if (
             prefetch_compile
             and mode == "cli"
@@ -454,7 +467,6 @@ def solve_multigrid(
             and not jax.config.jax_disable_jit
             and (
                 int(ns_arr[igrid + 1]) != nsval
-                or float(ftol_arr[igrid + 1]) != float(ftol_arr[igrid])
                 or int(niter_arr[igrid + 1]) != int(niter_arr[igrid])
             )
         ):
@@ -483,6 +495,7 @@ def solve_multigrid(
         with device_context(device, resolution):
             carry = _solve_stage(
                 rt, state, mode=mode, verbose=verbose, emit=emit,
+                time_step0=time_step0, nstep=nstep_cadence,
                 # initialize_radial.f resets ijacob at every NS stage, so
                 # both bad-Jacobian and LMOVE_AXIS first-force retries remain
                 # available after interpolation and on hot starts.

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -58,6 +58,7 @@ reduced ``[0, pi]`` grid.
 
 from __future__ import annotations
 
+import collections
 import dataclasses
 import inspect
 import warnings
@@ -2393,6 +2394,62 @@ def residuals_from_tuples(
     return jnp.concatenate(rows)
 
 
+#: Bounded per-process registry of the per-problem jitted callables built by
+#: :func:`_least_squares_implicit`, keyed on the construction content their
+#: closures bake in (the ``implicit._canonical_config`` precedent one level
+#: up: ``jax.jit`` caches per function OBJECT, so the fresh closures this
+#: factory mints re-traced every graph on repeated problem construction in
+#: one process).  Entries hold the jitted callables, whose closures keep the
+#: keyed term/loss callables alive — identity keys therefore cannot be
+#: recycled while their entry lives.  Eviction only costs a later retrace,
+#: never correctness.
+_PROBLEM_JIT_CACHE: "collections.OrderedDict[tuple, dict[str, Any]]" = (
+    collections.OrderedDict()
+)
+_PROBLEM_JIT_CACHE_MAX = 8
+
+
+def _problem_callable_token(fun: Callable) -> tuple:
+    """Hashable identity token of one user term/loss callable.
+
+    Bound methods are minted fresh on every attribute access, so their own
+    ``id`` never repeats across constructions; token the OWNER instance
+    instead (the cached closures hold the owner via the wrapped term, so the
+    id stays valid).  Plain callables are tokened — and kept alive — by
+    identity.  Limitation (documented on the public factories): equal-content
+    but distinct callables (fresh lambdas per construction) lawfully miss,
+    and owners are assumed frozen after construction, matching the repo-wide
+    frozen-input convention.
+    """
+    owner = getattr(fun, "__self__", None)
+    if owner is not None:
+        return ("bound", id(owner), type(owner).__qualname__,
+                fun.__func__.__qualname__)
+    return ("callable", id(fun), getattr(fun, "__qualname__", repr(fun)))
+
+
+def _problem_jit(cache_key: tuple, slot: str, build: Callable):
+    """One shared jitted callable per ``(problem content, slot)``.
+
+    ``build`` runs at most once per live cache entry; a hit returns the
+    earlier construction's jitted callable, whose closures are content-equal
+    by construction of the key (same canonical config identity, term
+    identities/targets/weights, dof layout, seed point, and Jacobian
+    routing), so tracing and executables are shared instead of rebuilt.
+    """
+    entry = _PROBLEM_JIT_CACHE.get(cache_key)
+    if entry is None:
+        entry = {}
+        _PROBLEM_JIT_CACHE[cache_key] = entry
+    else:
+        _PROBLEM_JIT_CACHE.move_to_end(cache_key)
+    if slot not in entry:
+        entry[slot] = build()
+    while len(_PROBLEM_JIT_CACHE) > _PROBLEM_JIT_CACHE_MAX:
+        _PROBLEM_JIT_CACHE.popitem(last=False)
+    return entry[slot]
+
+
 def _least_squares_implicit(
     objective_terms: Sequence[tuple[Callable, float, Any]],
     inp: VmecInput,
@@ -2445,6 +2502,14 @@ def _least_squares_implicit(
     launch-bound, dof-count-scaling GPU compile (R1); an explicit
     ``device=`` overrides this.  The forward equilibrium callback uses the
     solver's independent automatic per-stage placement policy.
+
+    Repeated construction with identical content reuses the earlier
+    problem's jitted residual/Jacobian callables (``_PROBLEM_JIT_CACHE``,
+    bounded at 8).  User term/loss callables are keyed by IDENTITY (bound
+    methods by their owner instance): pass the same callable objects to hit
+    the cache — freshly minted lambdas per construction lawfully rebuild —
+    and treat term owners as frozen after construction, matching the
+    repo-wide frozen-input convention.
     """
     import scipy.optimize
 
@@ -2526,7 +2591,11 @@ def _least_squares_implicit(
     # and the custom-VJP backward re-enter the same placement context on
     # their own — no outer jax.default_device context needed.
     jac_device = resolve_implicit_device(device, cfg.resolution)
-    cfg = dataclasses.replace(cfg, device=jac_device)
+    # Re-canonicalize after the device replace (the implicit.run precedent):
+    # a fresh config identity here missed every identity-keyed implicit
+    # cache (_template_runtime, the residual lane, _LAST_SOLVE) on repeated
+    # problem construction with identical content.
+    cfg = imp._canonical_config(dataclasses.replace(cfg, device=jac_device))
     if initial_state is not None:
         imp._HOT_CACHE[cfg] = initial_state
 
@@ -2543,6 +2612,31 @@ def _least_squares_implicit(
         if k_cur:
             x0 = np.concatenate([x0, _pack_current(inp, k_cur, ac_scale)])
     x0 = np.asarray(x0, dtype=float)
+
+    # Content key of every degree of freedom the jitted closures below bake
+    # in: the canonical config identity (input deck, resolution, tolerances,
+    # device), the term/loss identities with resolved targets/weights, the
+    # dof layout, the seed point (penalty-wall center), and the Jacobian
+    # routing knobs.  Repeated problem construction with equal content then
+    # reuses the earlier jitted callables through _problem_jit instead of
+    # re-tracing every graph.
+    problem_jit_key = (
+        id(cfg),
+        tuple(
+            (_problem_callable_token(f_orig), float(t_res),
+             np.asarray(w_res).tobytes())
+            for (f_orig, _t, _w), (_f, t_res, w_res)
+            in zip(objective_terms, terms)
+        ),
+        (None if scalar_objective is None
+         else _problem_callable_token(scalar_objective)),
+        int(max_mode), bool(vary_major_radius),
+        None if current_dofs is None else int(current_dofs),
+        x0.shape, x0.tobytes(),
+        (jac_chunk_size if jac_chunk_size is None
+         or isinstance(jac_chunk_size, int) else str(jac_chunk_size)),
+        str(jac_solver),
+    )
 
     def params_of(x: jnp.ndarray):
         repl = dict(rbc=params0.rbc.at[row_idx, col_idx].set(x[:nm]),
@@ -2718,7 +2812,8 @@ def _least_squares_implicit(
             operand=None,
         )
 
-    rows_jit = jax.jit(residual_rows)
+    rows_jit = _problem_jit(
+        problem_jit_key, "rows", lambda: jax.jit(residual_rows))
 
     def scalar_loss(x: jnp.ndarray) -> jnp.ndarray:
         params = params_of(x)
@@ -2734,8 +2829,11 @@ def _least_squares_implicit(
             operand=None,
         )
 
-    scalar_loss_jit = jax.jit(scalar_loss)
-    value_grad_jit = jax.jit(jax.value_and_grad(scalar_loss))
+    scalar_loss_jit = _problem_jit(
+        problem_jit_key, "scalar_loss", lambda: jax.jit(scalar_loss))
+    value_grad_jit = _problem_jit(
+        problem_jit_key, "value_grad",
+        lambda: jax.jit(jax.value_and_grad(scalar_loss)))
 
     # The evolved-dof mask was fetched by the strict seed preflight above.
     mask_const = jax.tree.map(_place, mask_np)
@@ -2933,9 +3031,13 @@ def _least_squares_implicit(
         jac_impl = jacobian_rows_block
     else:
         jac_impl = jacobian_rows
-    jac_jit = jax.jit(jac_impl)
-    gmres_jit = jax.jit(jacobian_rows)
-    reverse_jit = jax.jit(jax.jacrev(residual_rows))
+    jac_jit = _problem_jit(
+        problem_jit_key, "jac", lambda: jax.jit(jac_impl))
+    gmres_jit = _problem_jit(
+        problem_jit_key, "jac_gmres", lambda: jax.jit(jacobian_rows))
+    reverse_jit = _problem_jit(
+        problem_jit_key, "jac_reverse",
+        lambda: jax.jit(jax.jacrev(residual_rows)))
 
     # The strict seed preflight above already evaluated and validated every
     # residual row.  Carry that known shape instead of compiling ``rows_jit``
@@ -2960,7 +3062,6 @@ def _least_squares_implicit(
     P_seed = imp._dof_projector(cfg, mask_const)
     edge_seed = imp._edge_mask(cfg)
 
-    @jax.jit
     def predicted_state(x_trial, x_ref, frozen, dz_cols):
         """First-order trial-state prediction around the stashed jac point.
 
@@ -2975,6 +3076,10 @@ def _least_squares_implicit(
             lambda d: jnp.tensordot(x_trial - x_ref, d, axes=1), dz_cols)
         z = jax.tree.map(jnp.add, P_seed(frozen), dz)
         return imp._assemble(z, rt_p, frozen, P_seed, edge_seed)
+
+    predicted_state = _problem_jit(
+        problem_jit_key, "predicted_state",
+        lambda fn=predicted_state: jax.jit(fn))
 
     def _stash_linearization(x: np.ndarray, dz_cols) -> None:
         """Record ``(x_ref, converged state, dz columns)`` for trial seeding."""
@@ -3325,7 +3430,9 @@ def _least_squares_implicit(
             lambda _: failure_value_and_gradient_jax(x), operand=None,
         )
 
-    residual_value_grad_jit = jax.jit(residual_value_and_gradient)
+    residual_value_grad_jit = _problem_jit(
+        problem_jit_key, "residual_value_grad",
+        lambda: jax.jit(residual_value_and_gradient))
 
     def jax_state_runtime(x: jnp.ndarray):
         """Converged implicit state/runtime pair for differentiable field APIs."""

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -43,9 +43,10 @@ Structural executable reuse
 :class:`SolverRuntime` is a registered pytree passed as an *argument* to the
 module-level jitted lanes :func:`_while_lane`/:func:`_block_lane`.
 Array-valued run data
-(:class:`~vmex.core.setup.RunSetup`, ``rcon0/zcon0``) are pytree data;
-the hashable configuration (:class:`~vmex.core.fourier.Resolution`,
-``gamma/tcon0/ftol/max_iterations/time_step0/nstep/jmax``) is pytree meta;
+(:class:`~vmex.core.setup.RunSetup`, ``rcon0/zcon0``, the ``ftol`` scalar)
+are pytree data; the hashable configuration
+(:class:`~vmex.core.fourier.Resolution`,
+``gamma/tcon0/max_iterations/jmax``) is pytree meta;
 the NumPy mode/trig/weight/gather tables — consumed with ``np.*``/fancy
 indexing at trace time — are derived from the meta resolution through the
 cached :func:`_static_tables` and never enter the pytree.  Consequence: two
@@ -389,13 +390,22 @@ class SolverRuntime:
 
     - **data fields** (traced): the :class:`RunSetup` arrays (profiles,
       radial grids, boundary, initial state — everything that changes with
-      boundary values) and the fixed-boundary constraint baselines
+      boundary values), the fixed-boundary constraint baselines
       ``rcon0/zcon0`` (``funct3d.f`` — constant per run because the edge
-      spectral row never evolves, but boundary-value dependent);
+      spectral row never evolves, but boundary-value dependent), and the
+      ``ftol`` scalar (read inside the trace only in exact comparisons, so
+      ladder/scan runs differing only in tolerance share one executable);
     - **meta fields** (static, hashable): the :class:`Resolution` plus the
       scalar configuration (``gamma`` is consumed concretely by
       ``fields.magnetic_fields``; ``max_iterations`` sizes the trajectory
       buffer; the rest are loop-control constants).
+
+    The host loop-driver scalars — initial ``DELT`` and the ``NSTEP`` print
+    cadence — deliberately do NOT live here: they are never read inside a
+    traced lane and as static meta they forced a full lane recompile for a
+    changed print cadence or initial time step.  They travel through the
+    :func:`_run_loop`/:func:`_initial_carry` call signatures instead
+    (resolved by :func:`_loop_driver_config`).
 
     The NumPy mode/trig/weight/gather tables are *derived* from the meta
     ``resolution`` via the cached :func:`_static_tables` (exposed as
@@ -408,8 +418,9 @@ class SolverRuntime:
     resolution: Resolution
     setup: RunSetup
     rcon0: Array; zcon0: Array
-    gamma: float; tcon0: float; ftol: float
-    max_iterations: int; time_step0: float; nstep: int
+    ftol: Array                         # data: convergence threshold scalar
+    gamma: float; tcon0: float
+    max_iterations: int
     jmax: int                           # evolved radial rows (fixed: ns-1)
     lforbal: bool = False               # tomnsp_mod.f m=1,n=0 force replacement
     lmove_axis: bool = True             # funct3d.f first-force irst=4 path
@@ -467,8 +478,8 @@ class SolverRuntime:
 
 
 _register(SolverRuntime, meta=(
-    "resolution", "gamma", "tcon0", "ftol", "max_iterations", "time_step0",
-    "nstep", "jmax", "lforbal", "lmove_axis",
+    "resolution", "gamma", "tcon0", "max_iterations",
+    "jmax", "lforbal", "lmove_axis",
     "lfreeb", "prec2d",
 ))
 
@@ -626,13 +637,39 @@ def _resolve_prec2d(
     return Prec2DConfig(threshold=float(thr), finest=bool(finest))
 
 
+def _loop_driver_config(
+    source: VmecInput | RunSetup,
+    *,
+    time_step: float | None = None,
+    nstep: int | None = None,
+) -> tuple[float, int]:
+    """Resolve the host loop-driver scalars ``(initial DELT, NSTEP cadence)``.
+
+    ``eqsolve.f`` driver configuration, not solver context: neither value is
+    read inside a traced lane (``DELT`` seeds the initial carry on the host,
+    ``NSTEP`` gates screen lines), so they deliberately stay off
+    :class:`SolverRuntime` and travel through the :func:`_run_loop` /
+    :func:`_initial_carry` call signatures.  Defaults mirror
+    :func:`prepare_runtime`: the input's ``DELT``/``NSTEP`` (RunSetup sources
+    fall back to the ``readin.f`` values), explicit keywords override.
+    """
+    if isinstance(source, RunSetup):
+        delt_default, nstep_default = 1.0, 200
+    else:
+        delt_default, nstep_default = float(source.delt), int(source.nstep)
+    return (
+        float(delt_default if time_step is None else time_step),
+        int(nstep_default if nstep is None else nstep),
+    )
+
+
 def prepare_runtime(
     source: VmecInput | RunSetup,
     resolution: Resolution | None = None,
     *,
     ftol: float | None = None, max_iterations: int | None = None,
-    time_step: float | None = None, tcon0: float | None = None,
-    gamma: float | None = None, nstep: int | None = None,
+    tcon0: float | None = None,
+    gamma: float | None = None,
     lconm1: bool = True, lforbal: bool | None = None,
     setup: RunSetup | None = None,
     precon_type: str | None = None, prec2d_threshold: float | None = None,
@@ -641,8 +678,11 @@ def prepare_runtime(
 ) -> SolverRuntime:
     """Build the static solver context from an input file or a RunSetup.
 
-    Defaults come from the input (``delt``, ``tcon0``, ``gamma``, ``nstep``,
-    ``ftol_array(1)``, ``niter_array(1)``); explicit keywords override.  The
+    Defaults come from the input (``tcon0``, ``gamma``, ``ftol_array(1)``,
+    ``niter_array(1)``); explicit keywords override.  The host loop-driver
+    scalars (initial ``DELT``, ``NSTEP`` print cadence) are resolved by
+    :func:`_loop_driver_config` at the loop-driver call sites, never stored
+    here.  The
     fixed-boundary constraint baselines ``rcon0/zcon0 = s * rcon(ns)``
     (``funct3d.f``) are computed once here from the initial state — the edge
     spectral row never evolves in fixed-boundary mode, so they are constants
@@ -659,8 +699,8 @@ def prepare_runtime(
         if resolution is None:
             raise ValueError("prepare_runtime(RunSetup) requires a Resolution")
         setup = source
-        defaults = dict(ftol=1e-10, niter=100, delt=1.0, tcon0=1.0, gamma=0.0,
-                        nstep=200, lforbal=False, lmove_axis=True)
+        defaults = dict(ftol=1e-10, niter=100, tcon0=1.0, gamma=0.0,
+                        lforbal=False, lmove_axis=True)
     else:
         inp = source
         if resolution is None:
@@ -678,8 +718,7 @@ def prepare_runtime(
                 infer_axis_if_missing=False, use_fft=use_fft,
             )
         defaults = dict(ftol=float(inp.ftol_array[0]), niter=int(inp.niter_array[0]),
-                        delt=float(inp.delt), tcon0=float(inp.tcon0),
-                        gamma=float(inp.gamma), nstep=int(inp.nstep),
+                        tcon0=float(inp.tcon0), gamma=float(inp.gamma),
                         lforbal=bool(inp.lforbal),
                         lmove_axis=bool(inp.lmove_axis))
     requested_iterations = int(
@@ -693,10 +732,14 @@ def prepare_runtime(
         resolution=resolution, setup=setup,
         gamma=float(defaults["gamma"] if gamma is None else gamma),
         tcon0=float(defaults["tcon0"] if tcon0 is None else tcon0),
-        ftol=float(defaults["ftol"] if ftol is None else ftol),
+        # Data scalar (not meta): the trace reads ftol only in exact
+        # comparisons, so equal-structure runs differing only in tolerance
+        # reuse one executable, bit-exactly.
+        ftol=jnp.asarray(
+            float(defaults["ftol"] if ftol is None else ftol),
+            dtype=setup.s_full.dtype,
+        ),
         max_iterations=effective_iterations,
-        time_step0=float(defaults["delt"] if time_step is None else time_step),
-        nstep=int(defaults["nstep"] if nstep is None else nstep),
         jmax=int(resolution.ns) - 1,
         lforbal=bool(defaults["lforbal"] if lforbal is None else lforbal),
         lmove_axis=bool(defaults["lmove_axis"]),
@@ -1572,6 +1615,7 @@ def _initial_carry(
     rt: SolverRuntime,
     *,
     ijacob: int,
+    time_step0: float,
     xcdot: SpectralState | None = None,
     residuals: tuple[float | Array, float | Array, float | Array] | None = None,
 ) -> _LoopCarry:
@@ -1581,7 +1625,9 @@ def _initial_carry(
     the module variables ``fsqr/fsqz/fsql`` unchanged across radial grids.
     Those retained values control the first-pass free-boundary edge gate in
     ``residue.f90``.  ``residuals=None`` is the cold-start
-    ``reset_params.f`` value ``(1, 1, 1)``.
+    ``reset_params.f`` value ``(1, 1, 1)``.  ``time_step0`` is the host
+    loop-driver initial ``DELT`` (:func:`_loop_driver_config`) — a carry
+    VALUE only, so it never keys a lane recompile.
     """
     dtype = rt.setup.s_full.dtype
     one = jnp.asarray(1.0, dtype=dtype)
@@ -1589,7 +1635,7 @@ def _initial_carry(
         jax.tree.map(jnp.zeros_like, state)
         if xcdot is None else xcdot
     )
-    delt0 = jnp.asarray(rt.time_step0, dtype=dtype)
+    delt0 = jnp.asarray(float(time_step0), dtype=dtype)
     zero, inf = jnp.zeros((), dtype=dtype), jnp.asarray(jnp.inf, dtype=dtype)
     # NOTE: scalar counters/flags carry explicit (non-weak) dtypes so that the
     # initial carry has exactly the avals of the carry the jitted lanes
@@ -1728,11 +1774,12 @@ def _result_from_carry(carry: _LoopCarry, rt: SolverRuntime) -> SolveResult:
 
 
 def _emit_lines(rt: SolverRuntime, trajectory: np.ndarray, upto: int,
-                printed: set[int], final: bool, emit) -> None:
+                printed: set[int], final: bool, emit, *,
+                nstep: int) -> None:
     """Print screen lines at the VMEC2000 cadence (eqsolve.f/printout.f)."""
     lasym = rt.resolution.lasym
     for it in range(1, upto + 1):
-        due = (it == 1) or (it % rt.nstep == 0) or (final and it == upto)
+        due = (it == 1) or (it % nstep == 0) or (final and it == upto)
         if not due or it in printed:
             continue
         row = trajectory[it - 1]
@@ -1822,7 +1869,9 @@ def _lane_signature(lane_name: str, carry: _LoopCarry, rt: SolverRuntime):
     return (lane_name, treedef, tuple(_leaf_signature(leaf) for leaf in leaves))
 
 
-def _prefetch_block_lane(rt: SolverRuntime, *, use_fft: bool) -> bool:
+def _prefetch_block_lane(
+    rt: SolverRuntime, *, use_fft: bool, time_step0: float
+) -> bool:
     """AOT-compile the CLI block lane for ``rt``'s structure ahead of use.
 
     Called from the multigrid prefetch thread.  Builds the same initial
@@ -1836,7 +1885,10 @@ def _prefetch_block_lane(rt: SolverRuntime, *, use_fft: bool) -> bool:
     lane = _block_lane_fft if use_fft else _block_lane
     lane_name = "block_fft" if use_fft else "block"
     carry = jax.tree.map(
-        jnp.array, _initial_carry(_initial_state(rt.setup), rt, ijacob=0)
+        jnp.array,
+        _initial_carry(
+            _initial_state(rt.setup), rt, ijacob=0, time_step0=time_step0
+        ),
     )
     key = _lane_signature(lane_name, carry, rt)
     if key in _LANE_EXECUTABLES or key in _USED_LANE_KEYS:
@@ -1880,6 +1932,7 @@ def _resolve_use_fft(
 
 def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
               ijacob: int, verbose: bool, emit,
+              time_step0: float, nstep: int,
               use_fft: bool = False,
               emit_banner: bool = True,
               emit_legend: bool = True,
@@ -1892,9 +1945,13 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
     ``emit_legend=False`` suppresses the ``BEGIN FORCE ITERATIONS`` legend
     while keeping the ``NS = ...`` banner and column header (runvmec.f
     prints the legend once per run, not once per radial grid).
+    ``time_step0``/``nstep`` are the host loop-driver scalars
+    (:func:`_loop_driver_config`) — kept out of ``rt`` so they never key a
+    lane recompile.
     """
     carry = _initial_carry(
-        state0, rt, ijacob=ijacob, xcdot=initial_xcdot,
+        state0, rt, ijacob=ijacob, time_step0=time_step0,
+        xcdot=initial_xcdot,
         residuals=initial_residuals,
     )
 
@@ -1911,7 +1968,7 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
     carry = jax.tree.map(jnp.array, carry)
     if verbose and emit_banner:
         # initialize_radial.f prints the total Fourier mode count (mnmax), not mpol.
-        emit(stage_banner(rt.resolution.ns, rt.resolution.mnmax, rt.ftol, rt.max_iterations), end="")
+        emit(stage_banner(rt.resolution.ns, rt.resolution.mnmax, float(rt.ftol), rt.max_iterations), end="")
         if emit_legend:
             emit(FORCE_ITERATIONS_BANNER, end="")
         emit(screen_header(lasym=rt.resolution.lasym, lfreeb=False), end="")
@@ -1955,7 +2012,8 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
             # Transfer, then slice: slicing on device compiles one XLA
             # program per distinct ``upto`` (~190 over a QA_lowres ladder).
             trajectory = np.asarray(carry.trajectory)[:max(upto, 0)]
-            _emit_lines(rt, trajectory, upto, printed, done, emit)
+            _emit_lines(rt, trajectory, upto, printed, done, emit,
+                        nstep=nstep)
         if done:
             break
     return carry
@@ -1963,6 +2021,7 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
 
 def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
                  mode: str, verbose: bool, emit,
+                 time_step0: float, nstep: int,
                  try_axis_reguess: bool = True,
                  use_fft: bool = False,
                  jacobian_retries: int = 2,
@@ -1993,6 +2052,7 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
         attempt_rt: SolverRuntime,
         attempt_state: SpectralState,
         *,
+        attempt_time_step0: float,
         emit_banner: bool,
         allow_axis_reguess: bool,
         attempt_residuals: (
@@ -2011,6 +2071,7 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
         carry = _run_loop(
             attempt_state, loop_rt, mode=mode, ijacob=0,
             verbose=verbose, emit=emit, use_fft=use_fft,
+            time_step0=attempt_time_step0, nstep=nstep,
             emit_banner=emit_banner, emit_legend=emit_legend,
             initial_residuals=attempt_residuals,
         )
@@ -2044,6 +2105,7 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
             carry = _run_loop(
                 attempt_state, attempt_rt, mode=mode, ijacob=1,
                 verbose=verbose, emit=emit, use_fft=use_fft,
+                time_step0=attempt_time_step0, nstep=nstep,
                 emit_banner=False,
                 initial_xcdot=(
                     carry.xcdot
@@ -2057,28 +2119,28 @@ def _solve_stage(rt: SolverRuntime, state0: SpectralState | None, *,
 
     attempt_state = _initial_state(rt.setup) if state0 is None else state0
     attempt_rt = rt
+    attempt_delt0 = float(time_step0)
     carry, attempt_rt = run_attempt(
-        attempt_rt, attempt_state, emit_banner=True, allow_axis_reguess=True,
+        attempt_rt, attempt_state, attempt_time_step0=attempt_delt0,
+        emit_banner=True, allow_axis_reguess=True,
         attempt_residuals=residual_continuation,
     )
     for attempt in range(1, int(jacobian_retries) + 1):
         if int(carry.ier) != JAC75_FLAG:
             break
-        retry_step = min(0.5, 0.5 * float(attempt_rt.time_step0))
+        attempt_delt0 = min(0.5, 0.5 * attempt_delt0)
         attempt_state = carry.xstore
-        attempt_rt = runtime_with_baselines(
-            replace(attempt_rt, time_step0=retry_step),
-            attempt_state,
-        )
+        attempt_rt = runtime_with_baselines(attempt_rt, attempt_state)
         if verbose:
             emit(
                 " JACOBIAN RECOVERY RETRY "
                 f"{attempt}/{int(jacobian_retries)}: "
                 "RESTARTING BEST FINITE STATE WITH "
-                f"DELT = {retry_step:.6g}"
+                f"DELT = {attempt_delt0:.6g}"
             )
         carry, attempt_rt = run_attempt(
-            attempt_rt, attempt_state, emit_banner=False,
+            attempt_rt, attempt_state, attempt_time_step0=attempt_delt0,
+            emit_banner=False,
             allow_axis_reguess=False,
             attempt_residuals=(carry.fsqr, carry.fsqz, carry.fsql),
         )
@@ -2103,7 +2165,7 @@ def _finalize(carry: _LoopCarry, rt: SolverRuntime) -> SolveResult:
         raise VmecConvergenceError(
             WERROR_MESSAGES[MORE_ITER_FLAG],
             hint=hint,
-            iteration=int(carry.iteration), fsq=fsq, ftol=rt.ftol,
+            iteration=int(carry.iteration), fsq=fsq, ftol=float(rt.ftol),
         )
     if ier == NONFINITE_FLAG:
         raise VmecNumericalError(
@@ -2313,10 +2375,13 @@ def solve(
     initial_state = _put_numeric_leaves(
         initial_state, _placement_device(device, resolution)
     )
+    time_step0, nstep_cadence = _loop_driver_config(
+        source, time_step=time_step, nstep=nstep
+    )
     with device_context(device, resolution):
         rt = prepare_runtime(
             source, resolution, ftol=ftol, max_iterations=max_iterations,
-            time_step=time_step, tcon0=tcon0, gamma=gamma, nstep=nstep,
+            tcon0=tcon0, gamma=gamma,
             lconm1=lconm1, precon_type=precon_type,
             prec2d_threshold=prec2d_threshold, prec2d=prec2d,
             use_fft=use_fft_resolved,
@@ -2336,6 +2401,7 @@ def solve(
             )  # funct3d.f iter2==iter1
         carry = _solve_stage(
             rt, initial_state, mode=mode, verbose=verbose, emit=emit,
+            time_step0=time_step0, nstep=nstep_cadence,
             use_fft=use_fft_resolved,
             jacobian_retries=jacobian_retries,
         )

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -1773,17 +1773,47 @@ def _result_from_carry(carry: _LoopCarry, rt: SolverRuntime) -> SolveResult:
     )
 
 
+def _due_rows_pending(start: int, upto: int, *, nstep: int,
+                      final: bool) -> bool:
+    """Whether any screen row in ``[start, upto]`` can be due this pass.
+
+    The host-side gate for the per-block device->host trajectory transfer:
+    with the typical ``nstep >> BLOCK_SIZE`` most block passes print
+    nothing, so the transfer (and the row rescan) is skipped entirely.
+    ``final`` marks the pass whose last row is unconditionally due
+    (``printout.f`` prints the terminating iteration).
+    """
+    if upto < start:
+        return False
+    if final or start <= 1:
+        return True
+    return ((start + nstep - 1) // nstep) * nstep <= upto
+
+
 def _emit_lines(rt: SolverRuntime, trajectory: np.ndarray, upto: int,
                 printed: set[int], final: bool, emit, *,
-                nstep: int) -> None:
-    """Print screen lines at the VMEC2000 cadence (eqsolve.f/printout.f)."""
+                nstep: int, start: int = 1) -> int:
+    """Print screen lines at the VMEC2000 cadence (eqsolve.f/printout.f).
+
+    Returns the resume index for the next pass: every row below it is
+    printed or permanently non-due, so the caller scans ``[resume, upto]``
+    instead of ``[1, upto]`` (the full rescan was O(N^2/BLOCK) over a run).
+    A due row whose trajectory slot is not yet written for its iteration
+    pins the resume index, so a later pass still prints it exactly as the
+    full rescan did.
+    """
     lasym = rt.resolution.lasym
-    for it in range(1, upto + 1):
+    resume = max(1, start)
+    advancing = True
+    for it in range(resume, upto + 1):
         due = (it == 1) or (it % nstep == 0) or (final and it == upto)
         if not due or it in printed:
+            if advancing:
+                resume = it + 1
             continue
         row = trajectory[it - 1]
         if int(row[0]) != it:      # row not (yet) written for this iteration
+            advancing = False
             continue
         emit(screen_line(
             it, float(row[1]), float(row[2]), float(row[3]),
@@ -1791,6 +1821,9 @@ def _emit_lines(rt: SolverRuntime, trajectory: np.ndarray, upto: int,
             z_axis=float(row[8]) if lasym else None,
         ), end="")
         printed.add(it)
+        if advancing:
+            resume = it + 1
+    return resume
 
 
 @jax.jit
@@ -1974,6 +2007,7 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
         emit(screen_header(lasym=rt.resolution.lasym, lfreeb=False), end="")
 
     printed: set[int] = set()
+    emit_start = 1
     max_passes = rt.max_iterations + 200
     lane = _block_lane_fft if use_fft else _block_lane
     # Prefetched-executable consumption + compile attribution.  The
@@ -2008,12 +2042,16 @@ def _run_loop(state0: SpectralState, rt: SolverRuntime, *, mode: str,
         retry_transfer = done and int(carry.ier) in (
             AXIS_REGUESS_FLAG, BAD_JACOBIAN_FLAG,
         )
-        if verbose and not retry_transfer:
+        if verbose and not retry_transfer and _due_rows_pending(
+                emit_start, upto, nstep=nstep, final=done):
             # Transfer, then slice: slicing on device compiles one XLA
             # program per distinct ``upto`` (~190 over a QA_lowres ladder).
+            # The _due_rows_pending gate skips the transfer outright on the
+            # (typical) block passes with no due row — nstep=200 against
+            # BLOCK_SIZE=10 made ~95% of these transfers dead weight.
             trajectory = np.asarray(carry.trajectory)[:max(upto, 0)]
-            _emit_lines(rt, trajectory, upto, printed, done, emit,
-                        nstep=nstep)
+            emit_start = _emit_lines(rt, trajectory, upto, printed, done,
+                                     emit, nstep=nstep, start=emit_start)
         if done:
             break
     return carry


### PR DESCRIPTION
Second wave of the cold-start campaign, sibling to the iteration-body and eager-lanes PRs. Removes needless lane-recompile keys and host-side quadratic work:

- **`nstep` and `time_step0` out of `SolverRuntime`**: they are host loop-driver config never read inside any trace, yet as static meta they forced a full lane recompile for a print-cadence or initial-delt change. They now travel through the `_run_loop`/`_initial_carry` signatures (`_loop_driver_config`). The register-with-drop alternative was rejected deliberately: dropped fields reset on unflatten and `implicit._device_pin` tree-maps runtimes, which would silently revert them.
- **`ftol` static → traced data scalar**: read only in exact comparisons, so cross-ftol runs now share one executable bit-exactly (measured: 1e-9 vs 1e-11 solves leave the jit cache at size 1, identical iteration histories).
- **Host print hygiene**: `_emit_lines`/`_emit_due` re-scanned trajectory rows 1..upto every block (O(N²/BLOCK)); they now carry a resume index, and block passes with no due row skip the device→host trajectory transfer entirely (~95% of transfers at nstep=200). CLI output byte-identical.
- **Per-problem jit caching in optimize.py**: the 8 fresh `jax.jit` objects per problem construction are cached (bounded, 8 entries) keyed on canonical-config identity + term identities + resolved targets/dof layout, following the `_canonical_config` precedent; repeated equal-content constructions reuse traces bit-exactly.

New `tests/test_runtime_recompile_keys.py` pins the executable-key properties (lower-only, no solves). li383 wout bit-identical (all 109 variables) at every commit; step-control (11), restart (16), CLI (16) suites pass; ruff clean.