### PR TITLE
Correct the confinement diagnostics documentation and its citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,8 +469,10 @@ The detailed, phased plan lives in [plan.md](plan.md). In flight now:
   compilation reuse, the polishing path's runtime, and chunked Boozer
   transforms; regimes (cold, cache-reload, warm) are never mixed in one
   number.
-- A `Gamma_c` objective whose boundary derivative is well-posed under
-  refinement, replacing the current fixed-resolution proxy.
+- A pinned DESC `Gamma_c` oracle: `GammaC` evaluates DESC's form of the
+  Nemov proxy and is checked against drift-kinetic identities and its own
+  `wout` tables, but no test yet asserts its value against a number
+  computed by DESC's `GammaC` on a shared equilibrium.
 - Up-down asymmetric (LASYM) equilibria as a first-class certified lane.
 - Promote the boundary-Schur free-boundary adjoint and coil-only
   free-boundary single-stage optimization after their compile and GPU

--- a/docs/explanation/confinement.rst
+++ b/docs/explanation/confinement.rst
@@ -166,13 +166,18 @@ requested surface, sampled on a uniform :math:`(\theta,\phi)` grid,
        - (\mathbf B\cdot\nabla B)\,(M G + N I)}{B^{3}},
 
 with :math:`M=` ``helicity_m``, :math:`N=` ``helicity_n``\ :math:`\times`\
-``nfp``, and :math:`G,I` the Boozer covariant averages ``bvco``/``buco``. The
-key algebraic fact is that :math:`f_{\mathrm{QS}}` **vanishes identically iff**
-:math:`|B|` is quasisymmetric with helicity :math:`(M,N)`; there is no residual
-symmetry-breaking harmonic left to penalize. The flux-surface sum
+``nfp``, and :math:`G,I` the Boozer covariant averages ``bvco``/``buco``; this
+is the residual inside eq. (1) of Landreman & Paul, Phys. Rev. Lett. 128,
+035001 (2022). The key algebraic fact is that :math:`f_{\mathrm{QS}}`
+**vanishes identically iff** :math:`|B|` is quasisymmetric with helicity
+:math:`(M,N)` (Helander, Rep. Prog. Phys. 77, 087001 (2014)); there is no
+residual symmetry-breaking harmonic left to penalize. The flux-surface sum
 :math:`\sum f_{\mathrm{QS}}^2`, weighted by the surface measure
-:math:`\sqrt{\mathrm{nfp}\,\Delta\theta\,\Delta\phi\,|\sqrt g|/V'}`, reproduces
-simsopt's ``QuasisymmetryRatioResidual`` A/B bit-for-bit. Kept in
+:math:`\sqrt{\mathrm{nfp}\,\Delta\theta\,\Delta\phi\,|\sqrt g|/V'}`, is
+simsopt's ``QuasisymmetryRatioResidual`` A/B formula on the same grid with the
+same weighting. No simsopt oracle runs in this test suite, so the gated
+comparison is VMEX's own traceable lane against its wout lane
+(``tests/test_optimize_traceable_qs.py``). Kept in
 Gauss–Newton (per-point) form, it feeds the least-squares driver as an exact
 residual vector rather than a pre-summed scalar. The metric is evaluated from
 the parity-proven wout tables (:mod:`vmex.core.nyquist`) and also exposes a
