### PR TITLE
Require finite true residuals for polished implicit derivatives

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -10,7 +10,9 @@ the remaining physics and distributed solver work is not yet implemented.
 
 - **Completed checkpoint (2026-09-05 UTC):** user approved this plan. A's
   true-residual acceptance gate (R1) is implemented and locally validated on this
-  branch; broader work packages remain open. Merge/CI status is tracked by PR.
+  branch; broader work packages remain open. Implementation commit `b2bd9da6`,
+  [PR #268](https://github.com/uwplasma/vmex/pull/268), stacked on #267; open,
+  awaiting CI/merge at this checkpoint. All commits are authored `rogeriojorge`.
 - **Resume location:** `/Users/rogeriojorge/local/vmex-acceptance`, branch
   `fix/polish-true-residual`, based on plan commit `8ff1af78` (plan PR #267).
   Original user worktrees are preserved. This branch stacks on the plan PR.
@@ -36,7 +38,7 @@ the remaining physics and distributed solver work is not yet implemented.
   `office:/home/rjorge/local/vmex-acceptance`, detached baseline `09f18464`;
   run the focused subset with `/home/rjorge/venvs/vmex-gpu/bin/python` and
   `JAX_PLATFORMS=cuda,cpu`. The GPU integration test has not been run.
-- **Next:** review/merge the scoped R1 PR stacked on #267. Then implement the
+- **Next:** review/merge R1 PR #268 stacked on #267. Then implement the
   next A checkpoint: unify the force certificate predicate at
   `polish_legacy_solution`'s early return and `polish_collocation_least_squares`'s
   completion, retaining finite-data, quadrature and geometry checks in both.

--- a/plan.md
+++ b/plan.md
@@ -3,8 +3,47 @@
 Reviewed 2026-09-05 UTC. This is the authoritative forward plan, replacing the
 August plan and its appended September ledger. Completed work is linked, open
 work has an owner and an acceptance gate, and unsuccessful experiments remain
-evidence rather than proposed defaults. This revision plans implementation; it
-does not claim that the remaining physics or distributed solver is implemented.
+evidence rather than proposed defaults. Implementation status is recorded below;
+the remaining physics and distributed solver work is not yet implemented.
+
+## Execution logbook
+
+- **Completed checkpoint (2026-09-05 UTC):** user approved this plan. A's
+  true-residual acceptance gate (R1) is implemented and locally validated on this
+  branch; broader work packages remain open. Merge/CI status is tracked by PR.
+- **Resume location:** `/Users/rogeriojorge/local/vmex-acceptance`, branch
+  `fix/polish-true-residual`, based on plan commit `8ff1af78` (plan PR #267).
+  Original user worktrees are preserved. This branch stacks on the plan PR.
+- **Implemented:** finite unpreconditioned derivative
+  certificates in `polish_implicit.py`; no new production API or files. Internal
+  Krylov flags cannot override the true certificate. Norm overflow fails closed.
+- **Validation:** focused `-k polish_linear` tests: 42 passed on office
+  RTX A4000 (8.68 s; `JAX_PLATFORMS=cuda,cpu`, JAX 0.9.2, float64), including
+  actual JIT, both operator directions and exhausted GMRES. Local static
+  preflight passed (43 guards, 3 skips; Ruff, mypy, documentation prose).
+  CPU focused plus existing `collocation_polish_primal_and_derivatives` integration
+  test: 43 passed, 60 deselected in 374.17 s. This includes tangent/adjoint duality,
+  custom VJP, Boozer-objective pullback and stationarity Taylor checks. The long
+  integration uses the suite's default disabled JIT; focused tests explicitly
+  enable it. No full-suite or distributed-equilibrium claim is made.
+- **Baseline repair:** plan PR #267 now uses portable evidence path/host
+  placeholders (`b10b7c8e`, `8ff1af78`); its portability regression passes.
+  Raw evidence files and hashes remain unchanged.
+- **Commands:** from the resume worktree,
+  `VMEX_COMPILATION_CACHE=disabled python3 -m pytest -q tests/test_polish_preconditioner.py -k 'polish_linear or collocation_polish_primal_and_derivatives'`
+  and `python3 tools/preflight.py --static`. Focused CPU subset: 42 passed in
+  2.32 s. GPU source/test copies are isolated in
+  `office:/home/rjorge/local/vmex-acceptance`, detached baseline `09f18464`;
+  run the focused subset with `/home/rjorge/venvs/vmex-gpu/bin/python` and
+  `JAX_PLATFORMS=cuda,cpu`. The GPU integration test has not been run.
+- **Next:** review/merge the scoped R1 PR stacked on #267. Then implement the
+  next A checkpoint: unify the force certificate predicate at
+  `polish_legacy_solution`'s early return and `polish_collocation_least_squares`'s
+  completion, retaining finite-data, quadrature and geometry checks in both.
+  Follow with explicit stationarity eligibility in `PolishContext` and the
+  derivative entry points; today's integration fixture deliberately permits
+  physics acceptance after one GN step, so it is not proof of nonlinear-root
+  derivative accuracy. Do not mark all of A complete after R1.
 
 ## 1. Outcome and order of work
 
@@ -229,7 +268,7 @@ mode. Do not silently change a diagnostic command's exit behavior.
 **Owner:** VMEX reports, tests and `benchmarks/profile_workflows.py`; SOLVAX owns
 only generic solve-result semantics. **Exit:** every status means what it says.
 
-- [ ] Make a finite, recomputed **unpreconditioned** tangent/adjoint residual the
+- [x] Make a finite, recomputed **unpreconditioned** tangent/adjoint residual the
   authoritative gate. A solver's flag may be diagnostic; it cannot override a
   failed true residual. Test false-positive flags, NaN/Inf, zero RHS, iteration
   exhaustion, eager behavior and real `jax.jit` behavior. Check solution and
@@ -1148,8 +1187,9 @@ A performance result is not complete while accuracy is unknown. A physics
 feature is not complete while its public usage and failure mode are unclear.
 
 Update the affected checkbox/table and link the merged commit/artifact in place.
-Keep completed history in git/PRs; keep this file focused on decisions still
-needed. Do not create a new report file for each experiment when the existing
+Keep a compact execution logbook here with the active branch, checks, blockers
+and exact next action so an independent agent can resume. Link detailed history
+in git/PRs; keep this file focused on decisions still needed. Do not create a new report file for each experiment when the existing
 manifest can hold a record. Commits made for this work are authored by
 `rogeriojorge`; preserve existing contributors' authorship when incorporating
 their changes. Release publishing, external announcements and archival deposits

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -70,6 +70,8 @@ from vmex.core.polish_implicit import (
     PolishLinearConfig,
     PolishLinearReport,
     _checked_solution,
+    _linear_report,
+    _solve_linear,
     _collocation_stationarity,
     _tree_norm as _implicit_tree_norm,
     collocation_polish_adjoint,
@@ -116,6 +118,101 @@ def test_polish_linear_failure_policy_is_explicit():
     )
     assert np.isnan(result).all()
     assert _implicit_tree_norm((jnp.asarray([3.0, 4.0]),)) == pytest.approx(5.0)
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+@pytest.mark.parametrize(
+    ("rhs", "value", "applied", "flag", "accepted"),
+    [
+        (1.0, 0.0, 0.0, True, False),
+        (1.0, 0.0, 0.0, False, False),
+        (1.0, 1.0, 1.0, False, True),
+        (1.0, np.nan, 1.0, True, False),
+        (1.0, np.inf, 1.0, True, False),
+        (np.nan, 1.0, 1.0, True, False),
+        (np.inf, 1.0, 1.0, True, False),
+        (1.0, 1.0, np.nan, True, False),
+        (1.0, 1.0, np.inf, True, False),
+        (1.0e200, 1.0e200, 1.0e200, True, False),
+        (1.0, 1.0e200, 1.0e200, True, False),
+        (0.0, 0.0, 0.0, False, True),
+        (0.0, 1.0e-12, 1.0e-12, False, True),
+        (0.0, 1.0e-9, 1.0e-9, True, False),
+    ],
+)
+def test_polish_linear_true_certificate(compiled, rhs, value, applied, flag, accepted):
+    def report_for(rhs, value, applied):
+        return _linear_report(
+            lambda _: applied,
+            rhs,
+            SimpleNamespace(x=value, converged=flag, iterations=jnp.asarray(30)),
+            PolishLinearConfig(),
+        )
+
+    with jax.disable_jit(False):
+        report = (jax.jit(report_for) if compiled else report_for)(
+            *[jnp.asarray([item, item]) for item in (rhs, value, applied)]
+        )
+    assert bool(report.converged) == accepted
+    assert int(report.iterations) == 30
+
+
+@pytest.mark.parametrize("policy", ["raise", "nan"])
+def test_polish_linear_compiled_failure_returns_nan_and_status(policy):
+    config = PolishLinearConfig(fail_policy=policy)
+
+    def checked(value):
+        report = _linear_report(
+            lambda x: x, jnp.ones(1),
+            SimpleNamespace(x=value, converged=True, iterations=jnp.asarray(1)),
+            config,
+        )
+        return _checked_solution(value, report, config, "tangent"), report
+
+    with jax.disable_jit(False):
+        value, report = jax.jit(checked)(jnp.zeros(1))
+    assert not bool(report.converged)
+    assert bool(jnp.all(jnp.isnan(value)))
+
+
+@pytest.mark.parametrize("transpose", [False, True])
+@pytest.mark.parametrize("compiled", [False, True])
+def test_polish_linear_krylov_true_residual(transpose, compiled):
+    matrix = jnp.asarray([[4.0, 1.0], [-2.0, 3.0]])
+    if transpose:
+        matrix = matrix.T
+    rhs = jnp.asarray([2.0, -1.0])
+
+    def solve(rhs):
+        return _solve_linear(
+            lambda x: matrix @ x, rhs, lambda x: x / 4.0,
+            PolishLinearConfig(), "adjoint" if transpose else "tangent",
+        )
+
+    with jax.disable_jit(False):
+        value, report = (jax.jit(solve) if compiled else solve)(rhs)
+    assert bool(report.converged)
+    np.testing.assert_allclose(value, np.linalg.solve(matrix, rhs), atol=1.0e-11)
+    assert float(jnp.linalg.norm(rhs - matrix @ value)) <= float(report.tolerance)
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_polish_linear_iteration_exhaustion(compiled):
+    matrix = jnp.asarray([[4.0, 1.0], [-2.0, 3.0]])
+    rhs = jnp.asarray([2.0, -1.0])
+
+    def solve(rhs):
+        return _solve_linear(
+            lambda x: matrix @ x, rhs, lambda x: x,
+            PolishLinearConfig(restart=1, max_restarts=1, fail_policy="nan"),
+            "tangent",
+        )
+
+    with jax.disable_jit(False):
+        value, report = (jax.jit(solve) if compiled else solve)(rhs)
+    assert not bool(report.converged)
+    assert float(report.residual_norm) > float(report.tolerance)
+    assert bool(jnp.all(jnp.isnan(value)))
 
 
 def test_collocation_certification_error_retains_both_failure_gates():

--- a/vmex/core/polish_implicit.py
+++ b/vmex/core/polish_implicit.py
@@ -52,7 +52,11 @@ class PolishLinearConfig:
 
 
 class PolishLinearReport(NamedTuple):
-    """True residual certificate for one tangent or adjoint solve."""
+    """Finite unpreconditioned residual certificate for a tangent/adjoint solve.
+
+    ``converged`` requires finite operands, solution, norms and tolerance, with
+    ``residual_norm <= tolerance``; an internal Krylov success flag is insufficient.
+    """
 
     residual_norm: jax.Array
     tolerance: jax.Array
@@ -103,9 +107,21 @@ def _add_correction(
 
 
 def _linear_report(operator, rhs, solution, config: PolishLinearConfig):
-    residual_norm = jnp.linalg.norm(rhs - operator(solution.x))
-    tolerance = jnp.maximum(config.atol, config.rtol * jnp.linalg.norm(rhs))
-    converged = jnp.logical_or(solution.converged, residual_norm <= tolerance)
+    applied = operator(solution.x)
+    residual_norm = jnp.linalg.norm(rhs - applied)
+    rhs_norm = jnp.linalg.norm(rhs)
+    tolerance = jnp.maximum(config.atol, config.rtol * rhs_norm)
+    # Krylov flags can describe a preconditioned estimate. Only the finite,
+    # recomputed unpreconditioned residual certifies a derivative here.
+    finite = (
+        jnp.all(jnp.isfinite(solution.x))
+        & jnp.all(jnp.isfinite(rhs))
+        & jnp.all(jnp.isfinite(applied))
+        & jnp.isfinite(rhs_norm)
+        & jnp.isfinite(residual_norm)
+        & jnp.isfinite(tolerance)
+    )
+    converged = finite & (residual_norm <= tolerance)
     return PolishLinearReport(
         residual_norm=residual_norm,
         tolerance=tolerance,
@@ -128,9 +144,10 @@ def _checked_solution(
         if config.fail_policy == "raise":
             raise StrongForceLinearSolveError(
                 message=(
-                    f"strong-root {solve_kind} solve did not converge: residual "
-                    f"{float(report.residual_norm):.3e} > tolerance "
-                    f"{float(report.tolerance):.3e} after "
+                    f"strong-root {solve_kind} solve did not converge: finite "
+                    f"true-residual certificate failed (residual "
+                    f"{float(report.residual_norm):.3e}, tolerance "
+                    f"{float(report.tolerance):.3e}) after "
                     f"{int(report.iterations)} Krylov iterations"
                 ),
                 hint=(


### PR DESCRIPTION
A polished tangent or adjoint could report convergence when SOLVAX returned a success flag even though the recomputed unpreconditioned residual failed its tolerance or was nonfinite. Require finite solution, RHS, operator output, norms and tolerance, and make the true residual authoritative. A valid true residual can still pass when the internal flag is false.

The existing report and failure-policy API remains intact. Add eager and explicitly JIT-enabled regressions, actual normal/transposed Krylov solves, and iteration-exhaustion coverage in the existing test file. Update plan.md with a resumable execution logbook. This is the first acceptance checkpoint; nonlinear stationarity and the remaining plan are still open.

Validation: 42 focused tests pass locally on CPU (2.32 s) and on the office RTX A4000 (8.68 s), using JAX 0.9.2 and float64. Static preflight passes (Ruff, mypy, prose, 43 guard tests; 3 skipped). CPU focused plus existing polished-state integration: 43 passed, 60 deselected in 374.17 s, including tangent/adjoint duality, custom VJP, Boozer pullback and stationarity Taylor checks. The full repository suite and GPU integration test were not run.

Stacked on #267; the base is the accepted research plan branch.
