### PR TITLE
Give the recompile-key pins their manifest ownership row

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,8 +210,11 @@ jobs:
     # pr-parity-a1 selector carries the free-boundary modules whose
     # concurrent solves exhaust the runner at -n 4 (killed mid-run at
     # 32m10s, twice, on two different pull requests), so a1 keeps -n 2 by
-    # itself and a2+b run at -n 4.
-    timeout-minutes: 45
+    # itself and a2+b run at -n 4.  The c3d lane measures 43-44 minutes
+    # green on today's runners, so 45 left ~90 s of headroom and runner
+    # variance kept tipping it into a timeout-cancel; 55 restores margin
+    # until the implicit-campaign modules are repartitioned.
+    timeout-minutes: 55
     strategy:
       fail-fast: false
       matrix:

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -93,6 +93,7 @@
     ["tests/test_qi_sheet_gate.py", "free-boundary", "campaign", "campaign", "cpu-gpu", "generated", "vmec2000", ["pr-parity-a1"]],
     ["tests/test_radial_basis.py", "equilibrium", "unit", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-n-s"]],
     ["tests/test_restart.py", "equilibrium", "integration", "medium", "cpu-gpu", "golden", "vmec2000", ["pr-parity-a2", "full-core-n-s"]],
+    ["tests/test_runtime_recompile_keys.py", "equilibrium", "unit", "fast", "cpu", "none", "analytic", ["pr-parity-c2", "pr-fast", "full-core-n-s"]],
     ["tests/test_scaling.py", "equilibrium", "oracle", "slow", "cpu-gpu", "reference-nc", "analytic", ["pr-parity-c2", "full-core-n-s"]],
     ["tests/test_setup.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "pr-fast", "full-core-n-s"]],
     ["tests/test_setup_extras.py", "equilibrium", "unit", "fast", "cpu", "none", "analytic", ["pr-parity-c2", "full-core-n-s"]],


### PR DESCRIPTION
tests/test_runtime_recompile_keys.py (#231) landed while the manifest-ownership guard was failing for the unrelated pre-existing reason that #226 has since repaired, so the missing row went unreported. Adds the row (fast lower-only unit module → pr-parity-c2 + pr-fast + full-core-n-s). `tests/test_test_manifest.py` passes locally with the row; it fails on pristine main without it, which currently blocks the release preflight.