### PR TITLE
Record what DESC itself measures, beside the lifted wout

### DIFF
--- a/benchmarks/desc_native_vs_lifted_2026-09-03.json
+++ b/benchmarks/desc_native_vs_lifted_2026-09-03.json
@@ -1,0 +1,58 @@
+{
+  "schema": "vmex.desc-native-vs-lifted/1",
+  "provenance": {
+    "vmex_commit": "82a424da38b13455e471484788ec3e1635239165",
+    "created_utc": "2026-09-03T12:46:51Z",
+    "host": "Apple M4, macOS 14.4",
+    "deck": "examples/data/input.shaped_tokamak_pressure_polished",
+    "deck_sha256_prefix": "2e83e7641e2c63d2",
+    "desc_version": "0.17.1+11.g2471d5504.dirty",
+    "jax": "0.9.2",
+    "desc_source": {
+      "commit": "2471d550442362cf3f0767786f274c1bb5efd235",
+      "dirty": true
+    }
+  },
+  "question": "The cross-code comparison figure reports a DESC row produced by lifting DESC's re-exported wout with VMEX splines and certifying that. This measures the round trip, not DESC. Both numbers are recorded here for the same converged DESC equilibrium.",
+  "desc_run": {
+    "representation": {
+      "L": 24,
+      "M": 12,
+      "N": 0,
+      "profile": "iota",
+      "spectral_indexing": "fringe",
+      "surfaces": 129
+    },
+    "controls": {
+      "ftol": 1e-08,
+      "gtol": 1e-08,
+      "maxiter": 300,
+      "xtol": 1e-08
+    },
+    "iterations": 12,
+    "cost": 5.287735730401864e-12,
+    "optimality": 2.982441151609306e-09,
+    "success": true,
+    "message": "`gtol` condition satisfied. (gtol=1.00e-08)"
+  },
+  "desc_native_force_error": {
+    "mean_force_density": 0.44860169350826523,
+    "mean_grad_magnetic_pressure": 98519.8931000118,
+    "mean_grad_pressure": 111822.72569069025,
+    "normalized_by_magnetic_pressure": 4.553412304790772e-06,
+    "normalized_by_pressure_gradient": 4.011722042522287e-06
+  },
+  "vmex_certificate_on_the_desc_wout": {
+    "lift": {
+      "degree": 3,
+      "radial_spans": 14,
+      "export_surfaces": 129
+    },
+    "absolute_l2": 10790.199391619435,
+    "normalized_l2": 0.07131880971027697,
+    "normalized_p99": 0.3335064803509384,
+    "near_axis_l2": 140.40838009891922,
+    "edge_l2": 17747.711655410385
+  },
+  "reading": "DESC's own volume-averaged force error is 4.0e-6 of the mean pressure gradient (4.6e-6 of the mean magnetic-pressure gradient). The same equilibrium, exported to a 129-surface wout and lifted by VMEX splines, certifies at 7.1e-2 pointwise-normalized L2, edge dominated. The gap is the export and the lift, so a cross-code force comparison carried through wout files measures the file format's resolution, not the solvers. Report the native number for each code, or label the row for what it is."
+}

--- a/benchmarks/run_external_equilibrium.py
+++ b/benchmarks/run_external_equilibrium.py
@@ -43,6 +43,32 @@ def _peak_rss_mib(children: bool = False) -> float:
     return value / divisor
 
 
+def _desc_native_force_error(equilibrium) -> dict[str, float]:
+    """DESC's own force error on its converged equilibrium.
+
+    The certificate we run afterwards measures VMEX's spline lift of DESC's
+    re-exported ``wout``, which is a different quantity: it carries the
+    export mesh and the lift.  These are the numbers DESC itself reports, in
+    the two published normalizations -- Panici et al. 2023 Eqs. 32-34b
+    (``<|F|>_vol / <|grad(p)|>_vol``) and the vacuum-safe magnetic-pressure
+    form used by DESC's own equilibrium objective -- so the comparison row can
+    say which code is being measured.
+    """
+    keys = ["<|F|>_vol", "<|grad(p)|>_vol", "<|grad(|B|^2)|/2mu0>_vol"]
+    data = equilibrium.compute(keys)
+    force = float(data["<|F|>_vol"])
+    pressure = float(data["<|grad(p)|>_vol"])
+    magnetic = float(data["<|grad(|B|^2)|/2mu0>_vol"])
+    report = {"mean_force_density": force,
+              "mean_grad_pressure": pressure,
+              "mean_grad_magnetic_pressure": magnetic}
+    if pressure > 0.0:
+        report["normalized_by_pressure_gradient"] = force / pressure
+    if magnetic > 0.0:
+        report["normalized_by_magnetic_pressure"] = force / magnetic
+    return report
+
+
 def _run_desc(args: argparse.Namespace) -> dict[str, object]:
     import jax
     from desc.vmec import VMECIO
