### PR TITLE
Polish observability: phase banner, GN progress, certificate verdict, and input-file knobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,13 +335,41 @@ Enable it in a VMEC-compatible input deck:
 
 ```fortran
 !@VMEX POLISH = AUTO
+!@VMEX POLISH_TOL = 1.0E-3
+!@VMEX POLISH_MAX_ITER = 40
 &INDATA
   ...
 /
 ```
 
-VMEX reads the comment; VMEC2000 ignores it. The same opt-in is available in
-Python:
+VMEX reads the comments; VMEC2000 ignores them. `POLISH = AUTO` resolves to:
+lift the converged final stage to clamped radial B-splines of degree 3 with
+about one span per two radial mesh points (capped at 32 spans), return at
+once if that lifted state already passes the independent certificate
+(volume L2 at or below `1.0E-2`), and otherwise run up to 80 Gauss-Newton
+iterations at relative tolerance `1.0E-3`. `ON` runs the same path today;
+`OFF` is the default. The other directives, each mapped onto the matching
+`PolishConfig` field:
+
+| Directive | Meaning | Default |
+|---|---|---|
+| `POLISH = AUTO \| ON \| OFF` | polish once after the final fixed-boundary stage | `OFF` |
+| `POLISH_TOL` | Gauss-Newton relative tolerance (`tolerance`) | `1.0E-3` |
+| `POLISH_DEGREE = 3 \| 5 \| 7` | radial B-spline degree (`radial_degree`) | `3` |
+| `POLISH_SPANS` | radial spans of the polished basis (`radial_spans`) | resolution-derived, at most 32 |
+| `POLISH_MAX_ITER` | Gauss-Newton iteration cap (`max_nonlinear_iterations`) | `80` |
+| `POLISH_FAIL = ERROR \| FALLBACK \| WARN` | failed polish: raise, return unpolished, or warn | `ERROR` |
+
+The CLI mirrors every directive (`--polish`, `--polish-tol`,
+`--polish-degree`, `--polish-spans`, `--polish-max-iter`, `--polish-fail`,
+`--no-polish`) and the precedence is `CLI flag > Python keyword > file
+directive > package default`; an explicit `polish_config` in Python wins
+over all scalar knobs. During a CLI run the phase announces itself: a
+`BEGIN FORCE POLISHING` banner with the resolved settings, a compile notice
+for the first polish executable build, one row per Gauss-Newton iteration,
+and a closing certificate verdict that names any failed check.
+
+The same opt-in is available in Python:
 
 ```python
 import vmex as vj

--- a/docs/reference/api/advanced.rst
+++ b/docs/reference/api/advanced.rst
@@ -47,6 +47,8 @@ VMEC deck enables the same path with comment directives that VMEC2000 ignores::
    !@VMEX POLISH_TOL = 1.0E-8
    !@VMEX POLISH_FAIL = ERROR
    !@VMEX POLISH_DEGREE = 5
+   !@VMEX POLISH_MAX_ITER = 40
+   !@VMEX POLISH_SPANS = 16
 
 (the original single-flag spelling ``! VMEX: POLISH_FORCE_BALANCE = .TRUE.``
 still parses).  Directives are execution metadata, owned by

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -101,6 +101,12 @@ Options
        return it and print a warning. Never a silent substitution.
    * - ``--polish-degree {3,5,7}``
      - Radial B-spline degree of the polished representation.
+   * - ``--polish-max-iter N``
+     - Cap the polish Gauss-Newton iterations
+       (:class:`vmex.PolishConfig` ``max_nonlinear_iterations``).
+   * - ``--polish-spans N``
+     - Radial B-spline spans of the polished representation
+       (default: derived from the solve resolution, at most 32).
    * - ``--restart WOUT``
      - Hot-restart the solve from a ``wout_*.nc`` file (VMEX- or
        VMEC2000-written): the equilibrium state is rebuilt from the file,

--- a/plan.md
+++ b/plan.md
@@ -765,6 +765,30 @@ print(result.polish_report.total_seconds)
 
 **Acceptance:** one documented input runs in both VMEC2000 and VMEX; only VMEX activates polishing.
 
+### 8.8 Phase 1 follow-ups (user feedback, recorded 2026-09-02)
+
+Field reports from a W7-X polish run; each item stays here until closed by a
+merged PR:
+
+1. Polish observability: the polish phase printed nothing after the legacy
+   iteration table — no banner, no compile attribution, no per-iteration
+   rows, no certificate verdict — so a run that was dying could not be told
+   from one that was converging. Fix in flight on
+   `feat/polish-verbosity-and-knobs`: CLI-only `BEGIN FORCE POLISHING`
+   banner with the resolved config, ` compiling ... polish executable`
+   notice, one row per Gauss-Newton step from the SOLVAX history, and a
+   certificate summary that names any failed check.
+2. Input-file control: `AUTO` was the only documented directive value and
+   the deck could not set the solver knobs. Same branch adds
+   `POLISH_MAX_ITER` and `POLISH_SPANS` beside `POLISH`/`POLISH_TOL`/
+   `POLISH_DEGREE`/`POLISH_FAIL`, matching CLI flags, and README reference
+   material stating what `AUTO` resolves to and the
+   `CLI > Python > file > default` precedence.
+3. The 0.8.0 report of the polish phase dying by OOM at `MPOL = NTOR = 10`
+   is fixed by #234 (polish jits no longer bake per-solve constants); the
+   fix shipped in v0.8.1 (2026-09-02). Close after confirming the reporter
+   runs v0.8.1 or later.
+
 ---
 
 ## 9. Phase 2 - Build one complete performance and compilation observability suite

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -329,3 +329,20 @@ def test_lforbal_iteration_exhaustion_writes_wout(tmp_path):
     wout = read_wout(wout_path)
     assert int(wout.ier_flag) == MORE_ITER_FLAG
     assert bool(wout.lmove_axis) is False
+
+
+def test_polish_cli_flags_override_file_directives():
+    """--polish-* flags beat !@VMEX directives; untouched fields stay file."""
+    from vmex.core.run_options import parse_indata_run_options
+
+    file_options = parse_indata_run_options(
+        "!@VMEX POLISH = AUTO\n!@VMEX POLISH_TOL = 5.0E-3\n"
+        "!@VMEX POLISH_MAX_ITER = 12\n&INDATA\n/\n")
+    args = cli.build_parser().parse_args(
+        ["input.x", "--polish-tol", "1e-2", "--polish-spans", "8"])
+    options, sources = cli._resolve_polish_cli(args, file_options)
+    assert options.polish == "auto" and sources["polish"] == "file"
+    assert options.polish_tol == 1e-2 and sources["polish_tol"] == "cli"
+    assert options.polish_max_iter == 12
+    assert sources["polish_max_iter"] == "file"
+    assert options.polish_spans == 8 and sources["polish_spans"] == "cli"

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -170,6 +170,48 @@ def test_compile_notice_variants():
     )
 
 
+def test_polish_banner_states_the_resolved_config():
+    banner = printing.polish_banner(
+        mode="auto", degree=3, spans=None, ns=31,
+        tolerance=1e-3, certificate_tolerance=1e-2, max_iterations=80)
+    assert "BEGIN FORCE POLISHING" in banner
+    assert "MODE = AUTO" in banner and "DEGREE = 3" in banner
+    assert "SPANS = AUTO" in banner and "NS =   31" in banner
+    assert "TOL = 1.000E-03" in banner
+    assert "CERTIFICATE TOL = 1.000E-02" in banner
+    assert "MAX ITER =   80" in banner
+    explicit = printing.polish_banner(
+        mode="on", degree=5, spans=16, ns=51,
+        tolerance=1e-2, certificate_tolerance=1e-2, max_iterations=40)
+    assert "MODE = ON" in explicit and "SPANS = 16" in explicit
+
+
+def test_polish_screen_rows():
+    assert printing.polish_screen_line(0, 1.23e-1, 4.5, 1e-3) == (
+        "    0  1.23E-01  4.50E+00  1.00E-03\n"
+    )
+    accepted = printing.polish_screen_line(
+        3, 2.3e-2, 1.1, 2.5e-4, ratio=0.98, linear_iterations=12)
+    assert accepted == "    3  2.30E-02  1.10E+00  2.50E-04  9.80E-01      12\n"
+    rejected = printing.polish_screen_line(
+        4, 2.3e-2, 1.1, 1e-3, ratio=-0.5, linear_iterations=30,
+        accepted=False)
+    assert rejected.endswith("  rejected\n")
+
+
+def test_polish_certificate_summary_names_failed_checks():
+    certified = printing.polish_certificate_summary(
+        1.281e-2, 1.807e-3, 1e-2, verdict="CERTIFIED")
+    assert "1.281E-02" in certified and "1.807E-03" in certified
+    assert certified.rstrip().endswith("POLISH CERTIFIED")
+    failed = printing.polish_certificate_summary(
+        1.281e-2, 2.3e-2, 1e-2, verdict="FAILED",
+        failed_checks=(
+            "independent force L2 2.300E-02 > tolerance 1.000E-02",))
+    assert "POLISH FAILED" in failed
+    assert "FAILED CHECK : independent force L2" in failed
+
+
 def test_emit_flushed_writes_and_flushes(capsys):
     """The CLI sink must flush every line so file-redirected cluster logs
     stream in real time (an unflushed run shows nothing for hours)."""

--- a/tests/test_run_options.py
+++ b/tests/test_run_options.py
@@ -40,11 +40,13 @@ def test_all_directives_parse_together_with_inline_comments():
         "  ! @ VMEX  POLISH_TOL = 2.5E-4   ! tighter than default\n"
         "!@vmex polish_fail = FALLBACK\n"
         "!@VMEX POLISH_DEGREE = 5\n"
+        "!@VMEX POLISH_MAX_ITER = 40\n"
+        "!@VMEX POLISH_SPANS = 16\n"
         "&INDATA\nMPOL = 3\n/\n"
     )
     assert options == RunOptions(
         polish="auto", polish_tol=2.5e-4, polish_fail="fallback",
-        polish_degree=5)
+        polish_degree=5, polish_max_iter=40, polish_spans=16)
 
 
 def test_no_directives_means_package_defaults():
@@ -78,6 +80,10 @@ def test_consistent_repetition_is_allowed_and_conflict_is_an_error():
         ("!@VMEX POLISH_DEGREE = 4", "3, 5, 7"),
         ("!@VMEX POLISH_DEGREE = five", "integer"),
         ("!@VMEX POLISH_FAIL = explode", "error"),
+        ("!@VMEX POLISH_MAX_ITER = 0", "positive"),
+        ("!@VMEX POLISH_MAX_ITER = soon", "integer"),
+        ("!@VMEX POLISH_SPANS = -2", "positive"),
+        ("!@VMEX POLISH_SPANS = few", "integer"),
         ("!@VMEX POLISH_MODE = auto", "unknown VMEX directive"),
     ],
 )
@@ -96,7 +102,7 @@ def test_quoted_exclamation_marks_do_not_become_directives():
 
 def test_directive_round_trip_through_format():
     options = RunOptions(polish="auto", polish_tol=1e-8, polish_fail="warn",
-                         polish_degree=7)
+                         polish_degree=7, polish_max_iter=40, polish_spans=16)
     text = format_indata_directives(options) + "&INDATA\nMPOL = 3\n/\n"
     assert parse_indata_run_options(text) == options
     assert format_indata_directives(RunOptions()) == ""
@@ -152,14 +158,44 @@ def test_precedence_python_over_file_over_default():
     assert sources["polish"] == "python" and sources["polish_degree"] == "file"
 
 
+def test_directive_file_reaches_the_polish_config(tmp_path):
+    """A deck's POLISH_* directives land on the driver PolishConfig fields."""
+    source = tmp_path / "input.knobs"
+    source.write_text(
+        "!@VMEX POLISH = AUTO\n"
+        "!@VMEX POLISH_TOL = 5.0E-3\n"
+        "!@VMEX POLISH_MAX_ITER = 12\n"
+        "!@VMEX POLISH_SPANS = 8\n"
+        + (DATA / "input.solovev").read_text(encoding="utf-8"),
+        encoding="utf-8")
+    request = read_input_request(source)
+    options, sources = resolve_run_options(request.options)
+    assert sources["polish_tol"] == "file"
+    config = polish_config_from_options(options)
+    assert config.tolerance == 5.0e-3
+    assert config.max_nonlinear_iterations == 12
+    assert config.radial_spans == 8
+    # A Python keyword (the CLI passes its flags through the same seam)
+    # overrides the deck for that field only.
+    options, sources = resolve_run_options(request.options, polish_max_iter=30)
+    config = polish_config_from_options(options)
+    assert config.max_nonlinear_iterations == 30
+    assert config.tolerance == 5.0e-3
+    assert sources["polish_max_iter"] == "python"
+    assert sources["polish_spans"] == "file"
+
+
 def test_polish_config_mapping_and_explicit_config_priority():
     from vmex.core.polish_driver import PolishConfig
 
     options = RunOptions(polish=True, polish_tol=1e-5, polish_degree=5,
-                         polish_fail="fallback")
+                         polish_fail="fallback", polish_max_iter=40,
+                         polish_spans=16)
     config = polish_config_from_options(options)
     assert config.tolerance == 1e-5
     assert config.radial_degree == 5
+    assert config.max_nonlinear_iterations == 40
+    assert config.radial_spans == 16
     assert config.fail_policy == "return_unpolished"
     # Nothing beyond driver defaults requested -> no config object at all,
     # keeping the plain path identical to before this module existed.

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -307,6 +307,18 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--polish-degree", type=int, default=None, choices=(3, 5, 7),
         help="Radial B-spline degree of the polished representation.")
+    p.add_argument(
+        "--polish-max-iter", type=int, default=None,
+        help=(
+            "Cap the polish Gauss-Newton iterations "
+            "(PolishConfig.max_nonlinear_iterations)."
+        ))
+    p.add_argument(
+        "--polish-spans", type=int, default=None,
+        help=(
+            "Radial B-spline spans of the polished representation "
+            "(default: derived from the solve resolution)."
+        ))
     p.add_argument("--ftol", type=float, default=None, help="Override the final-stage FTOL_ARRAY tolerance.")
     p.add_argument("--max-iter", type=int, default=None, help="Override the final-stage NITER_ARRAY iteration cap.")
     p.add_argument(
@@ -495,10 +507,14 @@ def _resolve_polish_cli(args, file_options):
         polish_tol=args.polish_tol,
         polish_fail=args.polish_fail,
         polish_degree=args.polish_degree,
+        polish_max_iter=args.polish_max_iter,
+        polish_spans=args.polish_spans,
     )
     cli_supplied = {
         "polish": args.polish, "polish_tol": args.polish_tol,
         "polish_fail": args.polish_fail, "polish_degree": args.polish_degree,
+        "polish_max_iter": args.polish_max_iter,
+        "polish_spans": args.polish_spans,
     }
     sources = {name: ("cli" if cli_supplied[name] is not None else origin)
                for name, origin in sources.items()}

--- a/vmex/core/multigrid.py
+++ b/vmex/core/multigrid.py
@@ -601,6 +601,8 @@ def solve_multigrid(
         polish=polish,
         polish_config=polish_config,
         lconm1=lconm1,
+        verbose=verbose,
+        emit=emit,
     )
 
 
@@ -990,6 +992,8 @@ def solve_file(
     polish_tol: float | None = None,
     polish_fail: str | None = None,
     polish_degree: int | None = None,
+    polish_max_iter: int | None = None,
+    polish_spans: int | None = None,
     write_wout: bool = True,
     outdir=None,
     **solve_kwargs,
@@ -1003,8 +1007,12 @@ def solve_file(
 
     ``polish_fail`` selects what a failed polish does: ``"error"`` raises
     (driver default), ``"fallback"`` returns the unpolished state, ``"warn"``
-    does the same and emits a :class:`RuntimeWarning`.  An explicit
-    ``polish_config`` wins over the scalar overrides entirely.
+    does the same and emits a :class:`RuntimeWarning`.  ``polish_tol``,
+    ``polish_degree``, ``polish_max_iter``, and ``polish_spans`` override
+    the matching :class:`~vmex.core.polish_driver.PolishConfig` fields, with
+    the documented precedence ``CLI flag > Python keyword > file directive >
+    package default``; an explicit ``polish_config`` wins over the scalar
+    overrides entirely.
 
     ``write_wout=True`` writes ``wout_<case>.nc`` beside the input (or into
     ``outdir``) — the same output contract as ``vmex <input>``.  When
@@ -1025,6 +1033,7 @@ def solve_file(
     options, sources = resolve_run_options(
         request.options, polish=polish, polish_tol=polish_tol,
         polish_fail=polish_fail, polish_degree=polish_degree,
+        polish_max_iter=polish_max_iter, polish_spans=polish_spans,
     )
     config = polish_config_from_options(options, polish_config)
     inp = request.input

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -21,6 +21,13 @@ import numpy as np
 from solvax import gmres
 
 from .errors import StrongForceCertificationError, StrongForceContinuationError
+from .printing import (
+    POLISH_SCREEN_HEADER,
+    compile_notice,
+    emit_flushed,
+    polish_certificate_summary,
+    polish_screen_line,
+)
 from .polish import (
     StrongModeBlockPreconditioner,
     StrongPhysicalChart,
@@ -1085,12 +1092,70 @@ def _collocation_variable_scale(
     return 1.0 / np.maximum(column_norm, column_floor)
 
 
+#: Lane structures whose first-use compile notice was already attributable
+#: in this process — the polish analogue of the solver's used-lane keys.
+_POLISH_LANE_NOTICED: set[Any] = set()
+
+
+def _failed_certificate_checks(
+    certificate: StrongForceReport, config: PolishConfig
+) -> tuple[str, ...]:
+    """Name each independent acceptance check the certificate failed."""
+
+    failed = []
+    if float(certificate.normalized_l2) > config.certificate_tolerance:
+        failed.append(
+            f"independent force L2 {float(certificate.normalized_l2):.3E}"
+            f" > tolerance {config.certificate_tolerance:.3E}")
+    if (float(certificate.radial_refinement_difference)
+            > config.radial_refinement_tolerance):
+        failed.append(
+            "radial refinement difference "
+            f"{float(certificate.radial_refinement_difference):.3E}"
+            f" > tolerance {config.radial_refinement_tolerance:.3E}")
+    if float(certificate.minimum_signed_jacobian) <= 0.0:
+        failed.append(
+            "minimum signed Jacobian "
+            f"{float(certificate.minimum_signed_jacobian):.3E} <= 0")
+    return tuple(failed)
+
+
+def _emit_gauss_newton_rows(solution: Any, emit: Any) -> None:
+    """Print the fixed-shape SOLVAX history as a screen table.
+
+    The Gauss--Newton loop runs inside one jitted ``lax.while_loop`` with no
+    host callbacks, so rows appear when the solve returns rather than live;
+    the banner and compile notice bracket that silent window on screen.
+    Everything printed already exists in ``solution.history`` — no extra
+    computation.
+    """
+
+    history = solution.history
+    cost = np.asarray(history.cost)
+    gradient = np.asarray(history.gradient_norm)
+    damping = np.asarray(history.damping)
+    ratio = np.asarray(history.ratio)
+    accepted = np.asarray(history.accepted)
+    linear = np.asarray(history.linear_iterations)
+    emit(POLISH_SCREEN_HEADER, end="")
+    emit(polish_screen_line(0, float(cost[0]), float(gradient[0]),
+                            float(damping[0])), end="")
+    for step in range(int(solution.steps)):
+        emit(polish_screen_line(
+            step + 1, float(cost[step + 1]), float(gradient[step + 1]),
+            float(damping[step + 1]), ratio=float(ratio[step]),
+            linear_iterations=int(linear[step]),
+            accepted=bool(accepted[step])), end="")
+
+
 def polish_collocation_least_squares(
     runtime: StrongRootRuntime,
     *,
     config: PolishConfig | None = None,
     chart: StrongPhysicalChart | None = None,
     initial_certificate: StrongForceReport | None = None,
+    verbose: bool = False,
+    emit: Any = emit_flushed,
 ) -> PolishResult:
     """Solve and certify the overdetermined physical force residual.
 
@@ -1098,6 +1163,10 @@ def polish_collocation_least_squares(
     point. SOLVAX applies matrix-free JVP/VJP normal products; no dense
     Jacobian is formed. The returned correction uses the full constrained
     layout so it composes with the existing native-state utilities.
+
+    ``verbose=True`` prints the CLI progress lines (compile notice,
+    Gauss--Newton rows, certificate summary) through ``emit``; the default
+    keeps the Python API silent, and printing never changes the numerics.
     """
 
     from solvax import LeastSquaresConfig
@@ -1117,6 +1186,19 @@ def polish_collocation_least_squares(
         1.0e-12,
     )
     collocation_scale_array = jnp.asarray(collocation_scale)
+
+    if verbose:
+        emit(f" collocation: {int(initial_collocation.size)} residual rows, "
+             f"{int(chart.size)} unknowns")
+    # First use of this lane structure in the process compiles the probe and
+    # Gauss-Newton executables — the pause users previously read as a hang.
+    if not jax.config.jax_disable_jit:
+        lane_key = (int(chart.size), int(initial_collocation.size), config)
+        first_use = lane_key not in _POLISH_LANE_NOTICED
+        _POLISH_LANE_NOTICED.add(lane_key)
+        if verbose and first_use:
+            emit(compile_notice(int(np.asarray(runtime.radial_nodes).size),
+                                lane="polish"), end="")
 
     variable_scale = _collocation_variable_scale(
         runtime,
@@ -1142,6 +1224,8 @@ def polish_collocation_least_squares(
         zero, runtime, chart, variable_scale_array,
         collocation_scale_array, least_squares_config)
     jax.block_until_ready(solution)
+    if verbose:
+        _emit_gauss_newton_rows(solution, emit)
     vector = variable_scale_array * solution.x
     state = _corrected_state(vector, runtime, chart)
     certificate = certify_strong_force(state)
@@ -1190,6 +1274,15 @@ def polish_collocation_least_squares(
         variable_scale_max=float(np.max(variable_scale)),
         variable_scale_probes=config.collocation_scale_probes,
     )
+    if verbose:
+        emit(polish_certificate_summary(
+            report.initial_normalized_l2, report.final_normalized_l2,
+            config.certificate_tolerance,
+            verdict="CERTIFIED" if converged else "FAILED",
+            failed_checks=(
+                () if converged
+                else _failed_certificate_checks(certificate, config))),
+            end="")
     if converged:
         return PolishResult(
             state,
@@ -1220,8 +1313,15 @@ def polish_legacy_solution(
     *,
     config: PolishConfig | None = None,
     lconm1: bool = True,
+    verbose: bool = False,
+    emit: Any = emit_flushed,
 ) -> PolishResult:
-    """Refine and lift one converged legacy solve, then run the strong driver."""
+    """Refine and lift one converged legacy solve, then run the strong driver.
+
+    ``verbose=True`` routes the CLI progress lines through ``emit`` (the
+    solver prints the phase banner before calling here); the default keeps
+    the Python API silent and printing never changes the numerics.
+    """
 
     started = perf_counter()
     from . import implicit
@@ -1272,6 +1372,10 @@ def polish_legacy_solution(
         degree=config.radial_degree,
     )
     initial_certificate = certify_strong_force(certified_native)
+    if verbose:
+        emit(" initial certificate: EPS-F = "
+             f"{float(initial_certificate.normalized_l2):.3E}"
+             f"  (tolerance {config.certificate_tolerance:.3E})")
     if float(initial_certificate.normalized_l2) <= config.certificate_tolerance:
         report = PolishReport(
             converged=True,
@@ -1289,6 +1393,11 @@ def polish_legacy_solution(
             factor_build_seconds=0.0,
             solve_seconds=perf_counter() - started,
         )
+        if verbose:
+            emit(polish_certificate_summary(
+                report.initial_normalized_l2, report.final_normalized_l2,
+                config.certificate_tolerance,
+                verdict="ALREADY CERTIFIED (no correction applied)"), end="")
         return PolishResult(
             certified_native,
             initial_certificate,
@@ -1317,6 +1426,8 @@ def polish_legacy_solution(
         runtime,
         config=config,
         initial_certificate=initial_certificate,
+        verbose=verbose,
+        emit=emit,
     )
     return result._replace(
         compatibility_state=polished_compatibility_state(refined_state, result)

--- a/vmex/core/printing.py
+++ b/vmex/core/printing.py
@@ -214,6 +214,96 @@ def threed1_line(
     return line + "\n"
 
 
+def polish_banner(
+    *,
+    mode: str,
+    degree: int,
+    spans: int | None,
+    ns: int,
+    tolerance: float,
+    certificate_tolerance: float,
+    max_iterations: int,
+) -> str:
+    """Polish-phase opening banner (VMEX-native; no VMEC2000 counterpart).
+
+    Printed in the register of :data:`FORCE_ITERATIONS_BANNER` when the
+    optional force-balance polish starts, stating the resolved
+    :class:`~vmex.core.polish_driver.PolishConfig`: the request mode, radial
+    B-spline degree and spans (``spans=None`` means the resolution-derived
+    default of ``lift_high_order_state``), the solve radial resolution
+    feeding the lift (``ns``; the driver reports the actual collocation grid
+    on its own lines), the Gauss--Newton relative tolerance, the independent
+    certificate tolerance, and the nonlinear iteration cap.
+    """
+    spans_text = "AUTO" if spans is None else f"{int(spans)}"
+    return (
+        "\n -----------------------\n"
+        " BEGIN FORCE POLISHING\n"
+        " -----------------------\n"
+        f"  MODE = {mode.upper()}  DEGREE = {int(degree)}"
+        f"  SPANS = {spans_text}  NS = {int(ns):4d}\n"
+        f"  TOL = {float(tolerance):9.3E}"
+        f"  CERTIFICATE TOL = {float(certificate_tolerance):9.3E}"
+        f"  MAX ITER = {int(max_iterations):4d}\n"
+    )
+
+
+#: Column header for the Gauss--Newton polish rows (:func:`polish_screen_line`).
+POLISH_SCREEN_HEADER = (
+    "\n  ITER    COST      GRAD     DAMPING     RATIO   LIN-ITS\n"
+)
+
+
+def polish_screen_line(
+    iteration: int,
+    cost: float,
+    gradient_norm: float,
+    damping: float,
+    *,
+    ratio: float | None = None,
+    linear_iterations: int | None = None,
+    accepted: bool = True,
+) -> str:
+    """One Gauss--Newton polish row in the screen-line register.
+
+    Row 0 is the initial state and carries no trial diagnostics; later rows
+    add the trust ratio, the inner PCG iteration count, and a ``rejected``
+    marker for trial steps the trust region refused (their damping still
+    adapts, so the row is informative even without an accepted move).
+    """
+    line = f"{iteration:5d}{cost:10.2E}{gradient_norm:10.2E}{damping:10.2E}"
+    if ratio is not None and linear_iterations is not None:
+        line += f"{ratio:10.2E}{linear_iterations:8d}"
+        if not accepted:
+            line += "  rejected"
+    return line + "\n"
+
+
+def polish_certificate_summary(
+    initial_l2: float,
+    final_l2: float,
+    tolerance: float,
+    *,
+    verdict: str,
+    failed_checks: tuple[str, ...] = (),
+) -> str:
+    """Closing certificate block for one polish attempt.
+
+    ``verdict`` is the human-readable outcome (``CERTIFIED``, ``ALREADY
+    CERTIFIED``, ``FAILED``); ``failed_checks`` names each independent check
+    that rejected the state so a failure is diagnosable from the console
+    alone.
+    """
+    lines = [
+        "",
+        f" POLISH CERTIFICATE : EPS-F {float(initial_l2):10.3E} ->"
+        f" {float(final_l2):10.3E}  (TOLERANCE {float(tolerance):10.3E})",
+        f" POLISH {verdict}",
+    ]
+    lines.extend(f"   FAILED CHECK : {check}" for check in failed_checks)
+    return "\n".join(lines) + "\n"
+
+
 def termination_summary(
     ier_flag: int,
     input_name: str,

--- a/vmex/core/run_options.py
+++ b/vmex/core/run_options.py
@@ -14,6 +14,8 @@ Two directive spellings are accepted, both VMEC-safe comments::
     !@VMEX POLISH_TOL = 1.0E-8
     !@VMEX POLISH_FAIL = ERROR
     !@VMEX POLISH_DEGREE = 5
+    !@VMEX POLISH_MAX_ITER = 40
+    !@VMEX POLISH_SPANS = 16
 
 and the original single-flag form from the polishing integration::
 
@@ -72,8 +74,11 @@ class RunOptions:
 
     ``polish`` is ``False``, ``True``, or ``"auto"`` (polish only when the
     legacy solve converged and the physics is in the supported set).
-    ``polish_tol``/``polish_degree`` override the matching
-    :class:`~vmex.core.polish_driver.PolishConfig` fields when set.
+    ``polish_tol``/``polish_degree``/``polish_max_iter``/``polish_spans``
+    override the matching :class:`~vmex.core.polish_driver.PolishConfig`
+    fields (``tolerance``, ``radial_degree``, ``max_nonlinear_iterations``,
+    ``radial_spans``) when set; only knobs that exist on the driver config
+    are exposed here.
     ``polish_fail`` maps onto the driver's fail policy: ``"error"`` raises,
     ``"fallback"`` returns the unpolished state silently, ``"warn"`` returns
     it with a :class:`RuntimeWarning`.
@@ -83,6 +88,8 @@ class RunOptions:
     polish_tol: float | None = None
     polish_fail: str = "error"
     polish_degree: int | None = None
+    polish_max_iter: int | None = None
+    polish_spans: int | None = None
 
     def __post_init__(self) -> None:
         if self.polish not in _POLISH_MODES:
@@ -99,6 +106,12 @@ class RunOptions:
             raise VmecInputError(
                 f"POLISH_DEGREE must be one of {_DEGREES}, "
                 f"got {self.polish_degree!r}")
+        if self.polish_max_iter is not None and self.polish_max_iter < 1:
+            raise VmecInputError(
+                f"POLISH_MAX_ITER must be positive, got {self.polish_max_iter!r}")
+        if self.polish_spans is not None and self.polish_spans < 1:
+            raise VmecInputError(
+                f"POLISH_SPANS must be positive, got {self.polish_spans!r}")
 
 
 @dataclass(frozen=True)
@@ -134,15 +147,16 @@ def _parse_directive_value(key: str, token: str) -> tuple[str, Any]:
                 f"POLISH_TOL must be a real number, got {token!r}") from error
     if key == "POLISH_FAIL":
         return "polish_fail", token.strip().lower()
-    if key == "POLISH_DEGREE":
+    if key in ("POLISH_DEGREE", "POLISH_MAX_ITER", "POLISH_SPANS"):
         try:
-            return "polish_degree", int(token.rstrip(","))
+            return key.lower(), int(token.rstrip(","))
         except ValueError as error:
             raise VmecInputError(
-                f"POLISH_DEGREE must be an integer, got {token!r}") from error
+                f"{key} must be an integer, got {token!r}") from error
     raise VmecInputError(
         f"unknown VMEX directive {key!r} "
-        "(known: POLISH, POLISH_TOL, POLISH_FAIL, POLISH_DEGREE)")
+        "(known: POLISH, POLISH_TOL, POLISH_FAIL, POLISH_DEGREE, "
+        "POLISH_MAX_ITER, POLISH_SPANS)")
 
 
 def parse_indata_run_options(text: str) -> RunOptions:
@@ -210,6 +224,10 @@ def format_indata_directives(options: RunOptions) -> str:
         lines.append(f"!@VMEX POLISH_FAIL = {options.polish_fail.upper()}")
     if options.polish_degree is not None:
         lines.append(f"!@VMEX POLISH_DEGREE = {options.polish_degree}")
+    if options.polish_max_iter is not None:
+        lines.append(f"!@VMEX POLISH_MAX_ITER = {options.polish_max_iter}")
+    if options.polish_spans is not None:
+        lines.append(f"!@VMEX POLISH_SPANS = {options.polish_spans}")
     return "\n".join(lines) + ("\n" if lines else "")
 
 
@@ -244,6 +262,8 @@ def resolve_run_options(
     polish_tol: float | None = None,
     polish_fail: str | None = None,
     polish_degree: int | None = None,
+    polish_max_iter: int | None = None,
+    polish_spans: int | None = None,
 ) -> tuple[RunOptions, dict[str, str]]:
     """Apply the documented precedence and record where each value came from.
 
@@ -260,7 +280,9 @@ def resolve_run_options(
         for field in fields(RunOptions)
     }
     overrides = {"polish": polish, "polish_tol": polish_tol,
-                 "polish_fail": polish_fail, "polish_degree": polish_degree}
+                 "polish_fail": polish_fail, "polish_degree": polish_degree,
+                 "polish_max_iter": polish_max_iter,
+                 "polish_spans": polish_spans}
     updates = {name: value for name, value in overrides.items()
                if value is not None}
     if updates:
@@ -284,6 +306,10 @@ def polish_config_from_options(options: RunOptions, base: Any = None) -> Any:
         updates["tolerance"] = options.polish_tol
     if options.polish_degree is not None:
         updates["radial_degree"] = options.polish_degree
+    if options.polish_max_iter is not None:
+        updates["max_nonlinear_iterations"] = options.polish_max_iter
+    if options.polish_spans is not None:
+        updates["radial_spans"] = options.polish_spans
     if options.polish_fail in ("fallback", "warn"):
         updates["fail_policy"] = "return_unpolished"
     if not updates:

--- a/vmex/core/solver.py
+++ b/vmex/core/solver.py
@@ -159,7 +159,7 @@ from .preconditioner import (
 from .preconditioner_2d import Prec2DConfig, newton_direction
 from .printing import (
     FORCE_ITERATIONS_BANNER, compile_notice, emit_flushed, improved_axis_block,
-    screen_header, screen_line, stage_banner,
+    polish_banner, screen_header, screen_line, stage_banner,
 )
 from .residuals import (
     ForceResiduals, PreconditionedResiduals, apply_lambda_preconditioner,
@@ -2486,8 +2486,16 @@ def _polish_solve_result(
     polish: bool | str,
     polish_config: Any,
     lconm1: bool,
+    verbose: bool = False,
+    emit: Any = emit_flushed,
 ) -> SolveResult:
-    """Attach the optional certified native and sampled polish products."""
+    """Attach the optional certified native and sampled polish products.
+
+    ``verbose`` follows the solver's CLI printing convention: the phase
+    banner states the resolved polish configuration, and the driver prints
+    its own progress through the same ``emit``.  The default keeps library
+    calls silent.
+    """
 
     if polish is False:
         return result
@@ -2495,12 +2503,25 @@ def _polish_solve_result(
 
     if polish_config is not None and not isinstance(polish_config, PolishConfig):
         raise TypeError("polish_config must be a PolishConfig")
+    if verbose:
+        resolved = PolishConfig() if polish_config is None else polish_config
+        emit(polish_banner(
+            mode="auto" if polish == "auto" else "on",
+            degree=resolved.radial_degree,
+            spans=resolved.radial_spans,
+            ns=int(resolution.ns),
+            tolerance=resolved.tolerance,
+            certificate_tolerance=resolved.certificate_tolerance,
+            max_iterations=resolved.max_nonlinear_iterations,
+        ), end="")
     polished = polish_legacy_solution(
         source,
         resolution,
         result.state,
         config=polish_config,
         lconm1=lconm1,
+        verbose=verbose,
+        emit=emit,
     )
     return replace(
         result,
@@ -2677,4 +2698,6 @@ def solve(
             polish=polish,
             polish_config=polish_config,
             lconm1=lconm1,
+            verbose=verbose,
+            emit=emit,
         )


### PR DESCRIPTION
From direct user feedback: a W7-X polish run printed nothing after the force iterations and then died — no way to tell proceeding from stalling (the death itself was the v0.8.0 OOM, fixed by #234 and already shipped in v0.8.1; the silence is what this PR fixes).

**Console output** (CLI verbose path; python API stays silent by default): a BEGIN FORCE POLISHING banner stating the resolved configuration — so `AUTO` is no longer a black box — a `compiling NS = .. polish executable...` notice exactly where users perceived a hang, one row per Gauss–Newton iteration (cost, gradient, damping, ratio, linear iterations — values SOLVAX already computes; printing is read-only), and a certificate summary: `EPS-F 1.284E-02 -> 1.811E-03, POLISH CERTIFIED`, or on rejection one `FAILED CHECK :` line per independent check before the exception. A run dying mid-polish is now attributable to a phase.

**Input-file directives** (only knobs that already exist on PolishConfig): `!@VMEX POLISH = AUTO|ON|OFF`, `POLISH_TOL`, `POLISH_DEGREE = 3|5|7`, `POLISH_FAIL = ERROR|FALLBACK|WARN`, and newly-plumbed `POLISH_MAX_ITER` and `POLISH_SPANS`, with mirrored `--polish-max-iter/--polish-spans` CLI flags and `solve_file` keywords. Precedence: CLI flag > Python keyword > file directive > default, recorded per field and stated in the docstrings and README.

**README/docs**: the polishing section documents concretely what AUTO resolves to (degree-3 clamped B-spline lift, ~one span per two radial points capped at 32, immediate return if the certificate already passes at 1e-2, else ≤80 GN iterations at rtol 1e-3), a directive table with defaults, an example snippet, and the precedence rule. plan.md records the feedback under a Phase 1 follow-ups section.

Verified: reference tokamak polish certificate unchanged (1.284e-2 → 1.811e-3); a directive deck observed end-to-end (banner shows TOL = 5e-3, MAX ITER = 40, certified at the looser tolerance); run-options/printing/CLI suites 67 passed; docs-prose, ruff, sphinx -W all clean. No numerics changed.