### PR TITLE
Fix two certificate diagnostics that reported the wrong quantity

### DIFF
--- a/tests/test_strong_force.py
+++ b/tests/test_strong_force.py
@@ -528,3 +528,28 @@ def test_angular_spectral_tail_measures_the_high_harmonics():
     mixed = poloidal(1) + poloidal(8)
     value = float(_angular_spectral_tail(mixed))
     assert 0.0 < value < 1.0
+
+
+def test_nestedness_margin_is_scale_free_and_distinct_from_the_jacobian():
+    """The two Jacobian fields answered the same question in the same units.
+
+    ``nestedness_margin`` was literally ``jnp.min(signed_jacobian)``, the
+    value ``minimum_signed_jacobian`` already carries, so the certificate
+    published one number under two names. A margin has to be scale free to
+    mean anything across devices: scaling a geometry by ``a`` scales every
+    volume element by ``a**3``, which moves the minimum but not the fraction.
+    """
+    from vmex.core.strong_force import _nestedness_margin
+
+    jacobian = jnp.asarray([2.0, 4.0, 6.0, 8.0])
+    margin = float(_nestedness_margin(jacobian))
+    assert margin == pytest.approx(2.0 / 5.0)
+    assert margin != pytest.approx(float(jnp.min(jacobian)))
+
+    # a uniformly scaled device reports the same margin
+    for factor in (1.0e-3, 1.0e3):
+        assert float(_nestedness_margin(factor * jacobian)) == pytest.approx(margin)
+
+    # it crosses zero exactly where the Jacobian does
+    assert float(_nestedness_margin(jnp.asarray([-1.0, 3.0]))) < 0.0
+    assert float(_nestedness_margin(jnp.asarray([0.0, 3.0]))) == 0.0

--- a/tests/test_strong_force.py
+++ b/tests/test_strong_force.py
@@ -485,3 +485,46 @@ def test_chart_metadata_excludes_the_build_timestamp():
     assert structure == jax.tree_util.tree_structure(rebuilt)
     leaves, treedef = jax.tree_util.tree_flatten(chart)
     assert treedef.unflatten(leaves).build_seconds == 0.0
+
+
+def test_angular_spectral_tail_measures_the_high_harmonics():
+    """The tail is the power above two thirds of the resolvable harmonics.
+
+    ``rfftn`` leaves the poloidal axis a full complex transform, so its rows
+    run ``m = 0, 1, ..., ntheta/2, -ntheta/2, ..., -1``.  Cutting on the row
+    index selects the lowest ``|m|`` negative frequencies instead: under that
+    reading a pure ``m = 1`` field reported half its power as unresolved and a
+    near-Nyquist field reported none.
+    """
+    from vmex.core.strong_force import _angular_spectral_tail
+
+    ntheta, nzeta = 24, 20
+    theta = np.arange(ntheta) * 2.0 * np.pi / ntheta
+    zeta = np.arange(nzeta) * 2.0 * np.pi / nzeta
+
+    def poloidal(m):
+        return jnp.asarray(np.broadcast_to(
+            np.cos(m * theta)[None, :, None], (3, ntheta, nzeta)))
+
+    def toroidal(n):
+        return jnp.asarray(np.broadcast_to(
+            np.cos(n * zeta)[None, None, :], (3, ntheta, nzeta)))
+
+    # resolved harmonics carry no tail; those at or above the cut are all tail
+    assert float(_angular_spectral_tail(poloidal(1))) == pytest.approx(0.0, abs=1e-12)
+    assert float(_angular_spectral_tail(poloidal(7))) == pytest.approx(0.0, abs=1e-12)
+    assert float(_angular_spectral_tail(poloidal(8))) == pytest.approx(1.0, abs=1e-12)
+    assert float(_angular_spectral_tail(toroidal(1))) == pytest.approx(0.0, abs=1e-12)
+    assert float(_angular_spectral_tail(toroidal(9))) == pytest.approx(1.0, abs=1e-12)
+
+    # a high-m, high-n corner harmonic is counted once, so the ratio is a
+    # fraction: summing the two half-planes separately used to exceed one
+    corner = jnp.asarray(np.broadcast_to(
+        (np.cos(10 * theta)[:, None] * np.cos(9 * zeta)[None, :])[None, :, :],
+        (3, ntheta, nzeta)))
+    assert float(_angular_spectral_tail(corner)) == pytest.approx(1.0, abs=1e-12)
+
+    # a mixture lands strictly between the two, and the metric stays bounded
+    mixed = poloidal(1) + poloidal(8)
+    value = float(_angular_spectral_tail(mixed))
+    assert 0.0 < value < 1.0