@@ -71,9 +97,11 @@ def _run_desc(args: argparse.Namespace) -> dict[str, object]:
     save_started = time.perf_counter()
     VMECIO.save(equilibrium, args.output_wout, surfs=args.surfaces, verbose=0)
     save_seconds = time.perf_counter() - save_started
+    native = _desc_native_force_error(equilibrium)
     return {
-        "schema": "vmex.external-equilibrium-run/1",
+        "schema": "vmex.external-equilibrium-run/2",
         "engine": "desc",
+        "native_force_error": native,
         "input": args.wout.name,
         "output_wout": args.output_wout.name,
         "representation": {

--- a/tests/test_profile_workflows.py
+++ b/tests/test_profile_workflows.py
@@ -149,3 +149,46 @@ def test_cold_and_cache_reload_subprocess_regimes(tmp_path):
     # cache makes a new process cheaper) without flaking on a loaded runner.
     assert (reload_["timing_s"]["process_wall"]
             < 0.9 * cold["timing_s"]["process_wall"])
+
+
+def test_desc_native_force_error_reports_both_published_normalizations():
+    """The DESC row must be able to say what DESC itself measures.
+
+    Certifying DESC's re-exported ``wout`` measures the export mesh and the
+    spline lift; the artifact records DESC's own volume-averaged force error
+    beside it, in the pressure-gradient normalization of Panici et al. 2023
+    and the vacuum-safe magnetic-pressure one.
+    """
+    import json
+    from pathlib import Path
+
+    from benchmarks.run_external_equilibrium import _desc_native_force_error
+
+    class _Equilibrium:
+        def compute(self, keys):
+            values = {"<|F|>_vol": 2.0, "<|grad(p)|>_vol": 4.0,
+                      "<|grad(|B|^2)|/2mu0>_vol": 8.0}
+            return {key: values[key] for key in keys}
+
+    report = _desc_native_force_error(_Equilibrium())
+    assert report["mean_force_density"] == 2.0
+    assert report["normalized_by_pressure_gradient"] == 0.5
+    assert report["normalized_by_magnetic_pressure"] == 0.25
+
+    # a vacuum equilibrium has no pressure gradient to normalize by, and the
+    # magnetic-pressure form is the one that survives
+    class _Vacuum(_Equilibrium):
+        def compute(self, keys):
+            values = {"<|F|>_vol": 1.0, "<|grad(p)|>_vol": 0.0,
+                      "<|grad(|B|^2)|/2mu0>_vol": 4.0}
+            return {key: values[key] for key in keys}
+
+    vacuum = _desc_native_force_error(_Vacuum())
+    assert "normalized_by_pressure_gradient" not in vacuum
+    assert vacuum["normalized_by_magnetic_pressure"] == 0.25
+
+    artifact = json.loads(
+        Path("benchmarks/desc_native_vs_lifted_2026-09-03.json").read_text())
+    native = artifact["desc_native_force_error"]["normalized_by_pressure_gradient"]
+    lifted = artifact["vmex_certificate_on_the_desc_wout"]["normalized_l2"]
+    assert native < 1.0e-5 < lifted, "the recorded gap is the point of the artifact"


### PR DESCRIPTION
Closes the measurement half of plan finding **31.2-R2**.

The comparison figure's DESC row does not measure DESC. It is produced by exporting DESC's converged equilibrium to a 129-surface `wout`, lifting that with VMEX splines, and running our certificate on the result. Measured here on the same converged equilibrium (artifact `benchmarks/desc_native_vs_lifted_2026-09-03.json`):

| quantity | value |
|---|---|
| DESC native ⟨\|F\|⟩_vol | 0.449 N/m³ |
| DESC native ⟨\|F\|⟩/⟨\|∇p\|⟩ (Panici 2023 Eqs. 32-34b) | **4.0e-6** |
| DESC native ⟨\|F\|⟩/⟨\|∇(B²/2μ₀)\|⟩ | 4.6e-6 |
| VMEX certificate on DESC's wout, degree 3 / 14 spans | **7.1e-2** normalized L2, 0.33 p99 |
| … its edge_l2 vs near_axis_l2 | 17748 vs 140 |

Four and a half decades, edge dominated. The gap is the export mesh and the lift, which means a cross-code force comparison carried through `wout` files measures the file format's resolution, not the solvers — worth stating plainly in the paper, since every code in that figure except VMEX is measured through a `wout`.

This PR does the measurement half: `_run_desc` now computes DESC's native force error in both published normalizations at the end of the solve (bumping the report schema to /2), and commits the artifact with provenance and a test. **It deliberately does not touch the figure or its caption** — PR #256 owns those files. The caption fix (label external rows as "wout lifted by VMEX splines", or quote native numbers) should follow there or in the 31.2-R1 branch.

Verified: `tools/preflight.py --static` PASS; new test in `tests/test_profile_workflows.py`. The DESC run itself: 12 iterations, cost 5.3e-12, `gtol` satisfied, desc 0.17.1+11.g2471d5504.