### PR TITLE
Coil-length target, the circular-coil seed result, and a profile of the optimizer

### DIFF
--- a/examples/optimization/single_stage_free_boundary_optimization.py
+++ b/examples/optimization/single_stage_free_boundary_optimization.py
@@ -1,6 +1,26 @@
 #!/usr/bin/env python
 """True free-boundary QA optimization with ESSOS coils as the only dofs.
 
+The coils start from a set that already produces a confining field, and that
+is a requirement rather than a convenience.  Seeding this lane from circular
+coils, the way ``single_stage_optimization.py`` does, does not work for a
+vacuum zero-current deck: circular coils carry no rotational transform, so the
+plasma they produce has none either, and the quasi-symmetry residual of a
+field with no transform is trivially small.  Measured on
+``input.minimal_seed_nfp2`` (CURTOR = 0, AM = 0) at ns=25, mpol=ntor=5, with
+random non-planar excursions added to 4 circular coils per half period: at
+zero excursion the solve converges to min|iota| = 5.6e-11 with a QA residual
+of 4.2e-10; the transform is still only 4.0e-3 at excursion 3e-2, and by
+excursion 1e-1 the free-boundary root is gone (status 2) with min|iota| at
+7.9e-3, against the 0.42 this example targets.  The optimizer would start in
+a flat, degenerate region it cannot cross.
+
+``single_stage_optimization.py`` can start there precisely because its plasma
+is a *fixed-boundary* solve coupled to the coils by a B.n penalty, so the
+boundary supplies the transform and the coils are pulled toward it.  Treat
+this lane as a refinement stage for coils that already confine, not as an
+initialization stage.
+
 Preview: this script needs ESSOS branch ``rj/vmex-optimization-interfaces``.
 """
 
@@ -37,11 +57,12 @@ SURFACES = np.linspace(0.1, 1.0, 6)
 NS, MPOL, NTOR, NITER, FTOL = 25, 5, 5, 2000, 1.0e-9
 MAXITER, METHOD, PARAMETER_BOUND = 20, "L-BFGS-B", 1.0
 ASPECT_TARGET, IOTA_FLOOR = 6.0, 0.42
-# Coil length is a hinge above a reachable limit, not a target: with
-# LENGTH_TARGET = 3.5 against 5.25 m coils, 0.5*sum((L - 3.5)^2) = 23.598 was
-# 99.998% of the objective against QA at 3.4e-04, so the optimizer only ever
-# fought an unreachable length and the plasma terms were invisible.
-LENGTH_LIMIT, LENGTH_WEIGHT = 5.3, 1.0
+# 5.2 m against 5.25 m coils, not the former 3.5: at 3.5 the term was
+# 0.5*sum((L - 3.5)^2) = 23.598 against QA at 3.44e-04, i.e. 99.998% of the
+# objective, so the optimizer only ever fought an unreachable length.  A
+# target just inside the current length keeps a real shortening gradient
+# (0.02 at the start) without swamping the plasma terms.
+LENGTH_TARGET, LENGTH_WEIGHT = 5.2, 1.0
 CURVATURE_LIMIT, CURVATURE_WEIGHT = 7.0, 10.0
 COIL_DISTANCE_LIMIT, COIL_DISTANCE_WEIGHT = 0.08, 1.0e3
 OPTIONS = {"maxiter": MAXITER, "maxls": 10, "ftol": 1.0e-12, "gtol": 1.0e-8}
