### PR TITLE
Pass the loop-driver DELT to the trace-budget carry

### DIFF
--- a/tests/test_trace_budgets.py
+++ b/tests/test_trace_budgets.py
@@ -82,8 +82,13 @@ def _lane_operands():
     """The exact ``lane(carry, rt)`` operands a solovev CLI solve dispatches."""
     inp = VmecInput.from_file(str(SOLOVEV_DECK))
     rt = solver.prepare_runtime(inp, solver.resolution_from_input(inp))
+    time_step0, _ = solver._loop_driver_config(inp)
     carry = jax.tree.map(
-        jnp.array, solver._initial_carry(solver._initial_state(rt.setup), rt, ijacob=0)
+        jnp.array,
+        solver._initial_carry(
+            solver._initial_state(rt.setup), rt, ijacob=0,
+            time_step0=time_step0,
+        ),
     )
     return carry, rt
 


### PR DESCRIPTION
#233's `test_trace_budgets` built its lane carry against the pre-#231 `_initial_carry` signature; the branches merged without a combined CI run, so the missing required `time_step0` argument only surfaced on merged main (2 errors in parity lane c2 on the release branch's run). Resolves DELT via `_loop_driver_config` exactly as the production call sites do. Suite passes locally (3 passed).