### PR TITLE
Stage the fixed-point refinement; defer the seed anchor out of problem construction

### DIFF
--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -93,6 +93,7 @@
     ["tests/test_qi_sheet_gate.py", "free-boundary", "campaign", "campaign", "cpu-gpu", "generated", "vmec2000", ["pr-parity-a1"]],
     ["tests/test_radial_basis.py", "equilibrium", "unit", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-n-s"]],
     ["tests/test_restart.py", "equilibrium", "integration", "medium", "cpu-gpu", "golden", "vmec2000", ["pr-parity-a2", "full-core-n-s"]],
+    ["tests/test_refine_staging.py", "ad", "unit", "fast", "cpu", "none", "analytic", ["pr-parity-c2", "pr-fast", "full-core-n-s"]],
     ["tests/test_runtime_recompile_keys.py", "equilibrium", "unit", "fast", "cpu", "none", "analytic", ["pr-parity-c2", "pr-fast", "full-core-n-s"]],
     ["tests/test_scaling.py", "equilibrium", "oracle", "slow", "cpu-gpu", "reference-nc", "analytic", ["pr-parity-c2", "full-core-n-s"]],
     ["tests/test_setup.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "pr-fast", "full-core-n-s"]],

--- a/tests/test_implicit_grad.py
+++ b/tests/test_implicit_grad.py
@@ -1332,13 +1332,14 @@ def test_nearby_refinement_seed_is_guarded_and_conservative(monkeypatch):
 
     calls = []
 
-    def incomplete_step(_operator, rhs, _config, **_kwargs):
-        calls.append(float(rhs[0]))
+    def incomplete_step(_config, _params, _frozen, _dof_mask, z, fz):
+        calls.append(float(fz[0]))
         # Both paths improve, but neither reaches the requested tolerance.
-        delta = 1.0 if float(rhs[0]) < 7.0 else 2.0
-        return jnp.asarray([delta]), None
+        delta = 1.0 if float(fz[0]) < 7.0 else 2.0
+        z_new = z - delta
+        return z_new, z_new, jnp.linalg.norm(z_new)
 
-    monkeypatch.setattr(im, "_adjoint_solve_gcrot", incomplete_step)
+    monkeypatch.setattr(im, "_refine_step", incomplete_step)
     legacy = im._refined_state(cfg, params, state, state)
     warm = im._refined_state(
         cfg, params, state, state, initial_correction=jnp.asarray([-5.0]))

--- a/tests/test_refine_staging.py
+++ b/tests/test_refine_staging.py
@@ -1,0 +1,67 @@
+"""Startup-latency contracts of the staged fixed-point refinement.
+
+Pins the perf behavior behind the QA_optimization evaluation-latency fix (the
+``tests/test_runtime_recompile_keys.py`` idiom — lower-only, no repeated full
+solves): ``_refine_step_core`` is one reusable per-config executable.  Every
+per-trial quantity (iterate, residual, parameters, frozen anchor, dof mask) is
+a program ARGUMENT, never a baked closure constant, so consecutive optimizer
+trial boundaries share one compiled program.  The previous host-eager step
+re-linearized ``F`` per call and handed ``solvax.gcrot`` a fresh closure, so
+the ``lax.while_loop`` it staged missed the compile cache on every trial —
+one measured ``jit(while)`` recompile per optimizer evaluation.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import jax
+import numpy as np
+
+from vmex.core import implicit as im
+from vmex.core.input import VmecInput
+
+DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
+
+
+def _small_solovev_setup():
+    """Smallest meaningful analytic equilibrium (one fast forward solve)."""
+    inp = VmecInput.from_file(str(DATA / "input.solovev"))
+    inp = inp.change_resolution(mpol=3, ntor=0, ntheta=12, nzeta=4)
+    inp = dataclasses.replace(
+        inp,
+        ns_array=np.asarray([5]),
+        ftol_array=np.asarray([1.0e-10]),
+        niter_array=np.asarray([1000]),
+    )
+    cfg = im.make_config(inp, ftol=1.0e-10, max_iterations=1000)
+    return inp, cfg, im.params_from_input(inp)
+
+
+def test_refine_step_lowering_is_shared_across_trial_points() -> None:
+    """Two trial iterates lower to one identical refinement program.
+
+    The lowered text is what the compile cache keys on (one cfg, fixed
+    avals), so byte-identical lowerings ARE executable reuse: the second and
+    every later optimizer trial run the already-compiled refinement step
+    instead of restaging a fresh ``while_loop`` closure.
+    """
+    _, cfg, p0 = _small_solovev_setup()
+    state, mask = im.solve_implicit_with_aux(p0, cfg)
+    P = im._dof_projector(cfg, mask)
+    F = im.residual_fn(cfg, state, mask)
+    z0 = P(state)
+    fz0 = F(z0, p0)
+
+    # A nearby trial: different values, same structure — exactly what a
+    # line-search hands the refinement on consecutive evaluations.
+    z1 = jax.tree.map(lambda a: a * (1.0 + 1.0e-6), z0)
+    p1 = dataclasses.replace(p0, rbc=p0.rbc * (1.0 + 1.0e-6))
+    fz1 = F(z1, p1)
+
+    text_a = im._refine_step_core.lower(z0, fz0, p0, state, mask, cfg=cfg).as_text()
+    text_b = im._refine_step_core.lower(z1, fz1, p1, state, mask, cfg=cfg).as_text()
+    assert text_a == text_b
+    # ... while the trial values genuinely differ.
+    assert not np.array_equal(np.asarray(z0.R_cos), np.asarray(z1.R_cos))

--- a/tests/test_refine_staging.py
+++ b/tests/test_refine_staging.py
@@ -1,14 +1,20 @@
 """Startup-latency contracts of the staged fixed-point refinement.
 
-Pins the perf behavior behind the QA_optimization evaluation-latency fix (the
-``tests/test_runtime_recompile_keys.py`` idiom — lower-only, no repeated full
-solves): ``_refine_step_core`` is one reusable per-config executable.  Every
-per-trial quantity (iterate, residual, parameters, frozen anchor, dof mask) is
-a program ARGUMENT, never a baked closure constant, so consecutive optimizer
-trial boundaries share one compiled program.  The previous host-eager step
-re-linearized ``F`` per call and handed ``solvax.gcrot`` a fresh closure, so
-the ``lax.while_loop`` it staged missed the compile cache on every trial —
-one measured ``jit(while)`` recompile per optimizer evaluation.
+Pins the two perf behaviors behind the QA_optimization startup fixes (the
+``tests/test_runtime_recompile_keys.py`` idiom — lower-only and counter-based,
+no repeated full solves):
+
+- ``_refine_step_core`` is one reusable per-config executable: every per-trial
+  quantity (iterate, residual, parameters, frozen anchor, dof mask) is a
+  program ARGUMENT, never a baked closure constant, so consecutive optimizer
+  trial boundaries share one compiled program.  The previous host-eager step
+  re-linearized ``F`` per call and handed ``solvax.gcrot`` a fresh closure, so
+  the ``lax.while_loop`` it staged missed the compile cache on every trial —
+  one measured ``jit(while)`` recompile per optimizer evaluation;
+- the problem-factory seed preflight (``refine=False``) never pays for the
+  Newton anchor: refinement runs on the first derivative evaluation instead,
+  which memo-hits the preflight's solve, so the work moves behind the
+  ``compile_value_and_gradient`` heartbeat without being duplicated.
 """
 
 from __future__ import annotations
@@ -65,3 +71,58 @@ def test_refine_step_lowering_is_shared_across_trial_points() -> None:
     assert text_a == text_b
     # ... while the trial values genuinely differ.
     assert not np.array_equal(np.asarray(z0.R_cos), np.asarray(z1.R_cos))
+
+
+def test_preflight_skips_refinement_and_first_derivative_pays_it_once() -> None:
+    """``refine=False`` returns the raw solver state without the anchor.
+
+    The subsequent default (``refine=True``) call at the same parameters
+    memo-hits the solve and runs the refinement exactly once, so deferring
+    the anchor out of problem construction conserves total work.
+    """
+    _, cfg, p0 = _small_solovev_setup()
+    params_np = jax.tree.map(lambda a: np.asarray(a, dtype=np.float64), p0)
+
+    calls = {"refine": 0, "solve": 0}
+    original_refine = im._refine_fixed_point
+    original_solve = im._host_solve
+
+    def counting_refine(*args, **kwargs):
+        calls["refine"] += 1
+        return original_refine(*args, **kwargs)
+
+    def counting_solve(*args, **kwargs):
+        calls["solve"] += 1
+        return original_solve(*args, **kwargs)
+
+    im._refine_fixed_point = counting_refine
+    im._host_solve = counting_solve
+    try:
+        raw_state, _ = im._host_solve_and_mask(cfg, params_np, refine=False)
+        assert calls == {"refine": 0, "solve": 1}
+        hit = im._LAST_SOLVE.get(cfg)
+        assert hit is not None
+        for raw_leaf, solver_leaf in zip(
+            jax.tree.leaves(raw_state), jax.tree.leaves(hit[1].state)
+        ):
+            np.testing.assert_array_equal(
+                np.asarray(raw_leaf), np.asarray(solver_leaf))
+
+        refined_state, _ = im._host_solve_and_mask(cfg, params_np)
+        # Memo-hit solve (the counted host call returns the stored result
+        # without iterating) and exactly one refinement.
+        assert calls == {"refine": 1, "solve": 2}
+        stats = im._SOLVE_STATS.get(cfg)
+        assert stats is not None and stats["solves"] == 1
+    finally:
+        im._refine_fixed_point = original_refine
+        im._host_solve = original_solve
+
+    # The refined anchor is the memoized one later derivative lanes read.
+    memo = im._LAST_REFINED.get(cfg)
+    assert memo is not None
+    for refined_leaf, memo_leaf in zip(
+        jax.tree.leaves(refined_state), jax.tree.leaves(memo[1])
+    ):
+        np.testing.assert_array_equal(
+            np.asarray(refined_leaf), np.asarray(memo_leaf))

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -1390,6 +1390,64 @@ def _refine_fixed_point(cfg: ImplicitConfig, params: ImplicitParams,
     return hit[1]
 
 
+# One staged Newton refinement step per config (the ``_adjoint_gcrot_core``
+# argument): module scope with ``cfg`` static and the per-call state/params
+# as traced arguments is what makes the executable REUSABLE.  The previous
+# host-eager step re-linearized ``F`` per call and handed ``solvax.gcrot`` a
+# fresh closure over that call's residuals, so the ``lax.while_loop`` it
+# stages missed the compile cache on every trial boundary — one measured
+# ``jit(while)`` recompile per optimizer evaluation — and the remaining ops
+# dispatched one primitive at a time: 5.7-8.6 s of every 11-14 s smoke-mode
+# QA_optimization evaluation was this eager refinement.
+@functools.partial(jax.jit, static_argnames=("cfg",))
+def _refine_step_core(z: SpectralState, fz: SpectralState,
+                      params: ImplicitParams, frozen: SpectralState,
+                      dof_mask: SpectralState, cfg: ImplicitConfig):
+    """Staged inexact-Newton refinement step; returns ``(z, F(z), |F(z)|)``.
+
+    Linearizes the preconditioned residual at ``z``, runs the same
+    GCROT(m, k) solve as the eager :func:`_adjoint_solve_gcrot` lane with
+    the refinement's forcing term and cycle budget (best-effort: the host
+    caller in :func:`_refined_state` applies the acceptance policy on the
+    concrete residual norm, so convergence is never enforced here), and
+    evaluates the residual at the stepped iterate inside the same
+    executable.
+    """
+    F = residual_fn(cfg, frozen, dof_mask)
+    _, jvp = jax.linearize(lambda t: F(t, params), z)
+    b_flat, unravel = ravel_pytree(fz)
+    n = int(b_flat.shape[0])
+    m = min(int(cfg.adjoint_gcrot_m), n)
+    k = min(int(cfg.adjoint_gcrot_k), n)
+
+    def matvec(v):
+        return ravel_pytree(jvp(unravel(v)))[0]
+
+    sol = _solvax_gcrot(
+        matvec, b_flat, rtol=_REFINE_FORCING, atol=0.0, m=m, k=k,
+        max_restarts=_REFINE_MAX_RESTARTS)
+    z_new = jax.tree.map(jnp.subtract, z, unravel(sol.x))
+    fz_new = F(z_new, params)
+    return z_new, fz_new, _tree_norm(fz_new)
+
+
+def _refine_step(cfg: ImplicitConfig, params: ImplicitParams,
+                 frozen: SpectralState, dof_mask: SpectralState,
+                 z: SpectralState, fz: SpectralState):
+    """One Newton refinement step through the staged per-config executable.
+
+    The host-level indirection exists so :func:`_refined_state` keeps its
+    concrete best-state/early-exit control flow (and tests keep a seam to
+    fake incomplete steps) while the linearize + GCROT + residual work runs
+    as one compiled program.  Arguments are committed to ``cfg.device``
+    exactly like the eager Krylov lane's RHS pin.
+    """
+    return _refine_step_core(
+        _pin_concrete(cfg, z), _pin_concrete(cfg, fz),
+        _pin_concrete(cfg, params), _pin_concrete(cfg, frozen),
+        _pin_concrete(cfg, dof_mask), cfg)
+
+
 def _refined_state(cfg: ImplicitConfig, params: ImplicitParams,
                    state: SpectralState,
                    dof_mask: SpectralState,
@@ -1426,15 +1484,13 @@ def _refined_state(cfg: ImplicitConfig, params: ImplicitParams,
     def refine_from(z, fz, residual):
         best_z, best = z, residual
         for _ in range(_REFINE_MAX_STEPS):
-            _, jvp = jax.linearize(lambda t: F(t, params), z)
             # GCROT avoids the small-eigenvalue stagnation seen with ordinary
-            # restarted GMRES on this fixed-point solve.
-            delta, _ = _adjoint_solve_gcrot(
-                jvp, fz, cfg, rtol=_REFINE_FORCING, enforce=False,
-                max_restarts=_REFINE_MAX_RESTARTS)
-            z = jax.tree.map(lambda a, b: a - b, z, delta)
-            fz = F(z, params)
-            residual = float(_tree_norm(fz))
+            # restarted GMRES on this fixed-point solve; the linearize +
+            # solve + residual evaluation run as one staged per-config
+            # executable (see _refine_step_core).
+            z, fz, residual_norm = _refine_step(
+                cfg, params, state, dof_mask, z, fz)
+            residual = float(residual_norm)
             if not np.isfinite(residual):
                 break
             # Newton need not be monotone: iterate from the latest point but

--- a/vmex/core/implicit.py
+++ b/vmex/core/implicit.py
@@ -1549,7 +1549,8 @@ def _mask_cache_key(cfg: ImplicitConfig) -> tuple:
     return (cfg.resolution, bool(cfg.lconm1), int(cfg.inp.ncurr))
 
 
-def _host_solve_and_mask(cfg: ImplicitConfig, params_np) -> tuple:
+def _host_solve_and_mask(cfg: ImplicitConfig, params_np, *,
+                         refine: bool = True) -> tuple:
     # This function executes on a pure_callback WORKER THREAD, where the
     # caller's thread-local ``jax.default_device`` context is not active.
     # Re-enter the config's device context explicitly, otherwise everything
@@ -1558,10 +1559,11 @@ def _host_solve_and_mask(cfg: ImplicitConfig, params_np) -> tuple:
     # explicitly placed state (observed as NaN diagnostics / zero gradients
     # on a non-default GPU).
     with _device_context(cfg):
-        return _host_solve_and_mask_impl(cfg, params_np)
+        return _host_solve_and_mask_impl(cfg, params_np, refine=refine)
 
 
-def _host_solve_and_mask_impl(cfg: ImplicitConfig, params_np) -> tuple:
+def _host_solve_and_mask_impl(cfg: ImplicitConfig, params_np, *,
+                              refine: bool = True) -> tuple:
     _HOST_ERROR.clear()  # fresh callback: drop any stale relayed error
     # The callback payload arrives committed to the runtime's LOCAL CPU
     # regardless of ``cfg.device``, and ``jnp.asarray`` preserves an existing
@@ -1603,7 +1605,13 @@ def _host_solve_and_mask_impl(cfg: ImplicitConfig, params_np) -> tuple:
         _MASK_CACHE[cache_key] = mask
     # Anchor the state at the root of the residual the adjoint linearizes, so
     # every consumer — value, cotangent and linearization — reads the same
-    # point (see _refined_state).
+    # point (see _refined_state).  ``refine=False`` is the problem-factory
+    # seed preflight, which only validates shape/finiteness and never
+    # differentiates: it skips the (expensive) anchor so the first user
+    # output is not held behind it, and the first derivative evaluation —
+    # which memo-hits this solve — computes the identical refinement then.
+    if not refine:
+        return as_np(result.state), mask
     state = _refine_fixed_point(
         cfg, params, result.state,
         _device_pin(cfg, jax.tree.map(jnp.asarray, mask)))

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -2672,7 +2672,12 @@ def _least_squares_implicit(
     params0_np = jax.tree.map(
         lambda a: np.asarray(a, dtype=np.float64), params_of(_place(x0))
     )
-    state0_np, mask_np = imp._host_solve_and_mask(cfg, params0_np)
+    # ``refine=False``: the preflight validates the seed solve and the
+    # residual shape but never differentiates this state, so it does not pay
+    # for the fixed-point anchor here.  The first derivative evaluation
+    # memo-hits this exact solve and refines then — under the compile
+    # heartbeat instead of the silent factory (user-visible startup gap).
+    state0_np, mask_np = imp._host_solve_and_mask(cfg, params0_np, refine=False)
     state0 = jax.tree.map(_place, state0_np)
     params_at_x0 = params_of(_place(x0))
     runtime0 = imp.runtime_from_params(params_at_x0, cfg)


### PR DESCRIPTION
Fixes both user-reported optimization latencies, from measured attribution (not guesswork — two of three pre-formed hypotheses were refuted by the compile census before touching code).

**Gap A — silence before `dof_names`**: `VmecProblem.from_loss` ran a strict seed preflight including the Newton fixed-point refinement `_refined_state` host-eagerly — `jax.linearize` re-traced per Newton step, solvax GCROT restaged its `lax.while_loop` from a fresh closure per call (~1100 eager dispatches; the same disease `_adjoint_gcrot_core` fixed for the reverse adjoint in #219, still live on the refinement lane). Measured: time-to-first-output **62.0 → 6.5 s cold, 9.7 → 2.5 s warm**.

**Gap B — the stall after "Value and gradient ready"**: the first scipy evaluation was already free (bitwise-equal point, content-keyed cache, 0 compiles — hypothesis refuted); the silence is the *subsequent* trial points each re-running the eager refinement (5.7–8.6 s of every 11–14 s evaluation). Per-new-trial-point: **12.5 → 8.0 s cold, 8.9 → 7.6 s warm**; smoke-mode example wall **207 → 88 s cold**.

Two commits:
1. `_refine_step_core` — the refinement Newton step as one module-scope per-config executable (cfg static, per-trial arrays traced), keeping the concrete best-state/early-exit policy on the host; lower-only test pins that two trial points lower to byte-identical programs.
2. Seed preflight runs `refine=False` (it only validates shape/finiteness, never differentiates); the first derivative evaluation memo-hits that solve and refines once, under the existing heartbeat — work conserved, counter-based test pins the contract.

**Parity**: first evaluation bitwise identical (21.44875245554685); later evaluations deviate at ~2e-10 relative (the staged step is the same algorithm under one fused program; the Newton/GCROT anchor lands within the linear-solve noise floor |F|~1e-13), same trajectory, same accepted iterates. Deliberately untouched: the refinement's Krylov budget, the certified adjoint, the failure-gating pre-probe (numerical policy, not staging).

Suites: implicit-grad/multi-RHS/recompile-keys 45 passed, problem+penalty 28, optimize 34, new pins 2; ruff clean.