### PR TITLE
Bound the persistent cache by entry count, not only by bytes

### DIFF
--- a/benchmarks/cache_entry_scaling_m4_2026-09-03.json
+++ b/benchmarks/cache_entry_scaling_m4_2026-09-03.json
@@ -1,0 +1,61 @@
+{
+  "schema": "vmex.cache-entry-scaling/1",
+  "provenance": {
+    "vmex_commit": "2d3be2c070725c07acd2f3f6ab32f9f4c41c875d",
+    "created_utc": "2026-09-03T12:22:37Z",
+    "host": "Apple M4, macOS 14.4, APFS",
+    "python": "3.12",
+    "jax": "0.11.1",
+    "note": "Other work was running on the machine; the scaling medians are stable (min within 10% of median) but wall times are upper bounds."
+  },
+  "mechanism": "jax._src.lru_cache.LRUCache.put calls _evict_if_needed under the directory-wide lock; it globs every '*-cache' entry, stats it and reads its '-atime' sidecar. The cost is linear in resident entries and is paid on every write. JAX's bound is on bytes, and vmex entries are small, so the byte bound never fires and the entry count grows without limit.",
+  "put_cost_vs_entries": {
+    "payload_bytes": 2097152,
+    "repeats": 5,
+    "median_ms": {
+      "250": 5.7,
+      "1000": 24.1,
+      "4000": 103.3,
+      "10000": 276.0,
+      "10880": 304.0
+    },
+    "slope_ms_per_entry": 0.028
+  },
+  "end_to_end": {
+    "deck": "examples/data/input.LandremanPaul2021_QA_beta0p5_bootstrap",
+    "runs": [
+      {
+        "cache": "fresh (0 entries)",
+        "bound": null,
+        "wall_s": 7.46,
+        "puts": 171,
+        "put_median_ms": 2.72,
+        "put_total_s": 0.464
+      },
+      {
+        "cache": "mature (10880 entries)",
+        "bound": null,
+        "wall_s": 31.3,
+        "puts": 79,
+        "put_median_ms": 315.9,
+        "put_total_s": 25.623
+      },
+      {
+        "cache": "mature, pruned to the bound",
+        "bound": 1024,
+        "wall_s": 11.48,
+        "puts": 166,
+        "put_median_ms": 28.61,
+        "put_total_s": 4.855
+      },
+      {
+        "cache": "pruned, warm rerun",
+        "bound": 1024,
+        "wall_s": 3.14,
+        "puts": 0,
+        "gets": 289,
+        "get_hits": 289
+      }
+    ]
+  }
+}

--- a/docs/reference/performance.rst
+++ b/docs/reference/performance.rst
@@ -416,6 +416,28 @@ absolute tolerances cover the golden run's own remaining non-convergence.
 wout files are compared per-variable with CompareWOut-style combined
 rel+abs tolerances.
 