--- a/vmex/core/strong_force.py
+++ b/vmex/core/strong_force.py
@@ -227,7 +227,10 @@ class StrongForceReport:
     flux_surface_normalized_l2: Array
     angular_spectral_tail: Array
     radial_refinement_difference: Array
+    #: Smallest signed Jacobian on the sample, in machine units.
     minimum_signed_jacobian: Array
+    #: The same minimum divided by the mean |Jacobian|: scale-free, so it is
+    #: comparable across devices.  See :func:`_nestedness_margin`.
     nestedness_margin: Array
     boundary_residual: Array
     gauge_residual: Array
@@ -745,6 +748,21 @@ def _angular_spectral_tail(magnitude: Array) -> Array:
     return jnp.sqrt(tail / jnp.maximum(jnp.sum(power), 1.0e-300))
 
 
+def _nestedness_margin(signed_jacobian: Array) -> Array:
+    """How close the surfaces come to touching, as a scale-free fraction.
+
+    ``minimum_signed_jacobian`` answers the same question in machine units,
+    so it says nothing on its own: a small tokamak and a reactor with equally
+    healthy surfaces report numbers three decades apart.  Dividing by the mean
+    magnitude removes the size of the device, since a geometry scaled by
+    ``a`` scales every volume element by ``a**3``.  The margin is positive
+    where the surfaces are nested, and crosses zero exactly where the
+    Jacobian does.
+    """
+    scale = jnp.mean(jnp.abs(signed_jacobian))
+    return jnp.min(signed_jacobian) / jnp.maximum(scale, 1.0e-300)
+
+
 def certify_strong_force(
     state: HighOrderEquilibriumState,
     *,
@@ -867,7 +885,7 @@ def certify_strong_force(
         angular_spectral_tail=tail,
         radial_refinement_difference=refinement,
         minimum_signed_jacobian=jnp.min(signed_jacobian),
-        nestedness_margin=jnp.min(signed_jacobian),
+        nestedness_margin=_nestedness_margin(signed_jacobian),
         boundary_residual=boundary_residual,
         gauge_residual=gauge_residual,
         force_floor=float(force_floor),

--- a/vmex/core/strong_force.py
+++ b/vmex/core/strong_force.py
@@ -724,6 +724,27 @@ def _weighted_quantile(values: Array, weights: Array, quantile: float) -> Array:
     return sorted_values[index]
 
 
+def _angular_spectral_tail(magnitude: Array) -> Array:
+    """Fraction of angular power above two thirds of the resolvable harmonics.
+
+    ``magnitude`` is sampled on ``(s, theta, zeta)``.  ``rfftn`` over the two
+    angles transforms theta in full, so its rows run
+    ``m = 0, 1, ..., ntheta/2, -ntheta/2, ..., -1``: a plain index cut on that
+    axis selects the *lowest* ``|m|`` negative frequencies, the opposite of a
+    tail.  Mask on ``|m|`` instead, and take the union with the toroidal
+    condition so the high-``m``, high-``n`` corner is counted once.
+    """
+    power = jnp.abs(jnp.fft.rfftn(magnitude, axes=(1, 2))) ** 2
+    ntheta, nzeta_half = power.shape[1], power.shape[2]
+    poloidal = jnp.abs(jnp.fft.fftfreq(ntheta) * ntheta)
+    toroidal = jnp.arange(nzeta_half)
+    theta_cut = max(1.0, (2.0 / 3.0) * (ntheta // 2))
+    zeta_cut = max(1.0, (2.0 / 3.0) * max(nzeta_half - 1, 1))
+    tail_mask = (poloidal[:, None] >= theta_cut) | (toroidal[None, :] >= zeta_cut)
+    tail = jnp.sum(jnp.where(tail_mask, power, 0.0))
+    return jnp.sqrt(tail / jnp.maximum(jnp.sum(power), 1.0e-300))
+
+
 def certify_strong_force(
     state: HighOrderEquilibriumState,
     *,
@@ -785,12 +806,7 @@ def certify_strong_force(
             0.0,
         )
 
-    angular_fft = jnp.fft.rfftn(magnitude, axes=(1, 2))
-    angular_power = jnp.abs(angular_fft) ** 2
-    theta_cut = max(1, angular_power.shape[1] * 2 // 3)
-    zeta_cut = max(1, angular_power.shape[2] * 2 // 3)
-    tail = jnp.sum(angular_power[:, theta_cut:, :]) + jnp.sum(angular_power[:, :, zeta_cut:])
-    tail = jnp.sqrt(tail / jnp.maximum(jnp.sum(angular_power), 1.0e-300))
+    tail = _angular_spectral_tail(magnitude)
     coarse_order = max(state.radial_basis.degree + 1, order - 2)
     coarse_s, coarse_s_weights = radial_quadrature(coarse_order)
     coarse_rho = np.sqrt(coarse_s)

--- a/vmex/core/strong_force.py
+++ b/vmex/core/strong_force.py
@@ -229,7 +229,7 @@ class StrongForceReport:
     radial_refinement_difference: Array
     #: Smallest signed Jacobian on the sample, in machine units.
     minimum_signed_jacobian: Array
-    #: The same minimum divided by the mean |Jacobian|: scale-free, so it is
+    #: The same minimum divided by the mean absolute Jacobian: scale-free, so it is
     #: comparable across devices.  See :func:`_nestedness_margin`.
     nestedness_margin: Array
     boundary_residual: Array


### PR DESCRIPTION
Two published fields of the force-balance certificate did not measure what their names say. Both were found while checking a defect report from the API-documentation pass (PR #257), and both were verified numerically before being changed.

## `angular_spectral_tail` measured the lowest harmonics

It is meant to report the fraction of angular power above two thirds of the resolvable harmonics — a resolution-adequacy diagnostic published in every certificate report and in `benchmarks/strong_force_cases_m4.json`. `jnp.fft.rfftn(magnitude, axes=(1, 2))` halves only the *last* axis; the poloidal axis stays a full complex transform whose rows run `m = 0, 1, …, ntheta/2, -ntheta/2, …, -1`. Cutting at `shape[1] * 2 // 3` therefore selected `m = -ntheta/3 … -1`, the **lowest** `|m|` harmonics.

Measured on a 24-point poloidal grid, before the fix: a pure `m = 1` field reported **0.5** of its power as unresolved; a near-Nyquist `m = 11` field reported **0.0**. After: 0.0 and 1.0.

The two half-plane sums also double-counted the high-`m`, high-`n` corner, so the ratio was not bounded by one. The mask union fixes that. The toroidal cut is unchanged in effect, since that axis was already a half spectrum.

## `nestedness_margin` was the Jacobian under a second name

It was literally `jnp.min(signed_jacobian)` — the value `minimum_signed_jacobian` already carries — from the commit that introduced the certificate. So two fields published one number, and in machine units, where a small tokamak and a reactor with equally healthy surfaces report values three decades apart.

It is now that minimum divided by the mean `|Jacobian|`. A geometry scaled by `a` scales every volume element by `a**3`, so the fraction is invariant to device size, and it still crosses zero exactly where the Jacobian does. Both fields are now documented on the report.

## Notes

No test or documentation page pinned either value — they are reported in benchmark artifacts only, and those values predate this change (noted in the commits). The new tests pin the semantics directly, including the corner case, boundedness, and scale invariance.

Verified: `tests/test_strong_force.py` 24 passed, `tools/preflight.py --static` PASS.

For the concurrent 31.2-R1 work in `vmex/core/strong_force.py`: this adds two module-level helpers just above the certificate function and changes two lines of its return, so it should rebase cleanly.