### PR TITLE
Apply the staging idioms universally; pin the optimization cold start in CI

### DIFF
--- a/tests/test_trace_budgets.py
+++ b/tests/test_trace_budgets.py
@@ -67,6 +67,29 @@ _LANE_STABLEHLO_FLOOR = 100_000
 #: ``_COMPILE_COUNT_SCRIPT`` below by hand.
 _COLD_SOLVE_PROGRAM_CEILING = 125
 
+QA_SEED_DECK = ROOT / "examples" / "data" / "input.minimal_seed_nfp2"
+
+#: XLA programs compiled while CONSTRUCTING the QA_optimization smoke
+#: problem (the ``VMEX_EXAMPLES_CI=1`` configuration of
+#: ``examples/optimization/QA_optimization.py``): the seed preflight solve
+#: plus its eager setup dispatch, and nothing derivative-shaped — the
+#: ``refine=False`` deferral means construction also runs ZERO fixed-point
+#: refinements, pinned exactly below rather than by headroom.  Measured
+#: 2026-09-02 at 510a2073 (jax 0.11.1, CPU, x64, persistent compilation
+#: cache disabled): 246 programs; ceiling is measured + ~25%.  Re-measure
+#: by running ``_OPTIMIZATION_STARTUP_SCRIPT`` below by hand.
+_PROBLEM_STARTUP_PROGRAM_CEILING = 310
+#: New XLA programs per LATER trial-point objective evaluation.  The
+#: per-trial path (status solve + scalar-loss lane) is fully
+#: content-keyed, so a steady-state trial must reuse every executable of
+#: the earlier ones — an exact zero, not a headroom budget.  The one
+#: exception is the second trial: the first trial to consume a stored
+#: refinement correction evaluates ``_preconditioned_residual_lane``
+#: standalone (outside ``_refine_step_core``) and may compile exactly that
+#: one program.  Measured 2026-09-02 as above: second trial 1, third 0.
+_SECOND_TRIAL_NEW_PROGRAM_CEILING = 1
+_STEADY_TRIAL_NEW_PROGRAMS = 0
+
 
 @pytest.fixture(autouse=True)
 def _enable_jit():
@@ -178,4 +201,157 @@ def test_cold_solve_compiled_program_count_stays_under_budget():
         "single-op dispatch crept into the setup/export/printout passes "
         "(see #227); jit the new pass, or re-measure and move the "
         "constant if the growth is deliberate."
