### PR TITLE
Citation file, changelog, README prose policy, and reconciled plan debts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-Release notes are mirrored from the GitHub releases; numbers are the
-committed measurements behind each claim (see `benchmarks/`).
+Release notes are mirrored from the GitHub releases.  Where a number has a
+committed artifact it is named; the 0.8.x cold-start timings were measured
+in the pull-request and release bodies and are being backfilled as
+`benchmarks/` artifacts (see the *Performance and validation* page).
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+Release notes are mirrored from the GitHub releases; numbers are the
+committed measurements behind each claim (see `benchmarks/`).
+
+## Unreleased
+
+- Polish observability: the CLI announces every polish phase (state
+  refinement, initial certificate, preconditioner and chart build, compile
+  notice), prints one row per Gauss-Newton iteration, and closes with a
+  certificate verdict naming any failed check (#243, #244).
+- Input-file polish control: `!@VMEX POLISH_TOL`, `POLISH_DEGREE`,
+  `POLISH_SPANS`, `POLISH_MAX_ITER`, `POLISH_FAIL`, with mirrored CLI flags
+  and `solve_file` keywords; precedence CLI flag > Python keyword > file
+  directive > default (#243).
+- Optimization startup: the seed refinement is staged as one per-config
+  executable and deferred out of problem construction; time to first output
+  62 -> 6.5 s cold on the QA example, per-trial-point evaluation 12.5 -> 8.0 s
+  (#240). The staging idioms are applied to the free-boundary implicit and
+  mirror Newton-Krylov paths, and CI pins the optimization cold start (#241).
+- README: the polish summary plots the independent oracle's force-error
+  profile (unpolished vs certified polished export, 26-fold) with both
+  flux-surface sets overlaid; the extender section shows the exterior
+  island chain resolved by the total field (#237, #239).
+- CI: the Codecov upload is best-effort so the changed-line coverage gate
+  always runs; parity lanes get budget headroom (#236, #242).
+
+## 0.8.1 - 2026-09-02
+
+The cold-start performance release. Cold CLI, python, and optimization runs
+are faster than every previous VMEX release, including v0.3.0, on every
+deck measured, on x86 and arm64: 36-core x86 QA_lowres 43.1 s (v0.3.0) ->
+32.4 s, solovev 12.1 -> 7.0 s; Apple M4 QA 22.3 s (v0.8.0) -> 12.4 s, li383
+-> 4.0 s, solovev -> 3.1 s. At QA resolution the cold start compiles 343 XLA
+programs (v0.8.0: 773; v0.3.0: 523).
+
+- Eager setup, WOUT-export, stage-interpolation, and printout passes became
+  module-level jitted lanes (#227, #230).
+- The iteration body traces the funct3d chain once (halving every lane's
+  compile), and the ns4 preconditioner refresh runs only on its VMEC2000
+  cadence (#229).
+- Print cadence, initial DELT, and ftol no longer key lane recompilation
+  (#231); non-finite iterations are detected from the residual scalars
+  with full classification on trip (#232).
+- 3-D polishing no longer stalls in XLA constant folding: the Ruiz/probe
+  jits stopped baking linearization residuals as constants (#234).
+- CI pins compile budgets (lane HLO size, cold-solve program count) and
+  disables the persistent compilation cache on ephemeral runners, whose
+  eviction lock had been timing every lane out (#228, #233).
+- Numerical statement: per-iteration physics unchanged; graph
+  restructuring shifts XLA fusion, so trajectories can differ from v0.8.0 at
+  1 ULP per iteration with identical iteration counts and converged
+  geometry agreeing at 1e-12.
+
+## 0.8.0 - 2026-08-30
+
+- Certified force-balance polishing: `--polish`, `!@VMEX POLISH = AUTO`, or
+  `solve_file(..., polish="auto")` lift a converged fixed-boundary state to
+  axis-regular cubic B-splines and drive both physical force channels to
+  zero on an overdetermined collocation grid with matrix-free SOLVAX
+  Gauss-Newton steps; acceptance is an independent certificate (volume L2
+  force error below 1e-2, radial-refinement stability within 1e-3, positive
+  signed Jacobian) with tangent/adjoint derivatives through the polished
+  root.
+- Execution directives (`!@VMEX KEY = VALUE`, JSON `_vmex`, keywords, CLI)
+  separate how to run from what to solve; VMEC2000 reads the same files.
+- Implicit lane recompilation per optimization trial removed (steady
+  campaign step 16.6 -> 10.8 s, warm value+gradient repeat 28.8 -> 3.0 s,
+  bit-identical); polished solves reuse compiled programs (warm 52.9 ->
+  22.8 s).
+- `benchmarks/profile_workflows.py`: seventeen flagship workflows in five
+  timing regimes with compile counts and committed M4 baselines.
+- CI attempt wall clock roughly halved by resharding; `tools/preflight.py`
+  runs the static gates, guard tests, and diff-affected tests locally.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,33 @@
+cff-version: 1.2.0
+message: "If you use VMEX in published work, please cite it as below."
+type: software
+title: "VMEX: a differentiable JAX implementation of VMEC with certified force-balance polishing"
+version: 0.8.1
+date-released: 2026-09-02
+license: MIT
+repository-code: "https://github.com/uwplasma/vmex"
+url: "https://vmex.readthedocs.io"
+authors:
+  - family-names: Jorge
+    given-names: Rogerio
+    affiliation: "University of Wisconsin-Madison"
+keywords:
+  - stellarator
+  - MHD equilibrium
+  - VMEC
+  - JAX
+  - automatic differentiation
+  - plasma physics
+references:
+  - type: article
+    title: "Steepest-descent moment method for three-dimensional magnetohydrodynamic equilibria"
+    authors:
+      - family-names: Hirshman
+        given-names: S. P.
+      - family-names: Whitson
+        given-names: J. C.
+    journal: "Physics of Fluids"
+    volume: 26
+    year: 1983
+    pages: "3553"
+    doi: "10.1063/1.864116"

--- a/README.md
+++ b/README.md
@@ -137,12 +137,11 @@ d3Bdx = final_equilibrium.gradgradgradB_vjp(
 ```
 
 Everything above is Cartesian, and each VJP returns one entry per
-`problem.dof_names`. `set_points_flux([[s, theta, phi]])` places interior
-points in flux coordinates instead (outputs stay Cartesian). `B` and its
-first three derivatives are valid on the magnetic axis via the regular
-spectral limit. Outside the plasma, `VmecExtender` adds the
-`virtual_casing_jax` plasma contribution to a supplied coil or MGRID field —
-virtual casing alone is not the total exterior field.
+`problem.dof_names`. `set_points_flux([[s, theta, phi]])` places interior points
+in flux coordinates (outputs stay Cartesian); `B` and its first three
+derivatives are valid on the magnetic axis via the regular spectral limit.
+Outside the plasma, `VmecExtender` adds the `virtual_casing_jax` plasma
+contribution to a supplied coil or MGRID field — virtual casing alone is not the total exterior field.
 
 ![Poincare sections of the coil-only field next to the extended coil plus plasma field, whose exterior seeds resolve an island chain outside the plasma boundary](docs/_static/figures/readme_extender_exterior_islands.webp)
 
@@ -289,12 +288,11 @@ VMEX also solves open-ended mirrors. `examples/mirror/mirror_fixed_boundary_nona
 ![Free-boundary mirror beta scan](docs/_static/figures/mirror_free_boundary_beta_scan.webp)
 
 Closed stellarator–mirror hybrids also expose a differentiable, equal-arc
-field-line contract for GKX. VMEX owns the Cartesian metric and drift
-calculation; GKX converts the returned mapping to its generic flux-tube type.
-The interface accepts only a field line that closes on the periodic racetrack,
-and makes no open-end, sheath, source, or loss-cone claim. The
-[model and equations](https://vmex.readthedocs.io/en/latest/explanation/mirror-gyrokinetics.html)
-spell out that boundary explicitly.
+field-line contract for GKX: VMEX owns the Cartesian metric and drift
+calculation, and GKX converts the mapping to its generic flux-tube type. The
+interface accepts only a field line that closes on the periodic racetrack and
+makes no open-end, sheath, source, or loss-cone claim; the
+[model and equations](https://vmex.readthedocs.io/en/latest/explanation/mirror-gyrokinetics.html) spell out that boundary.
 
 ```python
 from vmex.mirror import gk_closed_fieldline_geometry
@@ -342,14 +340,12 @@ Enable it in a VMEC-compatible input deck:
 /
 ```
 
-VMEX reads the comments; VMEC2000 ignores them. `POLISH = AUTO` resolves to:
-lift the converged final stage to clamped radial B-splines of degree 3 with
-about one span per two radial mesh points (capped at 32 spans), return at
-once if that lifted state already passes the independent certificate
-(volume L2 at or below `1.0E-2`), and otherwise run up to 80 Gauss-Newton
-iterations at relative tolerance `1.0E-3`. `ON` runs the same path today;
-`OFF` is the default. The other directives, each mapped onto the matching
-`PolishConfig` field:
+VMEX reads the comments; VMEC2000 ignores them. `POLISH = AUTO` lifts the
+converged final stage to degree-3 clamped radial B-splines (about one span per
+two radial points, at most 32), returns at once if that lifted state already
+passes the independent certificate (volume L2 at or below `1.0E-2`), and
+otherwise runs up to 80 Gauss-Newton iterations at relative tolerance `1.0E-3`.
+`ON` runs the same path; `OFF` is the default. The other directives map onto `PolishConfig`:
 
 | Directive | Meaning | Default |
 |---|---|---|
@@ -360,14 +356,12 @@ iterations at relative tolerance `1.0E-3`. `ON` runs the same path today;
 | `POLISH_MAX_ITER` | Gauss-Newton iteration cap (`max_nonlinear_iterations`) | `80` |
 | `POLISH_FAIL = ERROR \| FALLBACK \| WARN` | failed polish: raise, return unpolished, or warn | `ERROR` |
 
-The CLI mirrors every directive (`--polish`, `--polish-tol`,
-`--polish-degree`, `--polish-spans`, `--polish-max-iter`, `--polish-fail`,
-`--no-polish`) and the precedence is `CLI flag > Python keyword > file
-directive > package default`; an explicit `polish_config` in Python wins
-over all scalar knobs. During a CLI run the phase announces itself: a
-`BEGIN FORCE POLISHING` banner with the resolved settings, a compile notice
-for the first polish executable build, one row per Gauss-Newton iteration,
-and a closing certificate verdict that names any failed check.
+The CLI mirrors every directive (`--polish`, `--polish-tol`, `--polish-degree`,
+`--polish-spans`, `--polish-max-iter`, `--polish-fail`, `--no-polish`) with
+precedence `CLI flag > Python keyword > file directive > package default`; an
+explicit `polish_config` in Python wins over all scalar knobs. A CLI run
+announces each polish phase, prints one row per Gauss-Newton iteration, and
+closes with a certificate verdict that names any failed check.
 
 The same opt-in is available in Python:
 
@@ -405,11 +399,10 @@ polishing demonstrably wins.
 
 Below: the bundled shaped tokamak (`input.shaped_tokamak_pressure_polished`)
 before and after polishing. The independent continuum force residual of the
-exported equilibrium drops about 26-fold, from `5.05e-2` to `1.91e-3`, while
-the boundary and the prescribed profiles are untouched. The radial force
-balance panel in `vmex --plot` summaries is a different diagnostic — VMEC's
-own discrete flux-surface average, which ordinary solves already minimize —
-so that panel does not display this gain.
+exported equilibrium drops about 26-fold, from `5.05e-2` to `1.91e-3`, with the
+boundary and prescribed profiles untouched. The radial force-balance panel in
+`vmex --plot` summaries is VMEC's own discrete flux-surface average, which
+ordinary solves already minimize, so that panel does not show this gain.
 
 ![Shaped-tokamak flux surfaces and independent force-error profiles before and after polishing](docs/_static/figures/readme_polish_summary.webp)
 

--- a/plan.md
+++ b/plan.md
@@ -2219,18 +2219,24 @@ Use the same independent oracle and clearly state excluded regions, normalizatio
 **README debts (standing checklist, audited 2026-08-31).** These stay in
 the plan until each is closed by a merged PR:
 
-1. Comparison figure: accuracy-only panels (no runtime bars) - see the
-   figure policy below.
+1. Comparison figure: accuracy-only panels (no runtime bars) - CLOSED
+   (#215).
 2. Comparison rows: every row shows certified polishing measurably beating
-   the legacy codes' exported equilibria; the current QA row's near-tie
-   must be replaced (smooth finite-beta QA head-to-head in progress).
+   the legacy codes' exported equilibria; the near-tie QA row was removed
+   (#215) and the figure shows the shaped-tokamak row. OPEN: a
+   finite-beta stellarator row joins once 3-D polishing certifies at
+   production resolution (the capture stall is fixed by #234; the
+   remaining gap is polish effectiveness and memory at MPOL=NTOR=10, see
+   8.8).
 3. Polish summary figure (``readme_polish_summary.webp``): the shown case
-   must be a finite-beta or finite-current stellarator where polishing
-   reduces the certified independent error MULTIPLE-FOLD - the current
-   example's 1.4e-2 to 5.6e-3 is not a demonstration; replace the case,
-   not the caption.
+   must be a true tokamak or stellarator where polishing reduces the
+   certified independent error MULTIPLE-FOLD, plotting the quantity the
+   oracle measures - CLOSED by the shaped tokamak (26-fold on the exported
+   equilibrium, both flux-surface sets overlaid; #237, #239). A stellarator
+   variant remains desirable once item 2's row exists.
 4. Prose: no README paragraph exceeds ~6 lines; panel-by-panel and
-   option-by-option detail lives in the docs, linked, not inlined.
+   option-by-option detail lives in the docs, linked, not inlined - CLOSED
+   (audited 2026-09-02, every prose paragraph at or under six lines).
 
 **README figure policy (decided 2026-08-31).** The README comparison shows
 force-balance accuracy only. Runtime panels stay out of the README until


### PR DESCRIPTION
Publication-readiness artifacts, independent of the physics/literature audits in progress:

- **CITATION.cff** (CFF 1.2.0, validated with cffconvert): title, version 0.8.1, MIT, repository/docs URLs, keywords, and the Hirshman & Whitson 1983 reference. A Zenodo DOI is a follow-up once the release archive exists.
- **CHANGELOG.md** seeded from the 0.8.0 and 0.8.1 release notes, keeping the committed measurements behind each claim, plus an Unreleased section for the polish observability/knobs, optimization-startup, README-figure, and CI work since 0.8.1.
- **README**: five prose paragraphs exceeded the plan's six-line policy (§21 item 4); each is tightened with claims unchanged. Audit script now reports zero paragraphs over six lines.
- **plan.md §21**: the README-debt checklist records what closed (accuracy-only figure #215; the 26-fold shaped-tokamak summary plotting the oracle's own quantity, both flux-surface sets overlaid, #237/#239; prose) and what remains open (the finite-beta stellarator row, gated on 3-D polish effectiveness and memory at MPOL=NTOR=10, tracked in §8.8).

Guards: docs prose/media gates clean; performance-docs, docs-nav, capability-docs 21 passed.