### PR TITLE
Pin compile budgets in CI and add measured-memory auto chunk sizes

### DIFF
--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -103,6 +103,7 @@
     ["tests/test_step_control.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "pr-fast", "full-core-n-s"]],
     ["tests/test_strong_force.py", "equilibrium", "oracle", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-n-s"]],
     ["tests/test_stress_high_force.py", "equilibrium", "integration", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "full-core-n-s"]],
+    ["tests/test_trace_budgets.py", "infrastructure", "unit", "medium", "cpu", "none", "golden", ["pr-parity-c2", "full-core-t-z"]],
     ["tests/test_tracing.py", "diagnostics", "integration", "medium", "cpu", "none", "analytic", ["pr-parity-c2", "optional", "full-core-t-z"]],
     ["tests/test_turbulence.py", "diagnostics", "oracle", "slow", "cpu-gpu", "reference-nc", "external", ["pr-parity-c2", "optional", "full-core-t-z"]],
     ["tests/test_vacuum_analytic_recurrence.py", "free-boundary", "oracle", "slow", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "full-core-t-z"]],

--- a/tests/test_implicit_multi_rhs.py
+++ b/tests/test_implicit_multi_rhs.py
@@ -144,18 +144,6 @@ def test_block_response_forward_transpose_and_fd():
     ):
         np.testing.assert_allclose(got, expected, rtol=2e-8, atol=2e-10)
 
-    # Opt-in "auto" resolves both chunk sizes from measured memory and the
-    # operand avals; the pullback itself must match the default within the
-    # same batched-reduction tolerance as the block path above.
-    audited = im.implicit_state_pullback_multi_rhs(
-        p0, cfg, state, mask, cotangents,
-        probe_chunk_size="auto", response_chunk_size="auto",
-    )
-    for got, expected in zip(
-        jax.tree.leaves(audited), jax.tree.leaves(reference)
-    ):
-        np.testing.assert_allclose(got, expected, rtol=2e-8, atol=2e-10)
-
     for i, (tangent, step) in enumerate(zip(tangents, (3e-5, 1e-4))):
         directional = jax.jvp(
             lambda x, p: im.aspect_ratio(x, im.runtime_from_params(p, cfg)),
@@ -298,6 +286,36 @@ def test_raw_block_apply_requires_stored_factors():
         row_scale=jnp.ones((1, 1)), column_scale=jnp.ones((1, 1)))
     with pytest.raises(ValueError, match="raw block factors"):
         im._raw_block_apply(system, jnp.zeros((1, 1)))
+
+
+@pytest.mark.full
+def test_auto_chunks_match_the_default_pullback():
+    """Opt-in "auto" chunk sizes change scheduling only, never values.
+
+    A full extra pullback solve: parity lane c3d sits within ~90 s of its
+    45-minute budget, so this equivalence runs in the full tier while the
+    cheap resolver/memory-model pins below stay on the fast path.
+    """
+    _, cfg, p0 = _small_solovev_setup()
+    state, mask = im.solve_implicit_with_aux(p0, cfg)
+    keys = jax.random.split(jax.random.PRNGKey(4), 2)
+    cotangents = jax.tree.map(
+        lambda value: jnp.stack([
+            jax.random.normal(key, value.shape, value.dtype) for key in keys
+        ]),
+        state,
+    )
+    reference = im.implicit_state_pullback_multi_rhs(
+        p0, cfg, state, mask, cotangents
+    )
+    audited = im.implicit_state_pullback_multi_rhs(
+        p0, cfg, state, mask, cotangents,
+        probe_chunk_size="auto", response_chunk_size="auto",
+    )
+    for got, expected in zip(
+        jax.tree.leaves(audited), jax.tree.leaves(reference)
+    ):
+        np.testing.assert_allclose(got, expected, rtol=2e-8, atol=2e-10)
 
 
 def test_measured_chunk_size_follows_the_memory_budget(monkeypatch):