+    )
+
+
+# The construction below is examples/optimization/QA_optimization.py under
+# VMEX_EXAMPLES_CI=1, inlined constant-for-constant (MAX_MODE=1 smoke,
+# MINIMUM_MPOL=5) so the guard cannot drift from the example silently and
+# needs no example import machinery.  Same log-capture pattern as
+# ``_COMPILE_COUNT_SCRIPT``; ``_refine_fixed_point`` is additionally
+# counted because the startup contract is one seed solve WITHOUT the
+# fixed-point anchor (the refine=False deferral) — a refinement here would
+# stall the first user-visible output behind an adjoint-grade Newton solve.
+_OPTIMIZATION_STARTUP_SCRIPT = """\
+import logging
+import sys
+from dataclasses import replace
+
+import numpy as np
+
+import vmex as vj  # must precede the handler: import configures JAX logging
+from vmex import optimize as opt
+import vmex.core.implicit as imp
+import jax
+import jax.numpy as jnp
+
+
+class CompileCounter(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.count = 0
+
+    def emit(self, record):
+        if "Finished XLA compilation of" in record.getMessage():
+            self.count += 1
+
+
+counter = CompileCounter()
+jax_logger = logging.getLogger("jax")
+jax_logger.addHandler(counter)
+jax_logger.setLevel(logging.INFO)  # compile records log at WARNING
+jax.config.update("jax_log_compiles", True)
+jax.config.update("jax_enable_compilation_cache", False)
+
+refine_calls = []
+_real_refine = imp._refine_fixed_point
+
+
+def counting_refine(*args, **kwargs):
+    refine_calls.append(1)
+    return _real_refine(*args, **kwargs)
+
+
+imp._refine_fixed_point = counting_refine
+
+inp = vj.VmecInput.from_file(sys.argv[1])
+rbc, zbs = inp.rbc.copy(), inp.zbs.copy()
+rbc[inp.ntor - 1, 1], zbs[inp.ntor - 1, 1] = -0.05, 0.05
+inp = replace(inp, rbc=rbc, zbs=zbs)
+
+qs = opt.QuasisymmetryRatioResidual(
+    np.linspace(0.1, 1.0, 10), helicity_m=1, helicity_n=0)
+
+
+def iota_floor(state, rt):
+    return jnp.maximum(0.42 - opt.min_abs_iota(state, rt), 0.0)
+
+
+terms = [(qs, 0.0, 1.0), (opt.aspect_ratio, 5.0, 1.0),
+         (iota_floor, 0.0, 10.0), (opt.magnetic_well, 0.01, 1.0)]
+
+
+def loss(state, rt):
+    rows = opt.residuals_from_tuples(state, rt, terms)
+    return 0.5 * jnp.vdot(rows, rows)
+
+
+mpol = 5  # smoke: max(MAX_MODE + 2, MINIMUM_MPOL) with MAX_MODE=1
+inp = replace(inp, delt=0.5).change_resolution(
+    mpol=mpol, ntor=mpol, ntheta=2 * mpol + 6, nzeta=2 * mpol + 4)
+problem = opt.VmecProblem.from_loss(
+    inp, loss, max_mode=1, use_ess=True, ess_alpha=1.2)
+print("CONSTRUCTION_PROGRAMS:", counter.count)
+print("CONSTRUCTION_REFINES:", len(refine_calls))
+
+step = 1.0e-3 * problem.scales
+values = [float(problem.fun(problem.x0 + k * step)) for k in (1.0,)]
+after_first_trial = counter.count
+values.append(float(problem.fun(problem.x0 + 2.0 * step)))
+after_second_trial = counter.count
+values.append(float(problem.fun(problem.x0 + 3.0 * step)))
+assert all(np.isfinite(v) for v in values), values
+print("SECOND_TRIAL_NEW_PROGRAMS:", after_second_trial - after_first_trial)
+print("THIRD_TRIAL_NEW_PROGRAMS:", counter.count - after_second_trial)
+"""
+
+
+def test_problem_construction_compile_budget_and_no_refinement():
+    """One cold subprocess, so suite order cannot pre-warm any cache.
+
+    Pins the optimization cold start end to end: constructing the
+    QA_optimization smoke problem compiles at most the budgeted program
+    count and runs zero fixed-point refinements (the seed preflight only
+    validates the solve — the first derivative evaluation pays the anchor,
+    under the compile heartbeat), the second trial-point objective
+    evaluation compiles at most the one warm-seed residual lane, and a
+    third compiles nothing at all.  Unmarked but heavier than the
+    cold-solve probe (measured ~40 s: one construction solve plus three
+    trial solves); the ``pr-fast`` lane excludes this module.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(ROOT), env.get("PYTHONPATH", "")) if part
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", _OPTIMIZATION_STARTUP_SCRIPT,
+         str(QA_SEED_DECK)],
+        capture_output=True, text=True, timeout=600, cwd=ROOT, env=env,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    keys = ("CONSTRUCTION_PROGRAMS", "CONSTRUCTION_REFINES",
+            "SECOND_TRIAL_NEW_PROGRAMS", "THIRD_TRIAL_NEW_PROGRAMS")
+    matches = {key: re.search(rf"{key}: (\d+)", proc.stdout) for key in keys}
+    assert all(matches.values()), proc.stdout + proc.stderr
+    values = {key: int(match.group(1)) for key, match in matches.items()}
+    assert 0 < values["CONSTRUCTION_PROGRAMS"], (
+        "no compile records — the log-capture pattern broke"
+    )
+    assert values["CONSTRUCTION_REFINES"] == 0, (
+        f"problem construction ran {values['CONSTRUCTION_REFINES']} "
+        "fixed-point refinements; the refine=False seed preflight must "
+        "never pay for the derivative anchor (see optimize.py's factory)."
+    )
+    assert values["CONSTRUCTION_PROGRAMS"] <= _PROBLEM_STARTUP_PROGRAM_CEILING, (
+        f"constructing the QA smoke problem compiled "
+        f"{values['CONSTRUCTION_PROGRAMS']} XLA programs, over the "
+        f"{_PROBLEM_STARTUP_PROGRAM_CEILING}-program budget. Eager "
+        "dispatch or a fresh per-call jit crept into problem "
+        "construction; stage it, or re-measure and move the constant if "
+        "the growth is deliberate."
+    )
+    assert (values["SECOND_TRIAL_NEW_PROGRAMS"]
+            <= _SECOND_TRIAL_NEW_PROGRAM_CEILING), (
+        f"a second trial-point evaluation compiled "
+        f"{values['SECOND_TRIAL_NEW_PROGRAMS']} new XLA programs, over "
+        "the one-program warm-seed allowance (see the constant's note); "
+        "a fresh per-call jit or an identity-keyed cache crept into the "
+        "per-trial path."
+    )
+    assert values["THIRD_TRIAL_NEW_PROGRAMS"] == _STEADY_TRIAL_NEW_PROGRAMS, (
+        f"a third trial-point evaluation compiled "
+        f"{values['THIRD_TRIAL_NEW_PROGRAMS']} new XLA programs; a "
+        "steady-state trial must reuse every executable of the earlier "
+        "trials — a fresh per-call jit or an identity-keyed cache crept "
+        "into the per-trial path."
     )

--- a/vmex/core/freeboundary_implicit.py
+++ b/vmex/core/freeboundary_implicit.py
@@ -148,40 +148,77 @@ def _projected_residual(
     ``fixed_bsqvac`` freezes only NESTOR's edge pressure.  The resulting raw
     Jacobian is exactly block tridiagonal in radius and is the bulk operator
     used by the boundary-Schur adjoint.
+
+    The returned closure is memoized on ``(cfg, formulation, mask content)``
+    (``fixed_bsqvac=None`` only): the host callback hands each backward pass
+    a fresh numpy mask tree of identical content, and a stable closure
+    identity is what lets :func:`_transpose_matvec` reuse its compiled
+    transpose across gradient calls.  A ``fixed_bsqvac`` closure changes
+    value every iterate and is never a jit key, so it is not cached; the
+    pressure still enters the lane as a traced argument, never a baked
+    constant.
     """
     if formulation not in {"preconditioned", "raw"}:
         raise ValueError(f"unknown formulation {formulation!r}")
