### PR TITLE
Differentiate polished states at their actual native inputs

### DIFF
--- a/docs/explanation/high-order-force-balance.rst
+++ b/docs/explanation/high-order-force-balance.rst
@@ -296,7 +296,10 @@ implicit-function theorem to the least-squares stationarity equation
    g_c\,\dot c = -g_q\,\dot q,
 
 so a gradient costs one Krylov solve rather than a replay of Gauss--Newton
-steps.
+steps.  The custom VJP retains the native inputs of its own forward call for
+backward linearization.  Reusing a discretization does not reuse its original
+native parameter values; callers still need a stationary correction for the
+current inputs.
 
 Both Jacobian actions are JAX JVPs/VJPs of ``g``; SOLVAX GMRES solves the
 tangent and the transposed adjoint system, right-preconditioned by the squared

--- a/plan.md
+++ b/plan.md
@@ -12,10 +12,12 @@ the remaining physics and distributed solver work is not yet implemented.
   Resume in `/Users/rogeriojorge/local/vmex-vjp-native`, branch
   `fix/polish-vjp-native-input`, based on `4c2d29a3` (PR #269). Production fix,
   focused regressions and full CPU derivative integration are validated.
+  Implementation `ac759d09`, [PR #270](https://github.com/uwplasma/vmex/pull/270).
   Preserve original user worktrees. All commits use author `rogeriojorge`.
 - **PR stack:** plan [#267](https://github.com/uwplasma/vmex/pull/267) →
   true linear residual [#268](https://github.com/uwplasma/vmex/pull/268) →
-  shared force certificate [#269](https://github.com/uwplasma/vmex/pull/269).
+  shared force certificate [#269](https://github.com/uwplasma/vmex/pull/269) →
+  native-input VJP [#270](https://github.com/uwplasma/vmex/pull/270).
   These remain open at this checkpoint; local checks do not imply CI/merge.
 - **Completed R1:** `b2bd9da6` / #268. Finite unpreconditioned derivative
   residuals are authoritative. CPU focused plus integration: 43 tests, 374.17 s;

--- a/plan.md
+++ b/plan.md
@@ -8,53 +8,69 @@ the remaining physics and distributed solver work is not yet implemented.
 
 ## Execution logbook
 
-- **Completed checkpoint (2026-09-05 UTC):** A/R2 force-certificate consistency.
-  Worktree `/Users/rogeriojorge/local/vmex-certificates`, branch
-  `fix/polish-certificate-consistency`, based on R1 checkpoint `5d3b3829`.
-  Preserve the original user worktrees. All commits use author `rogeriojorge`.
-- **Previous checkpoint:** R1 implementation `b2bd9da6`, [PR #268](https://github.com/uwplasma/vmex/pull/268),
-  stacked on plan PR #267. CPU 43 selected tests passed in 374.17 s; GPU 42
-  focused tests passed in 8.68 s; static preflight passed. Both PRs remain open;
-  completed #268 CI checks have passed, with other lanes still running.
-- **Implemented:** reuse `_failed_certificate_checks` for the public legacy
-  early return, collocation completion and both retired continuation acceptance
-  points. Require finite nonnegative force/quadrature metrics within tolerance
-  and a finite strictly positive sampled Jacobian. Failure messages use the
-  same checks; no new acceptance API. All 68 route regressions pass (0.42 s).
-  Static preflight and the warning-strict documentation build pass.
-- **Integration finding:** the old public-solver test expected `already-certified`
-  after checking only the force norm; with the repaired predicate it performs
-  correction and returns `independently-certified` instead (274.61 s run).
-  Keep the existing thresholds and update the test to verify initial quadrature
-  failure, an actual correction and a valid final certificate. Rerun passed:
-  1 test, 170 deselected, 285.55 s with
-  `VMEX_COMPILATION_CACHE=disabled python3 -m pytest -q tests/test_polish_preconditioner.py -k public_solver_auto_corrects`.
-  The second selection, `-k 'polish_driver_skips or polish_driver_records or collocation_polish_primal_and_derivatives'`,
-  passed: 3 tests, 168 deselected, 358.04 s. This verifies retired early return,
-  bounded failure and the existing polished tangent/adjoint/VJP chain.
-  Static preflight: Ruff/mypy/prose and 43 guard tests passed (3 skipped).
-  Warning-strict Sphinx build passed. These CPU test durations are validation
-  costs, not performance benchmarks; the GPU integration suite was not rerun.
-- **Consumer audit:** `core/cli.py::_write_wout_from_result` (the native export
-  gate near line 711) already requires `polish_report.converged`; multigrid
-  reports failed polish explicitly. The public result retains the original
-  native lift on `return_unpolished`, so callers must inspect the polish report,
-  not infer certification from a non-None native state. Direct native export and
-  resumed-solve contracts remain to test under the wider A task.
-- **New derivative reproducer:** `_implicit_collocation_leaves_fwd` saves correction
-  and variable scale but discards primal native leaves. Its backward pass uses
-  `runtime.native`, which can differ from the input. Analytic `g(c,q)=c-q^2`,
-  output `q+c`, stale runtime `q=1`, input `q=2`, stationary `c=4`: expected
-  implicit gradient 5, observed 3. Script is outside git at
-  `vmex-review-evidence-20260905/polish_native_provenance_probe.py`. This is a
-  synthetic provenance regression, not an MHD benchmark. Fix/reject stale native
-  data as part of derivative eligibility, with changed-input JIT regression.
-- **Next:** commit this checkpoint and open a PR stacked on #268. Fix the
-  reproduced stale-native VJP in a separate checkpoint, then enforce
-  nonlinear stationarity eligibility separately in `PolishContext` and derivative
-  entry points. Physics acceptance alone still does not certify an IFT gradient.
-  Keep the wider A acceptance/export/resume task open until all paths and
-  stationarity contracts are covered.
+- **Completed checkpoint (2026-09-05 UTC):** custom-VJP native-input provenance.
+  Resume in `/Users/rogeriojorge/local/vmex-vjp-native`, branch
+  `fix/polish-vjp-native-input`, based on `4c2d29a3` (PR #269). Production fix,
+  focused regressions and full CPU derivative integration are validated.
+  Preserve original user worktrees. All commits use author `rogeriojorge`.
+- **PR stack:** plan [#267](https://github.com/uwplasma/vmex/pull/267) →
+  true linear residual [#268](https://github.com/uwplasma/vmex/pull/268) →
+  shared force certificate [#269](https://github.com/uwplasma/vmex/pull/269).
+  These remain open at this checkpoint; local checks do not imply CI/merge.
+- **Completed R1:** `b2bd9da6` / #268. Finite unpreconditioned derivative
+  residuals are authoritative. CPU focused plus integration: 43 tests, 374.17 s;
+  GPU focused: 42 tests, 8.68 s; static preflight passed.
+- **Completed R2 subset:** `02a31622` / #269. One finite force/quadrature/Jacobian
+  predicate serves all four early/final acceptance points; diagnostics agree.
+  Follow-up `4c2d29a3` preserves solver success when the independent force
+  certificate fails; all 68 route regressions passed again (0.46 s).
+  68 route tests passed (0.42 s), 3 continuation/derivative tests passed
+  (358.04 s), and the public Solovev correction regression passed (285.55 s).
+  That real lift passed the force threshold but failed quadrature; retaining
+  the existing thresholds now triggers correction before certification.
+  Static preflight and warning-strict Sphinx build passed. No new production
+  API or file was added. Full A remains open.
+- **Current reproducer/fix:** the custom VJP discarded primal native leaves and
+  used `runtime.native` in its backward pass. For analytic `g(c,q)=c-q^2=0`,
+  output `q+c`, stale runtime `q=1`, input `q=2`, stationary `c=4`, it returned
+  gradient 3 instead of 5. Both eager and JIT regressions failed before the fix.
+  The forward now saves its native leaves; backward replaces only the native
+  state in the frozen runtime before applying the adjoint. Chart/discretization
+  remain fixed. This does not solve or certify nonlinear stationarity.
+- **Current validation:** CPU focused `-k 'polish_vjp_uses_primal_native_input or polish_linear'`:
+  44 passed, 129 deselected, 3.06 s. The analytic regression uses the real
+  adjoint/GMRES/custom-VJP chain and successive inputs through one compiled
+  function; only the physics equation is substituted. It is not an MHD benchmark.
+  GPU focused subset: 44 passed, 129 deselected, 12.73 s on RTX A4000
+  (JAX 0.9.2, float64, actual JIT enabled). Static preflight passed (43 guards,
+  3 skips, Ruff/mypy/prose); warning-strict Sphinx build passed. The existing
+  CPU MHD derivative integration passed: 1 test, 172 deselected, 292.00 s.
+  No full repository-suite or distributed-equilibrium claim is made.
+- **Resume commands:** from this worktree use
+  `VMEX_COMPILATION_CACHE=disabled python3 -m pytest -q tests/test_polish_preconditioner.py -k collocation_polish_primal_and_derivatives`,
+  `python3 tools/preflight.py --static`, and a warning-strict Sphinx build.
+  GPU source/test copies are isolated in `office:/home/rjorge/local/vmex-vjp-native`
+  (detached `09f18464` plus current driver/implicit/test copies); use
+  `/home/rjorge/venvs/vmex-gpu/bin/python`, `JAX_PLATFORMS=cuda,cpu` and the
+  focused selection above. No full GPU MHD integration claim is made.
+- **Consumer audit:** `core/cli.py::_write_wout_from_result` already gates native
+  export on `polish_report.converged`; multigrid reports failed polish explicitly.
+  `return_unpolished` retains an uncertified native lift, so callers must inspect
+  the report. Direct native export and resumed-solve contracts remain to test.
+- **Next:** review/merge the stacked acceptance/VJP PRs as CI permits, then
+  enforce stationarity eligibility for current native data
+  at derivative entry points, with explicit scaling/tolerances and eager/JIT
+  failure status. Preserve the distinction between physics acceptance, nonlinear
+  stationarity and linear-solve certification. The existing MHD test permits
+  physics acceptance after one GN step; its duality/Taylor checks alone do not
+  prove nonlinear-root derivative accuracy. For that next gate, reuse the primal
+  `g` already returned by tangent `jax.linearize` and adjoint `jax.vjp` instead
+  of adding another force evaluation. Match the primal scaling explicitly:
+  for `c=D*y` and `r_scaled=r/a`, the scaled stationarity is `D*g/a**2`.
+  The existing solver optimality is in these scaled coordinates; a raw `g`
+  threshold is not interchangeable. Carry the required scale/threshold provenance
+  through `PolishContext` and the custom-VJP saved data, and certify at the actual
+  forward native inputs. Continue the wider A gates in order.
 
 ## 1. Outcome and order of work
 

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -215,6 +215,36 @@ def test_polish_linear_iteration_exhaustion(compiled):
     assert bool(jnp.all(jnp.isnan(value)))
 
 
+@pytest.mark.parametrize("compiled", [False, True])
+def test_polish_vjp_uses_primal_native_input(monkeypatch, compiled):
+    """An analytic stationary root detects reuse of a stale native parameter."""
+    from vmex.core import polish_implicit as pi
+
+    @dataclasses.dataclass(frozen=True, eq=False)
+    class Runtime:
+        native: jax.Array
+
+    # g(c,q)=c-q^2=0, output=q+c, hence d(output)/dq=1+2q.
+    # Keep the actual adjoint/Krylov/custom-VJP chain; replace only the physics.
+    runtime = Runtime(jnp.asarray([1.0]))
+    context = PolishContext(runtime, SimpleNamespace(size=1), jnp.ones(1), jnp.ones(1))
+    monkeypatch.setattr(pi, "_collocation_stationarity", lambda c, q, runtime, chart: c - q*q)
+    monkeypatch.setattr(pi, "_collocation_corrected_state", lambda q, c, runtime, chart: q + c)
+
+    def objective(q):
+        stationary = context._replace(correction=jax.lax.stop_gradient(q*q))
+        return jnp.sum(implicit_collocation_polished_state(q, stationary))
+
+    with jax.disable_jit(False):
+        derivative = jax.grad(objective)
+        if compiled:
+            derivative = jax.jit(derivative)
+        # One compiled function must handle changed native data correctly.
+        for q in (1.0, 2.0, -0.5):
+            np.testing.assert_allclose(
+                derivative(jnp.asarray([q])), [1.0 + 2.0*q], atol=1.0e-11)
+
+
 def test_collocation_certification_error_retains_both_failure_gates():
     error = StrongForceCertificationError(
         "not certified",

--- a/vmex/core/polish_implicit.py
+++ b/vmex/core/polish_implicit.py
@@ -344,7 +344,7 @@ def _implicit_collocation_leaves_fwd(
         chart,
         config,
     )
-    return output, (correction, variable_scale)
+    return output, (native_leaves, correction, variable_scale)
 
 
 def _implicit_collocation_leaves_bwd(
@@ -354,7 +354,11 @@ def _implicit_collocation_leaves_bwd(
     saved,
     output_cotangent_leaves,
 ):
-    correction, variable_scale = saved
+    native_leaves, correction, variable_scale = saved
+    # The frozen discretization may be reused, but the adjoint must linearize
+    # at the native inputs of this forward call, not the runtime's old state.
+    native = jax.tree.unflatten(jax.tree.structure(runtime.native), native_leaves)
+    runtime = replace(runtime, native=native)
     output_cotangent = jax.tree.unflatten(
         jax.tree.structure(runtime.native), output_cotangent_leaves
     )


### PR DESCRIPTION
The polished-state custom VJP saved the correction and variable scale but discarded its native input leaves. Backward differentiation consequently used runtime.native even when the forward call received different native parameters, producing a silently stale gradient.

Retain the forward native leaves and replace only the native state in the frozen runtime for the adjoint. The discretization, chart, correction and solver controls remain unchanged. An analytic stationary-root regression uses the actual custom VJP, adjoint and GMRES chain: g(c,q)=c-q², output=q+c. Reusing a runtime created at q=1 for q=2 previously returned derivative 3 instead of 5. Both eager and JIT cases fail before the fix and pass afterward, including successive changed inputs through one compiled function.

Validation: 44 focused tests passed on CPU (3.06 s) and office RTX A4000 (12.73 s), with real JIT execution; static preflight and warning-strict Sphinx passed. The existing full CPU polished-state derivative integration passed (1 test, 292.00 s), including tangent/adjoint duality, custom VJP, Boozer-objective pullback and stationarity Taylor checks. The plan logbook records the remaining stationarity-eligibility gate: this fix corrects the evaluation point but does not certify or re-solve a nonlinear root.

Stacked on #269. All commits authored by rogeriojorge.