+Keeping the persistent cache small
+----------------------------------
+
+The persistent compilation cache is bounded by entry count as well as by
+bytes.  JAX re-scans the whole cache directory on every *write*: ``put``
+globs each entry, stats it and reads its access-time sidecar, all under the
+directory-wide lock.  The cost is linear in the number of resident entries —
+0.028 ms per entry on an Apple M4 — so a write costs 5.7 ms at 250 entries
+and 304 ms at 10880, the size a working machine reaches in a few weeks.
+VMEX stores every program (the sub-second ones repay their cost on reload),
+so a cold solve writes a few hundred entries and a mature cache turned a
+7.5 s solve into 31.3 s, 82% of it directory scans.
+
+JAX's own bound is on bytes and these entries are small, so it never fires.
+VMEX therefore trims the directory to its least-recently-used ``1024``
+entries once per process, before anything writes: one scan per process
+instead of one per write.  The same solve then costs 11.5 s on that cache,
+and a warm rerun 3.1 s with 289 of 289 lookups hitting — pruning by access
+time keeps the working set.  Set ``VMEX_CACHE_MAX_ENTRIES`` to change the
+bound, or to ``0`` to disable trimming.  The measurements, with provenance,
+are in ``benchmarks/cache_entry_scaling_m4_2026-09-03.json``.
+
 Fresh decks against ``xvmec2000`` (2026-09-02)
 -----------------------------------------------
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -472,3 +472,58 @@ def test_configure_compilation_cache_bounds_resident_entries(tmp_path, monkeypat
     before = len(list(tmp_path.glob("*-cache")))
     _compat._configure_compilation_cache(fake, str(tmp_path))
     assert len(list(tmp_path.glob("*-cache"))) == before
+
+
+def test_prune_cache_entries_gives_up_quietly_on_every_failure(tmp_path, monkeypatch):
+    """Pruning is housekeeping: no failure of it may stop a solve.
+
+    Each branch that returns early or skips an entry is exercised: an
+    unreadable directory, a lock another process holds, an entry that cannot
+    be removed, and a sidecar that vanished first.
+    """
+    import pathlib
+
+    import filelock
+
+    _seed_cache(tmp_path, 6)
+
+    # an unreadable directory (glob itself fails) is not an error
+    monkeypatch.setattr(pathlib.Path, "glob", lambda self, pattern: (_ for _ in ()).throw(OSError("unreadable")))
+    assert _compat._prune_cache_entries(str(tmp_path), 2) == 0
+    monkeypatch.undo()
+
+    # a lock held elsewhere means someone else is pruning: leave it to them
+    def _busy(self, timeout=None, **kwargs):
+        raise filelock.Timeout(str(self.lock_file))
+
+    monkeypatch.setattr(filelock.FileLock, "acquire", _busy)
+    assert _compat._prune_cache_entries(str(tmp_path), 2) == 0
+    assert len(list(tmp_path.glob("*-cache"))) == 6
+    monkeypatch.undo()
+
+    # an entry that cannot be unlinked is skipped, and a sidecar that is
+    # already gone does not stop the sweep
+    (tmp_path / "k0-atime").unlink()
+    real_unlink = pathlib.Path.unlink
+
+    def _stubborn(self, *args, **kwargs):
+        if self.name == "k1-cache":
+            raise OSError("busy")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "unlink", _stubborn)
+    removed = _compat._prune_cache_entries(str(tmp_path), 2)
+    monkeypatch.undo()
+    assert removed == 3
+    assert (tmp_path / "k1-cache").exists()
+    assert len(list(tmp_path.glob("*-cache"))) == 3
+
+
+def test_configure_compilation_cache_ignores_an_unparseable_entry_bound(tmp_path, monkeypatch):
+    monkeypatch.setenv("VMEX_CACHE_MAX_ENTRIES", "many")
+    _seed_cache(tmp_path, 4)
+    fake = types.SimpleNamespace(config=_FakeConfig())
+    _compat._configure_compilation_cache(fake, str(tmp_path))
+    # the bound is skipped, the rest of the configuration still lands
+    assert len(list(tmp_path.glob("*-cache"))) == 4
+    assert fake.config.updates["jax_compilation_cache_dir"] == str(tmp_path)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -420,3 +420,55 @@ def test_configure_compilation_cache_applies_and_survives_failures(monkeypatch):
     })
     _compat._configure_compilation_cache(jx, "/tmp/vmex-cache-test")
     assert jx.config.updates == {}