+
+    def residual(z, params, field_parameters, frozen, rcon0, zcon0):
+        return _projected_residual_lane(
+            z, params, field_parameters, frozen, rcon0, zcon0, dof_mask,
+            fixed_bsqvac, cfg=cfg, formulation=formulation)
+
+    if fixed_bsqvac is not None:
+        return residual
+    key = (cfg, formulation, tuple(
+        np.asarray(leaf).tobytes() for leaf in jax.tree.leaves(dof_mask)))
+    cached = _RESIDUAL_CLOSURE_CACHE.get(key)
+    if cached is None:
+        _RESIDUAL_CLOSURE_CACHE[key] = cached = residual
+        while len(_RESIDUAL_CLOSURE_CACHE) > _RESIDUAL_CLOSURE_CACHE_MAX:
+            _RESIDUAL_CLOSURE_CACHE.pop(next(iter(_RESIDUAL_CLOSURE_CACHE)))
+    return cached
+
+
+_RESIDUAL_CLOSURE_CACHE: dict[tuple, Callable] = {}
+_RESIDUAL_CLOSURE_CACHE_MAX = 8
+
+
+# Module scope with ``cfg``/``formulation`` static and the per-iterate arrays
+# (mask included) as traced arguments, the ``implicit.
+# _preconditioned_residual_lane`` idiom: the previous per-call ``@jax.jit``
+# closure inside :func:`_projected_residual` was a fresh function object, so
+# every backward pass of a free-boundary optimization re-traced and
+# recompiled the coupled NESTOR+VMEC residual up to four times (both
+# formulations plus the Schur frozen root) before its first adjoint matvec.
+@functools.partial(jax.jit, static_argnames=("cfg", "formulation"))
+def _projected_residual_lane(z, params, field_parameters, frozen, rcon0,
+                             zcon0, dof_mask, fixed_bsqvac, *,
+                             cfg: FreeBoundaryImplicitConfig,
+                             formulation: str):
     icfg = cfg.implicit
     project = im._dof_projector(icfg, dof_mask)
