### PR TITLE
Use one finite force certificate for every polish acceptance path

### DIFF
--- a/docs/explanation/high-order-force-balance.rst
+++ b/docs/explanation/high-order-force-balance.rst
@@ -207,10 +207,14 @@ default.
 Acceptance is the certificate, not solver convergence
 -----------------------------------------------------
 
-A polished state is accepted when three independent certificate checks pass:
+Both drivers accept a polished state only when all three certificate checks pass:
 ``normalized_l2 <= validation_tolerance`` (default ``1e-2``),
 ``radial_refinement_difference <= radial_refinement_tolerance`` (default
-``1e-3``), and a strictly positive minimum signed Jacobian.  The Gauss--Newton
+``1e-3``), and a strictly positive minimum signed Jacobian.  All three metrics
+must be finite; both norm/difference metrics must be nonnegative.  When
+``validation_tolerance=None``, the force threshold is ``tolerance``.  These
+checks apply to early returns as well as final acceptance; nonfinite values
+are named in the failure message.  The Gauss--Newton
 solver's own relative stationarity tolerance is recorded as
 ``least_squares_success`` and is a diagnostic only.
 
@@ -267,7 +271,7 @@ Driver sequence
 :func:`~vmex.core.polish_driver.polish_legacy_solution` is the only entry point
 the solver uses.  It refines the converged legacy state with the implicit
 Newton anchor, lifts it into the spline basis, and evaluates the independent
-certificate.  A state already inside ``validation_tolerance`` returns
+certificate.  A state satisfying all three acceptance checks above returns
 immediately with ``termination_reason="already-certified"`` and an empty
 correction; no chart, factorization, or solve is constructed.
 

--- a/plan.md
+++ b/plan.md
@@ -8,44 +8,53 @@ the remaining physics and distributed solver work is not yet implemented.
 
 ## Execution logbook
 