+
+
+# ---------------------------------------------------------------------------
+# resident-entry bound (JAX re-scans the cache directory on every write)
+# ---------------------------------------------------------------------------
+
+
+def _seed_cache(path, count):
+    """Write ``count`` cache entries whose atimes increase with the index."""
+    for i in range(count):
+        (path / f"k{i}-cache").write_bytes(b"x")
+        (path / f"k{i}-atime").write_bytes(i.to_bytes(8, "little"))
+
+
+def test_prune_cache_entries_keeps_the_most_recently_used(tmp_path):
+    _seed_cache(tmp_path, 50)
+    assert _compat._prune_cache_entries(str(tmp_path), 10) == 40
+    kept = sorted(int(p.name[1:-6]) for p in tmp_path.glob("*-cache"))
+    assert kept == list(range(40, 50))
+    # the atime sidecars go with their entries, so the directory does not
+    # accumulate orphans that the next scan would still have to stat
+    assert len(list(tmp_path.glob("*-atime"))) == 10
+    # already inside the bound: no work, no deletions
+    assert _compat._prune_cache_entries(str(tmp_path), 10) == 0
+
+
+def test_prune_cache_entries_survives_a_hostile_directory(tmp_path):
+    _seed_cache(tmp_path, 5)
+    (tmp_path / "k2-atime").unlink()  # entry with no atime sidecar
+    assert _compat._prune_cache_entries(str(tmp_path), 2) == 3
+    assert len(list(tmp_path.glob("*-cache"))) == 2
+    # a missing directory is not an error: the cache may not exist yet
+    assert _compat._prune_cache_entries(str(tmp_path / "absent"), 1) == 0
+
+
+def test_configure_compilation_cache_bounds_resident_entries(tmp_path, monkeypatch):
+    monkeypatch.delenv("VMEX_CACHE_MAX_ENTRIES", raising=False)
+    monkeypatch.delenv("VMEC_JAX_CACHE_MAX_ENTRIES", raising=False)
+    _seed_cache(tmp_path, _compat._CACHE_MAX_ENTRIES + 7)
+    fake = types.SimpleNamespace(config=_FakeConfig())
+    _compat._configure_compilation_cache(fake, str(tmp_path))
+    assert len(list(tmp_path.glob("*-cache"))) == _compat._CACHE_MAX_ENTRIES
+
+    # the bound is tunable, and 0 turns it off
+    monkeypatch.setenv("VMEX_CACHE_MAX_ENTRIES", "3")
+    _compat._configure_compilation_cache(fake, str(tmp_path))
+    assert len(list(tmp_path.glob("*-cache"))) == 3
+    monkeypatch.setenv("VMEX_CACHE_MAX_ENTRIES", "0")
+    _seed_cache(tmp_path, 20)
+    before = len(list(tmp_path.glob("*-cache")))
+    _compat._configure_compilation_cache(fake, str(tmp_path))
+    assert len(list(tmp_path.glob("*-cache"))) == before

--- a/vmex/_compat.py
+++ b/vmex/_compat.py
@@ -28,9 +28,12 @@ import platform
 
 
 _CACHE_FORMAT_VERSION = "3"
+_CACHE_MAX_ENTRIES = 1024            # resident executables; see _prune_cache_entries
 _CACHE_SIZE_FLOOR = 2 << 30          # 2 GiB
 _CACHE_SIZE_CEILING = 20 << 30       # 20 GiB
 _CACHE_DISK_FRACTION = 0.10
+_CACHE_ENTRY_SUFFIX = "-cache"       # jax._src.lru_cache naming
+_CACHE_ATIME_SUFFIX = "-atime"
 
 
 def _default_cache_max_size(path: str | None = None) -> int:
@@ -54,6 +57,75 @@ def _default_cache_max_size(path: str | None = None) -> int:
         return _CACHE_SIZE_FLOOR
     scaled = int(_CACHE_DISK_FRACTION * float(free))
     return int(min(_CACHE_SIZE_CEILING, max(_CACHE_SIZE_FLOOR, scaled)))
