### PR TITLE
Scale the wout pressure coefficients with the pressure they echo

### DIFF
--- a/docs/howto/scale-a-configuration.md
+++ b/docs/howto/scale-a-configuration.md
@@ -44,6 +44,14 @@ For inputs, pressure scales once through `PRES_SCALE`; `AM`, `AM_AUX_F`,
 current/iota profiles, and every normalized spline coordinate remain shape
 data. `CURTOR` scales only in prescribed-current mode.
 
+A wout records no `PRES_SCALE`, so `scale_wout` puts $B_s^2$ into the
+coefficients it echoes: every `AM_AUX_F` knot value, and the entries of `AM`
+that multiply the profile for its `PMASS_TYPE` (all of a power series, only
+the leading coefficient of `two_power`, the numerator of `rational`), so the
+profile a scaled wout describes evaluates to its `presf`. `AC`, `AI`, and the
+knot positions stay shape data: iota is dimensionless, and every current
+profile is normalized to `ctor`, which scales as $B_s R_s$.
+
 ## ARIES-CS targets from an input
 
 A wout contains `b0` and `Aminor_p`, so its factors are exact. A fixed
@@ -66,9 +74,11 @@ their geometry and currents must be scaled before field tabulation.
 The defining test is commutation: (1) solve the original input and scale its
 wout; (2) scale the input (and mgrid when present) and reconverge it;
 (3) compare every physical wout scalar, profile, Fourier coefficient,
-Mercier term, and NESTOR potential/surface field. VMEX runs this check for
-finite-pressure prescribed-current fixed boundary and for symmetric and
-LASYM free-boundary NESTOR cases. The structured functions
+Mercier term, and NESTOR potential/surface field. The pressure coefficients
+are compared through the profile they evaluate to, because the input path
+carries $B_s^2$ in `PRES_SCALE` and the wout path in `AM`. VMEX runs this
+check for finite-pressure prescribed-current fixed boundary and for symmetric
+and LASYM free-boundary NESTOR cases. The structured functions
 {func}`vmex.core.scaling.scale_input`,
 {func}`vmex.core.scaling.scale_mgrid`, and
 {func}`vmex.core.scaling.scale_wout` use parsed objects; they never edit

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -11,11 +11,12 @@ import jax
 import numpy as np
 import pytest
 
-from vmex.core import cli
+from vmex.core import cli, profiles, scaling
 from vmex.core.errors import INPUT_ERROR_FLAG
-from vmex.core.input import VmecInput
+from vmex.core.input import VmecInput, _trim_aux
 from vmex.core.mgrid import MgridData, read_mgrid, write_mgrid
 from vmex.core.multigrid import solve_free_boundary_multigrid, solve_multigrid