-    # The executable/topology was fixed concretely when the config was built;
-    # all equilibrium and coil values below remain dynamic traced arrays.
-    fused = cfg.vacuum_program
-
-    @jax.jit
-    def residual(z, params, field_parameters, frozen, rcon0, zcon0):
-        # Unlike fixed boundary, every active edge coefficient comes from z;
-        # the input boundary is only the forward solver's initial guess.
-        dz = project(jax.tree.map(lambda a, b: a - b, z, frozen))
-        state = jax.tree.map(jnp.add, frozen, dz)
-        rt = dataclasses.replace(
-            im.runtime_from_params(params, icfg), rcon0=rcon0, zcon0=zcon0,
-            lfreeb=True, jmax=int(icfg.resolution.ns),
-            presf_ns_scale=_presf_ns_scale_traceable(
-                params, icfg.inp, int(icfg.resolution.ns)),
-        )
-        if fixed_bsqvac is None:
-            external_field = cfg.field_from_parameters(field_parameters)
-            bsqvac = fused.bsq(state, rt, external_field)
-        else:
-            bsqvac = fixed_bsqvac
-        rt = dataclasses.replace(rt, bsqvac_edge=bsqvac)
-        if formulation == "preconditioned":
-            force, _, _ = evaluate_forces(state, rt)
-        else:
-            force = im._raw_force_state(state, rt, include_edge=True)
-        return project(force)
-
-    return residual
+    # Unlike fixed boundary, every active edge coefficient comes from z;
+    # the input boundary is only the forward solver's initial guess.
+    dz = project(jax.tree.map(lambda a, b: a - b, z, frozen))
+    state = jax.tree.map(jnp.add, frozen, dz)
+    rt = dataclasses.replace(
+        im.runtime_from_params(params, icfg), rcon0=rcon0, zcon0=zcon0,
+        lfreeb=True, jmax=int(icfg.resolution.ns),
+        presf_ns_scale=_presf_ns_scale_traceable(
+            params, icfg.inp, int(icfg.resolution.ns)),
+    )
+    if fixed_bsqvac is None:
+        # The executable/topology was fixed concretely when the config was
+        # built; all equilibrium and coil values stay dynamic traced arrays.
+        external_field = cfg.field_from_parameters(field_parameters)
+        bsqvac = cfg.vacuum_program.bsq(state, rt, external_field)
+    else:
+        bsqvac = fixed_bsqvac
+    rt = dataclasses.replace(rt, bsqvac_edge=bsqvac)
+    if formulation == "preconditioned":
+        force, _, _ = evaluate_forces(state, rt)
+    else:
+        force = im._raw_force_state(state, rt, include_edge=True)
+    return project(force)
 
 
 _FREE_MASK_CACHE: dict[tuple, SpectralState] = {}
@@ -724,6 +761,20 @@ def _solve_status_bwd(cfg, saved, cotangents):
     )
 
 