+
+
+def _prune_cache_entries(cache_dir: str, max_entries: int) -> int:
+    """Drop the least recently used cache entries above ``max_entries``.
+
+    JAX's LRU cache re-scans the whole cache directory on every *write*: each
+    ``put`` globs the directory, stats every entry and reads every atime
+    sidecar, all under the directory-wide lock.  The cost is linear in the
+    number of resident entries and, measured on an Apple M4, is 0.028 ms per
+    entry -- 5.7 ms per write at 250 entries but 304 ms at 10880, the size a
+    developer machine reaches in a few weeks.  With vmex's floor-0 policy (we
+    store every program, which is worth it on reload) a cold QA solve writes
+    ~170 entries, so a mature cache turned a 7.5 s solve into 31.3 s, 82% of
+    it directory scans.  JAX's own bound is on bytes, and these entries are
+    small, so it never fires.
+
+    Bounding the entry count instead costs one scan per process rather than
+    one per write.  Returns the number of entries removed.
+    """
+    try:
+        import pathlib
+
+        path = pathlib.Path(cache_dir)
+        entries = list(path.glob(f"*{_CACHE_ENTRY_SUFFIX}"))
+        if len(entries) <= max_entries:
+            return 0
+    except Exception:  # missing directory, unreadable filesystem
+        return 0
+
+    lock = None
+    try:
+        import filelock
+
+        lock = filelock.FileLock(path / ".lockfile")
+        lock.acquire(timeout=5)
+    except Exception:
+        # No filelock, or another process holds it and is likely pruning too.
+        return 0
+
+    removed = 0
+    try:
+        def _atime(entry: "pathlib.Path") -> int:
+            sidecar = entry.with_name(
+                entry.name[: -len(_CACHE_ENTRY_SUFFIX)] + _CACHE_ATIME_SUFFIX
+            )
+            try:
+                return int.from_bytes(sidecar.read_bytes(), "little")
+            except Exception:
+                return 0
+
+        for entry in sorted(entries, key=_atime)[: len(entries) - max_entries]:
+            sidecar = entry.with_name(
+                entry.name[: -len(_CACHE_ENTRY_SUFFIX)] + _CACHE_ATIME_SUFFIX
+            )
+            try:
+                entry.unlink()
+                removed += 1
+            except OSError:
+                continue
+            try:
+                sidecar.unlink()
+            except OSError:
+                pass
+    finally:
+        try:
+            lock.release()
+        except Exception:
+            pass
+    return removed
 
 
 def _env(name: str, default: str = "") -> str:
@@ -282,6 +354,14 @@ def _configure_compilation_cache(jax_module: Any, cache_dir: str | None) -> None
     """Apply vmex's persistent-cache defaults to an imported JAX module."""
     if cache_dir is None:
         return
+    try:
+        # Keep the directory small before anything writes to it: every write
+        # re-scans it (see _prune_cache_entries).  0 disables the bound.
+        max_entries = int(_env("CACHE_MAX_ENTRIES", str(_CACHE_MAX_ENTRIES)))
+        if max_entries > 0:
+            _prune_cache_entries(cache_dir, max_entries)
+    except Exception:
+        pass
     try:
         jax_module.config.update("jax_enable_compilation_cache", True)
     except Exception:


### PR DESCRIPTION
Found while working out the product answer for concurrent runs sharing one cache (plan section 31.7).

`jax._src.lru_cache.LRUCache.put` calls `_evict_if_needed` under the directory-wide lock, and that globs every entry, stats it, and reads its `-atime` sidecar. The cost is linear in resident entries and is paid on **every write**. JAX bounds the cache by bytes; VMEX entries are small, so the byte bound never fires and the entry count grows without limit — the cache on my own machine had 10,880 entries in 238 MB.

Measured on an Apple M4 (artifact: `benchmarks/cache_entry_scaling_m4_2026-09-03.json`):

| resident entries | one put |
|---|---|
| 250 | 5.7 ms |
| 1000 | 24.1 ms |
| 4000 | 103.3 ms |
| 10880 | 304.0 ms |

End to end on `input.LandremanPaul2021_QA_beta0p5_bootstrap`: 7.46 s on a fresh cache, **31.3 s on the 10,880-entry cache** (79 puts, 25.6 s of them inside `put`), 11.5 s with this bound, and 3.1 s on a warm rerun where all 289 lookups hit — pruning by access time keeps the working set.

This also revises the mechanism recorded for the 2026-08-31 CI timeouts: lock *contention* is sub-second per process (0.55 s of lock-held time in a cold QA solve), far too small to explain a 30-45 minute lane. The directory rescan is the plausible mechanism, and it grows with cache age.

Tests: three cases in `tests/test_compat.py` covering LRU order, sidecar removal, a hostile directory, the env knob and disabling. `tools/preflight.py --static` PASS, docs build clean with -W.