+from vmex.core.postprocess import full_mesh_from_half
 from vmex.core.scaling import (
     aries_cs_scales,
     input_minor_radius,
@@ -24,7 +25,7 @@ from vmex.core.scaling import (
     scale_mgrid,
     scale_wout,
 )
-from vmex.core.wout import read_wout, wout_from_state, write_wout
+from vmex.core.wout import _preset_array, read_wout, wout_from_state, write_wout
 
 DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
 
@@ -157,15 +158,146 @@ def test_scale_wout_commutes_with_finite_beta_solve(finite_beta_similarity):
     original, solved_scaled_input = finite_beta_similarity
     scaled_wout = scale_wout(original, b_scale=2.3, r_scale=1.7)
     _assert_wout_similarity(solved_scaled_input, scaled_wout)
+    # The input path carries B**2 in PRES_SCALE, which a wout does not
+    # record, and the wout path carries it in ``am``; both echoes evaluate
+    # to the same pressure.
+    inp = VmecInput.from_file(DATA / "input.nfp2_QA_finite_beta")
+    _assert_pressure_echo(scaled_wout, inp)
+    _assert_pressure_echo(
+        solved_scaled_input, scale_input(inp, b_scale=2.3, r_scale=1.7)
+    )
+
+
+def test_scale_wout_keeps_pressure_coefficients_consistent_with_presf(
+    finite_beta_similarity,
+):
+    original, _ = finite_beta_similarity
+    inp = VmecInput.from_file(DATA / "input.nfp2_QA_finite_beta")
+    _assert_pressure_echo(original, inp)
+    scaled = scale_wout(original, b_scale=2.3, r_scale=1.7)
+    _assert_pressure_echo(scaled, inp)
+    np.testing.assert_allclose(scaled.am, 2.3**2 * original.am)
+    np.testing.assert_allclose(scaled.am_aux_f, 2.3**2 * original.am_aux_f)
+    # Knot positions are normalized flux, iota is dimensionless, and the
+    # current shape is normalized to ``ctor`` (scaled as B*R) for every
+    # ``pcurr_type``, this deck's tabulated I' knots included.
+    assert original.pcurr_type == "cubic_spline_ip"
+    assert scaled.ctor == pytest.approx(2.3 * 1.7 * original.ctor)
+    for name in (
+        "am_aux_s", "ac", "ac_aux_s", "ac_aux_f", "ai", "ai_aux_s", "ai_aux_f",
+    ):
+        np.testing.assert_array_equal(
+            getattr(scaled, name), getattr(original, name), err_msg=name
+        )
+
+
+_KNOTS = np.linspace(0.0, 1.0, 6)
+_PRESSURE_ECHO_CASES = {
+    # Entries of ``am`` past the amplitudes are exponents, widths, centres,
+    # mixing fractions, or a denominator; each case sets them so a blanket
+    # B**2 on the whole array would change the profile shape.
+    "power_series": dict(am=[7.2e5, -7.1e5, 0.0, 0.0, 0.0, -7.1e5, 7.0e5]),
+    "two_power": dict(am=[1.0e4, 5.0, 10.0]),
+    "two_power_gs": dict(am=[1.0e4, 2.0, 1.5, 0.3, 0.5, 0.1]),
+    "two_lorentz": dict(am=[1.0e4, 0.6, 0.5, 2.0, 1.0, 0.8, 1.0, 2.0]),
+    "gauss_trunc": dict(am=[1.0e4, 0.7]),
+    "pedestal": dict(am=[1.0e4, -5.0e3] + [0.0] * 15 + [2.0e3, 0.9, 0.1, 0.0]),
+    "rational": dict(am=[1.0e4, -9.0e3] + [0.0] * 8 + [1.0, 0.5]),
+    "cubic_spline": dict(am_aux_s=_KNOTS, am_aux_f=1.0e4 * (1.0 - _KNOTS**2)),
+    "akima_spline": dict(am_aux_s=_KNOTS, am_aux_f=1.0e4 * (1.0 - _KNOTS) ** 2),
+    "line_segment": dict(
+        am_aux_s=_KNOTS, am_aux_f=1.0e4 * np.cos(0.5 * np.pi * _KNOTS),
+    ),
+}
+
+
+def test_pressure_amplitude_table_covers_every_pmass_type():
+    assert set(scaling._PRESSURE_AMPLITUDES) == profiles._PMASS_KINDS
+    assert set(_PRESSURE_ECHO_CASES) == profiles._PMASS_KINDS
+
+
+@pytest.mark.parametrize("kind", sorted(_PRESSURE_ECHO_CASES))
+def test_scale_wout_scales_only_pressure_amplitudes(finite_beta_similarity, kind):
+    original, _ = finite_beta_similarity
+    case = _PRESSURE_ECHO_CASES[kind]
+    wout = dataclasses.replace(
+        original,
+        pmass_type=kind,
+        am=_preset_array(case.get("am")),
+        am_aux_s=_preset_array(case.get("am_aux_s"), 101, -1.0),
+        am_aux_f=_preset_array(case.get("am_aux_f"), 101, 0.0),
+    )
+    s = np.linspace(0.0, 1.0, 9)
+    before = _echo_pressure(wout, s)
+    assert np.isfinite(before).all() and before[0] > 0.0
+    scaled = scale_wout(wout, b_scale=2.3, r_scale=1.7)
+    np.testing.assert_allclose(
+        _echo_pressure(scaled, s), 2.3**2 * before,
+        rtol=1e-9, atol=1e-9 * np.max(np.abs(before)),
+    )
+    amplitudes = sorted(scaling._PRESSURE_AMPLITUDES[kind])
+    shapes = sorted(set(range(21)) - set(amplitudes))
+    np.testing.assert_allclose(scaled.am[amplitudes], 2.3**2 * wout.am[amplitudes])
+    np.testing.assert_array_equal(scaled.am[shapes], wout.am[shapes])
+    np.testing.assert_array_equal(scaled.am_aux_s, wout.am_aux_s)
+    np.testing.assert_allclose(scaled.am_aux_f, 2.3**2 * wout.am_aux_f)
+
+
+def test_scale_wout_tolerates_absent_profile_coefficients(finite_beta_similarity):
+    original, _ = finite_beta_similarity
+    bare = dataclasses.replace(original, am=None, am_aux_f=None)
+    scaled = scale_wout(bare, b_scale=2.0)
+    assert scaled.am is None and scaled.am_aux_f is None
+    np.testing.assert_allclose(scaled.presf, 4.0 * original.presf)
+    with pytest.raises(NotImplementedError, match="pmass_type"):
+        scale_wout(dataclasses.replace(original, pmass_type="two_gauss"))
+
+
+def _echo_pressure(wout, s, **deck):
+    """Pressure described by a wout's ``am``/``am_aux_f`` echo at ``s``.
+
+    The knot arrays carry wrout.f's ``-1``/``0`` fill past the live knots,
+    which ``VmecInput`` trims exactly as ``profile_functions.f`` counts them.
+    """
+    aux_s, aux_f = _trim_aux(wout.am_aux_s, wout.am_aux_f)
+    return np.array(
+        profiles.pressure(wout.pmass_type, wout.am, aux_s, aux_f, s, **deck),
+        dtype=float,
+    )
+
+
+def _assert_pressure_echo(wout, inp):
+    """``am``/``am_aux_f`` evaluate to the wout's own ``pres`` and ``presf``.
+
+    A wout records neither ``PRES_SCALE`` nor ``BLOAT``/``SPRES_PED``, so
+    those come from the deck that produced it.  The decks here keep the
+    identity flux map and ``GAMMA = 0``, under which the half-mesh ``pres``
+    is the profile itself and ``presf`` its eqfor.f full-mesh companion.
+    """
+    aphi = np.asarray(inp.aphi, dtype=float)
+    assert float(inp.gamma) == 0.0 and aphi[0] == 1.0 and not aphi[1:].any()
+    s_half = (np.arange(wout.ns) - 0.5) / (wout.ns - 1)
+    pres = _echo_pressure(
+        wout, s_half, pres_scale=inp.pres_scale, bloat=inp.bloat,
+        spres_ped=inp.spres_ped,
+    )
+    pres[0] = 0.0
+    tolerance = dict(rtol=1e-9, atol=1e-9 * np.max(np.abs(wout.pres)))
+    np.testing.assert_allclose(pres, wout.pres, **tolerance)
+    np.testing.assert_allclose(full_mesh_from_half(pres), wout.presf, **tolerance)
 
 
 def _assert_wout_similarity(actual, expected):
     operational = {
         "mgrid_file", "niter", "itfsq", "fsql", "fsqr", "fsqz", "fsqt", "wdot",
     }
+    # ``scale_input`` puts B**2 into PRES_SCALE and ``scale_wout`` into the
+    # ``am``/``am_aux_f`` amplitudes, because a wout records no PRES_SCALE;
+    # the callers compare those echoes through the pressure they evaluate to.
+    echo = {"am", "am_aux_f"}
     for field in dataclasses.fields(expected):
         name = field.name
-        if name in operational:
+        if name in operational or name in echo:
             continue
         expected_value = getattr(expected, name)
         actual_value = getattr(actual, name)
@@ -213,10 +345,10 @@ def _assert_free_boundary_similarity(
     scaled_mgrid_path = tmp_path / f"{Path(mgrid_path).stem}_scaled.nc"
     write_mgrid(scaled_mgrid_path, scaled_mgrid)
     actual = run(scaled_input, scaled_mgrid, scaled_mgrid_path)
-    _assert_wout_similarity(
-        actual,
-        scale_wout(original, b_scale=b_scale, r_scale=r_scale),
-    )
+    expected = scale_wout(original, b_scale=b_scale, r_scale=r_scale)
+    _assert_wout_similarity(actual, expected)
+    _assert_pressure_echo(expected, inp)
+    _assert_pressure_echo(actual, scaled_input)
 
 
 @pytest.mark.full

--- a/vmex/core/scaling.py
+++ b/vmex/core/scaling.py
@@ -39,7 +39,9 @@ _WOUT_POWERS = {
     **{name: (1, 2) for name in (
         "phi", "phipf", "chi", "chipf", "phips",
     )},
-    **{name: (2, 0) for name in ("presf", "mass", "pres", "bdotb")},
+    **{name: (2, 0) for name in (
+        "presf", "mass", "pres", "bdotb", "am_aux_f",
+    )},
     **{name: (0, 3) for name in ("volume_p", "vp", "gmnc", "gmns")},
     **{name: (1, -1) for name in (
         "bdotgradv", "bsupumnc", "bsupvmnc", "bsupumns", "bsupvmns",
@@ -51,6 +53,42 @@ _WOUT_POWERS = {
     **{name: (-2, -4) for name in (
         "DMerc", "DShear", "DWell", "DCurr", "DGeod",
     )},
+}
+
+# Pressure-profile coefficients.  ``presf``/``pres``/``mass`` scale as B**2,
+# and the parameterization that produced them has to follow, or the wout's
+# namelist echo re-runs to the unscaled pressure.  A wout records no
+# PRES_SCALE, so the factor lands in the coefficients themselves, and only
+# in the entries that multiply the profile: widths, exponents, centres, and
+# mixing fractions are shape data.  Which entries are amplitudes depends on
+# ``pmass_type`` (``vmex.core.profiles``): the power series and the
+# pedestal polynomial are linear in every coefficient, the peaked shapes
+# carry one amplitude ahead of their shape parameters, ``rational`` scales
+# through its numerator, and the tabulated kinds ignore ``am`` and keep the
+# pressure in ``am_aux_f``, which is linear in the knot values for every
+# tabulated kind (and zero-filled otherwise), so it sits in the table above.
+#
+# ``ai``/``ai_aux_f`` are deliberately left alone: iota (or q under lrfp) is
+# dimensionless.  ``ac``/``ac_aux_f`` are deliberately left alone for every
+# ``pcurr_type``, including the ``*_i``/``*_ip`` spline kinds whose knots
+# tabulate I or I': ``profil1d.f`` (``setup.flux_profiles``) divides the
+# shape by its own edge value and multiplies by CURTOR,
+# ``Itor = signgs*mu0*curtor/(2*pi*pcurr(1))``, and drops the profile
+# entirely when ``pcurr(1)`` vanishes, so the coefficients never carry an
+# ampere.  The current amplitude lives in ``ctor``, scaled as B*R above.
+_PRESSURE_AMPLITUDES: dict[str, tuple[int, ...]] = {
+    "power_series": tuple(range(21)),
+    # c[0:16] polynomial, c[17] pedestal height; c[16] unused, c[18] centre,
+    # c[19] width, c[20] the normalization VMEC recomputes.
+    "pedestal": tuple(range(16)) + (17,),
+    "two_power": (0,),
+    "two_power_gs": (0,),
+    "two_lorentz": (0,),
+    "gauss_trunc": (0,),
+    "rational": tuple(range(10)),   # numerator c[0:10] over denominator c[10:21]
+    "cubic_spline": (),
+    "akima_spline": (),
+    "line_segment": (),
 }
 
 
@@ -115,15 +153,38 @@ def scale_mgrid(
     )
 
 
+def _scale_pressure_coefficients(pmass_type: str, am: Any, factor: float) -> Any:
+    """Scale the amplitude entries of ``am`` for ``pmass_type`` by ``factor``."""
+    if am is None:
+        return None
+    kind = str(pmass_type).strip().lower()
+    if kind not in _PRESSURE_AMPLITUDES:
+        raise NotImplementedError(
+            f"pmass_type={pmass_type!r} not implemented "
+            f"(supported: {sorted(_PRESSURE_AMPLITUDES)})"
+        )
+    scaled = np.array(am, dtype=float).reshape(-1)
+    slots = [i for i in _PRESSURE_AMPLITUDES[kind] if i < scaled.size]
+    scaled[slots] *= factor
+    return scaled.reshape(np.shape(am))
+
+
 def scale_wout(
     data: WoutData, *, b_scale: float = 1.0, r_scale: float = 1.0,
 ) -> WoutData:
-    """Return the dimensional similarity transform of a converged WOUT."""
+    """Return the dimensional similarity transform of a converged WOUT.
+
+    The pressure arrays and the ``am``/``am_aux_f`` coefficients that
+    generated them scale together, so the profile the wout echoes evaluates
+    to its own ``presf``; see ``_PRESSURE_AMPLITUDES`` for which entries of
+    ``am`` carry the factor and why ``ac``/``ai`` do not move.
+    """
     b, r = _scales(b_scale, r_scale)
     changes = {
         name: _times(getattr(data, name), b**b_power * r**r_power)
         for name, (b_power, r_power) in _WOUT_POWERS.items()
     }
+    changes["am"] = _scale_pressure_coefficients(data.pmass_type, data.am, b**2)
     return replace(data, **changes)
 
 


### PR DESCRIPTION
## Summary

`scale_wout` scaled `pres`, `presf` and `mass` by `B**2` through `_WOUT_POWERS` but left the profile coefficients alone: `am` and `am_aux_f` were absent from the table, so a scaled wout carried pressure arrays for the scaled device and pressure-profile coefficients for the original one. A deck rebuilt from the scaled wout's namelist echo re-ran to the unscaled pressure.

A wout records no `PRES_SCALE`, so the factor has to land in the coefficients themselves, and only in the entries that multiply the profile.

## What changed

- `am_aux_f` joins `_WOUT_POWERS` at `(2, 0)`: every tabulated `pmass_type` (`cubic_spline`, `akima_spline`, `line_segment`) is linear in its knot values, and the array is zero-filled for the other kinds.
- `am` is scaled by a new `_PRESSURE_AMPLITUDES` table keyed by `pmass_type`, applied in `scale_wout` after the power table. A blanket `am: (2, 0)` would have been wrong for most kinds: the repo's own `input.cth_like_free_bdy` is `two_power` with `AM = 1, 5, 10`, where entries 1 and 2 are exponents, and for `rational` the factor cancels between numerator and denominator. The table scales every entry of a `power_series` or `pedestal` polynomial, the leading coefficient of `two_power`, `two_power_gs`, `two_lorentz` and `gauss_trunc`, the numerator of `rational`, and nothing for the tabulated kinds (they ignore `am`). An unknown `pmass_type` raises `NotImplementedError`, as `profiles.pressure` does.
- `_times` already returns `None` for `None`; the new helper does the same, so a wout read from a file without the profile variables scales through.
- `docs/howto/scale-a-configuration.md` states the wout convention and why `AC`/`AI` do not move.

## Deliberately unscaled

- `ai` / `ai_aux_f`: iota (or `q` under `lrfp`) is dimensionless.
- `ac` / `ac_aux_f`, for every `pcurr_type`: `profil1d.f` (`setup.flux_profiles`) divides the shape by its own edge value and multiplies by `CURTOR` (`Itor = signgs*mu0*curtor/(2*pi*pcurr(1))`, dropped entirely when `pcurr(1)` vanishes). I checked the `*_i` / `*_ip` spline kinds where `ac_aux_f` tabulates `I` or `I'`: they go through the same normalization, so the knots never carry an ampere. The amplitude lives in `ctor`, which the table already scales as `(1, 1)`. The comment in `scaling.py` records this so the omission reads as a decision.

## Tests

- `test_scale_wout_keeps_pressure_coefficients_consistent_with_presf`: evaluates the scaled wout's echo from `am` / `pmass_type` on the half mesh and compares it with `pres` and with `presf` (the eqfor.f full-mesh companion), on the finite-beta deck whose current profile is `cubic_spline_ip`; asserts `ac`, `ac_aux_f`, `ai`, `ai_aux_f` and every `*_aux_s` are untouched and `ctor` scales as `B*R`.
- `test_scale_wout_scales_only_pressure_amplitudes[kind]`: one synthetic coefficient set per `pmass_type`, with shape entries chosen so a blanket factor would change the profile; checks the scaled echo is `B**2` times the original and that the shape entries are bit-identical.
- `test_pressure_amplitude_table_covers_every_pmass_type`: keeps the table and the case list in step with `profiles._PMASS_KINDS`.
- `test_scale_wout_tolerates_absent_profile_coefficients`: `None` passes through; an unknown kind raises.
- The commuting tests (`fixed boundary`, and the `full`-marked symmetric and LASYM free-boundary NESTOR cases) now skip `am` / `am_aux_f` in the field-by-field loop and instead check both wouts' echoes against their own pressure, because the input path carries `B**2` in `PRES_SCALE` and the wout path in `am`.

## Worth a separate decision

`scale_input` still carries `B**2` in `PRES_SCALE`, so a wout solved from a scaled deck echoes the original `AM` next to the scaled `presf`, which is the same inconsistency produced by the other path. Moving the factor into the `AM` amplitudes there too (same table) would make the two paths agree field by field. I left the input contract as is, since it is tested and documented, and flag it here.

## `.gitleaksignore`

No entries added.

## Verification

- `python3 tools/preflight.py --static`: PASS (ruff, mypy, docs prose, 43 guard tests including the manifest check).
- `python3 -m pytest -q tests/test_scaling.py`: 24 passed, 2 skipped (the `full`-marked free-boundary cases).
- `RUN_FULL=1 ... -k "lasym_free_boundary or symmetric_free_boundary"`: LASYM case passed (1h40m locally); the symmetric `cth_like` case skipped here because `mgrid_cth_like.nc` is not fetched, so the `two_power` deck is exercised end to end only in the CI full lane.
- `python3 tools/preflight.py` (affected tests under coverage + `diff-cover --fail-under=95`): PASS; 24 tests, diff coverage 100% (12 of 12 changed executable lines).