+# ``residual`` is a static jit key, so its identity must be stable across
+# gradient calls — :func:`_projected_residual`'s memo provides exactly that.
+# The previous per-call ``@jax.jit`` closure re-lowered and recompiled this
+# transpose (the largest program of the backward pass) on every host adjoint.
+@functools.partial(jax.jit, static_argnames=("residual",))
+def _transpose_matvec(value, z, p, field, base, rcon, zcon, *, residual):
+    """One compiled action of the coupled residual transpose at ``z``."""
+    _, unravel = ravel_pytree(z)
+    _, pullback = jax.vjp(
+        lambda zz: residual(zz, p, field, base, rcon, zcon), z
+    )
+    return ravel_pytree(pullback(unravel(value))[0])[0]
+
+
 def _host_adjoint(
     residual, z_star, params, field_parameters, frozen, rcon0, zcon0, rhs, cfg,
     *, x0=None,
@@ -737,12 +788,8 @@ def _host_adjoint(
     """
     rhs_flat, unravel = ravel_pytree(rhs)
 
-    @jax.jit
-    def matvec(value, z, p, field, base, rcon, zcon):
-        _, pullback = jax.vjp(
-            lambda zz: residual(zz, p, field, base, rcon, zcon), z
-        )
-        return ravel_pytree(pullback(unravel(value))[0])[0]
+    def matvec(value, *dynamic_args):
+        return _transpose_matvec(value, *dynamic_args, residual=residual)
 
     dynamic = (z_star, params, field_parameters, frozen, rcon0, zcon0)
 

--- a/vmex/mirror/free_boundary.py
+++ b/vmex/mirror/free_boundary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass, fields
 from typing import Any, Callable
 
@@ -250,11 +251,15 @@ class _FreeEquilibriumProblem:
 
         def matvec(direction: np.ndarray) -> np.ndarray:
             tangent = jnp.asarray(direction).reshape(-1)
-            return np.asarray(jax.jvp(residual, (point,), (tangent,))[1], dtype=float)
+            return np.asarray(
+                _tangent_action_lane(point, tangent, residual=residual),
+                dtype=float)
 
         def rmatvec(cotangent: np.ndarray) -> np.ndarray:
             cotangent = jnp.asarray(cotangent).reshape(-1)
-            return np.asarray(jax.vjp(residual, point)[1](cotangent)[0], dtype=float)
+            return np.asarray(
+                _adjoint_action_lane(point, cotangent, residual=residual),
+                dtype=float)
 
         return LinearOperator(
             (residual_size, self.size),
@@ -267,13 +272,27 @@ class _FreeEquilibriumProblem:
         """Return the JAX-native exact residual Jacobian action."""
 
         point = jnp.asarray(vector)
-        return jax.jit(
-            lambda direction: jax.jvp(
-                self.residual_function,
-                (point,),
-                (direction,),
-            )[1]
-        )
+        return lambda direction: _tangent_action_lane(
+            point, direction, residual=self.residual_function)
+
+
+# Module scope with ``residual`` static and the linearization point traced —
+# ``residual_function`` is built once per problem, so its identity keys one
+# compiled program per problem.  The previous per-call staging paid per
+# Newton step (``linear_action``: a fresh ``jax.jit`` closure re-tracing and
+# recompiling the residual JVP) or per Krylov iteration
+# (``linear_operator``: an eager ``jax.jvp``/``jax.vjp`` re-linearizing the
+# residual on every LSMR matvec of the host trust-region solve).
+@functools.partial(jax.jit, static_argnames=("residual",))
+def _tangent_action_lane(point: Array, direction: Array, *,
+                         residual: Callable[[Array], Array]) -> Array:
+    return jax.jvp(residual, (point,), (direction,))[1]
+
+
+@functools.partial(jax.jit, static_argnames=("residual",))
+def _adjoint_action_lane(point: Array, cotangent: Array, *,
+                         residual: Callable[[Array], Array]) -> Array:
+    return jax.vjp(residual, point)[1](cotangent)[0]
 
 
 def _spline_boundary_work(


### PR DESCRIPTION
Completes the campaign directive to make the cold-start/jit idioms universal, from a repo-wide static audit against the five disease classes fixed elsewhere this campaign (per-call fresh jits, linearize/transpose outside jit on hot paths, eager op-by-op setup chains, eager preflight before first output, identity-keyed caches).

**Fixed (3 findings, each with the per-call cost it removes):**
1. `freeboundary_implicit`: a fresh `@jax.jit` residual re-traced up to 4× per free-boundary gradient — now module-level `_projected_residual_lane` (cfg/formulation static) with a content-keyed mask memo (the `_canonical_config` precedent, cap 8).
2. `freeboundary_implicit._host_adjoint`: a fresh `matvec` jit recompiled the coupled transpose per adjoint solve — now module-level `_transpose_matvec` on the identity-stable residual.
3. `vmex/mirror/free_boundary`: the bounded Newton–Krylov polish built a fresh jit per Newton step and re-linearized eagerly per LSMR iteration — now `_tangent_action_lane`/`_adjoint_action_lane`, verified bit-exact against `jax.jvp`/`jax.vjp` and the dense-Jacobian parity test at 2e-13. Host SciPy orchestration untouched.

Measured: second free-boundary gradient 88.2 s → 42–54 s; third gradient compiles ~nothing (26.0 s).

**Deliberately left, with reasons in the audit**: already-content-keyed campaign machinery (problem jits, vacuum executables), the non-default Schur lane, test-only and cold-path linearizations, polish continuation numerics, per-driver mirror entry jits amortized within a host run, and the one-time hot-restart lane re-specialization. Examples audited: all clean — every jit already at module scope, nothing to change.

**Future runs guarded**: `tests/test_trace_budgets.py` gains `test_problem_construction_compile_budget_and_no_refinement` — smoke problem construction ≤ 310 compiled programs (measured 246 + headroom) with exactly 0 refinements, second trial point ≤ 1 program, third exactly 0.

Suites: trace-budgets 4, freeboundary-implicit 10 (incl. FD gradient certificates), mirror free-boundary 3 (incl. new-lane parity), refine-staging 2; ruff clean.