--- a/tests/test_implicit_multi_rhs.py
+++ b/tests/test_implicit_multi_rhs.py
@@ -144,6 +144,18 @@ def test_block_response_forward_transpose_and_fd():
     ):
         np.testing.assert_allclose(got, expected, rtol=2e-8, atol=2e-10)
 
+    # Opt-in "auto" resolves both chunk sizes from measured memory and the
+    # operand avals; the pullback itself must match the default within the
+    # same batched-reduction tolerance as the block path above.
+    audited = im.implicit_state_pullback_multi_rhs(
+        p0, cfg, state, mask, cotangents,
+        probe_chunk_size="auto", response_chunk_size="auto",
+    )
+    for got, expected in zip(
+        jax.tree.leaves(audited), jax.tree.leaves(reference)
+    ):
+        np.testing.assert_allclose(got, expected, rtol=2e-8, atol=2e-10)
+
     for i, (tangent, step) in enumerate(zip(tangents, (3e-5, 1e-4))):
         directional = jax.jvp(
             lambda x, p: im.aspect_ratio(x, im.runtime_from_params(p, cfg)),
@@ -286,3 +298,38 @@ def test_raw_block_apply_requires_stored_factors():
         row_scale=jnp.ones((1, 1)), column_scale=jnp.ones((1, 1)))
     with pytest.raises(ValueError, match="raw block factors"):
         im._raw_block_apply(system, jnp.zeros((1, 1)))
+
+
+def test_measured_chunk_size_follows_the_memory_budget(monkeypatch):
+    """``"auto"`` = measured available memory over exact per-column bytes.
+
+    The budget regime is solvax's "largest chunk that fits":
+    ``memory_fraction * available // per_column_bytes`` clamped to
+    ``[1, dim]``; without a measurement the square-root heuristic bounds
+    the chunk instead of guessing a budget.
+    """
+    monkeypatch.setattr(im, "_measured_memory_bytes", lambda device=None: 1000)
+    assert im.measured_chunk_size(64, 100) == 5  # 0.5 * 1000 // 100
+    assert im.measured_chunk_size(3, 100) == 3  # clamped to dim
+    assert im.measured_chunk_size(64, 10**9) == 1  # never below one column
+    monkeypatch.setattr(im, "_measured_memory_bytes", lambda device=None: None)
+    assert im.measured_chunk_size(64, 100) == 8  # ceil(sqrt(64)) fallback
+
+
+def test_chunk_size_resolver_accepts_auto_and_rejects_other_strings():
+    resolved = im._resolve_chunk_size(
+        "auto", name="probe_chunk_size", dim=17, per_column_bytes=1 << 20)
+    assert isinstance(resolved, int) and 1 <= resolved <= 17
+    assert im._resolve_chunk_size(
+        4, name="probe_chunk_size", dim=17, per_column_bytes=1) == 4
+    with pytest.raises(ValueError, match="response_chunk_size"):
+        im._resolve_chunk_size(
+            "wide", name="response_chunk_size", dim=17, per_column_bytes=1)
+    with pytest.raises(ValueError, match="probe_chunk_size"):
+        im._resolve_chunk_size(
+            0, name="probe_chunk_size", dim=17, per_column_bytes=1)
+
+
+def test_tree_bytes_is_exact_from_shapes():
+    tree = {"a": jnp.zeros((3, 4)), "b": np.zeros(5, dtype=np.float32)}
+    assert im._tree_bytes(tree) == 3 * 4 * 8 + 5 * 4

