### PR TITLE
Report the symmetry a high-order state carries, not the one requested

### DIFF
--- a/tests/test_boozer_tables.py
+++ b/tests/test_boozer_tables.py
@@ -609,3 +609,32 @@ def test_refine_booz_grids_preserves_the_parity_grid_layout(asym):
     coarse_rows = int(constants.ntheta) if asym else int(constants.nu2_b)
     assert np.allclose(np.asarray(grids.theta_grid).reshape(coarse_rows, -1)[:, 0],
                        theta.reshape(rows, -1)[::factor, 0][:coarse_rows])
+
+
+def test_boozer_high_order_uses_the_symmetry_the_state_carries():
+    """``asym`` sets the transform's poloidal range; the sine families always go.
+
+    A state carrying asymmetric harmonics with ``asym=False`` integrates that
+    geometry over a half period and returns a spectrum for a plasma that does
+    not exist, with nothing said. The flag now follows the state.
+    """
+    import numpy as np
+
+    from vmex.core.omnigenity import _tables_are_asymmetric
+
+    class _State:
+        def __init__(self):
+            self.nfp = 2
+            self.R_sin = np.zeros((3, 4))
+            self.Z_cos = np.zeros((3, 4))
+
+    assert _tables_are_asymmetric(_State()) is False
+
+    poloidal = _State()
+    poloidal.R_sin[1, 2] = 1.0e-6
+    assert _tables_are_asymmetric(poloidal) is True
+
+    # either family is enough, at any magnitude
+    vertical = _State()
+    vertical.Z_cos[0, 0] = -2.0e-8
+    assert _tables_are_asymmetric(vertical) is True

--- a/tests/test_strong_force.py
+++ b/tests/test_strong_force.py
@@ -989,3 +989,24 @@ def test_force_error_measures_and_record_expose_the_non_saturating_numbers():
     assert record["window_normalizations"]["node_count"] < record[
         "global_normalizations"
     ]["node_count"]
+def test_high_order_surface_reports_asymmetry_it_carries():
+    """A state with asymmetric harmonics is not handed over as symmetric.
+
+    ``surface_field_data_from_wout`` sets ``stellsym=(not lasym) and
+    use_stellsym``; the high-order route took the caller's request verbatim,
+    so an asymmetric polished state reached the exterior solver labelled
+    symmetric, which folds the boundary onto a half period that does not
+    describe it.
+    """
+    from vmex.core.virtual_casing import surface_field_data_from_high_order
+
+    symmetric = _constant_toroidal_field_state()
+    asymmetric = replace(
+        symmetric, R_sin=jnp.asarray(symmetric.R_sin).at[0, 0].set(1.0e-3))
+
+    kwargs = dict(nphi=8, ntheta=10)
+    assert surface_field_data_from_high_order(symmetric, **kwargs).stellsym is True
+    assert surface_field_data_from_high_order(asymmetric, **kwargs).stellsym is False
+    # an explicit request for no symmetry is still honoured
+    assert surface_field_data_from_high_order(
+        symmetric, use_stellsym=False, **kwargs).stellsym is False

--- a/vmex/core/omnigenity.py
+++ b/vmex/core/omnigenity.py
@@ -205,6 +205,27 @@ def _boozer_kernel_state(state, rt, *, rows, s_half, mboz, nboz, oversample):
     }
 
 
