### PR TITLE
Say that a jitted polish-derivative failure returns NaN, not an error

### DIFF
--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -2248,3 +2248,42 @@ def test_declined_auto_does_not_warn_under_the_warn_fail_policy(tmp_path):
         warnings.simplefilter("error", RuntimeWarning)
         result = solve_file(path, write_wout=False)
     assert result.polish_report.termination_reason == "auto-declined-cost"
+def test_polish_derivative_failure_is_nan_under_tracing_and_raises_outside():
+    """``fail_policy="raise"`` cannot raise on a traced convergence flag.
+
+    Outside jit the policy raises; under jit the flag is a tracer, so both
+    policies return NaN. The docstring says so, and this pins it: a jitted
+    gradient that fails comes back as NaN, never as an exception.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    from vmex.core.polish_implicit import (
+        PolishLinearConfig, PolishLinearReport, StrongForceLinearSolveError,
+        _checked_solution,
+    )
+
+    def report(converged):
+        return PolishLinearReport(
+            residual_norm=jnp.asarray(1.0), tolerance=jnp.asarray(1.0e-8),
+            iterations=jnp.asarray(30), converged=converged)
+
+    value = jnp.ones(3)
+    raising = PolishLinearConfig(fail_policy="raise")
+
+    # eager, failed: the documented exception
+    with pytest.raises(StrongForceLinearSolveError):
+        _checked_solution(value, report(jnp.asarray(False)), raising, "tangent")
+    # eager, converged: the value passes through
+    ok = _checked_solution(value, report(jnp.asarray(True)), raising, "tangent")
+    assert bool(jnp.all(ok == value))
+
+    # traced, failed: NaN, no exception, whatever the policy says.  The
+    # conftest disables jit suite-wide, so ask for it explicitly here --
+    # which is also why the interpreted suite never exercised this path.
+    def traced(flag):
+        return _checked_solution(value, report(flag), raising, "tangent")
+
+    with jax.disable_jit(False):
+        assert bool(jnp.all(jnp.isnan(jax.jit(traced)(jnp.asarray(False)))))
+        assert bool(jnp.all(jax.jit(traced)(jnp.asarray(True)) == value))

--- a/vmex/core/polish_implicit.py
+++ b/vmex/core/polish_implicit.py
@@ -30,7 +30,19 @@ from .strong_force import HighOrderEquilibriumState
 
 @dataclass(frozen=True)
 class PolishLinearConfig:
-    """Krylov controls and failure policy for polished-root derivatives."""
+    """Krylov controls and failure policy for polished-root derivatives.
+
+    ``fail_policy`` decides what a non-converged Krylov solve produces:
+    ``"raise"`` (the default) raises :class:`StrongForceLinearSolveError`,
+    ``"nan"`` returns NaN. **The raise only happens outside tracing.** Under
+    ``jax.jit`` -- which is where these derivatives are normally taken -- the
+    convergence flag is a traced value, so no Python exception can be raised
+    from it and both policies return NaN through :func:`jnp.where`. A jitted
+    gradient that fails therefore comes back as NaN, not as an error; check
+    for it rather than relying on an exception. Making it raise would need a
+    host callback in the traced graph, which would stop those programs being
+    written to the persistent compilation cache.
+    """
 
     rtol: float = 1.0e-8
     atol: float = 1.0e-11


### PR DESCRIPTION
Third item from the API-documentation pass's defect list (PR #257), verified and scoped.

`PolishLinearConfig.fail_policy` defaults to `"raise"`, and outside tracing it does raise `StrongForceLinearSolveError`. Under `jax.jit` it cannot: the convergence flag is a traced value, so `_checked_solution` falls through to `jnp.where(converged, value, nan)` and both policies return NaN. Since implicit derivatives of a polished state are normally taken inside `jit`, the practical behaviour of the default is "silently NaN", which is the opposite of what the name promises.

I did not change the behaviour. Making it raise under trace would require a host callback in the traced graph, and JAX refuses to write programs with host callbacks to the persistent compilation cache — a real cost for a failure path. So this documents the semantics precisely and pins them with a test.

The test has to re-enable jit explicitly (`tests/conftest.py` disables it suite-wide to keep unit tests fast). That is also why no existing test covered this branch: the interpreted suite only ever took the eager path.

Verified: new test passes, `ruff`, `tools/preflight.py --static` PASS.