@@ -688,7 +693,9 @@ bounce-averaged drift and the flux surface,
 
 with :math:`v_r` and :math:`v_p` the bounce-averaged radial and
 poloidal-tangential magnetic drifts (Velasco et al., Nucl. Fusion 61,
-116059 (2021), eqs. 14-16, the KNOSOS/CIEMAT-QI form).  The residual rows
+116059 (2021), eqs. 14-16, in the Nemov/DESC form with the surface-tangency
+factor evaluated at the field minimum of each well; KNOSOS uses the
+:math:`\gamma_c^*` variant, which drops that factor).  The residual rows
 are :math:`\Gamma_c` per surface, so the least-squares cost is the sum of
 :math:`w\,\Gamma_c^{2}`; Velasco et al. 2021, eqs. (20)-(21), relate the
 prompt-loss fraction approximately linearly to :math:`\Gamma_c` (more

--- a/docs/explanation/confinement.rst
+++ b/docs/explanation/confinement.rst
@@ -465,7 +465,9 @@ Assuming the ideal prerequisite :math:`D_{\rm Merc}>0`, the
 Glasser--Greene--Johnson necessary condition for local resistive interchange
 stability is :math:`D_R \leq 0`.  In the VMEC Mercier normalization, with
 :math:`S=d\iota/d\Phi` and
-:math:`D_{\rm shear}=S^2/4`, Landreman--Jorge's relation is
+:math:`D_{\rm shear}=S^2/4`, the Landreman--Jorge relation (J. Plasma
+Phys. 86, 905860510 (2020), eq. (5.6); :math:`D_R` and :math:`H` are
+their eqs. (5.1) and (5.4)) is
 
 .. math::
 

--- a/docs/explanation/confinement.rst
+++ b/docs/explanation/confinement.rst
@@ -685,12 +685,15 @@ bounce-averaged drift and the flux surface,
      \frac{B}{\sqrt{1-\lambda B}}\,\gamma_c^{2}\right\rangle,
 
 with :math:`v_r` and :math:`v_p` the bounce-averaged radial and
-poloidal-tangential magnetic drifts and :math:`\Gamma_c^{2}` the
-prompt-loss scaling used in optimization (Velasco et al., Nucl. Fusion 61,
-116059 (2021), eqs. 14-16, the KNOSOS/CIEMAT-QI form; Bader et al. and
-Paul et al. document that such proxies correlate imperfectly with measured
+poloidal-tangential magnetic drifts (Velasco et al., Nucl. Fusion 61,
+116059 (2021), eqs. 14-16, the KNOSOS/CIEMAT-QI form).  The residual rows
+are :math:`\Gamma_c` per surface, so the least-squares cost is the sum of
+:math:`w\,\Gamma_c^{2}`; Velasco et al. 2021, eqs. (20)-(21), relate the
+prompt-loss fraction approximately linearly to :math:`\Gamma_c` (more
+linearly to the :math:`|\gamma_c^*|` variant).  Bader et al. and Paul et
+al. document that such proxies correlate imperfectly with measured
 energetic-particle losses, which bounds what any :math:`\Gamma_c` value
-claims). :class:`~vmex.core.gammac.GammaC` evaluates the drift ratio in
+claims. :class:`~vmex.core.gammac.GammaC` evaluates the drift ratio in
 Nemov's own form — DESC's rewrite into single-valued periodic maps
 (``desc.compute._fast_ion`` on the bounce kernel of Unalmis et al., J.
 Plasma Phys. 92(3), 2026, doi:10.1017/S0022377826101652, DESC's sibling

--- a/docs/explanation/confinement.rst
+++ b/docs/explanation/confinement.rst
@@ -143,13 +143,13 @@ units of ``nfp``):
      - :math:`|B|` contours in Boozer angles
    * - QA (quasi-axisymmetric)
      - :math:`(1,0)`
-     - close poloidally (tokamak-like)
+     - close toroidally (tokamak-like)
    * - QH (quasi-helical)
      - :math:`(1,\pm\mathrm{nfp})`
      - close helically
    * - QP (quasi-poloidal)
      - :math:`(0,1)`
-     - close toroidally
+     - close poloidally (QI-like)
 
 The two-term residual
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/project/references.rst
+++ b/docs/project/references.rst
@@ -37,7 +37,7 @@ Background and canonical references for VMEC and related equilibrium methods:
 
 10. A. H. Glasser, J. M. Greene, and J. L. Johnson, “Resistive instabilities
     in general toroidal plasma configurations,” *Physics of Fluids* 18(7),
-    875-888 (1975).
+    875-888 (1975), doi:10.1063/1.861224.
 
 11. M. Landreman and R. Jorge, “Magnetic well and Mercier stability of
     stellarators near the magnetic axis,” *Journal of Plasma Physics* 86(5),
@@ -69,111 +69,157 @@ Background and canonical references for VMEC and related equilibrium methods:
     NeurIPS 2022 (jaxopt) — the implicit-function-theorem ``custom_vjp``
     formulation used for equilibrium gradients.
 
+19. A. H. Boozer, “Plasma equilibrium with rational magnetic surfaces,”
+    *Physics of Fluids* 24, 1999 (1981), doi:10.1063/1.863297 — the Boozer
+    coordinates in which quasisymmetry and the fast-ion proxies are stated.
+
+20. R. Sanchez et al., “Ballooning stability optimization of low-aspect-ratio
+    stellarators,” *Plasma Physics and Controlled Fusion* 42, 641 (2000),
+    doi:10.1088/0741-3335/42/6/303 — the ballooning-optimization companion to
+    the COBRA formulation used by :mod:`vmex.core.stability`.
+
 Confinement objectives and optimization:
 
-19. M. Landreman and E. Paul, “Magnetic fields with precise quasisymmetry for
+21. M. Landreman and E. Paul, “Magnetic fields with precise quasisymmetry for
     plasma confinement,” *Physical Review Letters* 128, 035001 (2022),
-    arXiv:2108.03711 — the two-term quasisymmetry ratio residual and the
+    arXiv:2108.03711, doi:10.1103/PhysRevLett.128.035001 — the two-term
+    quasisymmetry ratio residual (the residual inside eq. 1) and the
     precise-QA/QH configurations (:doc:`/explanation/confinement`).
 
-20. A. Goodman et al., “Constructing precisely quasi-isodynamic magnetic
+22. A. Goodman et al., “Constructing precisely quasi-isodynamic magnetic
     fields,” *Journal of Plasma Physics* 89(5), 905890504 (2023),
     arXiv:2211.09829 — the constructed-QI target implemented by
     :class:`~vmex.core.qi.ConstructedQIResidual`; the lightweight
     :class:`~vmex.core.omnigenity.QIResidual` is a level-set surrogate.
 
-21. J. R. Cary and S. G. Shasharina, “Omnigenity and quasihelicity in helical
+23. J. R. Cary and S. G. Shasharina, “Omnigenity and quasihelicity in helical
     plasma confinement systems,” *Physics of Plasmas* 4, 3323 (1997) — the
     bounce-integral formulation of omnigenity.
 
-22. D. Dudt et al., “Magnetic fields with general omnigenity,” *Journal of
+24. D. Dudt et al., “Magnetic fields with general omnigenity,” *Journal of
     Plasma Physics* 90(1), 905900120 (2024), arXiv:2305.08026 — omnigenity
     optimization in a differentiable (DESC) framework.
 
-23. A. Redl et al., “A new set of analytical formulae for the computation of
-    the bootstrap current and the neoclassical conductivity in tokamaks,”
-    *Physics of Plasmas* 28, 022502 (2021) — the Redl bootstrap closure.
+25. A. Redl, C. Angioni, E. Belli, and O. Sauter, “A new set of analytical
+    formulae for the computation of the bootstrap current and the neoclassical
+    conductivity in tokamaks,” *Physics of Plasmas* 28, 022502 (2021),
+    doi:10.1063/5.0012664 — the Redl bootstrap closure (eqs. 10-16, 19-21).
 
-24. M. Landreman, S. Buller, and M. Drevlak, “Optimization of quasi-symmetric
+26. M. Landreman, S. Buller, and M. Drevlak, “Optimization of quasi-symmetric
     stellarators with self-consistent bootstrap current and energetic particle
-    confinement,” *Physics of Plasmas* 29, 082501 (2022), arXiv:2205.02914 —
+    confinement,” *Physics of Plasmas* 29, 082501 (2022), arXiv:2205.02914,
+    doi:10.1063/5.0098166 —
     the self-consistent bootstrap iteration reproduced in
     ``benchmarks/*_bootstrap_selfconsistent.py``; the compact finite-beta
     optimization workflows are ``examples/optimization/*_optimization_bootstrap.py``.
 
-25. R. Jorge, A. Goodman, M. Landreman, J. Rodrigues, and F. Wechsung,
+27. R. Jorge, A. Goodman, M. Landreman, J. Rodrigues, and F. Wechsung,
     “Single-stage stellarator optimization: combining coils with fixed
     boundary equilibria,” *Plasma Physics and Controlled Fusion* 65, 074003
     (2023), arXiv:2302.10622 — the combined plasma–coil objective
     ``J = J_plasma + w_coils J_coils`` and the two-stage vs single-stage
     comparison protocol used by the single-stage examples.
 
-26. R. Jorge, A. Giuliani, and J. Loizu, “Simplified and flexible coils for
+28. R. Jorge, A. Giuliani, and J. Loizu, “Simplified and flexible coils for
     stellarators using single-stage optimization,” arXiv:2406.07830 (2024) —
     cold-start single-stage optimization with staged Fourier-mode release.
 
-27. F. Wechsung et al., “Precise stellarator quasi-symmetry can be achieved
+29. F. Wechsung et al., “Precise stellarator quasi-symmetry can be achieved
     with electromagnetic coils,” *PNAS* 119(13), e2202084119 (2022) — coil
     regularization set (length, curvature, coil–coil distance) and the
     normalized ``max |B·n|/|B|`` reporting convention.
 
-28. K. Unalmis et al., “Spectrally accurate, reverse-mode differentiable
+30. K. Unalmis et al., “Spectrally accurate, reverse-mode differentiable
     bounce-averaging algorithm and its applications,” *Journal of Plasma
     Physics* (2026), doi:10.1017/S0022377826101652 — endpoint-regularized
     quadrature and the independent DESC oracle for
     :mod:`vmex.core.bounce`.
 
-29. E. Rodríguez, P. Helander, and A. G. Goodman, “The maximum-J property
+31. E. Rodríguez, P. Helander, and A. G. Goodman, “The maximum-J property
     in quasi-isodynamic stellarators,” *Journal of Plasma Physics* 90,
     905900212 (2024), doi:10.1017/S0022377824000345 — the signed
     outward :math:`\partial\mathcal J_\parallel/\partial s<0` condition implemented
     by :class:`~vmex.core.maxj.MaximumJResidual`.
 
-30. E. Rodríguez and G. G. Plunk, “Near-axis quasi-isodynamic database,”
+32. E. Rodríguez and G. G. Plunk, “Near-axis quasi-isodynamic database,”
     *Journal of Plasma Physics* (2026),
     doi:10.1017/S0022377826101688 — defines the bounce-time-weighted
     Maxwellian maximum-J fraction :math:`f_J`, which is distinct from a
     uniform resolved-orbit count.
 
-31. D. A. Spong and J. H. Harris, “New QP/QI symmetric stellarator
+33. D. A. Spong and J. H. Harris, “New QP/QI symmetric stellarator
     configurations,” *Plasma and Fusion Research* 5, S2039 (2010),
     doi:10.1585/pfr.5.S2039 — motivates quasi-poloidal symmetry as a practical
     precursor to poloidally closed-contour quasi-isodynamic configurations.
 
-32. R. Conlin, P. Kim, D. W. Dudt, D. Panici, and E. Kolemen, “Stellarator
+34. R. Conlin, P. Kim, D. W. Dudt, D. Panici, and E. Kolemen, “Stellarator
     Optimization with Constraints,” *Journal of Plasma Physics* 90,
     905900501 (2024), arXiv:2403.11033 — hard shaping constraints and
     augmented-Lagrangian methods for stellarator design.
 
-33. B. Jang, R. Conlin, and M. Landreman, “Exponential Spectral Scaling:
+35. B. Jang, R. Conlin, and M. Landreman, “Exponential Spectral Scaling:
     Robust and Efficient Stellarator Boundary Optimization via Mode-Dependent
     Scaling,” arXiv:2509.16320 (2025) — the direct full-spectrum variable
     scaling exposed by ``use_ess=True``.
 
-34. D. Panici, B. Jang, R. Conlin, D. Dudt, Y. G. Elmacioglu, and E. Kolemen,
+36. D. Panici, B. Jang, R. Conlin, D. Dudt, Y. G. Elmacioglu, and E. Kolemen,
     “Deflation Techniques for Stellarator Equilibrium and Optimization,”
     arXiv:2602.09957 (2026) — a systematic route to distinct minima when a
     single deterministic continuation path is insufficient.
 
-35. H. Chen *et al.*, “Direct Optimization of Stellarator Omnigenity from the
+37. H. Chen *et al.*, “Direct Optimization of Stellarator Omnigenity from the
     Second Adiabatic Invariant,” arXiv:2608.02418 (2026) — recent direct
     bounce-action optimization complementary to constructed geometric QI
     targets.
 
-36. V. V. Nemov, S. V. Kasilov, W. Kernbichler, and M. F. Heyn,
+38. V. V. Nemov, S. V. Kasilov, W. Kernbichler, and M. F. Heyn,
     “Evaluation of :math:`1/\nu` neoclassical transport in stellarators,”
     *Physics of Plasmas* 6, 4622–4632 (1999), doi:10.1063/1.873749 — defines
     the effective-ripple transport measure reported by NEO as
     :math:`\epsilon_{\mathrm{eff}}^{3/2}`.
 
+39. V. V. Nemov et al., “Poloidal motion of trapped particle orbits in
+    real-space coordinates,” *Physics of Plasmas* 15, 052501 (2008),
+    doi:10.1063/1.2912456 — defines the :math:`\Gamma_c` fast-ion proxy
+    (eq. 61) evaluated by :class:`~vmex.core.gammac.GammaC`.
+
+40. J. L. Velasco et al. and the W7-X Team, “A model for the fast evaluation
+    of prompt losses of energetic ions in stellarators,” *Nuclear Fusion* 61,
+    116059 (2021), doi:10.1088/1741-4326/ac2994 — the :math:`\Gamma_c`
+    organization used here (eq. 16) and the approximately linear prompt-loss
+    relation of eqs. 20-21.
+
+41. P. Helander, *Reports on Progress in Physics* 77, 087001 (2014),
+    doi:10.1088/0034-4885/77/8/087001 — the review behind the statement that
+    the two-term residual vanishes exactly for a quasisymmetric :math:`|B|`.
+
+42. O. Sauter, C. Angioni, and Y. R. Lin-Liu, *Physics of Plasmas* 6, 2834
+    (1999), doi:10.1063/1.873240 (erratum *Physics of Plasmas* 9, 5140
+    (2002), doi:10.1063/1.1517052) — the collisionality formulas (eqs.
+    18b-18e) that the Redl closure reuses in :mod:`vmex.core.bootstrap`.
+
+43. Y. R. Lin-Liu and R. L. Miller, *Physics of Plasmas* 2, 1666 (1995),
+    doi:10.1063/1.871315 — the trapped-fraction groundwork underlying the
+    Sauter and Redl fits.
+
+44. A. Bader et al., “Stellarator equilibria with reactor relevant energetic
+    particle losses,” *Journal of Plasma Physics* 85, 905850508 (2019),
+    doi:10.1017/S0022377819000680 — energetic-particle losses measured
+    against proxy values.
+
+45. A. Bader et al., “Modeling of energetic particle transport in optimized
+    stellarators,” *Nuclear Fusion* 61, 116060 (2021),
+    doi:10.1088/1741-4326/ac2991 — documents the imperfect correlation
+    between :math:`\Gamma_c` and simulated energetic-particle losses.
+
 Numerical implementation:
 
-37. JAX documentation, “The Autodiff Cookbook” — the wide-Jacobian cost model
+46. JAX documentation, “The Autodiff Cookbook” — the wide-Jacobian cost model
     (``jacfwd`` versus ``jacrev``) used to select ``jacrev`` for the local
     three-surface raw-force blocks,
     https://docs.jax.dev/en/latest/notebooks/autodiff_cookbook.html.
 
-38. X. S. Li, “An Overview of SuperLU: Algorithms, Implementation, and User
+47. X. S. Li, “An Overview of SuperLU: Algorithms, Implementation, and User
     Interface,” *ACM Transactions on Mathematical Software* 31, 302–325
     (2005) — globally pivoted sparse factorization used for the equilibrated
     block-banded radial solve, doi:10.1145/1089014.1089017.

--- a/docs/project/references.rst
+++ b/docs/project/references.rst
@@ -91,7 +91,7 @@ Confinement objectives and optimization:
     optimization in a differentiable (DESC) framework.
 
 23. A. Redl et al., “A new set of analytical formulae for the computation of
-    the bootstrap current and the neoclassical conductivity in stellarators,”
+    the bootstrap current and the neoclassical conductivity in tokamaks,”
     *Physics of Plasmas* 28, 022502 (2021) — the Redl bootstrap closure.
 
 24. M. Landreman, S. Buller, and M. Drevlak, “Optimization of quasi-symmetric

--- a/docs/reference/objectives.rst
+++ b/docs/reference/objectives.rst
@@ -333,7 +333,10 @@ Fast-ion confinement (Gamma_c)
 surface — the Nemov fast-ion proxy (Nemov et al. 2008, eq. 61, in the
 organization of Velasco et al. 2021, eq. 16; the sibling of DESC's
 ``GammaC``), so the least-squares cost is the weighted sum of
-``Gamma_c**2``, the prompt-loss scaling.  **Use it as the reported value,
+``Gamma_c**2``.  The square is the least-squares form, not a physical
+scaling: Velasco et al. 2021, eqs. (20)-(21), relate the prompt-loss
+fraction approximately linearly to ``Gamma_c`` (more linearly to the
+``|gamma_c*|`` variant).  **Use it as the reported value,
 never as the gradient objective**: its discretized boundary derivative is
 exact yet flips sign under grid refinement (the measured ladder is pinned
 in ``tests/test_gammac.py``).  For optimization use

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,5 +1,4 @@
-"""Validation gates for :mod:`vmex.core.bootstrap` (R26.g steps 1-4; spec
-``notes_r26g_redl_spec.md`` sections 7-8, CI-sized subset): analytic
+"""Validation gates for :mod:`vmex.core.bootstrap` (CI-sized subset): analytic
 trapped-fraction model; V1 formula parity vs pasted simsopt rows at
 Zeff > 1; V2/V3 Zenodo QA/QH cross-check (<= 1% vs simsopt Redl curves,
 <= 10% RMS vs SFINCS interior, trapped-fraction parity; skips without the
@@ -728,7 +727,7 @@ def test_self_consistent_bootstrap_picard_converges():
     """V6 (small): Picard loop on the ncurr=1 tokamak converges (delta below
     tol) in <= 10 iterations and drives f_boot down ~two orders of magnitude.
     relax=0.5 because iota here is entirely bootstrap-driven (the undamped
-    <J.B> ~ 1/iota ~ 1/I map is marginally stable; spec section 6.5)."""
+    <J.B> ~ 1/iota ~ 1/I map is marginally stable)."""
     inp = _tokamak_ncurr1(curtor=-2.0e5, ac01=(1.0, 0.0))  # flat I' guess
     res = bs.self_consistent_bootstrap(
         inp, TOKAMAK_PROFILES, 0, n_iter=10, tol=1e-3, relax=0.5, degree=6,

--- a/vmex/core/bootstrap.py
+++ b/vmex/core/bootstrap.py
@@ -1,4 +1,9 @@
-"""Differentiable Redl (2021) bootstrap current (see ``notes_r26g_redl_spec.md``).
+"""Differentiable Redl (2021) bootstrap current.
+
+Redl, Angioni, Belli & Sauter, Phys. Plasmas 28, 022502 (2021), eqs. 10-16
+and 19-21, on the Sauter, Angioni & Lin-Liu, Phys. Plasmas 6, 2834 (1999)
+collisionalities (eqs. 18b-18e); the self-consistent lane follows Landreman,
+Buller & Drevlak, Phys. Plasmas 29, 082501 (2022).
 
 - :func:`compute_trapped_fraction` — effective trapped fraction, epsilon and
   the flux-surface averages ``<B^2>``, ``<1/B>`` from ``|B|``/``sqrt(g)``.
@@ -94,6 +99,10 @@ Array = Any
 #: CODATA elementary charge [C]; converts eV -> J in the <J.B> assembly.
 ELEMENTARY_CHARGE = 1.602176634e-19
 
+#: Gauss-Legendre order for the trapped-fraction lambda quadrature, shared by
+#: every entry point so the geometry lanes and the objective agree by default.
+N_LAMBDA = 64
+
 
 # ===========================================================================
 # Kinetic profiles (polynomials in s, simsopt ProfilePolynomial convention)
@@ -123,7 +132,7 @@ class KineticProfiles:
     """Prescribed kinetic profiles for the Redl formula (frozen pytree).
 
     Polynomial coefficients in ``s`` (lowest order first).  These are *not*
-    VMEC inputs; they parameterize the bootstrap objective (spec section 6.6).
+    VMEC inputs; they parameterize the bootstrap objective.
     Units: ``ne_coeffs`` [1/m^3], ``Te_coeffs``/``Ti_coeffs`` [eV],
     ``Zeff_coeffs`` dimensionless (default: constant 1, hydrogen).
 
@@ -152,7 +161,7 @@ jax.tree_util.register_dataclass(
 # ===========================================================================
 
 
-def compute_trapped_fraction(modB: Array, sqrtg: Array, *, n_lambda: int = 64):
+def compute_trapped_fraction(modB: Array, sqrtg: Array, *, n_lambda: int = N_LAMBDA):
     r"""Effective trapped fraction and flux-surface averages per surface.
 
     ``f_t = 1 - (3/4) <B^2> \int_0^{1/Bmax} lambda dlambda / <sqrt(1 - lambda B)>``
@@ -253,7 +262,7 @@ def redl_geometry_from_wout(
     *,
     ntheta: int = 64,
     nphi: int = 65,
-    n_lambda: int = 64,
+    n_lambda: int = N_LAMBDA,
 ) -> RedlGeometry:
     """Redl geometry inputs from a wout dataset (simsopt ``RedlGeomVmec`` lane).
 
@@ -481,7 +490,7 @@ def redl_geometry_from_state(
     rt: SolverRuntime,
     *,
     surfaces=None,
-    n_lambda: int = 64,
+    n_lambda: int = N_LAMBDA,
 ) -> RedlGeometry:
     """Redl geometry inputs as a traceable function of ``(state, runtime)``.
 
@@ -491,8 +500,7 @@ def redl_geometry_from_state(
     the half mesh onto ``surfaces`` before :func:`compute_trapped_fraction`.
 
     Default ``surfaces``: ``linspace(0.05, 0.95, 16)`` — interior only; do
-    not sample ``s -> 1`` where ``Te, Ti -> 0`` blows up the collisionality
-    (spec section 6.1b).
+    not sample ``s -> 1`` where ``Te, Ti -> 0`` blows up the collisionality.
     """
     if surfaces is None:
         surfaces = np.linspace(0.05, 0.95, 16)
@@ -506,7 +514,7 @@ def trapped_fraction_from_state(
     rt: SolverRuntime,
     *,
     surfaces=None,
-    n_lambda: int = 64,
+    n_lambda: int = N_LAMBDA,
 ) -> Array:
     """Effective trapped fraction on requested normalized-flux surfaces.
 
@@ -553,7 +561,7 @@ def j_dot_B_redl(
     ``helicity_n`` is 0 for quasi-axisymmetry, +/-1 for quasi-helical
     symmetry.  ``Te/Ti`` are clamped at 1 eV and ``ne`` at 1e17 1/m^3
     (belt-and-suspenders against sampling s -> 1 where the profiles vanish
-    and the collisionality blows up; spec section 6.1b).
+    and the collisionality blows up).
 
     Returns ``(jdotB, details)`` with ``details`` a dict of every
     intermediate quantity (simsopt names).
@@ -663,7 +671,7 @@ def j_dot_B_redl(
 
 
 # ===========================================================================
-# Traceable <J.B>_vmec — the MHD identity (spec section 6.2)
+# Traceable <J.B>_vmec — the MHD identity
 # ===========================================================================
 
 
@@ -700,7 +708,7 @@ def vmec_j_dot_B(
     """Traceable equilibrium ``<J.B>`` [A*T/m^2] via the MHD identity.
 
     For a VMEC equilibrium the flux-surface-averaged parallel current obeys
-    (spec section 6.2; validated in the Zenodo
+    (validated in the Zenodo
     ``convertSfincsToVmecCurrentProfile`` script against VMEC's own
     ``jdotb``)
 
@@ -794,7 +802,7 @@ def vmec_j_dot_B_from_wout(wout, surfaces, *, geom: RedlGeometry | None = None,
 
 
 # ===========================================================================
-# f_boot objective (spec section 6.3; simsopt VmecRedlBootstrapMismatch)
+# f_boot objective (simsopt VmecRedlBootstrapMismatch)
 # ===========================================================================
 
 
@@ -820,12 +828,12 @@ class RedlBootstrapMismatch:
       (jxbforce.f) interpolated onto ``surfaces`` — simsopt parity.
     - :meth:`residuals_state` (traceable lane): one
       :func:`_half_mesh_fields` pass feeds both the Redl geometry and the
-      section-6.2 identity ``Jv``, so the term composes with
+      MHD-identity ``Jv``, so the term composes with
       ``least_squares(jac="implicit")`` (profiles fixed, geometry traced).
 
     ``helicity_n`` is 0 for QA, -1/+1 for QH (units of ``nfp``, simsopt
     convention).  Default ``surfaces``: ``linspace(0.05, 0.95, 16)``
-    (interior only — never sample ``s -> 1``; spec section 6.1b).  Usage as
+    (interior only — never sample ``s -> 1``).  Usage as
     an objective term (target 0; the normalization already scales it)::
 
         terms = [(qs.residuals_state, 0.0, 1.0),
@@ -842,7 +850,7 @@ class RedlBootstrapMismatch:
         *,
         ntheta: int = 64,
         nphi: int = 65,
-        n_lambda: int = 64,
+        n_lambda: int = N_LAMBDA,
     ):
         self.profiles = profiles
         self.helicity_n = int(helicity_n)
@@ -926,7 +934,7 @@ class RedlBootstrapMismatch:
 
 
 # ===========================================================================
-# Fixed-boundary Picard self-consistency loop (spec section 6.5, secondary lane)
+# Fixed-boundary Picard self-consistency loop (secondary lane)
 # ===========================================================================
 
 
@@ -984,8 +992,9 @@ def self_consistent_bootstrap(
     """Fixed-boundary Picard iteration to a bootstrap-consistent current profile.
 
     The Zenodo ``convertSfincsToVmecCurrentProfile`` "smooth method" with
-    the Redl ``<J.B>`` in place of SFINCS (spec section 6.5, secondary
-    lane).  Host-side loop (no AD through it):
+    the Redl ``<J.B>`` in place of SFINCS, the self-consistent iteration of
+    Landreman, Buller & Drevlak (2022) (secondary lane).  Host-side loop (no
+    AD through it):
 
     1. solve the equilibrium (hot-restarted from the previous iterate);
     2. ``Jr = j_dot_B_redl(profiles, redl_geometry_from_wout(...))`` on the

--- a/vmex/core/gammac.py
+++ b/vmex/core/gammac.py
@@ -3,7 +3,9 @@
 ``Gamma_c`` measures how far the contours of the second adiabatic invariant
 ``J`` deviate from flux surfaces: trapped particles whose bounce-averaged
 drift has a radial component ride superbanana orbits out of the device, and
-``Gamma_c**2`` scales the prompt-loss fraction of energetic ions.  The proxy
+Velasco et al. 2021, eqs. (20)-(21), relate the prompt-loss fraction of
+energetic ions approximately linearly to ``Gamma_c`` (more linearly still
+to the ``|gamma_c*|`` variant).  The proxy
 of Nemov, Kasilov, Kernbichler, Leitold, Phys. Plasmas 15, 052501 (2008),
 equation 61, as organized by Velasco et al., Nucl. Fusion 61, 116059 (2021),
 equation 16, is
@@ -801,8 +803,11 @@ class GammaC:
     Velasco et al., Nucl. Fusion 61, 116059 (2021), eq. 16 — see the module
     docstring for the formula and conventions.  ``residuals_state`` returns
     ``sqrt(weight) * Gamma_c`` rows for VMEX's least-squares interface, so
-    the total cost is the weighted sum of ``Gamma_c**2``, the prompt-loss
-    scaling of the proxy.  Traceable in both gradient modes.
+    the total cost is the weighted sum of ``Gamma_c**2``.  That square is
+    the least-squares form, not a physical scaling: Velasco et al. 2021,
+    eqs. (20)-(21), relate the prompt-loss fraction approximately linearly
+    to ``Gamma_c`` (more linearly to the ``|gamma_c*|`` variant).
+    Traceable in both gradient modes.
 
     **This is the hard physical diagnostic — its value is the number to
     report, but its boundary derivative is NOT a convergent quantity**: the

--- a/vmex/core/gammac.py
+++ b/vmex/core/gammac.py
@@ -887,11 +887,16 @@ class GammaCSmooth(GammaC):
     and bounce quadrature with the branch-noise sources of the boundary
     derivative regularized, so the derivative is stable in sign and
     magnitude under refinement of every sampling grid — the property the
-    hard diagnostic's derivative measurably lacks.  The smoothing biases the
-    value slightly (measured in ``tests/test_gammac.py``; it anneals away
-    under refinement and preserves the tokamak << QA << unoptimized-3D
-    ordering), so use this class inside the optimizer and always recompute
-    the hard :class:`GammaC` value on the accepted result.
+    hard diagnostic's derivative measurably lacks.  The surrogate value is
+    systematically below the hard one: by a factor 2-3 on multi-well 3-D
+    fields and by orders of magnitude on near-omnigenous fields whose
+    ripple wells are shallower than the floor (measured smooth/hard ratios
+    at ``temperature = 0.15`` in ``tests/test_gammac.py``: 0.42 on li383,
+    0.004 on the QA, 0.02 on the tokamak).  It preserves the tokamak << QA
+    << unoptimized-3D ordering and anneals toward the hard value as
+    ``temperature`` drops, but it is a gradient objective only, never a
+    reported number: use this class inside the optimizer and always
+    recompute the hard :class:`GammaC` value on the accepted result.
 
     The three derivative semantics of the plan are thus explicit in the
     class name: :class:`GammaC` is the hard value (no derivative promise

--- a/vmex/core/optimize.py
+++ b/vmex/core/optimize.py
@@ -783,12 +783,11 @@ def mirror_ratio(state: SpectralState, rt: SolverRuntime, *, s_index: int = -1) 
 
 
 def magnetic_well(state: SpectralState, rt: SolverRuntime) -> Array:
-    """VMEC/simsopt magnetic-well proxy ``(V'(0) - V'(1)) / V'(0)``.
+    """simsopt's ``Vmec.vacuum_well`` proxy ``(V'(0) - V'(1)) / V'(0)``.
 
     ``V' = dV/ds`` endpoints are linear extrapolations of the half-mesh
     differential volume ``vp`` (``bcovar.f``); positive values mean a
-    favorable well (``vacuum_well`` in simsopt).  Ported from legacy
-    ``vmex.finite_beta.magnetic_well_from_vp``.
+    favorable well.  Ported from legacy ``vmex.finite_beta.magnetic_well_from_vp``.
     """
     _, _, _, _, energies = _field_chain(state, rt)
     dvol = jnp.abs(jnp.asarray(energies.vp))[1:]
@@ -1356,7 +1355,7 @@ def unpack_boundary(
 
 
 #: curtor dof storage scale (dof = CURTOR/1e6, i.e. MA) — keeps the trust
-#: region O(1) alongside the boundary dofs (spec notes_r26g section 6.4).
+#: region O(1) alongside the boundary dofs.
 _CURTOR_SCALE = 1.0e6
 
 

--- a/vmex/core/stability.py
+++ b/vmex/core/stability.py
@@ -278,7 +278,8 @@ def _mercier_data_state(
 
     The shared pure-JAX reconstruction follows VMEC2000 ``jxbforce.f`` and
     ``mercier.f``.  The returned Glasser ``H`` uses the normalization of
-    Landreman & Jorge (2020), Eqs. (51) and (53).
+    Landreman & Jorge (2020), Eqs. (5.1) and (5.4) (``D_R`` and ``H``;
+    their Eq. (5.6) is the ``D_R``--``D_Merc`` relation).
     """
     setup = rt.setup
     s = jnp.asarray(setup.s_full)


### PR DESCRIPTION
Documentation-only corrections to the confinement diagnostics and their
citations. No numerical code changed: the formulas were audited and are
correct. Every claim below was checked against the source file, the test it
names, or the cited paper.

### Corrections

- **QA/QP contour topology** (`docs/explanation/confinement.rst`). The table
  had the two families inverted. For quasi-axisymmetry `|B|` depends on the
  Boozer poloidal angle, so its contours close *toroidally*; for
  quasi-poloidal symmetry they close *poloidally*. `docs/reference/objectives.rst`
  was already correct and is now the consistent statement.

- **`Gamma_c**2` is not a prompt-loss scaling** (`vmex/core/gammac.py`,
  `docs/reference/objectives.rst`, `docs/explanation/confinement.rst`).
  Velasco et al. 2021 relate the prompt-loss fraction to `Gamma_c`
  approximately *linearly* (their eqs. 20-21, more linearly still to the
  `gamma_c*` variant). The square is only the least-squares form: the
  residual rows are `sqrt(w) * Gamma_c`, so the cost sums `w * Gamma_c**2`.
  All four sites now say exactly that.

- **The smoothing bias is not "slight"** (`vmex/core/gammac.py`).
  `tests/test_gammac.py` measures smooth/hard ratios of 0.42 (li383), 0.004
  (QA) and 0.02 (tokamak) at `temperature = 0.15`. The docstring now reports
  those measured numbers, cites the test, and states that `GammaCSmooth` is a
  gradient objective only whose value is never a reported number.

- **Landreman & Jorge 2020 equation numbers** (`vmex/core/stability.py`). That
  paper numbers equations by section, so "Eqs. 51, 53" do not exist. Corrected
  to `D_R` = eq. (5.1), `H` = eq. (5.4), and the `D_R`/`D_Merc` relation the
  implementation matches = eq. (5.6). DOI 10.1017/S002237782000121X.

- **Redl et al. 2021 title and authors** (`docs/project/references.rst`). The
  title ends "in tokamaks", not "in stellarators"; authors are Redl, Angioni,
  Belli and Sauter. DOI 10.1063/5.0012664 added.

- **No simsopt oracle exists** (`docs/explanation/confinement.rst`). The page
  claimed the weighted two-term sum reproduces simsopt's
  `QuasisymmetryRatioResidual` A/B "bit-for-bit". No simsopt oracle runs in
  this test suite, so the claim is now identical formula, grid and weighting
  (the residual inside eq. 1 of Landreman & Paul 2022), with the gated
  comparison being VMEX's traceable lane against its wout lane in
  `tests/test_optimize_traceable_qs.py` — verified to exist and to test that.

- **Stale roadmap entry** (`README.md`). `GammaCSmooth` has shipped, so the
  promise of "a `Gamma_c` objective whose boundary derivative is well-posed
  under refinement" is no longer forward-looking. Replaced with the genuinely
  open item: a pinned DESC `Gamma_c` oracle assertion. Today the 2.8%
  agreement with DESC is only a docstring note in `tests/test_gammac.py`;
  verified that no assertion covers it.

### Citations and cleanups

- Equation-number citations at the definition sites: quasisymmetry (Landreman
  & Paul 2022, the residual inside eq. 1; Helander 2014 for "vanishes iff"),
  Gamma_c (Velasco 2021 eq. 16, which is Nemov 2008 eq. 61), bootstrap (Redl
  2021 eqs. 10-16 and 19-21 on the Sauter 1999 eqs. 18b-18e).
- The docs now say "Nemov/DESC form (tangency factor at the field minimum of
  each well)"; KNOSOS uses the `gamma_c*` variant, which drops that factor.
- `notes_r26g_redl_spec.md` is absent from the repository, so its module
  pointer and the nine "spec section 6.x" markers led nowhere. Replaced with
  the published sources the code transcribes. Where a marker pointed at an
  internal design section with no published counterpart, it was dropped
  rather than replaced with a guessed equation number.
- `vmex/core/optimize.py`: the magnetic-well proxy is attributed to simsopt's
  `Vmec.vacuum_well`.
- `vmex/core/bootstrap.py`: the duplicated trapped-fraction quadrature order
  is hoisted to one `N_LAMBDA` constant (five call sites, default unchanged
  at 64 — verified by inspecting the resolved signatures).
- Missing bibliography entries added with Crossref-verified data: Boozer 1981,
  Sanchez et al. 2000, Nemov et al. 2008, Velasco et al. 2021, Helander 2014,
  Sauter et al. 1999 (with its 2002 erratum), Lin-Liu & Miller 1995, Bader et
  al. 2019 and 2021; DOIs added to the Glasser, Landreman & Paul, Redl and
  Landreman-Buller-Drevlak entries.

### Verification

- `python tools/check_docs_prose.py` — clean.
- `python -m sphinx -b html -W docs docs/_build/ci` — build succeeded.
- `python -m pytest tests/test_capability_docs.py tests/test_docs_nav.py
  tests/test_performance_docs.py tests/test_test_manifest.py
  tests/test_doctor.py` — 42 passed, 3 skipped.
- `python -m ruff check vmex tests` — all checks passed.

No guard test asserted any of the corrected claims, so no guard needed
updating.