+def _tables_are_asymmetric(state) -> bool:
+    """True when a high-order state carries stellarator-asymmetric harmonics.
+
+    ``asym`` decides the poloidal integration range of the Boozer transform
+    (half period when symmetric, full when not), while the sine families are
+    handed to the kernel either way.  Requesting ``asym=False`` for a state
+    that carries them therefore integrates asymmetric geometry over a half
+    period and returns a spectrum for a plasma that does not exist.  Traced
+    arrays cannot be inspected, so there the caller's declaration stands.
+    """
+    import jax
+
+    for family in (state.R_sin, state.Z_cos):
+        array = jnp.asarray(family)
+        if isinstance(array, jax.core.Tracer):
+            continue
+        if bool(np.any(np.asarray(array) != 0.0)):
+            return True
+    return False
+
+
 def boozer_spectrum_high_order(
     state,
     *,
@@ -225,6 +246,7 @@ def boozer_spectrum_high_order(
     surface_values = np.atleast_1d(np.asarray(surfaces, dtype=float))
     if np.any((surface_values <= 0.0) | (surface_values > 1.0)):
         raise ValueError("surfaces must satisfy 0 < s <= 1")
+    asym = bool(asym) or _tables_are_asymmetric(state)
     tables = [
         high_order_boozer_input_tables(
             state,
@@ -240,7 +262,7 @@ def boozer_spectrum_high_order(
         nfp=int(state.nfp),
         mboz=int(mboz),
         nboz=int(nboz),
-        asym=bool(asym),
+        asym=asym,
         xm=first["xm"],
         xn=first["xn"],
         xm_nyq=first["xm_nyq"],

--- a/vmex/core/virtual_casing.py
+++ b/vmex/core/virtual_casing.py
@@ -454,6 +454,21 @@ def surface_field_data_from_state(
         nphi=nphi, ntheta=ntheta, source_convention="vmex_state")
 
 
+def _carries_asymmetric_harmonics(state) -> bool:
+    """True when a high-order state has non-zero stellarator-asymmetric families.
+
+    Returns ``False`` for traced arrays: the values are unavailable, so the
+    caller's declaration stands.
+    """
+    for family in (state.R_sin, state.Z_cos):
+        array = jnp.asarray(family)
+        if isinstance(array, jax.core.Tracer):
+            continue
+        if bool(np.any(np.asarray(array) != 0.0)):
+            return True
+    return False
+
+
 def surface_field_data_from_high_order(
     state,
     *,
@@ -465,11 +480,20 @@ def surface_field_data_from_high_order(
 
     Geometry tangents and the edge field come from the continuous high-order
     representation. No sampled wout tables or finite differences are used.
+
+    ``use_stellsym`` is a request, not an assertion: a state carrying
+    asymmetric harmonics is reported as asymmetric whatever the caller asks
+    for, matching :func:`surface_field_data_from_wout`, whose ``stellsym`` is
+    ``(not lasym) and use_stellsym``. Handing an asymmetric state to the
+    exterior solver as symmetric would fold the boundary onto a half period
+    that does not describe it. Under tracing the harmonics cannot be
+    inspected, so the request is taken at face value.
     """
 
     from .strong_force import evaluate_high_order_surface
 
     surface = evaluate_high_order_surface(state, nphi=nphi, ntheta=ntheta)
+    stellsym = bool(use_stellsym) and not _carries_asymmetric_harmonics(state)
     return VmecSurfaceFieldData(
         gamma=jnp.moveaxis(surface.gamma, -1, 0),
         B_total=jnp.moveaxis(surface.B_total, -1, 0),
@@ -478,7 +502,7 @@ def surface_field_data_from_high_order(
         theta=surface.theta,
         phi=surface.phi,
         nfp=int(state.nfp),
-        stellsym=bool(use_stellsym),
+        stellsym=stellsym,
         signgs=int(state.jacobian_sign),
         source_convention="vmex_high_order",
     )


### PR DESCRIPTION
Two call sites took a caller's symmetry flag at face value while the state said otherwise. Both were reported by the API-documentation pass (PR #257) and verified against the code before fixing.

**Virtual casing.** `surface_field_data_from_wout` computes `stellsym=(not lasym) and bool(use_stellsym)` (virtual_casing.py:318). `surface_field_data_from_high_order` used `stellsym=bool(use_stellsym)` and never consulted the state, so a polished state carrying asymmetric harmonics was handed to the exterior solver labelled stellarator-symmetric — which folds the boundary onto a half period that does not describe it.

**Boozer transform.** `asym` decides the transform's poloidal integration range (`nu3_b = ntheta_full if asym else nu2_b` in booz_xform_jax), while the sine families `rmns`/`zmnc`/`lmnc`/`bmns` are passed to the kernel either way. `boozer_spectrum_high_order` defaulted `asym=False`, so an asymmetric state integrated over a half period and returned a spectrum for a plasma that does not exist, with nothing said.

In both places the flag is now derived from the state's `R_sin`/`Z_cos` families. Under tracing the harmonics cannot be inspected, so the caller's declaration stands; that limit is documented. An explicit `use_stellsym=False` is still honoured, and `asym=True` still forces the full range.

Both paths are latent today — the sibling live-state route's docstring already says stellarator symmetry is the validated path — so this closes the holes before an asymmetric polished state reaches them, rather than fixing an observed wrong answer.

Verified: new tests in `tests/test_strong_force.py` and `tests/test_boozer_tables.py` (19 passed in that module), the existing high-order handoff test, `tests/test_virtual_casing_api.py`, and `tools/preflight.py --static` PASS.