### PR TITLE
Stop baking linearization residuals into the polish Ruiz and probe jits

### DIFF
--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -326,10 +326,20 @@ def _tree_norm(value) -> float:
     return float(jnp.sqrt(_tree_dot(value, value)))
 
 
+def _matrix_residual(matrix):
+    """Module-level builder: the lane's static argument must be identity-stable."""
+
+    def residual(vector):
+        return matrix @ vector
+
+    return residual
+
+
 def test_streaming_equilibration_improves_conditioning_without_dropping_dofs():
     matrix = jnp.asarray([[1.0e-8, 0.0], [0.0, 2.0]])
     rows, columns = _streaming_ruiz_scales(
-        lambda vector: matrix @ vector,
+        _matrix_residual,
+        matrix,
         jnp.zeros((2,)),
     )
     balanced = rows[:, None] * np.asarray(matrix) * columns[None, :]
@@ -342,18 +352,15 @@ def test_streaming_equilibration_improves_conditioning_without_dropping_dofs():
 def test_streaming_equilibration_is_deterministic_and_validates_controls():
     matrix = jnp.asarray([[2.0, -1.0], [3.0, 4.0]])
 
-    def residual(vector):
-        return matrix @ vector
-
-    first = _streaming_ruiz_scales(residual, jnp.zeros((2,)), probes=2)
-    second = _streaming_ruiz_scales(residual, jnp.zeros((2,)), probes=2)
+    first = _streaming_ruiz_scales(_matrix_residual, matrix, jnp.zeros((2,)), probes=2)
+    second = _streaming_ruiz_scales(_matrix_residual, matrix, jnp.zeros((2,)), probes=2)
     for actual, expected in zip(first, second, strict=True):
         np.testing.assert_array_equal(actual, expected)
         assert np.all(actual > 0.0)
     with pytest.raises(ValueError, match="iterations"):
-        _streaming_ruiz_scales(residual, jnp.zeros((2,)), iterations=0)
+        _streaming_ruiz_scales(_matrix_residual, matrix, jnp.zeros((2,)), iterations=0)
     with pytest.raises(ValueError, match="probes"):
-        _streaming_ruiz_scales(residual, jnp.zeros((2,)), probes=0)
+        _streaming_ruiz_scales(_matrix_residual, matrix, jnp.zeros((2,)), probes=0)
 
 
 def _random_like(value, seed: int):

--- a/vmex/core/polish.py
+++ b/vmex/core/polish.py
@@ -14,6 +14,7 @@ and lambda gauge.  No dense high-order Jacobian is formed.
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass, replace
 from time import perf_counter
 from typing import Any, Callable, NamedTuple