--- a/tests/test_trace_budgets.py
+++ b/tests/test_trace_budgets.py
@@ -1,0 +1,176 @@
+"""Compile-budget guards for the solver lanes and the cold python-API solve.
+
+Two creep modes have historically surfaced as user-visible cold-start
+regressions months after the commit that caused them (most recently the
+0.3-class -> 0.8-class CLI start repaired in #227):
+
+- **lane-HLO creep** — the traced iteration lanes accrete ops until their
+  compile time dominates the start; and
+- **eager-dispatch creep** — host-eager setup/export code dispatches more
+  and more single-op XLA programs (``jit(copy)``, ``jit(multiply)``, ...)
+  outside the jitted passes.
+
+Both are pinned here against measured budgets with generous (~25%)
+headroom, DESC-benchmark style, so a regression fails CI loudly at the
+offending commit instead of surfacing as a complaint later.  Neither guard
+needs an XLA compile in-process: the lane guard stops at StableHLO
+lowering, and the dispatch guard counts compile log records inside one
+short subprocess solve (measured ~3 s), keeping the module honest about
+cold-start state without slowing the fast lanes.
+
+When a budget trips because of *deliberate* new physics or lane structure,
+re-measure (instructions at each constant) and move the constant in the
+same commit, stating the new measured value.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from vmex.core import solver
+from vmex.core.input import VmecInput
+
+ROOT = Path(__file__).resolve().parents[1]
+SOLOVEV_DECK = ROOT / "examples" / "data" / "input.solovev"
+
+#: StableHLO text-size ceilings for the two production iteration lanes,
+#: lowered on the solovev deck's own resolution (ns=11, mpol=6, ntor=0).
+#: Text size is a deliberately blunt but stable proxy for traced-graph
+#: size: op creep in ``_make_body`` grows it roughly linearly, and it needs
+#: no XLA compile to evaluate.  Measured 2026-09-01 at 03011303 (jax
+#: 0.11.1, CPU, x64): ``_block_lane`` 504,324 chars, ``_while_lane``
+#: 520,957 chars; ceilings are measured + ~25%.  Re-measure with
+#: ``lane.lower(carry, rt).as_text()`` (see ``_lane_operands`` below).
+_LANE_STABLEHLO_CEILINGS = {
+    "_block_lane": 630_000,
+    "_while_lane": 650_000,
+}
+#: A lane this size cannot legitimately shrink an order of magnitude; a
+#: sub-floor text means the metric itself degenerated (wrong carry, stub
+#: lowering), not that the lane got cheap.
+_LANE_STABLEHLO_FLOOR = 100_000
+
+#: Total XLA programs compiled by ONE cold python-API ``solve`` of the
+#: solovev deck — the jitted lanes plus every eager single-op dispatch of
+#: the setup/export/printout passes.  Measured 2026-09-01 at 03011303
+#: (jax 0.11.1, CPU, x64, persistent compilation cache disabled): 98
+#: programs, of which 92 are eager single-op programs; stable across
+#: repeat runs.  Ceiling is measured + ~27%.  Re-measure by running
+#: ``_COMPILE_COUNT_SCRIPT`` below by hand.
+_COLD_SOLVE_PROGRAM_CEILING = 125
+
+
+@pytest.fixture(autouse=True)
+def _enable_jit():
+    """Lane lowering needs JIT (the repo conftest disables it globally)."""
+    previous = bool(jax.config.jax_disable_jit)
+    jax.config.update("jax_disable_jit", False)
+    yield
+    jax.config.update("jax_disable_jit", previous)
+
+
+@pytest.fixture(scope="module")
+def _lane_operands():
+    """The exact ``lane(carry, rt)`` operands a solovev CLI solve dispatches."""
+    inp = VmecInput.from_file(str(SOLOVEV_DECK))
+    rt = solver.prepare_runtime(inp, solver.resolution_from_input(inp))
+    carry = jax.tree.map(
+        jnp.array, solver._initial_carry(solver._initial_state(rt.setup), rt, ijacob=0)
+    )
+    return carry, rt
+
+
+@pytest.mark.parametrize("lane_name", sorted(_LANE_STABLEHLO_CEILINGS))
+def test_lane_stablehlo_size_stays_under_budget(_lane_operands, lane_name):
+    """Lowering only — no XLA compile — so the fast guard stays fast."""
+    carry, rt = _lane_operands
+    text = getattr(solver, lane_name).lower(carry, rt).as_text()
+    assert "func.func public @main" in text  # a real lowered module
+    size = len(text)
+    assert _LANE_STABLEHLO_FLOOR < size, (
+        f"{lane_name}: StableHLO shrank to {size} chars — the lowering is "
+        "degenerate, or the lane got structurally cheaper; re-measure and "
+        "move both the ceiling and this floor."
+    )
+    assert size <= _LANE_STABLEHLO_CEILINGS[lane_name], (
+        f"{lane_name}: StableHLO grew to {size} chars, over the "
+        f"{_LANE_STABLEHLO_CEILINGS[lane_name]}-char budget. If the growth "
+        "is deliberate, re-measure and move the constant in this commit; "
+        "otherwise an op crept into the traced iteration body."
+    )
+
+
+# The counter follows the repo-external measurement pattern: install a
+# ``logging.Handler`` on ``logging.getLogger("jax")`` AFTER importing vmex
+# (vmex configures JAX logging on import), enable ``jax_log_compiles`` for
+# the duration, and count the per-program ``Finished XLA compilation of``
+# records that jax's dispatch logger emits (jax >= 0.10 wording).  The
+# persistent compilation cache is disabled so a warm on-disk cache cannot
+# hide (or skip) compile records.
+_COMPILE_COUNT_SCRIPT = """\
+import logging
+import sys
+
+import vmex as vj  # must precede the handler: import configures JAX logging
+import jax
+
+
+class CompileCounter(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.count = 0
+
+    def emit(self, record):
+        if "Finished XLA compilation of" in record.getMessage():
+            self.count += 1
+
+
+counter = CompileCounter()
+jax_logger = logging.getLogger("jax")
+jax_logger.addHandler(counter)
+jax_logger.setLevel(logging.INFO)  # compile records log at WARNING
+jax.config.update("jax_log_compiles", True)
+jax.config.update("jax_enable_compilation_cache", False)
+
+result = vj.solve(vj.VmecInput.from_file(sys.argv[1]))
+assert result.converged, "solovev budget solve did not converge"
+print("COMPILED_PROGRAMS:", counter.count)
+"""
+
+
+def test_cold_solve_compiled_program_count_stays_under_budget():
+    """One cold subprocess solve, so suite order cannot pre-warm any cache.
+
+    Unmarked by convention: the whole probe measures ~10 s (interpreter +
+    imports + a ~3 s solovev solve), inside the repo's unmarked-medium
+    band (compare ``tests/test_cli.py``); the ``pr-fast`` manifest lane
+    excludes this module.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(ROOT), env.get("PYTHONPATH", "")) if part
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", _COMPILE_COUNT_SCRIPT, str(SOLOVEV_DECK)],
+        capture_output=True, text=True, timeout=600, cwd=ROOT, env=env,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    match = re.search(r"COMPILED_PROGRAMS: (\d+)", proc.stdout)
+    assert match, proc.stdout + proc.stderr
+    count = int(match.group(1))
+    assert 0 < count, "no compile records — the log-capture pattern broke"
+    assert count <= _COLD_SOLVE_PROGRAM_CEILING, (
+        f"a cold solovev solve compiled {count} XLA programs, over the "
+        f"{_COLD_SOLVE_PROGRAM_CEILING}-program budget. New eager "
+        "single-op dispatch crept into the setup/export/printout passes "
+        "(see #227); jit the new pass, or re-measure and move the "
+        "constant if the growth is deliberate."
+    )

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -139,6 +139,7 @@ import jax.numpy as jnp
 from jax.flatten_util import ravel_pytree
 
 from solvax import (
+    auto_chunk_size,
     block_tridiag_matvec,
     block_thomas_factor,
     block_thomas_solve,
@@ -182,6 +183,7 @@ __all__ = [
     "make_config", "solve_implicit", "solve_implicit_status",
     "solve_implicit_with_aux",
     "implicit_state_tangent_multi_rhs", "implicit_state_pullback_multi_rhs", "run",
+    "measured_chunk_size",
     "mhd_energy", "plasma_volume", "aspect_ratio", "iota_profile",
     "iota_axis", "iota_edge", "edge_iota", "residual_fn", "adjoint_matvec",
     "frozen_path_directional_fd",
@@ -2052,6 +2054,144 @@ def _active_state_fields(cfg: ImplicitConfig) -> tuple[str, ...]:
     return ("R_cos", "Z_sin", "L_sin")
 
 
+#: Whole-state workspace vectors the GCROT(m, k) certifier pins per response
+#: column beyond its Krylov basis: right-hand side, warm start, iterate,
+#: defect, and the raw-operator certification pair, with slack for XLA
+#: transients.  The basis itself is counted exactly from the config
+#: (``adjoint_gcrot_m + 1`` inner FGMRES vectors plus ``2 k`` recycled
+#: ``(C, U)`` directions).
+_RESPONSE_WORKSPACE_VECTORS = 8
+
+#: Reverse-tape allowance per probe column, in units of the column's exact
+#: ``(3, block_size)`` operand.  The probe VJP retains the three-surface
+#: force kernel's real-space intermediates, whose count — unlike their
+#: shapes — is an XLA scheduling detail; this fixed allowance converts the
+#: shape-exact operand bytes into a conservative tape bound.
+_PROBE_TAPE_VECTORS = 64
+
+
+def _tree_bytes(tree: Any) -> int:
+    """Exact byte count of one pytree of arrays, from shapes/dtypes only."""
+    return sum(
+        int(np.prod(np.shape(leaf), dtype=np.int64))
+        * np.dtype(getattr(leaf, "dtype", np.float64)).itemsize
+        for leaf in jax.tree.leaves(tree)
+    )
+
+
+def _measured_memory_bytes(device: Any = None) -> int | None:
+    """Measured available memory of the execution target, in bytes.
+
+    An accelerator ``jax.Device`` reports through its own runtime
+    (``memory_stats()``: ``bytes_limit - bytes_in_use``).  Host execution
+    measures free RAM via :mod:`psutil` when importable, else Linux
+    ``/proc/meminfo`` ``MemAvailable``.  Returns ``None`` when nothing
+    trustworthy is measurable — callers then fall back to solvax's
+    device-independent square-root heuristic instead of guessing a budget.
+    """
+    if device is not None and getattr(device, "platform", "cpu") != "cpu":
+        stats = getattr(device, "memory_stats", lambda: None)() or {}
+        limit = stats.get("bytes_limit")
+        if limit:
+            return max(int(limit) - int(stats.get("bytes_in_use", 0)), 0)
+        return None
+    try:
+        import psutil
+        return int(psutil.virtual_memory().available)
+    except Exception:
+        pass
+    try:
+        with open("/proc/meminfo") as handle:
+            for line in handle:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024
+    except OSError:
+        pass
+    return None
+
+
+def measured_chunk_size(
+    dim: int,
+    per_column_bytes: int,
+    *,
+    device: Any = None,
+    memory_fraction: float = 0.5,
+) -> int:
+    """Largest chunk whose per-column workspace fits measured free memory.
+
+    DESC sizes its objective ``jac_chunk_size`` from measured available
+    memory divided by a hand-fit per-column constant
+    (``desc/objectives/objective_funs.py``, ``desc/__init__.py``); vmex
+    knows the response operands' avals exactly, so ``per_column_bytes``
+    is computed from the state pytree shapes instead.  Memory model: a
+    chunk holds ``chunk`` columns concurrently, each pinning
+    ``per_column_bytes`` of workspace, and may claim ``memory_fraction``
+    of the measured available bytes, so
+    ``chunk = memory_fraction * available // per_column_bytes`` clamped to
+    ``[1, dim]`` (:func:`solvax.auto_chunk_size`'s explicit-budget
+    regime).  With no measurement available the same helper's square-root
+    heuristic bounds the chunk instead.
+    """
+    return auto_chunk_size(
+        int(dim), int(max(1, per_column_bytes)),
+        max_memory_bytes=_measured_memory_bytes(device),
+        element_bytes=1, memory_fraction=memory_fraction,
+    )
+
+
+def _resolve_chunk_size(
+    value: int | str, *, name: str, dim: int, per_column_bytes: int,
+    device: Any = None,
+) -> int:
+    """Turn one user chunk request (positive int or ``"auto"``) into an int."""
+    if isinstance(value, str):
+        if value != "auto":
+            raise ValueError(
+                f"{name} must be a positive int or 'auto', got {value!r}")
+        return measured_chunk_size(dim, per_column_bytes, device=device)
+    if int(value) < 1:
+        raise ValueError(f"{name} must be positive")
+    return int(value)
+
+
+def _resolved_chunk_sizes(
+    cfg: ImplicitConfig,
+    x_star: SpectralState,
+    dof_mask: SpectralState,
+    active_fields: tuple[str, ...],
+    batch: Any,
+    probe_chunk_size: int | str,
+    response_chunk_size: int | str,
+) -> tuple[int, int]:
+    """Resolve the probe/response chunk requests for one multi-RHS call.
+
+    Probe columns cost their exact ``(3, block_size)`` local-Jacobian
+    operand times the :data:`_PROBE_TAPE_VECTORS` tape allowance; response
+    columns cost one whole :class:`SpectralState` (exact bytes from the
+    pytree shapes) per live Krylov/workspace vector of the GCROT(m, k)
+    certifier.  Budgets come from :func:`measured_chunk_size` against the
+    config's resolved placement device.
+    """
+    itemsize = np.dtype(x_star.R_cos.dtype).itemsize
+    block_size = max(1, len(active_fields)) * int(dof_mask.R_cos.shape[1])
+    probe = _resolve_chunk_size(
+        probe_chunk_size, name="probe_chunk_size", dim=block_size,
+        per_column_bytes=3 * block_size * itemsize * _PROBE_TAPE_VECTORS,
+        device=cfg.device,
+    )
+    krylov_vectors = (
+        cfg.adjoint_gcrot_m + 1 + 2 * cfg.adjoint_gcrot_k
+        + _RESPONSE_WORKSPACE_VECTORS
+    )
+    response = _resolve_chunk_size(
+        response_chunk_size, name="response_chunk_size",
+        dim=int(np.shape(jax.tree.leaves(batch)[0])[0]),
+        per_column_bytes=_tree_bytes(x_star) * krylov_vectors,
+        device=cfg.device,
+    )
+    return probe, response
+
+
 def _raw_block_system(
     params: ImplicitParams,
     cfg: ImplicitConfig,
@@ -2394,8 +2534,8 @@ def implicit_state_tangent_multi_rhs(
     dof_mask: SpectralState,
     tangent_batch: ImplicitParams,
     *,
-    probe_chunk_size: int = 1,
-    response_chunk_size: int = 1,
+    probe_chunk_size: int | str = 1,
+    response_chunk_size: int | str = 1,
 ) -> tuple[SpectralState, LinearResponseReport]:
     """State tangents for several parameter directions, factored once.
 
@@ -2403,11 +2543,19 @@ def implicit_state_tangent_multi_rhs(
     One three-color assembly and SOLVAX factorization therefore initializes
     every right-hand side; a warm-started solve then certifies the ordinary
     preconditioned residual against ``10 * cfg.adjoint_tol * ||rhs||``.  The
-    two chunk sizes independently bound probe assembly and response solves.
-    The ordinary implicit reverse rule remains the default for
-    :func:`solve_implicit`.
+    two chunk sizes independently bound probe assembly and response solves;
+    each is a positive int (default 1 — minimum memory, unchanged behavior)
+    or opt-in ``"auto"``, which sizes the chunk from measured available
+    memory on the config's placement device divided by the per-column
+    workspace computed exactly from the operand avals (see
+    :func:`measured_chunk_size` for the memory model).  The ordinary
+    implicit reverse rule remains the default for :func:`solve_implicit`.
     """
     active_fields = _active_state_fields(cfg)
+    probe_chunk_size, response_chunk_size = _resolved_chunk_sizes(
+        cfg, x_star, dof_mask, active_fields, tangent_batch,
+        probe_chunk_size, response_chunk_size,
+    )
     with _device_context(cfg):
         params, x_star, dof_mask, tangent_batch = _device_pin(
             cfg, (params, x_star, dof_mask, tangent_batch)
@@ -2616,8 +2764,8 @@ def implicit_state_pullback_multi_rhs(
     gbar_batch: SpectralState,
     *,
     solver: str = "gcrot",
-    probe_chunk_size: int = 1,
-    response_chunk_size: int = 1,
+    probe_chunk_size: int | str = 1,
+    response_chunk_size: int | str = 1,
 ) -> ImplicitParams:
     """Batched state-cotangent pullback with shared implicit-linearization setup.
 
@@ -2628,12 +2776,19 @@ def implicit_state_pullback_multi_rhs(
     reuses the same factors with ``transpose=True`` as a right preconditioner,
     and certifies the ordinary preconditioned VJP.  Runs inside the config's
     device context (see ``_solve_implicit_bwd``); the two chunk sizes bound
-    probe assembly and right-hand-side solves independently.
+    probe assembly and right-hand-side solves independently — each a
+    positive int (default 1, unchanged behavior) or opt-in ``"auto"``,
+    sized from measured available memory and the exact per-column operand
+    bytes (see :func:`measured_chunk_size`).
     """
     if solver not in ("gcrot", "block"):
         raise ValueError("solver must be 'gcrot' or 'block'")
     active_fields = (
         _active_state_fields(cfg) if solver == "block" else ()
+    )
+    probe_chunk_size, response_chunk_size = _resolved_chunk_sizes(
+        cfg, x_star, dof_mask, active_fields, gbar_batch,
+        probe_chunk_size, response_chunk_size,
     )
     with _device_context(cfg):
         params = _device_pin(cfg, params)


### PR DESCRIPTION
Campaign wave 3, additive. Two pieces:

**Trace-budget guards** (`tests/test_trace_budgets.py`): the regression class behind the 0.3→0.8 cold-start complaints — eager-dispatch creep and lane-HLO creep — now fails CI loudly instead of surfacing as user reports months later. (a) `_block_lane`/`_while_lane` StableHLO text sizes lowered at input.solovev's own resolution, pinned under ceilings with ~25% headroom (measured 2026-09-01 post-#229: 504,324 / 520,957 chars; the pre-#229 body measured 812k/856k, confirming the metric tracks real body changes; a 100k floor catches degenerate lowerings). (b) One cold python-API solovev solve in a subprocess with the persistent cache disabled, counting compiled programs via a logging handler on jax's compile records: measured 98 programs (92 eager single-op dispatches), ceiling 125. Excluded from the pr-fast lane via the manifest; ~10 s total.

**Measured-memory "auto" chunk** (`vmex/core/implicit.py`): `probe_chunk_size`/`response_chunk_size` on the multi-RHS tangent/pullback entry points accept opt-in `"auto"` (defaults stay 1 — no behavior change). Chunk = 0.5 × measured available bytes on the placement device (accelerator `memory_stats`, host psutil//proc/meminfo) ÷ exact per-column bytes from the operand avals (a response column costs one SpectralState × the live GCROT vector count; probe columns their exact local-Jacobian operand × a documented tape allowance), clamped to [1, dim], via solvax's explicit-budget regime. Model documented on `measured_chunk_size`.

Verification: new modules 11 passed / 3 skipped (RUN_FULL-gated); auto-vs-default pullback equivalence pinned on solovev; one solovev CLI run vs main **bit-identical** wout; ruff clean; manifest ownership gate clean (only the pre-existing essos-environment errors that reproduce on pristine main).