### PR TITLE
Show every optimizer trial, and make the free-boundary single stage converge

### DIFF
--- a/examples/optimization/QA_maxJ_continuation.py
+++ b/examples/optimization/QA_maxJ_continuation.py
@@ -70,7 +70,7 @@ report = opt.EquilibriumReporter(
     ("QS", qs.total, ".4e"), ("aspect", opt.aspect_ratio, ".3f"),
     ("min |iota|", opt.min_abs_iota, ".3f"),
     ("magnetic well", opt.magnetic_well, ".3f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected
 # once the optimizer leaves the seed and needs no action: the shipped

--- a/examples/optimization/QA_optimization_DMerc_vacuum.py
+++ b/examples/optimization/QA_optimization_DMerc_vacuum.py
@@ -81,7 +81,7 @@ objective_function_terms = [
 report = opt.EquilibriumReporter(
     ("QS total", qs.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
     ("min |iota|", opt.min_abs_iota, ".4f"), ("magnetic well", opt.magnetic_well, ".4f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 # Optimize for QA first, then add the pressure-stability proxy locally.
 equilibrium = opt.solve_equilibrium(inp)

--- a/examples/optimization/QA_optimization_ballooning.py
+++ b/examples/optimization/QA_optimization_ballooning.py
@@ -68,7 +68,7 @@ report = opt.EquilibriumReporter(
     ("QS total", qs.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
     ("mean iota", opt.mean_iota, ".4f"),
     ("ballooning bound", ballooning, ".4e"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 equilibrium = opt.solve_equilibrium(inp, verbose=not ci_smoke)
 seed_lambda = worst_lambda(equilibrium)

--- a/examples/optimization/QA_optimization_bootstrap.py
+++ b/examples/optimization/QA_optimization_bootstrap.py
@@ -106,7 +106,7 @@ report = opt.EquilibriumReporter(
     ("beta", opt.volume_average_beta, ".3%"), ("aspect", opt.aspect_ratio, ".3f"),
     ("min |iota|", opt.min_abs_iota, ".3f"), ("min DMerc", minimum_dmerc, ".2e"),
     ("max DR", maximum_dr, ".2e"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 report("self-consistent seed", equilibrium)
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected

--- a/examples/optimization/QH_optimization.py
+++ b/examples/optimization/QH_optimization.py
@@ -69,7 +69,7 @@ objective_function_terms = [
 report = opt.EquilibriumReporter(
     ("QS total", qs.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
     ("mean iota", opt.mean_iota, ".4f"), ("magnetic well", opt.magnetic_well, ".4f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 # Optimize for QH in stages, adding the optional stability proxy after stage 1.
 equilibrium = opt.solve_equilibrium(inp)

--- a/examples/optimization/QH_optimization_bootstrap.py
+++ b/examples/optimization/QH_optimization_bootstrap.py
@@ -94,7 +94,7 @@ report = opt.EquilibriumReporter(
     ("beta", opt.volume_average_beta, ".3%"), ("aspect", opt.aspect_ratio, ".3f"),
     ("iota", opt.mean_iota, ".3f"), ("min DMerc", minimum_dmerc, ".2e"),
     ("max DR", maximum_dr, ".2e"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 report("self-consistent seed", equilibrium)
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected

--- a/examples/optimization/QI_maxJ_continuation.py
+++ b/examples/optimization/QI_maxJ_continuation.py
@@ -100,7 +100,7 @@ report = opt.EquilibriumReporter(
     ("QI", qi.total, ".4e"), ("aspect", opt.aspect_ratio, ".3f"),
     ("iota", opt.mean_iota, ".3f"), ("mirror", opt.mirror_ratio, ".3f"),
     ("magnetic well", opt.magnetic_well, ".3f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 # First form a vacuum QI basin from the minimal seed. A common physical pitch
 # generally does not exist on the circular seed, so evaluating dJ/ds earlier

--- a/examples/optimization/QI_optimization.py
+++ b/examples/optimization/QI_optimization.py
@@ -71,7 +71,7 @@ report = opt.EquilibriumReporter(
     ("constructed QI", qi.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
     ("mean iota", opt.mean_iota, ".4f"), ("mirror", opt.mirror_ratio, ".4f"),
     ("elongation", opt.max_elongation, ".4f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 # Optimize for QI in stages, increasing the maximum mode number each time.
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected

--- a/examples/optimization/QI_optimization_bootstrap.py
+++ b/examples/optimization/QI_optimization_bootstrap.py
@@ -124,7 +124,7 @@ report = opt.EquilibriumReporter(
     ("beta", opt.volume_average_beta, ".3%"), ("aspect", opt.aspect_ratio, ".3f"),
     ("min |iota|", opt.min_abs_iota, ".3f"), ("mirror", opt.mirror_ratio, ".3f"),
     ("min DMerc", minimum_dmerc, ".2e"), ("max DR", maximum_dr, ".2e"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 report("self-consistent seed", equilibrium)
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected

--- a/examples/optimization/QP_optimization.py
+++ b/examples/optimization/QP_optimization.py
@@ -60,7 +60,7 @@ report = opt.EquilibriumReporter(
     ("QS total", qs.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
     ("mean iota", opt.mean_iota, ".4f"), ("elongation", opt.max_elongation, ".4f"),
     ("mirror", opt.mirror_ratio, ".4f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 objective_function_terms = [
     (qs, 0.0, 1.0),

--- a/examples/optimization/_scalar_driver.py
+++ b/examples/optimization/_scalar_driver.py
@@ -60,12 +60,13 @@ def run_scalar_stage(
 
     def value_and_gradient(y):
         value, gradient = problem.value_and_grad(x_from_y(y))
-        return value, step * gradient
+        # The monitor reads cost and optimality back from this cached
+        # evaluation, so the callback below never re-solves the equilibrium.
+        return monitor.cache_evaluation(x_from_y(y), value, step * gradient)
 
     def monitor_y(intermediate_result):
-        x = x_from_y(intermediate_result.x)
-        value, gradient = problem.value_and_grad(x)
-        monitor({"x": x, "fun": value, "jac": gradient})
+        monitor({"x": x_from_y(intermediate_result.x),
+                 "fun": intermediate_result.fun})
 
     initial_value = float(value_and_gradient(np.zeros_like(x0))[0])
     result = minimize(

--- a/examples/optimization/omnigenity_epsilon_gammac_maxj.py
+++ b/examples/optimization/omnigenity_epsilon_gammac_maxj.py
@@ -174,7 +174,7 @@ report = opt.EquilibriumReporter(
     ("maxJ", maximum_j.total, ".4e"), ("aspect", opt.aspect_ratio, ".3f"),
     ("min |iota|", opt.min_abs_iota, ".3f"),
     ("beta", opt.volume_average_beta, ".3%"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 report("seed", equilibrium)
 print_terms("seed", equilibrium)
 before = hard_confinement(equilibrium)
@@ -194,13 +194,12 @@ x0, step = problem.x0, PARAMETER_STEP * problem.scales
 def value_and_gradient(y):
     value, gradient = problem.value_and_grad(x0 + step * y)
     evaluation_costs.append(float(value))
-    return value, step * gradient
+    return monitor.cache_evaluation(x0 + step * y, value, step * gradient)
 
 
 def monitor_y(intermediate_result):
     monitor({"x": x0 + step * intermediate_result.x,
-             "fun": intermediate_result.fun,
-             "jac": value_and_gradient(intermediate_result.x)[1]})
+             "fun": intermediate_result.fun})
 
 
 evaluation_costs = []

--- a/examples/optimization/single_stage_free_boundary_optimization.py
+++ b/examples/optimization/single_stage_free_boundary_optimization.py
@@ -29,10 +29,19 @@ except ImportError as error:
     ) from error
 
 SURFACES = np.linspace(0.1, 1.0, 6)
-NS, MPOL, NTOR, NITER, FTOL = 25, 5, 5, 4000, 1.0e-10
+# FTOL = 1e-9 rather than 1e-10: measured on this deck at u = 0, the tighter
+# root costs 154 s against 59 s and moves the gradient by 0.6%, while 1e-8
+# is too loose for the adjoint (|grad| 36.7 against 11.2).  The Schur adjoint
+# stays conditioned on the marginally converged roots that a line search
+# visits, where the coupled Krylov solve stalls at 0.66 relative residual.
+NS, MPOL, NTOR, NITER, FTOL = 25, 5, 5, 2000, 1.0e-9
 MAXITER, METHOD, PARAMETER_BOUND = 20, "L-BFGS-B", 1.0
 ASPECT_TARGET, IOTA_FLOOR = 6.0, 0.42
-LENGTH_TARGET, LENGTH_WEIGHT = 3.5, 1.0
+# Coil length is a hinge above a reachable limit, not a target: with
+# LENGTH_TARGET = 3.5 against 5.25 m coils, 0.5*sum((L - 3.5)^2) = 23.598 was
+# 99.998% of the objective against QA at 3.4e-04, so the optimizer only ever
+# fought an unreachable length and the plasma terms were invisible.
+LENGTH_LIMIT, LENGTH_WEIGHT = 5.3, 1.0
 CURVATURE_LIMIT, CURVATURE_WEIGHT = 7.0, 10.0
 COIL_DISTANCE_LIMIT, COIL_DISTANCE_WEIGHT = 0.08, 1.0e3
 OPTIONS = {"maxiter": MAXITER, "maxls": 10, "ftol": 1.0e-12, "gtol": 1.0e-8}
@@ -67,7 +76,8 @@ def field_from_u(u):
 params = im.params_from_input(inp)
 config = vj.make_free_boundary_config(
     inp, BiotSavart(coils0), ns=NS, ftol=FTOL, max_iterations=NITER,
-    adjoint_tol=1.0e-8, field_from_parameters=field_from_u)
+    adjoint_tol=1.0e-8, adjoint_solver="boundary_schur",
+    adjoint_fail="best_effort", field_from_parameters=field_from_u)
 solver_context = im.runtime_from_params(params, config.implicit)
 # Floor the profile minimum, not its average: a mean target is satisfiable while
 # an interior surface sits near zero transform, which is what a current-carried
@@ -75,7 +85,8 @@ solver_context = im.runtime_from_params(params, config.implicit)
 # opt.soft_min_abs_iota is the smooth-minimum variant.
 def iota_floor(equilibrium_state, solver_context):
     return jnp.maximum(
-        IOTA_FLOOR - opt.min_abs_iota(equilibrium_state, solver_context), 0.0)
+        IOTA_FLOOR - opt.soft_min_abs_iota(
+            equilibrium_state, solver_context), 0.0)
 
 
 qs = opt.QuasisymmetryRatioResidual(SURFACES, helicity_m=1, helicity_n=0)
@@ -90,7 +101,8 @@ def objective(u):
         residual = opt.residuals_from_tuples(equilibrium_state, solver_context, tuples)
         coils = coils_from_u(u)
         costs = jnp.asarray([
-            0.5 * LENGTH_WEIGHT * jnp.sum((coils.length - LENGTH_TARGET)**2),
+            0.5 * LENGTH_WEIGHT * jnp.sum(
+                jnp.maximum(coils.length - LENGTH_LIMIT, 0.0)**2),
             0.5 * CURVATURE_WEIGHT * jnp.sum(
                 jnp.maximum(coils.curvature - CURVATURE_LIMIT, 0.0)**2),
             0.5 * COIL_DISTANCE_WEIGHT * loss_coil_separation(

--- a/examples/optimization/single_stage_free_boundary_optimization.py
+++ b/examples/optimization/single_stage_free_boundary_optimization.py
@@ -77,7 +77,7 @@ params = im.params_from_input(inp)
 config = vj.make_free_boundary_config(
     inp, BiotSavart(coils0), ns=NS, ftol=FTOL, max_iterations=NITER,
     adjoint_tol=1.0e-8, adjoint_solver="boundary_schur",
-    adjoint_fail="best_effort", field_from_parameters=field_from_u)
+    field_from_parameters=field_from_u)
 solver_context = im.runtime_from_params(params, config.implicit)
 # Floor the profile minimum, not its average: a mean target is satisfiable while
 # an interior surface sits near zero transform, which is what a current-carried

--- a/examples/optimization/single_stage_free_boundary_optimization_finite_beta.py
+++ b/examples/optimization/single_stage_free_boundary_optimization_finite_beta.py
@@ -31,10 +31,10 @@ except ImportError as error:
 
 TARGET_BETA = 0.025
 SURFACES = np.linspace(0.1, 0.9, 8)
-NS, MPOL, NTOR, NITER, FTOL = 31, 5, 5, 5000, 1.0e-10
+NS, MPOL, NTOR, NITER, FTOL = 31, 5, 5, 2500, 1.0e-9
 MAXITER, METHOD, PARAMETER_BOUND = 20, "L-BFGS-B", 1.0
 ASPECT_TARGET, IOTA_FLOOR = 6.0, 0.42
-LENGTH_TARGET, LENGTH_WEIGHT = 3.5, 1.0
+LENGTH_LIMIT, LENGTH_WEIGHT = 5.3, 1.0
 CURVATURE_LIMIT, CURVATURE_WEIGHT = 7.0, 10.0
 COIL_DISTANCE_LIMIT, COIL_DISTANCE_WEIGHT = 0.08, 1.0e3
 OPTIONS = {"maxiter": MAXITER, "maxls": 10, "ftol": 1.0e-12, "gtol": 1.0e-8}
@@ -76,7 +76,8 @@ def field_from_u(u):
 params = im.params_from_input(inp)
 config = vj.make_free_boundary_config(
     inp, BiotSavart(coils0), ns=NS, ftol=FTOL, max_iterations=NITER,
-    adjoint_tol=1.0e-8, field_from_parameters=field_from_u)
+    adjoint_tol=1.0e-8, adjoint_solver="boundary_schur",
+    adjoint_fail="best_effort", field_from_parameters=field_from_u)
 solver_context = im.runtime_from_params(params, config.implicit)
 
 # ne=n0(1-s^5), Te=Ti=T0(1-s); rescale n0*T0 to the peak pressure in AM.
@@ -91,7 +92,8 @@ profiles = KineticProfiles(n0 * np.array([1, 0, 0, 0, 0, -1]),
 # opt.soft_min_abs_iota is the smooth-minimum variant.
 def iota_floor(equilibrium_state, solver_context):
     return jnp.maximum(
-        IOTA_FLOOR - opt.min_abs_iota(equilibrium_state, solver_context), 0.0)
+        IOTA_FLOOR - opt.soft_min_abs_iota(
+            equilibrium_state, solver_context), 0.0)
 
 
 qs = opt.QuasisymmetryRatioResidual(SURFACES, helicity_m=1, helicity_n=0)
@@ -108,7 +110,8 @@ def objective(u):
         residual = opt.residuals_from_tuples(equilibrium_state, solver_context, tuples)
         coils = coils_from_u(u)
         costs = jnp.asarray([
-            0.5 * LENGTH_WEIGHT * jnp.sum((coils.length - LENGTH_TARGET)**2),
+            0.5 * LENGTH_WEIGHT * jnp.sum(
+                jnp.maximum(coils.length - LENGTH_LIMIT, 0.0)**2),
             0.5 * CURVATURE_WEIGHT * jnp.sum(
                 jnp.maximum(coils.curvature - CURVATURE_LIMIT, 0.0)**2),
             0.5 * COIL_DISTANCE_WEIGHT * loss_coil_separation(

--- a/examples/optimization/single_stage_free_boundary_optimization_finite_beta.py
+++ b/examples/optimization/single_stage_free_boundary_optimization_finite_beta.py
@@ -77,7 +77,7 @@ params = im.params_from_input(inp)
 config = vj.make_free_boundary_config(
     inp, BiotSavart(coils0), ns=NS, ftol=FTOL, max_iterations=NITER,
     adjoint_tol=1.0e-8, adjoint_solver="boundary_schur",
-    adjoint_fail="best_effort", field_from_parameters=field_from_u)
+    field_from_parameters=field_from_u)
 solver_context = im.runtime_from_params(params, config.implicit)
 
 # ne=n0(1-s^5), Te=Ti=T0(1-s); rescale n0*T0 to the peak pressure in AM.

--- a/examples/optimization/stellarator_asymmetry/QA_optimization.py
+++ b/examples/optimization/stellarator_asymmetry/QA_optimization.py
@@ -55,7 +55,7 @@ objective_function_terms = [(qs, 0.0, 1.0), (opt.aspect_ratio, ASPECT_TARGET, 1.
 report = opt.EquilibriumReporter(
     ("QS total", qs.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
     ("min |iota|", opt.min_abs_iota, ".4f"), ("magnetic well", opt.magnetic_well, ".4f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 equilibrium = opt.solve_equilibrium(inp)
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected

--- a/examples/optimization/stellarator_asymmetry/QA_optimization_finite_beta.py
+++ b/examples/optimization/stellarator_asymmetry/QA_optimization_finite_beta.py
@@ -65,7 +65,7 @@ objective_function_terms = [(qs, 0.0, 1.0), (opt.aspect_ratio, ASPECT_TARGET, 1.
 report = opt.EquilibriumReporter(
     ("QS", qs.total, ".4e"), ("beta", opt.volume_average_beta, ".3%"),
     ("aspect", opt.aspect_ratio, ".3f"), ("min |iota|", opt.min_abs_iota, ".3f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected
 # once the optimizer leaves the seed and needs no action: the shipped

--- a/examples/optimization/stellarator_asymmetry/QH_optimization.py
+++ b/examples/optimization/stellarator_asymmetry/QH_optimization.py
@@ -44,7 +44,7 @@ objective_function_terms = [(qs, 0.0, 1.0), (opt.aspect_ratio, ASPECT_TARGET, 1.
 report = opt.EquilibriumReporter(
     ("QS total", qs.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
     ("mean iota", opt.mean_iota, ".4f"), ("magnetic well", opt.magnetic_well, ".4f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 equilibrium = opt.solve_equilibrium(inp)
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected

--- a/examples/optimization/stellarator_asymmetry/QH_optimization_finite_beta.py
+++ b/examples/optimization/stellarator_asymmetry/QH_optimization_finite_beta.py
@@ -54,7 +54,7 @@ objective_function_terms = [(qs, 0.0, 1.0), (opt.aspect_ratio, ASPECT_TARGET, 1.
 report = opt.EquilibriumReporter(
     ("QS", qs.total, ".4e"), ("beta", opt.volume_average_beta, ".3%"),
     ("aspect", opt.aspect_ratio, ".3f"), ("iota", opt.mean_iota, ".3f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected
 # once the optimizer leaves the seed and needs no action: the shipped

--- a/examples/optimization/stellarator_asymmetry/QI_optimization.py
+++ b/examples/optimization/stellarator_asymmetry/QI_optimization.py
@@ -59,7 +59,7 @@ objective_function_terms = [(qi, 0.0, 10.0), (opt.aspect_ratio, ASPECT_TARGET, 0
 report = opt.EquilibriumReporter(
     ("constructed QI", qi.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
     ("mean iota", opt.mean_iota, ".4f"), ("mirror", opt.mirror_ratio, ".4f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 equilibrium = opt.solve_equilibrium(inp)
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected

--- a/examples/optimization/stellarator_asymmetry/QI_optimization_finite_beta.py
+++ b/examples/optimization/stellarator_asymmetry/QI_optimization_finite_beta.py
@@ -66,7 +66,7 @@ objective_function_terms = [(qi, 0.0, 10.0), (opt.aspect_ratio, ASPECT_TARGET, 0
 report = opt.EquilibriumReporter(
     ("constructed QI", qi.total, ".4e"), ("beta", opt.volume_average_beta, ".3%"),
     ("aspect", opt.aspect_ratio, ".3f"), ("iota", opt.mean_iota, ".3f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected
 # once the optimizer leaves the seed and needs no action: the shipped

--- a/examples/optimization/stellarator_asymmetry/QP_optimization.py
+++ b/examples/optimization/stellarator_asymmetry/QP_optimization.py
@@ -56,7 +56,7 @@ objective_function_terms = [(qs, 0.0, 1.0), (opt.aspect_ratio, ASPECT_TARGET, 1.
 report = opt.EquilibriumReporter(
     ("QS total", qs.total, ".6e"), ("aspect", opt.aspect_ratio, ".4f"),
     ("mean iota", opt.mean_iota, ".4f"), ("mirror", opt.mirror_ratio, ".4f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 equilibrium = opt.solve_equilibrium(inp)
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected

--- a/examples/optimization/stellarator_asymmetry/QP_optimization_finite_beta.py
+++ b/examples/optimization/stellarator_asymmetry/QP_optimization_finite_beta.py
@@ -57,7 +57,7 @@ objective_function_terms = [(qs, 0.0, 1.0), (opt.aspect_ratio, ASPECT_TARGET, 1.
 report = opt.EquilibriumReporter(
     ("QS", qs.total, ".4e"), ("beta", opt.volume_average_beta, ".3%"),
     ("aspect", opt.aspect_ratio, ".3f"), ("iota", opt.mean_iota, ".3f"))
-monitor = opt.OptimizationMonitor(stream=None)
+monitor = opt.OptimizationMonitor()
 
 # If a RuntimeWarning reports uncertified Jacobian columns, it is expected
 # once the optimizer leaves the seed and needs no action: the shipped

--- a/tests/test_freeboundary_implicit.py
+++ b/tests/test_freeboundary_implicit.py
@@ -105,8 +105,9 @@ def test_host_adjoint_best_effort_warns_instead_of_raising(monkeypatch):
     # A Krylov solve that returns a deliberately wrong answer, so the true
     # residual check that follows it cannot pass.
     monkeypatch.setattr(fbi, "gcrotmk", lambda *args, **kwargs: (np.zeros(4), 0))
-    call = lambda **kw: fbi._host_adjoint(
-        residual, z_star, None, None, z_star, None, None, rhs, cfg, **kw)
+    def call(**kwargs):
+        return fbi._host_adjoint(
+            residual, z_star, None, None, z_star, None, None, rhs, cfg, **kwargs)
 
     with pytest.raises(AdjointSolveError, match="did not converge"):
         call()

--- a/tests/test_freeboundary_implicit.py
+++ b/tests/test_freeboundary_implicit.py
@@ -87,6 +87,34 @@ def test_free_boundary_config_validates_adjoint_fail():
         make_free_boundary_config(inp, field, adjoint_fail="warn")
 
 
+def test_host_adjoint_best_effort_warns_instead_of_raising(monkeypatch):
+    """A stalled Krylov solve is a warning under the opt-in policy, not a stop.
+
+    The stall arrives inside the VJP, where an optimizer's own
+    ``lax.cond`` on the solve status cannot catch it, so a raise ends the
+    whole run over one bad line-search trial.  Under ``best_effort`` the
+    inaccurate direction is returned instead and the line search rejects it.
+    """
+    cfg = SimpleNamespace(adjoint_tol=1.0e-10, adjoint_maxiter=5,
+                          adjoint_gcrot_m=2, adjoint_gcrot_k=1)
+
+    def residual(z, params, field, base, rcon, zcon):
+        return 2.0 * z
+
+    z_star, rhs = jnp.arange(4.0), jnp.ones(4)
+    # A Krylov solve that returns a deliberately wrong answer, so the true
+    # residual check that follows it cannot pass.
+    monkeypatch.setattr(fbi, "gcrotmk", lambda *args, **kwargs: (np.zeros(4), 0))
+    call = lambda **kw: fbi._host_adjoint(
+        residual, z_star, None, None, z_star, None, None, rhs, cfg, **kw)
+
+    with pytest.raises(AdjointSolveError, match="did not converge"):
+        call()
+    with pytest.warns(RuntimeWarning, match="best_effort"):
+        solution = call(fail="best_effort")
+    np.testing.assert_allclose(np.asarray(solution), np.zeros(4))
+
+
 def test_free_boundary_warm_failure_retries_once_from_cold(monkeypatch):
     """A bad cached state is discarded, but implementation errors are not."""
     inp = dataclasses.replace(

--- a/tests/test_freeboundary_implicit.py
+++ b/tests/test_freeboundary_implicit.py
@@ -72,6 +72,21 @@ def test_free_boundary_config_validates_adjoint_solver():
         make_free_boundary_config(inp, field, adjoint_solver="dense")
 
 
+def test_free_boundary_config_validates_adjoint_fail():
+    """The adjoint failure policy is opt-in and defaults to raising.
+
+    ``best_effort`` returns a stalled Krylov solution so that one bad trial
+    in an optimization is a poor search direction rather than a dead run; a
+    typo must not silently select it.
+    """
+    inp, field = lasym_free_input(DATA), lasym_free_field()
+    assert make_free_boundary_config(inp, field).adjoint_fail == "error"
+    assert make_free_boundary_config(
+        inp, field, adjoint_fail="best_effort").adjoint_fail == "best_effort"
+    with pytest.raises(ValueError, match="'error' or 'best_effort'"):
+        make_free_boundary_config(inp, field, adjoint_fail="warn")
+
+
 def test_free_boundary_warm_failure_retries_once_from_cold(monkeypatch):
     """A bad cached state is discarded, but implementation errors are not."""
     inp = dataclasses.replace(

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -444,3 +444,26 @@ def test_compatibility_least_squares_failure_is_silent_and_counted(monkeypatch) 
         jac=None,
     )
     assert result.failed_trials == 1
+
+
+def test_trace_prints_one_line_per_evaluation():
+    """Rejected trials are visible; ``trace=False`` restores the old silence.
+
+    SciPy calls the objective for line-search trials it then rejects, and each
+    of those is a full equilibrium solve, so a monitor that prints only
+    accepted iterations leaves a long run with no output at all.
+    """
+    stream = io.StringIO()
+    monitor = OptimizationMonitor(stream=stream)
+    for index, cost in enumerate((10.0, 8.0, 9.5)):
+        monitor.cache_evaluation(np.array([float(index)]), cost, np.array([cost]))
+    text = stream.getvalue()
+    assert text.count("trial") == 2, text
+    assert "8.000000e+00" in text
+
+    quiet = io.StringIO()
+    silent = OptimizationMonitor(stream=quiet, trace=False)
+    for index, cost in enumerate((10.0, 8.0, 9.5)):
+        silent.cache_evaluation(np.array([float(index)]), cost, np.array([cost]))
+    assert "trial" not in quiet.getvalue()
+

--- a/vmex/core/freeboundary_implicit.py
+++ b/vmex/core/freeboundary_implicit.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import warnings
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -53,6 +54,7 @@ class FreeBoundaryImplicitConfig:
     implicit: im.ImplicitConfig
     field_from_parameters: Callable[[Any], Any]
     adjoint_solver: str = "coupled_gcrot"
+    adjoint_fail: str = "error"
     schur_probe_chunk_size: int = 1
     vacuum_program: Any = None
 
@@ -74,6 +76,7 @@ def make_free_boundary_config(
     adjoint_gcrot_m: int = 30,
     adjoint_gcrot_k: int = 5,
     adjoint_solver: str = "coupled_gcrot",
+    adjoint_fail: str = "error",
     schur_probe_chunk_size: int = 1,
     field_from_parameters: Callable[[Any], Any] | None = None,
     device: Any = AUTO,
@@ -88,7 +91,12 @@ def make_free_boundary_config(
     accelerator host unless the process already pins JAX placement; pass an
     explicit device to override that measured lower-memory default.
     ``adjoint_solver="coupled_gcrot"`` is the certified default;
-    ``"boundary_schur"`` selects the advanced radial-elimination path.
+    ``"boundary_schur"`` selects the advanced radial-elimination path, which
+    stays well conditioned on marginally converged roots where the coupled
+    Krylov solve stalls. ``adjoint_fail="best_effort"`` returns the stalled
+    Krylov solution with a warning instead of raising, so one bad trial in an
+    optimization is a poor search direction the line search rejects rather
+    than a dead run; a non-finite adjoint always raises.
     """
     if not inp.lfreeb:
         raise ValueError("free-boundary implicit differentiation requires LFREEB=T")
@@ -105,6 +113,8 @@ def make_free_boundary_config(
     if adjoint_solver not in {"boundary_schur", "coupled_gcrot"}:
         raise ValueError(
             "adjoint_solver must be 'boundary_schur' or 'coupled_gcrot'")
+    if adjoint_fail not in {"error", "best_effort"}:
+        raise ValueError("adjoint_fail must be 'error' or 'best_effort'")
     if schur_probe_chunk_size < 1:
         raise ValueError("schur_probe_chunk_size must be positive")
     config = FreeBoundaryImplicitConfig(
@@ -112,6 +122,7 @@ def make_free_boundary_config(
         field_from_parameters=(lambda value: value) if field_from_parameters is None
         else field_from_parameters,
         adjoint_solver=adjoint_solver,
+        adjoint_fail=adjoint_fail,
         schur_probe_chunk_size=int(schur_probe_chunk_size),
     )
     return dataclasses.replace(config, vacuum_program=_vacuum_program(config))
@@ -486,13 +497,13 @@ def _solve_bwd_impl(cfg, saved, state_bar):
     elif cfg.adjoint_solver == "boundary_schur":
         lam = _host_boundary_schur_adjoint(
             cfg, z_star, params, field_parameters, frozen, rcon0, zcon0,
-            mask, rhs,
+            mask, rhs, fail=cfg.adjoint_fail,
         )
         residual = _projected_residual(cfg, mask, formulation="raw")
     else:
         lam = _host_adjoint(
             residual, z_star, params, field_parameters, frozen, rcon0, zcon0,
-            rhs, cfg.implicit)
+            rhs, cfg.implicit, fail=cfg.adjoint_fail)
 
     _, parameter_pullback = jax.vjp(
         lambda p, field: residual(
@@ -507,6 +518,7 @@ def _solve_bwd_impl(cfg, saved, state_bar):
 
 def _host_boundary_schur_adjoint(
     cfg, z_star, params, field_parameters, frozen, rcon0, zcon0, mask, rhs,
+    *, fail="error",
 ):
     """Solve the coupled adjoint through an exact edge Schur complement.
 
@@ -759,7 +771,7 @@ def _host_boundary_schur_adjoint(
         # a small correction rather than a cold whole-state Krylov search.
         return _host_adjoint(
             coupled_residual, z_star, params, field_parameters, frozen, rcon0,
-            zcon0, rhs, icfg, x0=solution)
+            zcon0, rhs, icfg, x0=solution, fail=fail)
     return solution
 
 
@@ -850,7 +862,7 @@ def _transpose_matvec(value, z, p, field, base, rcon, zcon, *, residual):
 
 def _host_adjoint(
     residual, z_star, params, field_parameters, frozen, rcon0, zcon0, rhs, cfg,
-    *, x0=None,
+    *, x0=None, fail="error",
 ):
     """Solve one adjoint while reusing a separately compiled JAX matvec.
 
@@ -889,9 +901,18 @@ def _host_adjoint(
     tolerance = float(im._adjoint_acceptance(
         cfg, np.linalg.norm(np.asarray(rhs_flat))))
     if not np.isfinite(residual_norm) or residual_norm > tolerance:
-        im._raise_adjoint_unconverged(
-            cfg, iterations=calls, residual_norm=residual_norm,
-            tolerance=tolerance, method="host GCROT",
+        if fail != "best_effort" or not np.isfinite(residual_norm):
+            im._raise_adjoint_unconverged(
+                cfg, iterations=calls, residual_norm=residual_norm,
+                tolerance=tolerance, method="host GCROT",
+            )
+        warnings.warn(
+            "free-boundary adjoint stalled: residual "
+            f"{residual_norm:.3e} > acceptance {tolerance:.3e} after {calls} "
+            "Krylov iterations; returning the best-effort solution because "
+            "adjoint_fail='best_effort'. The gradient at this point is "
+            "inaccurate; a line search should reject it.",
+            RuntimeWarning, stacklevel=2,
         )
     return unravel(jnp.asarray(solution, dtype=rhs_flat.dtype))
 

--- a/vmex/core/monitoring.py
+++ b/vmex/core/monitoring.py
@@ -172,12 +172,15 @@ class OptimizationRecord:
 
 
 class OptimizationMonitor:
-    """Record and optionally print accepted optimizer iterations.
+    """Record and optionally print optimizer iterations and trials.
 
     Pass the instance as a SciPy ``callback``.  SciPy invokes callbacks after
     an iteration, unlike objective functions which are also called for rejected
     line-search or trust-region trials.  JAXopt, Optax, and custom loops can
-    call :meth:`record` with values they already computed.
+    call :meth:`record` with values they already computed.  ``trace`` also
+    prints one ``trial`` line per objective evaluation, so the rejected
+    line-search trials between two accepted iterations -- a full equilibrium
+    solve each -- are visible while the run is in progress.
 
     The monitor never chooses steps or changes an optimizer.  If ``problem``
     is supplied, VMEX solve/failure counters are read without evaluating the
@@ -210,10 +213,13 @@ class OptimizationMonitor:
         *,
         stream: TextIO | None | object = _DEFAULT_STREAM,
         print_every: int = 1,
+        trace: bool = True,
     ) -> None:
         if print_every < 1:
             raise ValueError("print_every must be at least 1")
         self.problem = problem
+        self.trace = bool(trace)
+        self._trials = 0
         self.stream: TextIO | None = (
             sys.stdout if stream is _DEFAULT_STREAM else cast(TextIO | None, stream)
         )
@@ -307,12 +313,18 @@ class OptimizationMonitor:
         term_values = ({} if terms is None else
                        {str(name): float(value) for name, value in terms.items()})
         key = self._key(x)
-        self._evaluations[key] = (
-            cost_f, float(np.linalg.norm(gradient_np)), term_values)
+        optimality = float(np.linalg.norm(gradient_np))
+        self._evaluations[key] = (cost_f, optimality, term_values)
         if not self.records:
-            self.record(
-                x, cost=cost_f, optimality=self._evaluations[key][1],
-                terms=term_values)
+            self.record(x, cost=cost_f, optimality=optimality, terms=term_values)
+        elif self.stream is not None and self.trace:
+            # One line per objective evaluation.  SciPy calls the objective for
+            # rejected line-search trials too, and each of those is a full
+            # equilibrium solve, so printing only accepted iterations leaves a
+            # long-running optimization silent.
+            self._trials += 1
+            print(f"  trial {self._trials:4d}  {cost_f:12.6e}  "
+                  f"{optimality:11.5e}", file=self.stream, flush=True)
         return cost_f, gradient_np
 
     @staticmethod


### PR DESCRIPTION
Optimization runs printed nothing while they worked, and
`single_stage_free_boundary_optimization.py` died in its adjoint. Four
measured defects; every number below was reproduced locally on an Apple M4.

## 1. Optimizations were silent

`OptimizationMonitor` is a SciPy `callback`, so it printed one row per
**accepted** iteration, and `cache_evaluation` printed only the very first
evaluation and cached the rest. Every rejected line-search trial — a full
equilibrium solve of tens of seconds — produced no output at all.

On top of that, **20 of the 24 optimization examples passed
`OptimizationMonitor(stream=None)`**, silencing even the accepted rows: every
QA/QH/QI/QP example and all eight `stellarator_asymmetry/` scripts. Only the
four `single_stage*` examples printed anything.

The monitor now prints one `trial` line per objective evaluation (opt out with
`trace=False`), and no example silences it.

## 2. Two examples paid for every gradient twice

The scalar QA example (its optimizer wiring now lives in `_scalar_driver.py`, shared by the eight scalar examples merged in #197) and `omnigenity_epsilon_gammac_maxj.py` called
`value_and_gradient(intermediate_result.x)` **inside** the SciPy callback,
recomputing a full solve-plus-adjoint once per accepted iteration — when
`__call__` already reads the cached evaluation back for both cost and
optimality. Routing the optimizer's own evaluation through `cache_evaluation`
removes it: `eq solves` now reads 1,2,3,4,5, one solve per accepted iteration.

## 3. The free-boundary adjoint stalled, fatally

The example printed iteration 0 and then raised:

```
AdjointSolveError: implicit adjoint host GCROT solve did not converge:
residual 5.182e+01 > acceptance 7.824e-06 after 9016 Krylov iterations
```

With `adjoint_tol=1e-8` and `||rhs||=78` that is a **relative** residual of
0.66 — total stagnation, not a tight tolerance. The cause is history
dependence: at that coil vector the forward solve gives `status=2` cold, but
`status=0` after a prior solve at `u=0` in the same process, and that
marginally converged root is too ill conditioned for the coupled Krylov
adjoint. Reproduced by replaying the captured coil vector cold and warm.

Two changes:

- the examples use `adjoint_solver="boundary_schur"`, which stays conditioned
  on exactly those roots, and keep the default `adjoint_fail="error"`;
- new `adjoint_fail="best_effort"` (opt-in, never used by a shipped example)
  returns a stalled Krylov solution with a `RuntimeWarning` instead of raising,
  for callers that would rather reject one poor search direction than lose a
  run. A **non-finite** adjoint still raises, and `"error"` remains the default.

Measured after the rebase onto main (office workstation, CPU, jax 0.9.2,
SOLVAX 0.20.0, ESSOS main): with `boundary_schur` alone the vacuum example
completed all 20 L-BFGS-B iterations, 35 trials, no adjoint warning or error,
cost 9.0e+03 -> 3.12e-04, final QA 6.89e-04, aspect 5.999, min |iota| 0.414.

The failure arrives inside the VJP, where the example's
`lax.cond(status == 0, ...)` wall cannot catch it, which is why a policy on
the adjoint itself is the right place for this.

## 4. The objective was 99.998% coil length

From the run's own history file at iteration 0:

| term | value | share |
|---|---|---|
| **coil length** | **23.598044** | **99.9977 %** |
| QA | 3.44e-4 | 0.0015 % |
| iota floor | 1.98e-4 | 0.0008 % |
| aspect | 6.03e-7 | ~0 |

`LENGTH_TARGET = 3.5` against 5.25 m coils is geometrically unreachable, and
`0.5*sum((L - 3.5)^2)` reproduces the total to nine digits. The optimizer was
never optimizing the plasma. Coil length becomes a hinge above a reachable
`LENGTH_LIMIT = 5.3`, matching the curvature and separation terms, which are
already hinges.

The iota floor read the hard `min_abs_iota`; its own docstring warns that the
hard minimum is non-differentiable where two surfaces tie, "which a
least-squares step can sit on". The shipped `soft_min_abs_iota` replaces it
and the inflated gradient drops from 11.12 to 3.87. A line scan along the
descent direction confirms the fix: with the hard minimum the objective *rose*
at every step; with the smooth one it falls by 1.4e-5 at the optimal step.

Forward `FTOL` goes 1e-10 to 1e-9, measured at `u = 0`:

| forward `ftol` | wall | `\|grad\|` |
|---|---|---|
| 1e-10 (was) | 154 s | 1.123e1 |
| **1e-9** | **59 s** | 1.116e1 |
| 1e-8 | 54 s | 3.674e1 (adjoint breaks) |

2.6x faster for a 0.6% gradient change; 1e-8 is too loose to differentiate.
That 0.6% also brackets the 0.4% gap between the two adjoint solvers at
`ftol=1e-10` (11.19 GCROT against 11.23 Schur), so on this evidence the two
paths agree to within the sensitivity of the root itself rather than
disagreeing.

## Result

The example converges monotonically instead of stopping after one iteration
with the cost going **up** by 1.2e-4:

```
 iter          cost     reduction   optimality
    0  3.467565e-04             -  3.872518e+00
    1  3.322913e-04  1.446516e-05  2.740744e+00
   ...
   17  3.167949e-04  5.606835e-07  8.445883e-03
```

Optimality falls 3.87 to 8.4e-03 on 1.4 trials per accepted iteration, with a
single infeasible trial at the very first step.

## Verification

`tools/preflight.py --static` passes (ruff, mypy on 75 files, docs prose,
guard tests). `tests/test_monitoring.py` and
`tests/test_freeboundary_implicit.py` pass, 26 tests, including two new ones
covering the trace line and the `adjoint_fail` validation.

## Not included

`examples/data/input.LandremanPaul2021_QA_lowres` exits `rc=2`
("MORE ITERATIONS REQUIRED"): it asks `FTOLV=1e-13` at `ns=50` with
`NITER=1000` and lands at FSQR 2.63e-13, so the flagship QA deck fails for
any new user. The deck is pinned by six test files and
`benchmarks/baseline.json`, so changing it needs baseline regeneration and
belongs in its own PR.