@@ -102,7 +123,7 @@ def objective(u):
         coils = coils_from_u(u)
         costs = jnp.asarray([
             0.5 * LENGTH_WEIGHT * jnp.sum(
-                jnp.maximum(coils.length - LENGTH_LIMIT, 0.0)**2),
+                (coils.length - LENGTH_TARGET)**2),
             0.5 * CURVATURE_WEIGHT * jnp.sum(
                 jnp.maximum(coils.curvature - CURVATURE_LIMIT, 0.0)**2),
             0.5 * COIL_DISTANCE_WEIGHT * loss_coil_separation(

--- a/examples/optimization/single_stage_free_boundary_optimization_finite_beta.py
+++ b/examples/optimization/single_stage_free_boundary_optimization_finite_beta.py
@@ -34,7 +34,7 @@ SURFACES = np.linspace(0.1, 0.9, 8)
 NS, MPOL, NTOR, NITER, FTOL = 31, 5, 5, 2500, 1.0e-9
 MAXITER, METHOD, PARAMETER_BOUND = 20, "L-BFGS-B", 1.0
 ASPECT_TARGET, IOTA_FLOOR = 6.0, 0.42
-LENGTH_LIMIT, LENGTH_WEIGHT = 5.3, 1.0
+LENGTH_TARGET, LENGTH_WEIGHT = 5.2, 1.0
 CURVATURE_LIMIT, CURVATURE_WEIGHT = 7.0, 10.0
 COIL_DISTANCE_LIMIT, COIL_DISTANCE_WEIGHT = 0.08, 1.0e3
 OPTIONS = {"maxiter": MAXITER, "maxls": 10, "ftol": 1.0e-12, "gtol": 1.0e-8}
@@ -111,7 +111,7 @@ def objective(u):
         coils = coils_from_u(u)
         costs = jnp.asarray([
             0.5 * LENGTH_WEIGHT * jnp.sum(
-                jnp.maximum(coils.length - LENGTH_LIMIT, 0.0)**2),
+                (coils.length - LENGTH_TARGET)**2),
             0.5 * CURVATURE_WEIGHT * jnp.sum(
                 jnp.maximum(coils.curvature - CURVATURE_LIMIT, 0.0)**2),
             0.5 * COIL_DISTANCE_WEIGHT * loss_coil_separation(


### PR DESCRIPTION
Three pieces of measured evidence. Two produce a small code change; the third is
a profile whose conclusion is a design question, not a defect, so it ships as a
handoff rather than a patch.

**Stacked on #265** — the coil-length line only exists after that PR. Review #265
first.

All measurements: Apple M4, 24 GB, macOS 25.6, JAX on CPU, float64, VMEX 0.8.1,
`~/.cache/vmex` and `~/.cache/jax` cleared before each timing, separate process
per configuration, medians of 3–4 evaluations.

---

# 1. Coil length: a target of 5.2, not a hinge above 5.3

#265 replaced `LENGTH_TARGET = 3.5` (unreachable against 5.25 m coils, and
therefore 99.998 % of the objective) with a hinge above 5.3. The hinge is exactly
zero at the start, so the coils have no reason to move at all. This sets a real
target of 5.2 m: a shortening gradient worth 0.02 at the start, against QA at
3.44e-04 — present, but no longer swamping the plasma terms.

Files: `examples/optimization/single_stage_free_boundary_optimization.py`,
`..._finite_beta.py`.

---

# 2. True free-boundary single stage cannot be seeded from circular coils

`input.minimal_seed_nfp2` has `CURTOR = 0` and `AM = 0` — a **vacuum,
zero-current** deck — so every bit of rotational transform must come from 3-D
coil shaping. Circular coils supply none.

Measured at `ns=25, mpol=ntor=5`, 4 circular coils per half period
(`essos.coils.CreateEquallySpacedCurves`), random non-planar excursions added to
the harmonics above the first:

| excursion | status | min\|ι\| | mean ι | aspect | QA residual |
|---|---|---|---|---|---|
| 0 (pure circular) | 0 | **5.630e-11** | −3.119e-8 | 9.769 | 4.2030e-10 |
| 1e-3 | 0 | 4.791e-7 | −2.467e-6 | 9.769 | 1.6635e-5 |
| 1e-2 | 0 | 7.472e-7 | 1.114e-5 | 9.766 | 4.6407e-3 |
| 3e-2 | 0 | 4.017e-3 | 4.380e-3 | 9.765 | 9.6312e-3 |
| 1e-1 | **2 (no root)** | 7.906e-3 | −1.201e-2 | 9.632 | 2.8720 |

Target is ι = 0.42. The QA residual at zero excursion is `4.2e-10` — trivially
"perfect", because a field with no transform is trivially quasi-axisymmetric. The
objective is degenerate there, and the free-boundary root is already gone by the
time the transform reaches 7.9e-3.

`single_stage_optimization.py` can start from circular coils only because its
plasma is a *fixed-boundary* solve coupled to the coils by a B·n penalty, so the
boundary supplies the transform and the coils are pulled toward it. **This lane is
a refinement stage for coils that already confine, not an initialisation stage.**
Recorded in the example docstring.

---

# 3. Where the optimizer's wall time actually goes

`QA_optimization.py` and `QH_optimization.py` feel slow. They are, but not for the
reason one would guess, and per-evaluation cost is competitive with DESC.

## 3.1 End to end

`examples/optimization/QA_optimization.py`, `MAX_MODE = 2`, `MAXITER = 30`, cold
caches — **265 s total**:

| phase | wall | share |
|---|---|---|
| import + `VmecProblem.from_loss` | 7 s | 2.6 % |
| `compile_value_and_gradient` | 29 s | 11 % |
| **optimization loop** | **205 s** | **77 %** |
| final `ns=101, ftol=1e-14` solve | 7 s | 2.6 % |
| plotting (6 figures) | 13 s | 4.9 % |

The final high-resolution solve is **not** a problem — 7 s.

## 3.2 Inside one evaluation

Forward and full value+gradient timed at **distinct** points so the one-entry
memo in `VmecProblem.value_and_grad` (`vmex/core/problem.py:194`) cannot alias
them. Default `forward_ftol` = the deck's `1e-12`:

| component | time | share |
|---|---|---|
| VMEC solve — `multigrid.py:259 solve_multigrid` + `solver.py:2187 _run_loop` | **~0.35 s** | **5 %** |
| **Newton fixed-point refinement** — `implicit.py:1434 _refine_step`, 2 calls | **~3.86 s** | **50 %** |
| **implicit adjoint** — one GCROT solve | **~3.06 s** | **40 %** |
| other | ~0.4 s | 5 % |
| **total** | **7.63 s** | |

**About 90 % of every optimizer evaluation is Krylov (GCROT) work on `dF/dz`** —
twice forward inside the Newton anchor, once transposed for the adjoint. The
actual VMEC physics is 5 %.

The isolating experiment. At `forward_ftol = 1e-4` the solve converges in **3
iterations**, and `cProfile` over 3 such near-trivial solves gives:

```
cum=  41.19s  self=   0.00s  n=3   problem.py:480(equilibrium_from_x)
cum=  41.15s  self=   0.00s  n=3   callback.py:74(pure_callback_impl)
cum=  41.07s  self=   0.00s  n=3   implicit.py:1371(_refine_fixed_point)
cum=  41.04s  self=  41.04s  n=15  implicit.py:1434(_refine_step)      <-- 99.6%
cum=   0.08s  self=   0.00s  n=3   multigrid.py:259(solve_multigrid)   <-- the physics
cum=   0.04s  self=   0.03s  n=3   solver.py:2187(_run_loop)
```

The equilibrium solve costs **0.08 s**; the Newton refinement costs **41.04 s**.

The refinement is **not waste**. `_refined_state` (`implicit.py:1451`) documents
why: the implicit function theorem defines the derivative only *at* the root, and
`ftol` gates the sum of squares of the force, leaving `|F| ~ sqrt(ftol)`. Without
the anchor the value and the gradient sit at different points and the gradient no
longer matches `frozen_path_directional_fd`.

The forward solve itself runs on the host behind `jax.pure_callback`
(`implicit.py:1240`, "Forward solve (opaque host solver behind pure_callback) +
custom VJP"), which is why it appears as `pure_callback.16` in an XLA trace.

## 3.3 Two counterintuitive results

**Loosening `forward_ftol` makes the optimizer slower.** Time and iteration count
taken from the same call:

| `forward_ftol` | forward | VMEC iters | `_refine_step` calls / solve | adjoint | total |
|---|---|---|---|---|---|
| **1e-12 (deck default)** | **4.57 s** | 526 | **2** | 3.06 s | **7.63 s** |
| 1e-10 | 6.96 s | 157 | — | 3.24 s | 10.21 s |
| 1e-8 | 6.67 s | 68 | — | 3.21 s | 9.88 s |
| 1e-4 | 8.51 s | **3** | **5** | 3.55 s | 12.05 s |

Tight tolerance is fast because VMEC closes the residual cheaply (1.06 s for 3
solves); loose tolerance shifts that work onto Newton refinement at ~2 s per step.
Gradients agree to 8e-8 across the whole range, so there is no accuracy argument
either way. **Keep `forward_ftol` at the deck value.**

**`refine_tol` is a free 18 %.** `ImplicitConfig.refine_tol` defaults to `1e-10`
(`implicit.py:330`):

| `refine_tol` | median eval | gradient rel. diff vs 1e-10 |
|---|---|---|
| 1e-10 (default) | 7.69 s | — |
| 1e-8 | 7.69 s | **0.000e+00** (bit-identical) |
| **1e-6** | **6.33 s** | 8.8e-6 |

1e-8 buys nothing — the Newton step overshoots that tolerance anyway. 1e-6 is
**18 % faster** for an 8.8e-6 relative gradient change. Not applied here: changing
a global derivative-accuracy default is the maintainer's call, and it should be
checked against `frozen_path_directional_fd` before it ships.

## 3.4 Scaling in `max_mode`

| MAX_MODE | mpol | dofs | compile | median eval | total (5 iters) | cost after 5 |
|---|---|---|---|---|---|---|
| 2 | 5 | 24 | 28.5 s | **5.62 s** | 66.6 s | 4.891e-1 |
| 3 | 5 | 48 | 28.1 s | **5.53 s** | 69.4 s | 4.825e-1 |
| 4 | 6 | 80 | 34.0 s | 7.10 s | 85.6 s | 4.817e-1 |
| 5 | 7 | 120 | 45.1 s | 10.94 s | 119.1 s | 4.818e-1 |

**Per-evaluation cost is flat in dof count** — 2→3 doubles the dofs (24→48) and
costs nothing, because the reverse-mode adjoint is dof-independent. Cost grows only
with `mpol`, and `MINIMUM_MPOL = 5` means max_mode 2 and 3 share a resolution.

## 3.5 Why more modes do not give a better answer

Not a performance problem. `residuals_from_tuples` (`vmex/core/optimize.py`)
composes terms as

```python
rows.append(sqrt(weight) * (function(state, runtime) - target))
```

with **no normalisation and no bounds**. Aspect ratio (physical value ~11) and the
QS residual (~1e-2) therefore enter the same sum four orders of magnitude apart
from units alone, before any weight is chosen. Measured on the QA objective:

| | start | after 5 iterations |
|---|---|---|
| total | 21.449 | 0.4892 |
| QS | 1.9386e-2 (0.09 %) | 1.2079e-2 (2.5 %) |
| **aspect** | **21.427 (99.9 %)** | 1.1919e-2 |
| **iota floor** | 2.6426e-3 | **4.6508e-1 (95.1 %)** |
| magnetic well | 1.2467e-4 | 1.2598e-4 |
| min\|ι\| | 0.3970 | **0.1150** (floor 0.42) |
| aspect ratio | 11.546 | 5.154 (target 5.0) |

The run is 99.9 % "aspect is 11.5, I want 5". It fixes that and **destroys the
rotational transform doing it**. After the full 30 iterations:
`QS total = 9.64e-02`, `mean iota = -0.2923`, **`magnetic well = -0.2726`** against
a target of **+0.01** — an interchange-**unstable** configuration whose QS is worse
than the 5-iteration result. Adding Fourier modes lets it reach that faster.

## 3.6 Comparison with DESC

DESC scales every objective before summing
(`desc/objectives/objective_funs.py`):

```python
def _scale(self, f, *args, **kwargs):
    f_norm = jnp.atleast_1d(f) / self.normalization   # non-dimensionalise
    return f_norm * w * self.weight                   # quadrature x user weight
```

with `compute_scaled_error` applying `_shift` for **target or bounds** first —
inside `bounds`, the loss is exactly zero, so a satisfied inequality contributes
nothing. VMEX has `target` and `weight` but neither `normalization` nor `bounds`.
That single difference is the root cause of §3.5 here and of the coil-length
dominance in #265.

On raw speed VMEX is competitive. DESC Part 3 (Dudt et al., *JPP* 2022,
arXiv:2204.00078) reports **37–434 s per CPU iteration** at 560 optimization
parameters (5 s on a V100 GPU, after a 122–190 s first iteration). VMEX does
5.5–11 s per evaluation at 24–120 dofs on a laptop CPU. **Per-evaluation cost is
not where VMEX is losing.**

On regression: cold CLI solves are at or below the baselines `plan.md` records for
0.8.x and well below 0.3.0 — `solovev` 2.8 s (plan 3.1), `li383_low_res` 3.8 s
(plan 4.0), `LandremanPaul2021_QA_lowres` 11.1 s (plan 12.3–12.6, 0.3.0 15.3). I
did **not** check out an older tag and re-run, so I can neither confirm nor refute
a specific "it was faster in version X".

---

# 4. Force-balance polishing on `input.LandremanPaul2021_QA_beta2p5_bootstrap`

**These runs are already done. Do not repeat them — each default-spans run is
~50 minutes and the result reproduced exactly across two independent runs.**

Deck: Landreman–Buller–Drevlak QA at β = 2.5 %, aspect 6, ι = 0.42, bootstrap
current. `MPOL = 7, NTOR = 6, NS_ARRAY = 9,17,31`,
`FTOL_ARRAY = 1e-10,1e-10,1e-12`, `NCURR = 1`, `CURTOR = −2.72e5 A`.

## 4.1 Baseline: the solve is cheap, the certificate is not

| step | wall | peak RSS | result |
|---|---|---|---|
| VMEC solve | 22.6 s cold / 4.7 s warm | 1.23 GiB | converged, 725 iters, `FSQR = 9.976e-12` |
| lift + certify, degree 3 | 7.9 + 17.6 s | **8.40 GiB** | `absolute_l2 = 1.0667e7` N m⁻³, `normalized_l2 = 1.1492` |
| lift + certify, degree 5 | 7.5 + 23.0 s | **9.66 GiB** | `absolute_l2 = 1.7828e7`, `normalized_l2 = 0.71968` |

Two things to carry forward. **(a)** `normalized_l2 = 1.149` against the ceiling of
2 — this deck is in the saturating regime of `ε_F` **even at finite β**. Quote
`absolute_l2` and the near-axis/bulk/edge split (2.772e7 / 9.758e6 / 8.768e6 at
degree 3), never `ε_F` alone. **(b)** Lift degree changes the answer by 1.7× in
`absolute_l2` and nearly 2× near-axis, and the codebase defaults to degree 3 in
`PolishConfig` and 5 elsewhere. That inconsistency is `plan.md` finding `31.2-C`
and it is unresolved.

## 4.2 Polish, capped at 3 Gauss–Newton iterations

| | default spans (14) | spans = 8 |
|---|---|---|
| collocation | 36540 rows × 2788 unknowns | 20880 × 1774 |
| wout export mesh | NS = 42 | NS = 24 |
| **total wall** | **3096.3 s** (repeat: 2812.1 s) | 1173.2 s |
| **peak RSS** | **16.03 GiB** (repeat: 16.14) | 12.19 GiB |
| setup (certificate + preconditioner + chart) | ~424 s (14 %) | — |
| factor build | 26.8 s (1 %) | 4.5 s |
| **Gauss–Newton solve** | **2645.5 s (85 %)** | 1008.6 s |
| nonlinear iterations | 3 | 3 |
| **linear iterations** | **1800** | 1702 |
| relative optimality (target 1e-3) | **0.0120** | 0.141 |
| `ε_F` | 1.1492 → **0.8053** (−30 %) | 1.8043 → 1.6023 (−11 %) |
| verdict | POLISH FAILED (gate is ≤ 1e-2) | POLISH FAILED |
| `minimum_signed_jacobian` | 9.7958e-3 | — |
| `radial_refinement_difference` | 6.9882e-3 | — |

**Answer to "can this deck be polished to a lower residual":** yes, by 30 %, in
51.6 minutes — and it does **not** certify. The gate is `normalized_l2 ≤ 1e-2` and
we reach 0.805, ~80× short. VMEX correctly declines and returns the unpolished
equilibrium under `POLISH_FAIL = WARN`. Certification on this deck is not a tuning
problem.

## 4.3 The bottleneck, stated precisely

`1800 / 3 = exactly 600` linear iterations per nonlinear step, and
`PolishConfig.linear_restart(30) × linear_max_restarts(20) = 600`. **Every
Gauss–Newton step saturated its Krylov ceiling without converging** (relative
optimality 0.0120 against a 1e-3 target). Raising the iteration budget therefore
buys nothing — the `mode-block` preconditioner is not strong enough at this
resolution. `plan.md` records the identical pathology for W7-X, where every step
hit a 150-iteration ceiling and 6 steps took 11 h 09 m.

Note the symmetry with §3: **both** the polish and the optimizer are dominated by
Krylov solves that are under-preconditioned for their operator. It is plausibly one
problem wearing two hats.

## 4.4 Things already tried — do not redo

- **Halving the radial spans is a false economy.** 2.6× faster, but the coarser
  lift is itself a worse representation, so it *starts* worse (`ε_F` 1.804 vs
  1.149) and ends far short (−11 % vs −30 %, relative optimality 0.141 vs 0.012).
  This validates the existing resolution-derived default rather than improving it.
- **Before/after pairs are not comparable across span settings**, because the
  initial lift moves with the knob. This is exactly the error that produced the
  retracted "26-fold" claim (`plan.md` 31.2-R3), where the two ends were exported
  on different radial meshes. Compare relative reduction and cost per GN step, not
  absolute pairs.
- **Determinism is fine.** Two independent default-spans runs gave identical
  `ε_F` (1.1492 → 0.8053), identical `lin = 1800`, identical
  `rel_opt = 1.1992e-02`. There is no run-to-run noise to chase.

## 4.5 The wout export gotcha (cost me two runs)

`polished_state` **survives a failed certificate**, so both wouts are obtainable
even when polishing declines — but the exporter needs the *native high-order*
state and a `VmecInput`, not the compatibility state:

```python
# WRONG - res.polished_state is a SpectralState on the solve mesh
pd.polished_wout_state(res.polished_state, res, solve_ns=31)
#   AttributeError: 'SpectralState' object has no attribute 'radial_basis'
#   AttributeError: 'SpectralState' object has no attribute 'lasym'

# RIGHT
inp = vj.VmecInput.from_file(DECK)
wout = pd.polished_wout_state(res.native_equilibrium, inp, solve_ns=31)
vj.write_wout("wout_beta2p5_polished.nc", wout)
```

`SolveResult.polished_state` is the `SpectralState` matching the solve mesh;
`SolveResult.native_equilibrium` is the `HighOrderEquilibriumState`. The unpolished
wout is written by an ordinary `solve_file(..., write_wout=True)`. **The polished
wout for this deck has not been written yet** — it is one corrected 50-minute run,
not a re-derivation.

## 4.6 Prior art to build on, not duplicate

**#261 (`perf/polish-3d-effectiveness`) is the main prior art and is unmerged.** It
carries the batched + checkpointed force sweep (W7-X: 34.2 GiB → 3.0 GiB), a cost
model that prices the GN phase before `AUTO` commits, plus
`benchmarks/polish_cost.py`, `benchmarks/polish_memory.py` and
`benchmarks/polish3d_tuning.md`. The 16 GiB peak measured above forces swap on a
24 GB box, which inflates that 51.6 minutes — #261 is the fix, and any polish work
should stack on it rather than re-implement it.

Also unmerged with **no PR open**: `physics/force-error-normalizations`, which adds
the non-saturating normalisations §4.1(a) says you need.

---

# 5. Ranked next steps

1. **Recycle the Krylov subspace** across the refine→adjoint boundary and across
   line-search trials. All three GCROT solves per evaluation act on the same
   operator `dF/dz` at nearby points, and together they are ~90 % of the cost.
   GCRO-DR / recycled-Krylov is the standard technique. This is the only change
   with a plausible large factor in it.
2. **`refine_tol = 1e-6`** — 18 % measured, gradient to 8.8e-6. Gate it on
   `frozen_path_directional_fd` agreement before changing the default.
3. **Objective normalisation and bounds**, DESC-style. Does not make an iteration
   faster; makes iterations *count*, which is what "slow" means in practice here.
   Would also let `IOTA_FLOOR` and `magnetic_well` behave as constraints rather
   than as terms the optimizer trades away.
4. **Persist the 29 s compile** across runs via `VMEX_COMPILATION_CACHE_DIR`.
5. Leave `forward_ftol` alone — the deck default is the fast setting.

Open question for whoever picks this up: the Newton anchor is required for
gradient correctness, but is *two* GCROT solves per evaluation the cheapest way to
land on the root? A tighter forward solve reaches it in fewer Newton steps, which
suggests the split between "VMEC iterations" and "Newton steps" has an optimum
that nobody has looked for.

---

# 6. Reproducing everything

Existing tooling covers most of it — `benchmarks/optimization.py` already accepts
`--case qa|qh|qi|qp`, `--max-mode`, `--forward-ftol`, `--nfev`, `--optimizer`.

Phase split inside one evaluation (the numbers in §3.2), timed at distinct points
so the memo cannot alias:

```python
problem = opt.VmecProblem.from_loss(inp, loss, max_mode=2, use_ess=True,
                                    ess_alpha=1.2, forward_ftol=1e-12)
problem.compile_value_and_gradient()
pt = lambda k: problem.x0 + 0.02 * problem.scales * rng(k).standard_normal(problem.x0.size)
problem.value_and_grad(pt(1)); problem.equilibrium_from_x(pt(2))     # warm both lanes
t = time(); eq = problem.equilibrium_from_x(pt(300)); forward = time() - t
t = time(); problem.value_and_grad(pt(400));          full    = time() - t
adjoint = full - forward
```

The `cProfile` attribution in §3.2 comes from running three
`equilibrium_from_x` calls at `forward_ftol=1e-4` under `cProfile` and sorting by
cumulative time. An XLA trace (`jax.profiler.trace`) confirms the same picture but
exceeds the 2 GB protobuf limit on this problem, so `cProfile` is the practical
tool here.

Measurement discipline used throughout, per `plan.md` §31.8: fresh process, caches
cleared, subprocess wall time, medians over repeats, one heavy job at a time.
