### PR TITLE
State what Velasco et al. actually relate to prompt losses

### DIFF
--- a/docs/explanation/confinement.rst
+++ b/docs/explanation/confinement.rst
@@ -697,9 +697,11 @@ poloidal-tangential magnetic drifts (Velasco et al., Nucl. Fusion 61,
 factor evaluated at the field minimum of each well; KNOSOS uses the
 :math:`\gamma_c^*` variant, which drops that factor).  The residual rows
 are :math:`\Gamma_c` per surface, so the least-squares cost is the sum of
-:math:`w\,\Gamma_c^{2}`; Velasco et al. 2021, eqs. (20)-(21), relate the
-prompt-loss fraction approximately linearly to :math:`\Gamma_c` (more
-linearly to the :math:`|\gamma_c^*|` variant).  Bader et al. and Paul et
+:math:`w\,\Gamma_c^{2}`; the square is the least-squares form, and
+:math:`\Gamma_c` itself is a proxy rather than a loss law — Velasco et al.
+2021 (section 5.4) find the prompt-loss fraction follows their
+:math:`|\gamma_c^*|` variant (eq. 21) more linearly, and validate
+:math:`\Gamma_\alpha` as the predictor.  Bader et al. and Paul et
 al. document that such proxies correlate imperfectly with measured
 energetic-particle losses, which bounds what any :math:`\Gamma_c` value
 claims. :class:`~vmex.core.gammac.GammaC` evaluates the drift ratio in

--- a/docs/reference/objectives.rst
+++ b/docs/reference/objectives.rst
@@ -334,9 +334,10 @@ surface — the Nemov fast-ion proxy (Nemov et al. 2008, eq. 61, in the
 organization of Velasco et al. 2021, eq. 16; the sibling of DESC's
 ``GammaC``), so the least-squares cost is the weighted sum of
 ``Gamma_c**2``.  The square is the least-squares form, not a physical
-scaling: Velasco et al. 2021, eqs. (20)-(21), relate the prompt-loss
-fraction approximately linearly to ``Gamma_c`` (more linearly to the
-``|gamma_c*|`` variant).  **Use it as the reported value,
+scaling, and ``Gamma_c`` is a proxy rather than a loss law: Velasco et al.
+2021 (section 5.4) find the prompt-loss fraction follows their
+``|gamma_c*|`` variant (eq. 21) more linearly, and validate ``Gamma_alpha``
+as the predictor.  **Use it as the reported value,
 never as the gradient objective**: its discretized boundary derivative is
 exact yet flips sign under grid refinement (the measured ladder is pinned
 in ``tests/test_gammac.py``).  For optimization use

--- a/vmex/core/gammac.py
+++ b/vmex/core/gammac.py
@@ -2,10 +2,12 @@
 
 ``Gamma_c`` measures how far the contours of the second adiabatic invariant
 ``J`` deviate from flux surfaces: trapped particles whose bounce-averaged
-drift has a radial component ride superbanana orbits out of the device, and
-Velasco et al. 2021, eqs. (20)-(21), relate the prompt-loss fraction of
-energetic ions approximately linearly to ``Gamma_c`` (more linearly still
-to the ``|gamma_c*|`` variant).  The proxy
+drift has a radial component ride superbanana orbits out of the device.
+``Gamma_c`` is an optimization proxy, not a loss law: Velasco et al. 2021
+define a rescaled ``Gamma_c`` (eq. 20) and a ``|gamma_c*|``-based variant
+(eq. 21), find in their section 5.4 that the prompt-loss fraction follows
+the eq. 21 variant more linearly while ``Gamma_c`` itself cannot predict it,
+and validate ``Gamma_alpha`` (their section 4.2) as the predictor.  The proxy
 of Nemov, Kasilov, Kernbichler, Leitold, Phys. Plasmas 15, 052501 (2008),
 equation 61, as organized by Velasco et al., Nucl. Fusion 61, 116059 (2021),
 equation 16, is
@@ -804,9 +806,10 @@ class GammaC:
     docstring for the formula and conventions.  ``residuals_state`` returns
     ``sqrt(weight) * Gamma_c`` rows for VMEX's least-squares interface, so
     the total cost is the weighted sum of ``Gamma_c**2``.  That square is
-    the least-squares form, not a physical scaling: Velasco et al. 2021,
-    eqs. (20)-(21), relate the prompt-loss fraction approximately linearly
-    to ``Gamma_c`` (more linearly to the ``|gamma_c*|`` variant).
+    the least-squares form, not a physical scaling, and ``Gamma_c`` itself is
+    a proxy, not a loss law: Velasco et al. 2021, section 5.4, find the
+    prompt-loss fraction follows their ``|gamma_c*|`` variant (eq. 21) more
+    linearly and validate ``Gamma_alpha`` as the predictor.
     Traceable in both gradient modes.
 
     **This is the hard physical diagnostic — its value is the number to


### PR DESCRIPTION
Corrects a statement #250 introduced on my brief. The docs and `gammac.py` said that eqs. (20)–(21) of Velasco et al. 2021 (Nucl. Fusion 61, 116059) relate the prompt-loss fraction approximately linearly to Γ_c. Read against the paper: eq. 20 defines a rescaled Γ̌_c, eq. 21 defines Γ̂_c built on |γ_c*|, and section 5.4 finds the loss fraction follows Γ̂_c more linearly while Γ_c itself cannot predict it; Γ_α (section 4.2) is the validated predictor. The three sites now say Γ_c is an optimization proxy, not a loss law, and point at the variant and the predictor.

Docs only plus two docstrings; no numerics change. Verified: `tools/check_docs_prose.py`, ruff, warning-strict Sphinx.