@@ -1578,15 +1579,8 @@ def make_strong_structured_chart(
         (physical_size,), dtype=jnp.asarray(runtime.native.R_cos).dtype
     )
     equation_scale, coordinate_scale = _streaming_ruiz_scales(
-        lambda value: basis.T
-        @ (
-            _strong_residual_unscaled(
-                basis @ value,
-                runtime,
-                include_coordinate_gauge=False,
-            )
-            / jnp.asarray(runtime.strong_scale)
-        ),
+        _chart_scale_residual,
+        (runtime, basis),
         zero,
         iterations=balance_iterations,
         probes=balance_probes,
@@ -1624,8 +1618,86 @@ def strong_physical_residual(
     return low + alpha * (strong - low)
 
 
+def _chart_scale_residual(
+    operands: tuple[StrongRootRuntime, Array],
+) -> Callable[[Array], Array]:
+    """Chart-projected strong residual for :func:`_ruiz_probe_lane`.
+
+    ``operands = (runtime, basis)``: everything the residual reads beyond its
+    argument must arrive through ``operands`` so the lane traces it instead
+    of baking it in.
+    """
+
+    runtime, basis = operands
+
+    def residual(value: Array) -> Array:
+        return basis.T @ (
+            _strong_residual_unscaled(
+                basis @ value,
+                runtime,
+                include_coordinate_gauge=False,
+            )
+            / jnp.asarray(runtime.strong_scale)
+        )
+
+    return residual
+
+
+def _full_root_residual(
+    operands: StrongRootRuntime,
+) -> Callable[[Array], Array]:
+    """Full constrained-layout strong residual for :func:`_ruiz_probe_lane`."""
+
+    def residual(value: Array) -> Array:
+        return _strong_residual_unscaled(value, operands)
+
+    return residual
+
+
+# One reusable executable per (builder, shapes) — the residual-lane argument
+# pattern of implicit._adjoint_gcrot_core. Wrapping the closure returned by a
+# host-eager ``jax.linearize`` in fresh jits promoted every linearization
+# residual of the force kernel PLUS the arrays the residual lambda closed
+# over (the dense chart basis included) into baked XLA constants; constant
+# folding those stalled 3-D polish setup before the first iteration.
+# Re-linearizing INSIDE the jit with the operands as traced arguments bakes
+# nothing.
+@functools.partial(jax.jit, static_argnames=("builder", "estimate_columns"))
+def _ruiz_probe_lane(
+    builder: Callable[[Any], Callable[[Array], Array]],
+    operands: Any,
+    zero: Array,
+    jvp_directions: Array,
+    transpose_directions: Array,
+    estimate_columns: bool = True,
+) -> tuple[Array, Array | None]:
+    """Stacked JVP and transpose-JVP responses of ``builder(operands)``.
+
+    ``builder`` must be a module-level function: it is a static argument, so
+    its identity keys the compile cache and a fresh lambda would defeat the
+    reuse this lane exists for. Linearize-inside-jit re-runs the primal on
+    every call — one extra force evaluation per host Ruiz iteration —
+    accepted as setup cost. The scale-update algebra stays on the host and is
+    verbatim; the responses themselves can move by O(1 ulp) relative to the
+    retired constant-baked executable, whose bits were fusion artifacts that
+    differed from its own un-jitted closure by the same margin.
+    """
+
+    residual = builder(operands)
+    _, jvp = jax.linearize(residual, zero)
+    responses = jax.vmap(jvp)(jvp_directions)
+    if not estimate_columns:
+        return responses, None
+    transpose = jax.linear_transpose(jvp, zero)
+    transpose_responses = jax.vmap(
+        lambda direction: transpose(direction)[0]
+    )(transpose_directions)
+    return responses, transpose_responses
+
+
 def _streaming_ruiz_scales(
-    residual: Callable[[Array], Array],
+    builder: Callable[[Any], Callable[[Array], Array]],
+    operands: Any,
     zero: Array,
     *,
     iterations: int = 6,
@@ -1638,18 +1710,14 @@ def _streaming_ruiz_scales(
     squared column-norm estimates from transpose JVPs. The fixed seed makes the
     setup deterministic, while a probe count independent of the root dimension
     avoids the former O(n) sequence of basis-vector JVPs. No Jacobian is stored.
+    ``builder``/``operands`` follow the :func:`_ruiz_probe_lane` contract;
+    each host iteration is one lane call, so the whole estimate compiles once.
     """
 
     if iterations < 1:
         raise ValueError("iterations must be positive")
     if probes < 1:
         raise ValueError("probes must be positive")
-
-    _, jvp = jax.linearize(residual, zero)
-    apply_jvp = jax.jit(jvp)
-    if estimate_columns:
-        transpose = jax.linear_transpose(jvp, zero)
-        apply_transpose = jax.jit(lambda value: transpose(value)[0])
 
     size = int(np.asarray(zero).size)
     dtype = np.asarray(zero).dtype
@@ -1664,17 +1732,24 @@ def _streaming_ruiz_scales(
     tiny = np.finfo(float).tiny
     limit = 1.0e12
     for _ in range(int(iterations)):
+        responses, transpose_responses = _ruiz_probe_lane(
+            builder,
+            operands,
+            zero,
+            jnp.asarray(columns[None, :] * directions),
+            jnp.asarray(rows[None, :] * directions),
+            estimate_columns=estimate_columns,
+        )
+        responses = np.asarray(responses)
+        if estimate_columns:
+            transpose_responses = np.asarray(transpose_responses)
         row_squared = np.zeros((size,), dtype=float)
         column_squared = np.zeros((size,), dtype=float)
-        for direction in directions:
-            response = rows * np.asarray(
-                apply_jvp(jnp.asarray(columns * direction))
-            )
+        for index in range(probe_count):
+            response = rows * responses[index]
             row_squared += response**2 / float(probe_count)
             if estimate_columns:
-                transpose_response = columns * np.asarray(
-                    apply_transpose(jnp.asarray(rows * direction))
-                )
+                transpose_response = columns * transpose_responses[index]
                 column_squared += transpose_response**2 / float(probe_count)
         row_norm = np.sqrt(row_squared)
         column_norm = (
@@ -1845,7 +1920,8 @@ def make_strong_root_runtime(
     if not balance_full_root:
         return replace(provisional, strong_scale=base_scale)
     equation_scale, coordinate_scale = _streaming_ruiz_scales(
-        lambda value: _strong_residual_unscaled(value, provisional),
+        _full_root_residual,
+        provisional,
         base_vector,
         iterations=balance_iterations,
         probes=4,

--- a/vmex/core/polish.py
+++ b/vmex/core/polish.py
@@ -2154,6 +2154,11 @@ def build_low_order_preconditioner(
 
     from . import implicit
 
+    # The transfer's project_config and the stored config ride in hashable
+    # jit metadata, so equal-content configs must be one shared identity or
+    # every polish call from a freshly minted config keys its own compiles.
+    # make_config already canonicalizes; this covers direct construction.
+    config = implicit._canonical_config(config)
     runtime = implicit.runtime_from_params(params, config)
     project = implicit._dof_projector(config, dof_mask)
     transfer = make_high_low_transfer(

--- a/vmex/core/polish.py
+++ b/vmex/core/polish.py
@@ -1768,6 +1768,29 @@ def _streaming_ruiz_scales(
     return np.clip(rows, 1.0 / limit, limit), np.clip(columns, 1.0 / limit, limit)
 
 
+@jax.jit
+def _low_solve_lane(
+    value: Array,
+    layout: StrongRootLayout,
+    transfer: HighLowTransfer,
+    low_preconditioner: LowOrderPreconditioner,
+    equation_scale: Array,
+    coordinate_scale: Array,
+) -> Array:
+    """Equilibrated low-order preconditioner solve for the balance probes.
+
+    A module lane: the former per-runtime ``jax.jit`` closure baked the
+    freshly built transfer and factor arrays into its executable as constants
+    and keyed one compile per runtime build; with the pytrees as traced
+    operands, every equal-structure build shares this one.
+    """
+
+    high = layout.unpack(value / equation_scale)
+    low = transfer.restrict(high)
+    solved = low_preconditioner.solve_scaled(low)
+    return layout.pack(transfer.prolong(solved)) / coordinate_scale
+
+
 def make_strong_root_runtime(
     native: HighOrderEquilibriumState,
     low_preconditioner: LowOrderPreconditioner,
@@ -1938,14 +1961,17 @@ def make_strong_root_runtime(
     )
     scaled = replace(provisional, strong_scale=base_scale)
     zero = jnp.zeros((layout.size,), dtype=rms.dtype)
+    equation_scale_array = jnp.asarray(provisional.equation_scale)
+    coordinate_scale_array = jnp.asarray(provisional.coordinate_scale)
 
-    @jax.jit
     def low_solve(value: Array) -> Array:
-        high = layout.unpack(value / jnp.asarray(provisional.equation_scale))
-        low = transfer.restrict(high)
-        solved = low_preconditioner.solve_scaled(low)
-        return layout.pack(transfer.prolong(solved)) / jnp.asarray(
-            provisional.coordinate_scale
+        return _low_solve_lane(
+            value,
+            layout,
+            transfer,
+            low_preconditioner,
+            equation_scale_array,
+            coordinate_scale_array,
         )
 
     low_solve(zero).block_until_ready()

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -1019,11 +1019,6 @@ def polish_strong_root(
 # compilation cache as well (different constants, different HLO). These
 # module lanes take the pytrees as arguments, so equal-structure polish
 # calls share one compiled program in memory and on disk.
-@jax.jit
-def _scaled_collocation_lane(value, runtime, chart, collocation_scale):
-    return strong_collocation_residual(value, runtime, chart) / collocation_scale
-
-
 @functools.partial(jax.jit, static_argnames=("config",))
 def _gauss_newton_polish_lane(value, runtime, chart, variable_scale,
                               collocation_scale, config):
@@ -1036,23 +1031,54 @@ def _gauss_newton_polish_lane(value, runtime, chart, variable_scale,
     return gauss_newton_least_squares(residual, value, config=config)
 
 
+@jax.jit
+def _collocation_probe_lane(probes, zero, runtime, chart, collocation_scale):
+    """Stacked transpose-JVP responses of the scaled collocation residual.
+
+    The former host-eager linearize/linear_transpose pair rebuilt and re-ran
+    a fresh linear program per polish call; like the Ruiz lanes in
+    :mod:`.polish`, linearizing inside one module jit with the pytrees as
+    traced operands bakes no constants and lets equal-structure polish calls
+    share the executable. The primal re-runs on each call — one extra force
+    evaluation at setup.
+    """
+
+    def residual(value):
+        return strong_collocation_residual(
+            value, runtime, chart) / collocation_scale
+
+    _, jvp = jax.linearize(residual, zero)
+    transpose = jax.linear_transpose(jvp, zero)
+    return jax.vmap(lambda probe: transpose(probe)[0])(probes)
+
+
 def _collocation_variable_scale(
-    residual,
+    runtime: StrongRootRuntime,
+    chart,
+    collocation_scale: jax.Array,
     zero: jax.Array,
     row_count: int,
     probes: int,
 ) -> np.ndarray:
-    """Estimate inverse column norms with deterministic transpose probes."""
+    """Estimate inverse column norms with deterministic transpose probes.
+
+    The probe draws keep the pre-lane sequence: one generator, one draw per
+    probe in order, so the sampled directions are bit-identical to the
+    retired per-call implementation.
+    """
 
     if probes == 0:
         return np.ones(np.asarray(zero).shape, dtype=float)
-    _, jvp = jax.linearize(residual, jnp.asarray(zero))
-    transpose = jax.linear_transpose(jvp, jnp.asarray(zero))
     generator = np.random.default_rng(0)
+    stacked = np.stack([
+        generator.choice(np.asarray([-1.0, 1.0]), size=row_count)
+        for _ in range(probes)
+    ])
+    responses = np.asarray(_collocation_probe_lane(
+        jnp.asarray(stacked), jnp.asarray(zero), runtime, chart,
+        jnp.asarray(collocation_scale)))
     column_squared = np.zeros(np.asarray(zero).shape, dtype=float)
-    for _ in range(probes):
-        probe = generator.choice(np.asarray([-1.0, 1.0]), size=row_count)
-        response = np.asarray(transpose(jnp.asarray(probe))[0])
+    for response in responses:
         column_squared += response * response
     column_norm = np.sqrt(column_squared / float(probes))
     column_floor = max(1.0e-8 * float(np.max(column_norm)), 1.0e-12)
@@ -1092,12 +1118,10 @@ def polish_collocation_least_squares(
     )
     collocation_scale_array = jnp.asarray(collocation_scale)
 
-    def physical_residual(value):
-        return _scaled_collocation_lane(
-            value, runtime, chart, collocation_scale_array)
-
     variable_scale = _collocation_variable_scale(
-        physical_residual,
+        runtime,
+        chart,
+        collocation_scale_array,
         zero,
         int(initial_collocation.size),
         config.collocation_scale_probes,


### PR DESCRIPTION
Campaign wave 3 — the fix for the 3-D polish stall (forward half of the #219 disease). Any `solve_file(polish=True)` at ntor>0 stalled in XLA constant folding: `_streaming_ruiz_scales` wrapped its `jax.linearize`-returned closures in two fresh jits, promoting every linearization residual of the force kernel plus the dense chart basis into baked constants (~16 GB literal / ~4.5 GB post-dedup at mpol=ntor=8, ns=49), and constant folding swap-killed the host before the first Gauss-Newton iteration.

Four commits:
1. `_ruiz_probe_lane` — one module-level jit (static residual builder + traced operand pytree) that re-linearizes inside the jit and vmaps jvp/transpose over the stacked probes; all scale-update algebra stays verbatim on host; 4 iterations = 4 lane calls = 1 compile.
2. `_collocation_probe_lane` — the per-polish-call eager linearize+transpose hoisted the same way (probe sequence bit-identical); the orphaned `_scaled_collocation_lane` removed with its last caller.
3. `_low_solve_lane` — the balance branch's fresh jit converted to a module lane; one executable shared across equal-structure builds.
4. `build_low_order_preconditioner` routes its config through `implicit._canonical_config` so equal-content polish calls share jit identities.

**Measured:** tiny-3D polish (li383 at mpol=3/ntor=2/ns=9): capture warnings 2 → **0**, wall 154.9 → **78.5 s**, identical control flow and termination. QA-scale proof without a run: `_ruiz_probe_lane.lower()` at mpol=ntor=8/ns=49 completes in **1.4 s** with **0.13 MB** of constants in the lowered module (largest single constant 1.2 KB) — versus the pre-fix ~4.5 GB.

**Parity, stated honestly:** ntor=0 polish reports match on every discrete outcome (legacy solve bit-identical at fsqr 9.77e-11/146 iters, same GN/continuation counts, same termination); the Ruiz scales differ by exactly 1 ULP and the final L2 by 1.5e-8 relative (143 vs 141 GMRES iterations). Bit-identity to the old executable is unattainable in principle — an isolation experiment showed the old jit-of-closure's own outputs sat 5.8e-15 from its un-jitted closure: the old last bits were XLA constant-fusion artifacts no non-capturing program reproduces. Polish acceptance is certificate-based against the independent oracle, which is unaffected.

Tests: test_polish_preconditioner 65 passed; test_strong_force 21 passed, 1 skipped (essos environment).