### PR TITLE
Make the Codecov upload best-effort so the diff-cover gate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,13 @@ jobs:
       - name: Publish combined coverage
         uses: codecov/codecov-action@v5.5.5
         with:
-          fail_ci_if_error: true
+          # Best-effort: the Codecov upload started 404ing ("Repository not
+          # found", OIDC/app installation drift) on 2026-09-02, and with
+          # fail_ci_if_error it aborted this job BEFORE the changed-line
+          # gate below could run — killing the local gate over a
+          # third-party outage.  The enforced gates are the mirror floor
+          # above and diff-cover below; the upload is telemetry.
+          fail_ci_if_error: false
           files: coverage.xml
           use_oidc: true
       - name: Enforce changed-line coverage


### PR DESCRIPTION
The Codecov upload began failing with `{"message":"Repository not found"}` (OIDC/app-installation drift on the service side) on 2026-09-02 — reproduced on the #240 and #241 runs. With `fail_ci_if_error: true` that abort happens **before** the changed-line diff-cover step, so the local coverage gate has been silently dead on every PR while a third-party service 404s. This flips the upload to best-effort; the enforced gates remain the mirror coverage floor and diff-cover, which now actually run.

Org-side follow-up (needs repository admin, out of scope here): re-link the repo in Codecov / refresh the app installation so uploads resume.