-- **Completed checkpoint (2026-09-05 UTC):** user approved this plan. A's
-  true-residual acceptance gate (R1) is implemented and locally validated on this
-  branch; broader work packages remain open. Implementation commit `b2bd9da6`,
-  [PR #268](https://github.com/uwplasma/vmex/pull/268), stacked on #267; open,
-  awaiting CI/merge at this checkpoint. All commits are authored `rogeriojorge`.
-- **Resume location:** `/Users/rogeriojorge/local/vmex-acceptance`, branch
-  `fix/polish-true-residual`, based on plan commit `8ff1af78` (plan PR #267).
-  Original user worktrees are preserved. This branch stacks on the plan PR.
-- **Implemented:** finite unpreconditioned derivative
-  certificates in `polish_implicit.py`; no new production API or files. Internal
-  Krylov flags cannot override the true certificate. Norm overflow fails closed.
-- **Validation:** focused `-k polish_linear` tests: 42 passed on office
-  RTX A4000 (8.68 s; `JAX_PLATFORMS=cuda,cpu`, JAX 0.9.2, float64), including
-  actual JIT, both operator directions and exhausted GMRES. Local static
-  preflight passed (43 guards, 3 skips; Ruff, mypy, documentation prose).
-  CPU focused plus existing `collocation_polish_primal_and_derivatives` integration
-  test: 43 passed, 60 deselected in 374.17 s. This includes tangent/adjoint duality,
-  custom VJP, Boozer-objective pullback and stationarity Taylor checks. The long
-  integration uses the suite's default disabled JIT; focused tests explicitly
-  enable it. No full-suite or distributed-equilibrium claim is made.
-- **Baseline repair:** plan PR #267 now uses portable evidence path/host
-  placeholders (`b10b7c8e`, `8ff1af78`); its portability regression passes.
-  Raw evidence files and hashes remain unchanged.
-- **Commands:** from the resume worktree,
-  `VMEX_COMPILATION_CACHE=disabled python3 -m pytest -q tests/test_polish_preconditioner.py -k 'polish_linear or collocation_polish_primal_and_derivatives'`
-  and `python3 tools/preflight.py --static`. Focused CPU subset: 42 passed in
-  2.32 s. GPU source/test copies are isolated in
-  `office:/home/rjorge/local/vmex-acceptance`, detached baseline `09f18464`;
-  run the focused subset with `/home/rjorge/venvs/vmex-gpu/bin/python` and
-  `JAX_PLATFORMS=cuda,cpu`. The GPU integration test has not been run.
-- **Next:** review/merge R1 PR #268 stacked on #267. Then implement the
-  next A checkpoint: unify the force certificate predicate at
-  `polish_legacy_solution`'s early return and `polish_collocation_least_squares`'s
-  completion, retaining finite-data, quadrature and geometry checks in both.
-  Follow with explicit stationarity eligibility in `PolishContext` and the
-  derivative entry points; today's integration fixture deliberately permits
-  physics acceptance after one GN step, so it is not proof of nonlinear-root
-  derivative accuracy. Do not mark all of A complete after R1.
+- **Completed checkpoint (2026-09-05 UTC):** A/R2 force-certificate consistency.
+  Worktree `/Users/rogeriojorge/local/vmex-certificates`, branch
+  `fix/polish-certificate-consistency`, based on R1 checkpoint `5d3b3829`.
+  Preserve the original user worktrees. All commits use author `rogeriojorge`.
+- **Previous checkpoint:** R1 implementation `b2bd9da6`, [PR #268](https://github.com/uwplasma/vmex/pull/268),
+  stacked on plan PR #267. CPU 43 selected tests passed in 374.17 s; GPU 42
+  focused tests passed in 8.68 s; static preflight passed. Both PRs remain open;
+  completed #268 CI checks have passed, with other lanes still running.
+- **Implemented:** reuse `_failed_certificate_checks` for the public legacy
+  early return, collocation completion and both retired continuation acceptance
+  points. Require finite nonnegative force/quadrature metrics within tolerance
+  and a finite strictly positive sampled Jacobian. Failure messages use the
+  same checks; no new acceptance API. All 68 route regressions pass (0.42 s).
+  Static preflight and the warning-strict documentation build pass.
+- **Integration finding:** the old public-solver test expected `already-certified`
+  after checking only the force norm; with the repaired predicate it performs
+  correction and returns `independently-certified` instead (274.61 s run).
+  Keep the existing thresholds and update the test to verify initial quadrature
+  failure, an actual correction and a valid final certificate. Rerun passed:
+  1 test, 170 deselected, 285.55 s with
+  `VMEX_COMPILATION_CACHE=disabled python3 -m pytest -q tests/test_polish_preconditioner.py -k public_solver_auto_corrects`.
+  The second selection, `-k 'polish_driver_skips or polish_driver_records or collocation_polish_primal_and_derivatives'`,
+  passed: 3 tests, 168 deselected, 358.04 s. This verifies retired early return,
+  bounded failure and the existing polished tangent/adjoint/VJP chain.
+  Static preflight: Ruff/mypy/prose and 43 guard tests passed (3 skipped).
+  Warning-strict Sphinx build passed. These CPU test durations are validation
+  costs, not performance benchmarks; the GPU integration suite was not rerun.
+- **Consumer audit:** `core/cli.py::_write_wout_from_result` (the native export
+  gate near line 711) already requires `polish_report.converged`; multigrid
+  reports failed polish explicitly. The public result retains the original
+  native lift on `return_unpolished`, so callers must inspect the polish report,
+  not infer certification from a non-None native state. Direct native export and
+  resumed-solve contracts remain to test under the wider A task.
+- **New derivative reproducer:** `_implicit_collocation_leaves_fwd` saves correction
+  and variable scale but discards primal native leaves. Its backward pass uses
+  `runtime.native`, which can differ from the input. Analytic `g(c,q)=c-q^2`,
+  output `q+c`, stale runtime `q=1`, input `q=2`, stationary `c=4`: expected
+  implicit gradient 5, observed 3. Script is outside git at
+  `vmex-review-evidence-20260905/polish_native_provenance_probe.py`. This is a
+  synthetic provenance regression, not an MHD benchmark. Fix/reject stale native
+  data as part of derivative eligibility, with changed-input JIT regression.
+- **Next:** commit this checkpoint and open a PR stacked on #268. Fix the
+  reproduced stale-native VJP in a separate checkpoint, then enforce
+  nonlinear stationarity eligibility separately in `PolishContext` and derivative
+  entry points. Physics acceptance alone still does not certify an IFT gradient.
+  Keep the wider A acceptance/export/resume task open until all paths and
+  stationarity contracts are covered.
 
 ## 1. Outcome and order of work
 

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -1330,6 +1330,7 @@ def test_polish_certificate_routes(monkeypatch, route, field, value, accepted):
                 driver.polish_strong_root(
                     runtime, config=dataclasses.replace(config, fail_policy="raise"),
                     initial_certificate=initial)
+            assert failure.value.solver_converged
             np.testing.assert_equal(failure.value.radial_refinement,
                                     certificate.radial_refinement_difference)
         return

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -1175,6 +1175,8 @@ def test_polish_driver_records_bounded_unpolished_return(
 ):
     class InitialCertificate:
         normalized_l2 = jnp.asarray(2.0)
+        radial_refinement_difference = jnp.asarray(0.0)
+        minimum_signed_jacobian = jnp.asarray(0.5)
 
     config = PolishConfig(
         max_continuation_stages=1,
@@ -1249,9 +1251,125 @@ def test_polish_driver_records_bounded_unpolished_return(
     assert result.native_equilibrium is small_strong_root.native
 
 
+@pytest.mark.parametrize("route", ["legacy", "continuation", "continuation-final", "collocation"])
+@pytest.mark.parametrize(
+    ("field", "value", "accepted"),
+    [("normalized_l2", 0.01, True),
+     ("normalized_l2", 0.011, False),
+     ("normalized_l2", -1.0, False),
+     ("radial_refinement_difference", 0.001, True),
+     ("radial_refinement_difference", 0.002, False),
+     ("radial_refinement_difference", -1.0, False),
+     ("minimum_signed_jacobian", 0.0, False),
+     ("minimum_signed_jacobian", -1.0, False)]
+    + [(field, value, False)
+       for field in ("normalized_l2", "radial_refinement_difference",
+                     "minimum_signed_jacobian")
+       for value in (np.nan, np.inf, -np.inf)],
+)
+def test_polish_certificate_routes(monkeypatch, route, field, value, accepted):
+    """Exercise the driver decisions while substituting costly physics kernels."""
+    from vmex.core import polish_driver as driver
+    from vmex.core import strong_force
+
+    certificate = SimpleNamespace(
+        normalized_l2=0.0, radial_refinement_difference=0.0,
+        minimum_signed_jacobian=0.5,
+    )
+    setattr(certificate, field, value)
+    native = SimpleNamespace(R_cos=jnp.zeros(1))
+    runtime = SimpleNamespace(
+        native=native, layout=SimpleNamespace(size=1), operator_balance=1.0,
+        low_preconditioner=SimpleNamespace(factor_build_seconds=0.0),
+    )
+    config = PolishConfig(fail_policy="return_unpolished")
+    failed = driver._failed_certificate_checks(certificate, config)
+    assert bool(failed) != accepted
+    if not np.isfinite(value):
+        assert "nonfinite" in failed[0]
+
+    class NeedsCorrection(Exception):
+        pass
+
+    def correction_required(*args, **kwargs):
+        raise NeedsCorrection
+
+    if route == "continuation":
+        monkeypatch.setattr(driver, "_solvax_continuation_api", correction_required)
+        run = lambda: driver.polish_strong_root(  # noqa: E731
+            runtime, config=config, initial_certificate=certificate)
+    elif route == "legacy":
+        for name in ("make_config", "params_from_input", "runtime_from_params",
+                     "_dof_mask", "_refined_state"):
+            monkeypatch.setattr(implicit, name, lambda *a, **k: native)
+        monkeypatch.setattr(strong_force, "lift_high_order_state", lambda *a, **k: native)
+        monkeypatch.setattr(strong_force, "certify_strong_force", lambda *a: certificate)
+        monkeypatch.setattr(driver, "build_low_order_preconditioner", correction_required)
+        run = lambda: driver.polish_legacy_solution(  # noqa: E731
+            _small_solovev_input(), SimpleNamespace(ns=5), native, config=config)
+    elif route == "continuation-final":
+        config = dataclasses.replace(config, preconditioner="none")
+        initial = SimpleNamespace(normalized_l2=1.0, radial_refinement_difference=0.0,
+                                  minimum_signed_jacobian=0.5)
+        continuation = lambda *a, **k: SimpleNamespace(  # noqa: E731
+            x=jnp.zeros(1), alpha=1.0, converged=True, steps=())
+        monkeypatch.setattr(driver, "_solvax_continuation_api",
+                            lambda: (None, None, continuation, None, None))
+        monkeypatch.setattr(driver, "_ptc_config", lambda *a, **k: None)
+        monkeypatch.setattr(driver, "_continuation_config", lambda *a: None)
+        monkeypatch.setattr(driver, "_minimum_signed_jacobian", lambda *a: 0.5)
+        monkeypatch.setattr(driver, "_solve_residual", lambda *a: jnp.zeros(1))
+        monkeypatch.setattr(driver, "_normalized_low_residual_norm", lambda *a: 0.0)
+        monkeypatch.setattr(driver, "_corrected_state", lambda *a: native)
+        monkeypatch.setattr(driver, "certify_strong_force", lambda *a: certificate)
+        result = driver.polish_strong_root(runtime, config=config, initial_certificate=initial)
+        assert result.polish_report.converged == accepted
+        assert result.polish_report.radial_refinement_tolerance == 0.001
+        if not accepted:
+            with pytest.raises(StrongForceCertificationError) as failure:
+                driver.polish_strong_root(
+                    runtime, config=dataclasses.replace(config, fail_policy="raise"),
+                    initial_certificate=initial)
+            np.testing.assert_equal(failure.value.radial_refinement,
+                                    certificate.radial_refinement_difference)
+        return
+    else:
+        chart = SimpleNamespace(size=1, lift=lambda x: x)
+        monkeypatch.setattr(driver, "strong_collocation_residual", lambda *a: jnp.ones(1))
+        monkeypatch.setattr(driver, "_collocation_variable_scale", lambda *a: np.ones(1))
+        monkeypatch.setattr(driver, "_corrected_state", lambda *a: native)
+        monkeypatch.setattr(driver, "certify_strong_force", lambda *a: certificate)
+        monkeypatch.setattr(driver, "_gauss_newton_polish_lane", lambda *a: SimpleNamespace(
+            x=jnp.zeros(1), accepted_steps=0, rejected_steps=0, steps=1,
+            linear_iterations=1, cost=0.0, gradient_norm=1.0,
+            history=SimpleNamespace(gradient_norm=jnp.ones(1)),
+            converged=False, damping=0.001,
+        ))
+        monkeypatch.setattr(jax, "block_until_ready", lambda x: x)
+        result = driver.polish_collocation_least_squares(
+            runtime, chart=chart, config=config, initial_certificate=certificate)
+        assert result.polish_report.converged == accepted
+        assert (result.context is not None) == accepted
+        if not accepted:
+            with pytest.raises(StrongForceCertificationError, match=failed[0].split()[0]):
+                driver.polish_collocation_least_squares(
+                    runtime, chart=chart, config=dataclasses.replace(config, fail_policy="raise"),
+                    initial_certificate=certificate)
+        return
+    if not accepted:
+        with pytest.raises(NeedsCorrection):
+            run()
+    else:
+        result = run()
+        assert result.polish_report.converged
+        assert result.polish_report.termination_reason == "already-certified"
+        assert result.polish_report.radial_refinement_tolerance == 0.001
+
+
 def test_polish_driver_skips_an_already_certified_state(small_strong_root):
     class InitialCertificate:
         normalized_l2 = jnp.asarray(1.0e-9)
+        radial_refinement_difference = jnp.asarray(0.0)
         minimum_signed_jacobian = jnp.asarray(0.5)
 
     result = polish_strong_root(
@@ -1557,7 +1675,18 @@ def test_public_solver_resolves_polish_keywords_only():
         solver._resolve_force_balance_polish(inp, False, True)
 
 
-def test_public_solver_auto_attaches_an_already_certified_native_state():
+def test_public_solver_auto_corrects_a_lift_that_fails_quadrature(monkeypatch):
+    from vmex.core import strong_force
+
+    initial_certificates = []
+    certify = strong_force.certify_strong_force
+
+    def record_certificate(*args, **kwargs):
+        report = certify(*args, **kwargs)
+        initial_certificates.append(report)
+        return report
+
+    monkeypatch.setattr(strong_force, "certify_strong_force", record_certificate)
     inp = VmecInput.from_file(DATA / "input.solovev").change_resolution(
         mpol=3,
         ntor=0,
@@ -1584,7 +1713,13 @@ def test_public_solver_auto_attaches_an_already_certified_native_state():
     assert result.native_equilibrium is not None
     assert result.strong_force is not None
     assert result.polish_report.converged
-    assert result.polish_report.termination_reason == "already-certified"
+    initial = initial_certificates[0]
+    assert float(initial.normalized_l2) <= 3.0
+    assert float(initial.radial_refinement_difference) > 1.0e-3
+    assert result.polish_report.termination_reason == "independently-certified"
+    assert result.polish_report.nonlinear_iterations > 0
+    assert float(result.strong_force.radial_refinement_difference) <= 1.0e-3
+    assert float(result.strong_force.minimum_signed_jacobian) > 0.0
     assert result.polished_state is not None
     assert result.state.R_cos.shape == (5, 3)
     assert result.polished_state.R_cos.shape == result.state.R_cos.shape

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -1010,6 +1010,7 @@ def polish_strong_root(
             "strong root failed the independent force certificate: "
             + "; ".join(failed_checks),
             hint="increase radial degree/resolution and retry once",
+            solver_converged=True,
             normalized_l2=float(certificate.normalized_l2),
             tolerance=config.certificate_tolerance,
             radial_refinement=float(certificate.radial_refinement_difference),

--- a/vmex/core/polish_driver.py
+++ b/vmex/core/polish_driver.py
@@ -768,7 +768,7 @@ def polish_strong_root(
         (solve_size,), dtype=jnp.asarray(runtime.native.R_cos).dtype
     )
     full_zero = jnp.zeros((runtime.layout.size,), dtype=zero.dtype)
-    if float(initial_certificate.normalized_l2) <= config.certificate_tolerance:
+    if not _failed_certificate_checks(initial_certificate, config):
         report = PolishReport(
             converged=True,
             termination_reason="already-certified",
@@ -784,6 +784,7 @@ def polish_strong_root(
             minimum_signed_jacobian=float(initial_certificate.minimum_signed_jacobian),
             factor_build_seconds=runtime.low_preconditioner.factor_build_seconds,
             solve_seconds=perf_counter() - started,
+            radial_refinement_tolerance=config.radial_refinement_tolerance,
         )
         return PolishResult(runtime.native, initial_certificate, report, full_zero)
     _, _, adaptive_continuation, _, pseudo_transient_continuation = (
@@ -985,7 +986,8 @@ def polish_strong_root(
 
     state = _corrected_state(vector, runtime, chart)
     certificate = certify_strong_force(state)
-    certified = float(certificate.normalized_l2) <= config.certificate_tolerance
+    failed_checks = _failed_certificate_checks(certificate, config)
+    certified = not failed_checks
     report = PolishReport(
         converged=certified,
         termination_reason="certified" if certified else "certification-failed",
@@ -1001,13 +1003,17 @@ def polish_strong_root(
         minimum_signed_jacobian=float(certificate.minimum_signed_jacobian),
         factor_build_seconds=factor_build_seconds,
         solve_seconds=perf_counter() - started,
+        radial_refinement_tolerance=config.radial_refinement_tolerance,
     )
     if not certified and config.fail_policy == "raise":
         raise StrongForceCertificationError(
-            "strong root failed the independent force certificate",
+            "strong root failed the independent force certificate: "
+            + "; ".join(failed_checks),
             hint="increase radial degree/resolution and retry once",
             normalized_l2=float(certificate.normalized_l2),
             tolerance=config.certificate_tolerance,
+            radial_refinement=float(certificate.radial_refinement_difference),
+            radial_refinement_tolerance=config.radial_refinement_tolerance,
         )
     if not certified:
         return PolishResult(runtime.native, initial_certificate, report, full_zero)
@@ -1103,20 +1109,22 @@ def _failed_certificate_checks(
     """Name each independent acceptance check the certificate failed."""
 
     failed = []
-    if float(certificate.normalized_l2) > config.certificate_tolerance:
-        failed.append(
-            f"independent force L2 {float(certificate.normalized_l2):.3E}"
-            f" > tolerance {config.certificate_tolerance:.3E}")
-    if (float(certificate.radial_refinement_difference)
-            > config.radial_refinement_tolerance):
-        failed.append(
-            "radial refinement difference "
-            f"{float(certificate.radial_refinement_difference):.3E}"
-            f" > tolerance {config.radial_refinement_tolerance:.3E}")
-    if float(certificate.minimum_signed_jacobian) <= 0.0:
-        failed.append(
-            "minimum signed Jacobian "
-            f"{float(certificate.minimum_signed_jacobian):.3E} <= 0")
+    for name, value, lower, upper in (
+        ("independent force L2", certificate.normalized_l2,
+         0.0, config.certificate_tolerance),
+        ("radial refinement difference", certificate.radial_refinement_difference,
+         0.0, config.radial_refinement_tolerance),
+        ("minimum signed Jacobian", certificate.minimum_signed_jacobian,
+         0.0, None),
+    ):
+        value = float(value)
+        if not np.isfinite(value):
+            failed.append(f"{name} is nonfinite ({value})")
+        elif upper is None:
+            if value <= lower:
+                failed.append(f"{name} {value:.3E} <= {lower:g}")
+        elif not lower <= value <= upper:
+            failed.append(f"{name} {value:.3E} outside [{lower:g}, {upper:.3E}]")
     return tuple(failed)
 
 
@@ -1232,12 +1240,8 @@ def polish_collocation_least_squares(
     vector = variable_scale_array * solution.x
     state = _corrected_state(vector, runtime, chart)
     certificate = certify_strong_force(state)
-    independently_certified = bool(
-        float(certificate.normalized_l2) <= config.certificate_tolerance
-        and float(certificate.radial_refinement_difference)
-        <= config.radial_refinement_tolerance
-        and float(certificate.minimum_signed_jacobian) > 0.0
-    )
+    failed_checks = _failed_certificate_checks(certificate, config)
+    independently_certified = not failed_checks
     # Acceptance is the independent certificate - the volume-L2 bar, radial
     # refinement stability, and a positive signed Jacobian - exactly as the
     # published contract states. The Gauss-Newton solver's internal relative
@@ -1282,9 +1286,7 @@ def polish_collocation_least_squares(
             report.initial_normalized_l2, report.final_normalized_l2,
             config.certificate_tolerance,
             verdict="CERTIFIED" if converged else "FAILED",
-            failed_checks=(
-                () if converged
-                else _failed_certificate_checks(certificate, config))),
+            failed_checks=failed_checks),
             end="")
     if converged:
         return PolishResult(
@@ -1296,7 +1298,7 @@ def polish_collocation_least_squares(
         )
     if config.fail_policy == "raise":
         raise StrongForceCertificationError(
-            "collocation polish failed its stationarity or force certificate",
+            "collocation polish failed its force certificate: " + "; ".join(failed_checks),
             hint="inspect the polish report and refine the radial representation",
             solver_converged=bool(solution.converged),
             normalized_l2=float(certificate.normalized_l2),
@@ -1387,7 +1389,7 @@ def polish_legacy_solution(
         emit(" initial certificate: EPS-F = "
              f"{float(initial_certificate.normalized_l2):.3E}"
              f"  (tolerance {config.certificate_tolerance:.3E})")
-    if float(initial_certificate.normalized_l2) <= config.certificate_tolerance:
+    if not _failed_certificate_checks(initial_certificate, config):
         report = PolishReport(
             converged=True,
             termination_reason="already-certified",
@@ -1403,6 +1405,7 @@ def polish_legacy_solution(
             minimum_signed_jacobian=float(initial_certificate.minimum_signed_jacobian),
             factor_build_seconds=0.0,
             solve_seconds=perf_counter() - started,
+            radial_refinement_tolerance=config.radial_refinement_tolerance,
         )
         if verbose:
             emit(polish_certificate_summary(


### PR DESCRIPTION
The public legacy-polish shortcut and the retired continuation driver could certify a state using only its force norm, bypassing quadrature stability and geometry. The collocation completion used a separate predicate, while NaN values could disappear from its failure messages.

Use the existing failure-check helper as the single acceptance decision for all four entry/completion points. Require finite, nonnegative force and quadrature metrics within their existing thresholds, and a finite positive sampled Jacobian. Preserve the public result API and report the quadrature tolerance on early returns. The documentation now states the same rules once.

Add 68 route regressions and update the real Solovev automatic-polish test to require correction when its lift fails quadrature, retaining all existing thresholds. Validation: 68 route regressions passed (0.42 s); real public Solovev correction passed (285.55 s); 3 continuation/derivative integration tests passed (358.04 s); static preflight passed (43 guards, 3 skips, Ruff/mypy/prose); warning-strict Sphinx build passed. CPU tests only for this host-side acceptance change. This checkpoint does not certify nonlinear stationarity or global nestedness; those gates remain open in plan.md.

Stacked on #268. All commits are authored by rogeriojorge.
