### PR TITLE
Announce every polish phase before it starts

### DIFF
--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -1171,6 +1171,80 @@ def test_polish_driver_skips_an_already_certified_state(small_strong_root):
     np.testing.assert_array_equal(result.correction, 0.0)
 
 
+def test_legacy_polish_announces_refinement_and_certificate_phases():
+    """The legacy driver's setup phases each emit a notice before starting.
+
+    Small solovev case; the raw lift never certifies at the default bar, so
+    the run passes through every phase (refinement, initial certificate,
+    preconditioner/root-runtime build) into one bounded Gauss-Newton step.
+    """
+    from vmex import VmecInput
+    from vmex.core.polish_driver import polish_legacy_solution
+    from vmex.core.solver import resolution_from_input, solve
+
+    inp = VmecInput.from_file(
+        str(DATA / "input.solovev")
+    ).change_resolution(mpol=3, ntor=0, ntheta=12, nzeta=4)
+    inp = dataclasses.replace(
+        inp, ns_array=np.asarray([5]), ftol_array=np.asarray([1.0e-9]),
+        niter_array=np.asarray([2000]),
+    )
+    result = solve(inp)
+    lines: list[str] = []
+
+    def capture(text="", **kwargs):
+        lines.append(str(text))
+
+    polish_legacy_solution(
+        inp,
+        resolution_from_input(inp, ns=5),
+        result.state,
+        config=PolishConfig(
+            max_nonlinear_iterations=1,
+            collocation_scale_probes=2,
+            fail_policy="return_unpolished",
+        ),
+        verbose=True,
+        emit=capture,
+    )
+    text = "\n".join(lines)
+    assert "refining the converged state" in text
+    assert "evaluating the initial force certificate" in text
+    assert "building the polish preconditioner and root runtime" in text
+
+
+def test_collocation_polish_announces_each_phase(small_strong_root):
+    """Every silent setup phase emits a notice before it starts.
+
+    A W7-X-scale user run showed the banner and then nothing for minutes;
+    the notices exist so a quiet console is always attributable to a named
+    phase.  Chart and certificate are deliberately NOT prebuilt here so the
+    driver's own build paths (and their notices) execute.
+    """
+    lines: list[str] = []
+
+    def capture(text="", **kwargs):
+        lines.append(str(text))
+
+    polish_collocation_least_squares(
+        small_strong_root,
+        config=PolishConfig(
+            tolerance=2.0,
+            validation_tolerance=10.0,
+            radial_refinement_tolerance=10.0,
+            collocation_scale_probes=2,
+            max_nonlinear_iterations=1,
+            fail_policy="return_unpolished",
+        ),
+        verbose=True,
+        emit=capture,
+    )
+    text = "\n".join(lines)
+    assert "building the polish chart" in text
+    assert "evaluating the initial force certificate" in text
+    assert "collocation:" in text
+
+
 def test_collocation_polish_primal_and_derivatives(small_strong_root):
     chart = make_strong_structured_chart(
         small_strong_root, balance_iterations=1, balance_probes=2

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -1172,12 +1172,15 @@ def polish_collocation_least_squares(
     from solvax import LeastSquaresConfig
 
     config = PolishConfig() if config is None else config
-    chart = make_strong_structured_chart(runtime) if chart is None else chart
-    initial_certificate = (
-        certify_strong_force(runtime.native)
-        if initial_certificate is None
-        else initial_certificate
-    )
+    if chart is None:
+        if verbose:
+            emit(" building the polish chart (scaling probes compile once)...")
+        chart = make_strong_structured_chart(runtime)
+    if initial_certificate is None:
+        if verbose:
+            emit(" evaluating the initial force certificate "
+                 "(independent oracle, compiles once)...")
+        initial_certificate = certify_strong_force(runtime.native)
     zero = jnp.zeros((chart.size,), dtype=jnp.asarray(runtime.native.R_cos).dtype)
     initial_collocation = strong_collocation_residual(zero, runtime, chart)
     collocation_scale = max(
@@ -1340,6 +1343,11 @@ def polish_legacy_solution(
     )
     params = implicit.params_from_input(source)
     legacy_runtime = implicit.runtime_from_params(params, implicit_config)
+    # Each phase below can run minutes at high resolution with no output of
+    # its own, so the CLI announces every one before it starts — a silent
+    # console must always be attributable to a named phase.
+    if verbose:
+        emit(" refining the converged state (Newton anchor)...")
     dof_mask = implicit._dof_mask(legacy_state, legacy_runtime, implicit_config)
     refined_state = implicit._refined_state(
         implicit_config,
@@ -1365,6 +1373,9 @@ def polish_legacy_solution(
             ),
         )
     )
+    if verbose:
+        emit(" evaluating the initial force certificate "
+             "(independent oracle, compiles once)...")
     certified_native = lift_high_order_state(
         refined_state,
         legacy_runtime,
@@ -1407,6 +1418,8 @@ def polish_legacy_solution(
             refined_state,
         )
     native = certified_native
+    if verbose:
+        emit(" building the polish preconditioner and root runtime...")
     low_preconditioner = build_low_order_preconditioner(
         native,
         params,


### PR DESCRIPTION
Follow-up to #243 from the user's W7-X run on current main: the banner printed, then silence — the phases BETWEEN the banner and the first Gauss-Newton row (state refinement, lift + initial certificate, preconditioner/root-runtime build, chart build) had no notices, and at MPOL=NTOR=10 the certificate step alone runs minutes (office profiling: it attempts a 34.5 GB allocation at that scale — the memory work is a separate track in flight). Each phase now announces itself before starting, in #243's register:

```
 BEGIN FORCE POLISHING
  MODE = ON  DEGREE = 3  SPANS = AUTO  NS =   31
  TOL = 1.000E-03  CERTIFICATE TOL = 1.000E-02  MAX ITER =   80
 refining the converged state (Newton anchor)...
 evaluating the initial force certificate (independent oracle, compiles once)...
 initial certificate: EPS-F = 1.284E-02  (tolerance 1.000E-02)
 building the polish preconditioner and root runtime...
 building the polish chart (scaling probes compile once)...
 collocation: 1764 residual rows, 148 unknowns
 compiling NS = 42 polish executable...
```

Emit-only under verbose; certificate numbers unchanged (1.284e-2 → 1.811e-3 on the reference tokamak). printing + run-options suites green, ruff clean.