### PR TITLE
Record the W7-X polish memory and cost measurements

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -3314,18 +3314,45 @@ this scale (normalized_l2 1.99999999997 before, normalized_linf 2.0 after
 Gauss-Newton" and "Gauss-Newton done" with no output, which is the user's
 original complaint about a silent, apparently hung polish.
 
+### 31.6c Persistent-cache cost, measured 2026-09-03 (corrects an earlier claim)
+
+The mechanism recorded for the 2026-08-31 CI timeout plague - cross-process
+eviction-lock serialization - is NOT supported by measurement and should not
+be repeated as fact. Measured on an Apple M4 (artifact
+`benchmarks/cache_entry_scaling_m4_2026-09-03.json`, PR #254): a cold QA
+solve spends 0.55 s in total inside the cache lock (289 gets at 0.18 ms
+median, 171 puts at 2.72 ms) on a fresh cache. Four-way concurrency cannot
+turn that into a thirty-minute lane.
+
+What IS measured, and is a real user-facing defect: `LRUCache.put` calls
+`_evict_if_needed` under the directory-wide lock, and that globs every
+entry, stats it and reads its atime sidecar, so a write costs 0.028 ms per
+resident entry - 5.7 ms at 250 entries, 304 ms at 10880. JAX bounds the
+cache by bytes, vmex entries are small, so the bound never fires and the
+count grows without limit (10880 entries in 238 MB on the author's
+machine). A cold QA solve took 7.46 s on a fresh cache and 31.3 s on the
+mature one, 25.6 s of it inside `put`. PR #254 trims to the 1024
+least-recently-used entries once per process: 11.5 s, and 3.1 s warm with
+289 of 289 lookups hitting.
+
+Whether that also explains CI is unproven: runners start with an empty
+cache, so the rescan is cheap early, though a long lane accumulates
+thousands of entries and the runner's disk is far slower than an M4's.
+Disabling the cache on runners (#228) coincided with the timeouts stopping;
+the mechanism was never established. Say that, rather than asserting the
+lock. For users running job arrays on a shared home the answer is now the
+entry bound plus `VMEX_COMPILATION_CACHE_DIR` per task; a measurement with
+N concurrent processes is still missing and needs an idle machine.
+
 ### 31.7 Remaining engineering items (carried from section 8.8 and the campaign)
 
 3-D polish effectiveness and memory at production resolution (the
 stellarator README row depends on it; W7-X numbers in 31.1); v0.8.2 after
 the polish memory PR; the section 9 matrix rerun with all five regimes;
 GPU validation of the 0.8.1 stack (office GPUs; host RAM shared with the
-polish run); persistent-cache eviction-lock behavior for concurrent
-processes on one cache directory (the CI symptom was serialization to
-timeout; users running job arrays on a shared home need a product answer:
-per-process shard, batched writes, or floor tuning); parity lane c3d at
-43-44 minutes of a 55-minute budget (repartition the implicit-campaign
-modules); tridiagonal method pinning per placement (bit-identical on CPU,
+polish run); parity lane c3d at
+43-44 minutes of a 55-minute budget (repartitioned by PR #252: the two
+polish-heavy modules move to lane e); tridiagonal method pinning per placement (bit-identical on CPU,
 needs a device-aware runtime field); booz_xform_jax 0.2.0 adoption.
 
 ### 31.8 Next-agent runbook
@@ -3372,7 +3399,8 @@ packaging metadata, API reference). Items 2 and 8 wait on the maintainer.
 P3 - performance and engineering, unblocked and parallel to P2: the 3-D
 polish memory fix and v0.8.2; the section 9 benchmark matrix rerun on 0.8.1+
 with all five regimes after #246; booz_xform_jax 0.2.0; GPU validation;
-c3d lane repartition; the cache eviction-lock product answer.
+c3d lane repartition (#252); the cache entry
+bound (#254).
 
 P4 - Phase 9/10 mirror and hybrid work is planning only until P0-P2 land.
 Section 16.3 (corrected above), 31.4-R3..R6 and the spec sheet are the

--- a/plan.md
+++ b/plan.md
@@ -3272,6 +3272,48 @@ Still open:
   and add the published global normalizations for every reported number.
 - GitHub topics and repository description.
 
+### 31.6b W7-X polish measurements (office box, completed 2026-09-03)
+
+Two bounded 3-D polish runs finished on the office box; the result files are
+`~/polish3d/run1_qa_tol1e-6.json` and `~/polish3d/run5_w7x_remat.json`
+there. They settle the memory question and reframe the effectiveness one.
+
+Memory: the batched, checkpointed certificate and force kernel took the
+W7-X deck (MPOL = NTOR = 10, ns 13/25/51) from an un-chunked 34.5 GB
+allocation and an OS kill to a clean exit at 17.1 GB peak RSS. That fix is
+the v0.8.2 blocker and should ship on its own merits.
+
+Cost: the same run took 11 h 09 m. Setup was bounded (legacy solve 40 s,
+refine/lift/initial certificate ~4 min, preconditioner 3 min, root runtime
+2 min, structured chart 22 min, projection 30 s); Gauss-Newton took 10 h
+35 m for six iterations, about 1.75 h each, every one of them hitting the
+150-iteration linear ceiling. The QA case that polishes well needed
+roughly forty iterations, so a comparable W7-X budget is of order three
+days. Cost per iteration, not futility, is the publishable obstacle.
+
+Effectiveness, stated carefully: W7-X moved its own collocation cost
+67900 -> 41570 (-39%) while the independent certificate moved
+absolute_l2 4.327e6 -> 4.279e6 (-1.1%), with edge_l2 -33% and near-axis
+and helical residuals slightly worse. The QA run moved cost 9009 -> 2170
+and absolute_l2 3.427e4 -> 2.042e4 (-40%). The W7-X run had six iterations
+against QA's forty and a quarter of the linear budget, so the two are not
+comparable evidence; the effectiveness question needs a long-budget W7-X
+run before anyone writes it down as a result.
+
+Do NOT gate AUTO on the projection unresolved fraction: it is 0.694 on the
+W7-X run and 0.734 on the QA run that polishes well, so it does not
+separate them. The diagnostic that does differ sharply is `sampled_rms`
+(0.0018 QA against 0.442 W7-X) at nearly equal `projected_residual_rms`;
+that is worth understanding but is two data points, not a threshold.
+Gate on predicted cost instead, and tell the user what the run would cost
+and which knob raises the ceiling.
+
+Also confirmed here: the certificate's normalized metrics are useless at
+this scale (normalized_l2 1.99999999997 before, normalized_linf 2.0 after
+- finding 31.2-R1), and ten and a half hours passed between "entering
+Gauss-Newton" and "Gauss-Newton done" with no output, which is the user's
+original complaint about a silent, apparently hung polish.
+
 ### 31.7 Remaining engineering items (carried from section 8.8 and the campaign)
 
 3-D polish effectiveness and memory at production resolution (the


### PR DESCRIPTION
Two bounded 3-D polish runs finished on the office box overnight. The batched certificate takes the W7-X deck from a 34.5 GB allocation and an OS kill to a clean exit at 17.1 GB peak RSS; the same run costs 11 h 09 m, of which 10 h 35 m is six Gauss-Newton iterations at the linear-iteration ceiling.

The section also records what the runs do NOT show: the W7-X case had six iterations against the QA case's forty, so its 1.1% certificate movement is not evidence that polishing fails at that resolution, and the projection unresolved fraction does not separate the two runs (0.694 W7-X against 0.734 QA) and must not be used to gate AUTO.