### PR TITLE
Unify the flux-tube epsilon and R0 across the core and mirror lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ in the pull-request and release bodies and are being backfilled as
   axisymmetric, and the two 3-D measurements (a QA deck at `MPOL = NTOR = 5`
   and the W7-X standard configuration) are quoted with their budgets and
   their certificate outcomes in `benchmarks/polish3d_tuning.md`.
+- Gyrokinetic flux-tube contract: the `epsilon` scalar is the field-line
+  `|B|` modulation depth `(Bmax - Bmin)/(Bmax + Bmin)` in both the core and
+  mirror lanes (`vmex.core.turbulence.b_modulation_depth`; exactly GKX's
+  inverse-aspect-ratio `epsilon` for its `1/(1 + eps cos theta)` model)
+  instead of `std|B|/mean|B|`, and `R0` is the effective major radius (the
+  wout `Rmajor_p`; `L_axis/(2 pi)` on the mirror) instead of `L_ref`, so the
+  `aminor = epsilon * R0` GKX derives when it writes run artifacts is a
+  physical minor radius. Neither scalar enters GKX's solver (#271).
 - Polish observability: the CLI announces every polish phase (state
   refinement, initial certificate, preconditioner and chart build, compile
   notice), prints one row per Gauss-Newton iteration, and closes with a

--- a/docs/explanation/mirror-geometry.rst
+++ b/docs/explanation/mirror-geometry.rst
@@ -847,11 +847,14 @@ Two related quantities elsewhere in VMEX are deliberately *not* mirror ratios.
 :func:`vmex.core.optimize.mirror_ratio` is the ``|B|`` modulation depth
 :math:`(B_{\max}-B_{\min})/(B_{\max}+B_{\min})` on one surface, the QI
 optimization knob, related by :math:`R_m = (1+m)/(1-m)`. And the ``epsilon``
-key of the gyrokinetic flux-tube contract is ``std(|B|)/mean(|B|)``, the VMEX
-convention shared with the toroidal core lane; GS2-family codes mean the
-inverse aspect ratio by that key, which a straight mirror does not have. The
-field-line mirror ratio is exported explicitly as
-``vmex_mirror["field_line_mirror_ratio"]``.
+key of the gyrokinetic flux-tube contract is that same modulation depth taken
+along one field line, in the mirror and the toroidal core lane alike
+(:func:`vmex.core.turbulence.b_modulation_depth`): GS2-family codes mean the
+inverse aspect ratio by the key, which a straight mirror does not have, and
+the depth is exactly that number for GKX's own
+:math:`|B| = B_0/(1+\epsilon\cos\theta)` model. The field-line mirror ratio
+:math:`(1+\epsilon)/(1-\epsilon)` is exported explicitly as
+``vmex_mirror["field_line_mirror_ratio"]``; see :doc:`mirror-gyrokinetics`.
 
 Interpreting beta
 -----------------

--- a/docs/explanation/mirror-gyrokinetics.rst
+++ b/docs/explanation/mirror-gyrokinetics.rst
@@ -75,6 +75,30 @@ normalizations are
    L_{\rm ref}=\sqrt{\frac{V}{\pi L_{\rm axis}}},\qquad
    B_{\rm ref}=\frac{2|\Psi'|}{L_{\rm ref}^2},\qquad \rho=\sqrt{s}.
 
+The scalar metadata ``epsilon`` and ``R0`` use the same definitions as the
+toroidal core lane (:func:`vmex.core.turbulence.gk_fieldline_geometry`):
+
+.. math::
+
+   \epsilon=\frac{\max|B|-\min|B|}{\max|B|+\min|B|},\qquad
+   R_0=\frac{L_{\rm axis}}{2\pi}=\frac{V}{2\pi^2L_{\rm ref}^2}.
+
+Both are what GKX means by the keys.  Its analytic geometry is
+:math:`|B|=B_0/(1+\epsilon\cos\theta)` with ``epsilon`` the inverse aspect
+ratio, and the modulation depth is exactly that :math:`\epsilon` for that
+model and for any :math:`1/R` tokamak field, while, unlike an aspect ratio, it
+exists on a straight mirror (:func:`vmex.core.turbulence.b_modulation_depth`).
+:math:`R_0` is the major radius of the circular torus with this axis length;
+the same volume identity gives VMEC's ``Rmajor_p`` on the toroidal lane.  GKX
+derives ``aminor = epsilon * R0`` and ``a_ref`` from the pair when it writes
+run artifacts, which is why ``R0`` is not :math:`L_{\rm ref}`.  Neither
+scalar enters its solver.  The field-line mirror ratio
+:math:`R_m=\max|B|/\min|B|=(1+\epsilon)/(1-\epsilon)` is exported by name as
+``vmex_mirror["field_line_mirror_ratio"]`` (the field-line member of the
+mirror-ratio definitions in :doc:`mirror-geometry`), and
+``vmex_mirror["field_line_b_modulation"]`` and ``vmex_mirror["R_major"]``
+repeat :math:`\epsilon` and :math:`R_0` under their VMEX names.
+
 At zero magnetic shear GKX interprets :math:`k_x` as the direct normalized
 radial wavenumber.  The complete perpendicular metric remains
 

--- a/tests/mirror/test_turbulence.py
+++ b/tests/mirror/test_turbulence.py
@@ -74,16 +74,23 @@ def test_closed_mirror_contract_is_periodic_equal_arc_and_positive(closed_mirror
         rtol=1.0e-14,
     )
     assert field_line_ratio > 1.5
-    # "epsilon" keeps the VMEX std/mean contract and is NOT the GS2/GX inverse
-    # aspect ratio; the tokamak-equivalent modulation depth is exported apart.
+    # "epsilon" is the field-line |B| modulation depth, the one definition
+    # shared with the core lane (GKX's own bmag = 1/(1 + eps cos theta) has
+    # exactly this eps); the VMEX-named diagnostic repeats it, and the
+    # field-line mirror ratio is (1 + eps) / (1 - eps).
     modulation = float(mapping["vmex_mirror"]["field_line_b_modulation"])
     np.testing.assert_allclose(modulation, (field_line_ratio - 1.0) / (field_line_ratio + 1.0), rtol=1.0e-14)
-    np.testing.assert_allclose(
-        float(mapping["epsilon"]),
-        float(np.std(mapping["bmag"]) / np.mean(mapping["bmag"])),
-        rtol=1.0e-14,
-    )
-    assert abs(float(mapping["epsilon"]) - modulation) > 1.0e-3
+    assert float(mapping["epsilon"]) == modulation
+    assert 0.0 < modulation < 1.0
+    # Not the former std/mean export, which is ~eps/sqrt(2) for a cosine-like
+    # modulation and never equal to the depth on a non-uniform line.
+    assert abs(float(np.std(mapping["bmag"]) / np.mean(mapping["bmag"])) - modulation) > 1.0e-3
+    # R0 is the effective major radius L_axis / (2 pi) (= V / (2 pi^2 L_ref^2)),
+    # not L_ref, so GKX's derived aminor = epsilon * R0 is a length in metres.
+    meta = mapping["vmex_mirror"]
+    np.testing.assert_allclose(float(mapping["R0"]), float(meta["axis_arc_length"]) / (2.0 * np.pi), rtol=1.0e-14)
+    assert float(meta["R_major"]) == float(mapping["R0"])
+    assert float(mapping["R0"]) > float(meta["L_ref"]) > 0.0
     assert abs(float(mapping["vmex_mirror"]["closure_residual"])) < 1.0e-12
     assert mapping["s_hat"] == 0.0
 

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -131,6 +131,44 @@ def test_geometry_internal_identities(shaped_eq):
     bgrad_fd = np.asarray(mapping["gradpar"]) * d_bmag / bmag
     scale = np.max(np.abs(bgrad_fd))
     assert np.max(np.abs(np.asarray(mapping["bgrad"]) - bgrad_fd)) < 0.05 * scale
+    # Scalar metadata: epsilon is the field-line |B| modulation depth (GKX's
+    # own bmag = 1/(1 + eps cos theta) has exactly this eps) and R0 the wout
+    # Rmajor_p, so GKX's derived aminor = epsilon * R0 is a length in metres.
+    depth = (bmag.max() - bmag.min()) / (bmag.max() + bmag.min())
+    assert float(mapping["epsilon"]) == pytest.approx(depth, rel=1e-12)
+    assert 0.0 < depth < 1.0
+    assert abs(float(np.std(bmag) / np.mean(bmag)) - depth) > 1e-3   # not std/mean
+    meta = mapping["vmex"]
+    assert float(mapping["R0"]) == pytest.approx(float(shaped_eq.wout.Rmajor_p), rel=1e-10)
+    assert float(meta["R_major"]) == float(mapping["R0"])
+    assert float(mapping["R0"]) > float(meta["L_ref"]) > 0.0
+    assert float(meta["L_ref"]) == pytest.approx(float(shaped_eq.wout.Aminor_p), rel=1e-10)
+
+
+def test_b_modulation_depth_is_gkx_analytic_epsilon():
+    """``b_modulation_depth`` recovers GKX's ``epsilon`` from its own bmag model."""
+    theta = jnp.linspace(-jnp.pi, jnp.pi, 257)     # includes theta = 0 and +-pi
+    for eps in (0.1, 0.18, 0.5):
+        bmag = 1.0 / (1.0 + eps * jnp.cos(theta))
+        assert float(turb.b_modulation_depth(bmag)) == pytest.approx(eps, rel=1e-12)
+    assert float(turb.b_modulation_depth(jnp.ones(16))) == 0.0
+
+
+def test_epsilon_is_local_inverse_aspect_ratio_on_circular_tokamak(vacuum_eq):
+    """On a ``1/R`` field the modulation depth is ``r / R_center`` of the surface.
+
+    The circular vacuum tokamak (``R = 6``, ``a = 2``) has ``|B| ~ 1/R`` up to
+    the ``O((eps iota)^2)`` poloidal-field share, so ``epsilon`` must land on
+    ``sqrt(s) L_ref / R0`` up to that and the current-driven Shafranov shift
+    of the surface centre.  ``std/mean`` would sit near ``eps / sqrt(2)``.
+    """
+    mapping = turb.gk_fieldline_geometry(vacuum_eq.state, vacuum_eq.runtime,
+                                         s_index=7, ntheta=128)
+    meta = mapping["vmex"]
+    expected = float(jnp.sqrt(meta["s"]) * meta["L_ref"] / meta["R_major"])
+    assert float(mapping["epsilon"]) == pytest.approx(expected, rel=0.1)
+    assert float(mapping["R0"]) == pytest.approx(6.0, rel=0.05)
+    assert float(meta["L_ref"]) == pytest.approx(2.0, rel=0.05)
 
 
 def test_vacuum_limit_cvdrift_equals_gbdrift(vacuum_eq):
@@ -199,6 +237,9 @@ def test_wout_geometry_rejects_invalid_normalization(shaped_eq):
     with pytest.raises(ValueError, match="Aminor_p"):
         turb.gk_fieldline_geometry_from_wout(
             dataclasses.replace(shaped_eq.wout, Aminor_p=0.0))
+    with pytest.raises(ValueError, match="Rmajor_p"):
+        turb.gk_fieldline_geometry_from_wout(
+            dataclasses.replace(shaped_eq.wout, Rmajor_p=0.0))
 
 
 # ---------------------------------------------------------------------------

--- a/vmex/core/stability.py
+++ b/vmex/core/stability.py
@@ -643,9 +643,10 @@ def _ballooning_context(state: SpectralState, rt: SolverRuntime) -> dict:
     full mesh (``lmns`` rescaled by ``lamscale/phipf`` exactly as the wout
     writer does), the half-mesh ``iota``/pressure profiles (the ``ncurr = 1``
     current-constrained iota comes from the solved ``chips``, as in
-    ``add_fluxes.f90``), and the GX/GS2-style normalizations ``L_ref``
+    ``add_fluxes.f90``), the GX/GS2-style normalizations ``L_ref``
     (effective minor radius, ``aspectratio.f`` quadrature) and
-    ``B_ref = 2|ψ_edge|/L_ref²``.
+    ``B_ref = 2|ψ_edge|/L_ref²``, and ``R_major`` (the wout ``Rmajor_p``,
+    same quadrature; the ``R0`` of the :mod:`vmex.core.turbulence` contract).
 
     Asymmetric (``lasym``) states additionally carry the sine-parity partners
     ``rmns``/``zmnc``/``lmnc``; they are ``None`` for symmetric states, which
@@ -686,14 +687,20 @@ def _ballooning_context(state: SpectralState, rt: SolverRuntime) -> dict:
         lmnc = jnp.asarray(state.L_cos) * mode_scale[None, :] * lam_factor[:, None]
 
     # Normalizations: L_ref = Aminor_p (aspectratio.f boundary quadrature,
-    # same math as the wout ``Aminor_p``), B_ref = 2|psi_edge|/L_ref^2.
+    # same math as the wout ``Aminor_p``), B_ref = 2|psi_edge|/L_ref^2, and
+    # R_major = Rmajor_p = volume_p / (2 pi <area>) from the same quadrature
+    # (statephysics._aspect_scalars): the flux-tube contract's ``R0``.
     sqrts_edge = jnp.asarray(setup.sqrts)[-1]
     rb = jnp.asarray(geometry.R_even)[-1] + sqrts_edge * jnp.asarray(geometry.R_odd)[-1]
     zub = (jnp.asarray(geometry.dZ_dtheta_even)[-1]
            + sqrts_edge * jnp.asarray(geometry.dZ_dtheta_odd)[-1])
     wint = jnp.asarray(rt.trig.wint)
-    area = 2.0 * jnp.pi * jnp.abs(jnp.sum(rb * zub * wint))
-    L_ref = jnp.sqrt(jnp.where(area != 0.0, area, 1.0) / jnp.pi)
+    t1 = rb * zub * wint
+    area = 2.0 * jnp.pi * jnp.abs(jnp.sum(t1))
+    area_safe = jnp.where(area != 0.0, area, 1.0)
+    L_ref = jnp.sqrt(area_safe / jnp.pi)
+    volume_p = 2.0 * jnp.pi ** 2 * jnp.abs(jnp.sum(rb * t1))
+    R_major = volume_p / (2.0 * jnp.pi * area_safe)
 
     hs = s[1] - s[0]
     psi_edge = hs * jnp.sum(phipf[1:])          # internal psi = phi/(2 pi)
@@ -708,7 +715,7 @@ def _ballooning_context(state: SpectralState, rt: SolverRuntime) -> dict:
         rmns=rmns, zmnc=zmnc, lmnc=lmnc, lasym=lasym,
         iotas=iotas, pres=jnp.asarray(fields.pressure),
         phipf=phipf, psi_edge=psi_edge, sign_psi=sign_psi,
-        L_ref=L_ref, B_ref=B_ref,
+        L_ref=L_ref, B_ref=B_ref, R_major=R_major,
     )
 
 

--- a/vmex/core/turbulence.py
+++ b/vmex/core/turbulence.py
@@ -76,6 +76,18 @@ Scope notes
   ``psi = s * psi_edge`` in vmex's internal (signed) edge-flux
   convention.  The default single-``kx`` proxies (``nx = 1``) are
   insensitive to this overall sign, matching GKX's own VMEC bridge.
+- The scalar metadata ``epsilon`` and ``R0`` carry GKX's meaning of those
+  keys -- the meaning it applies when it writes run artifacts
+  (``aminor = epsilon * R0``, ``a_ref``, ``rmaj``) and in its analytic model
+  ``|B| = B0 / (1 + epsilon cos theta)``.  ``epsilon`` is the field-line
+  ``|B|`` modulation depth ``(max|B| - min|B|) / (max|B| + min|B|)``
+  (:func:`b_modulation_depth`): exactly that model's ``epsilon``, and the
+  local inverse aspect ratio ``r / R0`` of a ``1/R`` tokamak field.  ``R0``
+  is the wout ``Rmajor_p`` (``volume_p / (2 pi <area>)``, metres), not
+  ``L_ref``.  :func:`vmex.mirror.gk_closed_fieldline_geometry` exports the
+  same two definitions (there ``R0 = L_axis / (2 pi)``, the same volume
+  identity), so the lanes never split on either key.  Neither enters GKX's
+  solver.  ``std(|B|) / mean(|B|)`` is no longer exported under the key.
 """
 
 from __future__ import annotations
@@ -100,6 +112,7 @@ __all__ = [
     "gk_fieldline_geometry",
     "gk_fieldline_geometry_from_wout",
     "flux_tube_geometry",
+    "b_modulation_depth",
     "turbulence_objective_vector",
     "turbulent_growth_rate",
     "quasilinear_flux_proxy",
@@ -223,6 +236,24 @@ def _line_arrays(ctx: dict, j: int, alpha: float, zeta0: float, x: Array):
 # ---------------------------------------------------------------------------
 
 
+def b_modulation_depth(bmag: Array) -> Array:
+    """``(max|B| - min|B|) / (max|B| + min|B|)`` along a sampled field line.
+
+    The ``epsilon`` of the flux-tube contract, shared by
+    :func:`gk_fieldline_geometry` and
+    :func:`vmex.mirror.gk_closed_fieldline_geometry`.  GKX's analytic
+    geometry is ``|B| = B0 / (1 + epsilon cos theta)`` with ``epsilon`` the
+    inverse aspect ratio, and GKX writes ``aminor = epsilon * R0`` into its
+    run artifacts; this depth *is* that ``epsilon`` for that model and for any
+    ``1/R`` field, and, unlike ``r / R0``, it exists on a straight mirror.
+    The field-line mirror ratio is ``max|B| / min|B| = (1 + eps) / (1 - eps)``.
+    Hard max/min, smooth almost everywhere (ties aside) -- the same depth
+    :func:`vmex.core.optimize.mirror_ratio` takes over a whole surface.
+    """
+    bmax, bmin = jnp.max(bmag), jnp.min(bmag)
+    return (bmax - bmin) / (bmax + bmin)
+
+
 def _gk_fieldline_geometry_from_context(
     ctx: dict,
     *,
@@ -243,9 +274,12 @@ def _gk_fieldline_geometry_from_context(
     ``nfp``), all in the GS2/GX normalizations of simsopt
     ``vmec_fieldlines`` with ``L_ref`` the effective minor radius and
     ``B_ref = 2 |psi_edge| / L_ref^2`` (identical to
-    :mod:`vmex.core.stability`).  A ``"vmex"`` sub-dict carries
-    diagnostics used by the parity tests (``dp_drho``, ``gradpar_profile``,
-    the sampled PEST angles, …).  Pure jnp — traceable and differentiable
+    :mod:`vmex.core.stability`).  ``epsilon`` is the field-line ``|B|``
+    modulation depth (:func:`b_modulation_depth`) and ``R0`` the wout
+    ``Rmajor_p`` in metres -- GKX's meaning of both keys (module notes).  A
+    ``"vmex"`` sub-dict carries diagnostics used by the parity tests
+    (``dp_drho``, ``gradpar_profile``, ``L_ref``/``B_ref``/``R_major``, the
+    sampled PEST angles, …).  Pure jnp — traceable and differentiable
     w.r.t. ``(state, runtime)``; no gkx import.
 
     Parameters
@@ -284,7 +318,7 @@ def _gk_fieldline_geometry_from_context(
     diota = (iotas[j + 1] - iotas[j]) / hs
     dpres = (pres[j + 1] - pres[j]) / hs            # internal units: mu0 dp/ds
     shat = -2.0 * s_j * diota / iota                # (r/q) dq/dr, r = L_ref sqrt(s)
-    L_ref, B_ref = ctx["L_ref"], ctx["B_ref"]
+    L_ref, B_ref, R_major = ctx["L_ref"], ctx["B_ref"], ctx["R_major"]
     psi_edge, sign_psi = ctx["psi_edge"], ctx["sign_psi"]
     alpha_c = jnp.asarray(alpha, dtype=dtype)
     zeta0_c = jnp.asarray(zeta0, dtype=dtype)
@@ -326,7 +360,6 @@ def _gk_fieldline_geometry_from_context(
     bgrad = L_ref * b_dot_gradb / (modB * modB)           # b . grad ln|B|, normalized
     grho = L_ref * jnp.sqrt(gss) / (2.0 * sqrt_s)         # |grad rho| L_ref, rho = sqrt(s)
 
-    mean_b = jnp.mean(bmag)
     return {
         "theta": theta,
         "gradpar": gradpar,
@@ -343,8 +376,8 @@ def _gk_fieldline_geometry_from_context(
         "grho": grho,
         "q": 1.0 / jnp.abs(iota),
         "s_hat": shat,
-        "epsilon": jnp.std(bmag) / mean_b,
-        "R0": L_ref,
+        "epsilon": b_modulation_depth(bmag),
+        "R0": R_major,
         "B0": B_ref,
         "alpha": float(alpha),
         "nfp": int(nfp),
@@ -357,6 +390,7 @@ def _gk_fieldline_geometry_from_context(
             "dp_drho": 2.0 * sqrt_s * dpres / (B_ref * B_ref),
             "L_ref": L_ref,
             "B_ref": B_ref,
+            "R_major": R_major,
             "psi_edge": psi_edge,
             "sign_psi": sign_psi,
             "theta_pest": alpha_c + x_eval,
@@ -432,6 +466,9 @@ def _wout_ballooning_context(wout: Any) -> dict:
     L_ref = float(wout.Aminor_p)
     if not np.isfinite(L_ref) or L_ref <= 0.0:
         raise ValueError(f"WOUT Aminor_p must be finite and positive, got {L_ref}")
+    R_major = float(wout.Rmajor_p)
+    if not np.isfinite(R_major) or R_major <= 0.0:
+        raise ValueError(f"WOUT Rmajor_p must be finite and positive, got {R_major}")
     psi_edge = float(np.asarray(wout.phi, dtype=float)[-1]) / (2.0 * np.pi * signgs)
     if not np.isfinite(psi_edge) or psi_edge == 0.0:
         raise ValueError(f"WOUT edge toroidal flux must be finite and nonzero, got {psi_edge}")
@@ -455,6 +492,7 @@ def _wout_ballooning_context(wout: Any) -> dict:
         "sign_psi": jnp.asarray(np.sign(psi_edge)),
         "L_ref": jnp.asarray(L_ref),
         "B_ref": jnp.asarray(2.0 * abs(psi_edge) / (L_ref * L_ref)),
+        "R_major": jnp.asarray(R_major),
     }
 
 

--- a/vmex/mirror/turbulence.py
+++ b/vmex/mirror/turbulence.py
@@ -23,6 +23,7 @@ from .geometry import (
 )
 from .model import MirrorState
 from .splines import SplineMirrorDiscretization, trace_closed_field_line
+from vmex.core.turbulence import b_modulation_depth
 
 Array = Any
 
@@ -174,18 +175,24 @@ def gk_closed_fieldline_geometry(
     Open mirrors are intentionally rejected by requiring a closed
     discretization.
 
-    The ``epsilon`` key follows the VMEX flux-tube contract shared with
-    :mod:`vmex.core.turbulence`: ``std(|B|) / mean(|B|)`` along the tube.  It
-    is deliberately *not* what GS2-family codes mean by that key.  In GKX's own
-    analytic geometry ``epsilon`` is the inverse aspect ratio, entering as
-    ``|B| = B0 / (1 + epsilon cos(theta))`` and used to set the minor radius
-    ``a = epsilon * R0`` when it writes run artifacts.  A straight mirror has
-    no aspect ratio, so nothing exported here can carry that meaning.  Read the
-    mirror ratio from ``vmex_mirror["field_line_mirror_ratio"]``
-    (``max|B| / min|B|`` on this field line, the field-line member of the
-    definitions in :mod:`vmex.mirror.metrics`), and read the tokamak-equivalent
-    modulation depth ``(max|B| - min|B|) / (max|B| + min|B|)`` from
-    ``vmex_mirror["field_line_b_modulation"]``.
+    The scalar metadata ``epsilon`` and ``R0`` use the one VMEX definition
+    shared with :mod:`vmex.core.turbulence`, chosen to be what GKX means by
+    the keys: its analytic geometry is ``|B| = B0 / (1 + epsilon cos(theta))``
+    and it sets ``aminor = epsilon * R0`` when it writes run artifacts.
+    ``epsilon`` is the field-line ``|B|`` modulation depth
+    ``(max|B| - min|B|) / (max|B| + min|B|)``
+    (:func:`vmex.core.turbulence.b_modulation_depth`): exactly that model's
+    ``epsilon``, and defined on a straight mirror, which has no aspect ratio
+    to offer instead.  ``R0`` is the effective major radius
+    ``L_axis / (2 pi)`` -- by the ``L_ref`` definition also
+    ``V / (2 pi^2 L_ref^2)``, the identity behind VMEC's ``Rmajor_p`` -- so
+    ``epsilon * R0`` is a length rather than a fraction of ``L_ref``.  The
+    same numbers are exported under their VMEX names:
+    ``vmex_mirror["field_line_mirror_ratio"]`` is ``max|B| / min|B|`` on this
+    field line, the field-line member of the definitions in
+    :mod:`vmex.mirror.metrics` and equal to ``(1 + epsilon) / (1 - epsilon)``;
+    ``vmex_mirror["field_line_b_modulation"]`` repeats ``epsilon``; and
+    ``vmex_mirror["R_major"]`` repeats ``R0``.
     """
 
     if not discretization.closed:
@@ -237,6 +244,9 @@ def gk_closed_fieldline_geometry(
     b_sup_u_fine = _surface_interpolate(tensors["b_sup_u"], discretization, line.theta, line.axial_parameter)
 
     effective_minor_radius = jnp.sqrt(geometry.volume / (jnp.pi * jnp.asarray(axis.arc_length)))
+    # Major radius of the circular torus with this axis length; with the L_ref
+    # above it is also V / (2 pi^2 L_ref^2), the identity behind VMEC's Rmajor_p.
+    effective_major_radius = jnp.asarray(axis.arc_length) / (2.0 * jnp.pi)
     b_reference = 2.0 * jnp.abs(jnp.asarray(axial_flux_derivative)) / (effective_minor_radius**2)
     gradpar_fine = effective_minor_radius * jnp.abs(b_sup_u_fine) / mod_b_fine
     du = line.axial_parameter[1] - line.axial_parameter[0]
@@ -286,6 +296,7 @@ def gk_closed_fieldline_geometry(
     grad_rho = effective_minor_radius * jnp.sqrt(sampled["grad_s_sq"]) / (2.0 * sqrt_s)
     iota = poloidal_advance / (2.0 * jnp.pi)
     q = jnp.where(jnp.abs(iota) > 1.0e-10, 1.0 / jnp.abs(iota), 1.0)
+    modulation = b_modulation_depth(bmag)
 
     return {
         "theta": theta,
@@ -303,8 +314,8 @@ def gk_closed_fieldline_geometry(
         "grho": grad_rho,
         "q": q,
         "s_hat": 0.0,
-        "epsilon": jnp.std(bmag) / jnp.mean(bmag),
-        "R0": effective_minor_radius,
+        "epsilon": modulation,
+        "R0": effective_major_radius,
         "B0": b_reference,
         "alpha": float(theta0),
         "nfp": 1,
@@ -312,14 +323,15 @@ def gk_closed_fieldline_geometry(
             "surface_index": j,
             "s": s_value,
             "iota": iota,
-            # The field-line member of the mirror-ratio definitions; see
-            # vmex.mirror.metrics for R_m,axis and R_m,LCFS, and the docstring
-            # above for why "epsilon" is not any of them.
+            # The field-line member of the mirror-ratio definitions (see
+            # vmex.mirror.metrics for R_m,axis and R_m,LCFS); "epsilon" above
+            # is the same modulation depth, R_m = (1 + eps) / (1 - eps).
             "field_line_mirror_ratio": jnp.max(bmag) / jnp.min(bmag),
-            "field_line_b_modulation": (jnp.max(bmag) - jnp.min(bmag)) / (jnp.max(bmag) + jnp.min(bmag)),
+            "field_line_b_modulation": modulation,
             "closure_residual": closure_residual,
             "axis_arc_length": axis.arc_length,
             "L_ref": effective_minor_radius,
+            "R_major": effective_major_radius,
             "B_ref": b_reference,
             "u": u_eval,
             "fieldline_theta": theta_eval,


### PR DESCRIPTION
Supersedes #271, which GitHub auto-closed when its base branch (the merged #263) was deleted; the branch is rebased onto main with the plan ledger left to main's copy.

## Summary

Both gyrokinetic geometry exports set the GKX/GS2 contract key `epsilon` to `std(|B|)/mean(|B|)` and `R0` to `L_ref`. Verified against the installed GKX source: GKX reads `epsilon` as the inverse aspect ratio (`geometry/analytic.py:251`, `bmag = 1/(1 + eps cos theta)`) and derives `aminor = epsilon * R0` and `a_ref` when it writes run artifacts (`artifacts/nonlinear_netcdf.py:119,181`; read back as `epsilon = aminor/rmaj` in `artifacts/run_summary.py:159` and `geometry/flux_tube.py:452`). With `R0 = L_ref` that derived minor radius was meaningless in both lanes. #263 documented the mismatch on the mirror lane and deliberately left the value alone so the two lanes would not split; this PR picks one definition and applies it to both in the same change.

**Stacked on #263** (`audit/mirror-31-4`): the base is that branch so the diff shows only this change; GitHub retargets it to `main` once #263 merges.

## The definition

- `epsilon = (max|B| - min|B|) / (max|B| + min|B|)` along the sampled tube, as the new `vmex.core.turbulence.b_modulation_depth`, used by both `gk_fieldline_geometry` and `gk_closed_fieldline_geometry`. It equals GKX's `epsilon` exactly for its own `1/(1 + eps cos theta)` model and the local `r/R0` of any `1/R` tokamak field, and, unlike an aspect ratio, it exists on a straight mirror. The field-line mirror ratio is `(1 + eps)/(1 - eps)`. Hard max/min, smooth almost everywhere, the same depth `vmex.core.optimize.mirror_ratio` takes over a surface. The alternative, the geometric `Aminor_p/Rmajor_p`, is undefined on the mirror and is not what a stellarator field line sees.
- `R0` stops being `L_ref`: with `aminor = epsilon * R0` on the GKX side, `R0` has to be a major radius. Core lane: `R0 = volume_p / (2 pi <area>)`, the wout `Rmajor_p`, computed in the ballooning context from the same boundary quadrature as `L_ref` (live route) and read from `wout.Rmajor_p` with the same validation as `Aminor_p` (WOUT route; the existing live/WOUT parity test covers it at 2e-11). Mirror lane: `R0 = L_axis / (2 pi)`, which under its `L_ref = sqrt(V / (pi L_axis))` is the same identity `V / (2 pi^2 L_ref^2)`. `R_major` is also exported under `vmex` / `vmex_mirror` next to `L_ref` and `B_ref`.
- Neither scalar enters GKX's solver (only `analytic.py`, the artifact writers, the snapshot plot, and the `vmec_state_sensitivity` observable consume them), so no proxy value changes.

## Pinned-value audit

- No benchmark artifact or golden file pins the old value: the `"epsilon"` entries in `benchmarks/baselines/m4/C1_*.json` are the eps_eff timings, `tests/test_bootstrap.py`'s are the bootstrap geometry table, and `tests/test_wout_golden.py` pins `Rmajor_p`, which is unchanged.
- `tests/test_turbulence.py` checked key presence and live/WOUT parity only. It now also pins `epsilon` to the depth and `R0` to `wout.Rmajor_p`, checks `b_modulation_depth` against GKX's analytic model, and checks `epsilon ≈ sqrt(s) L_ref / R0` (rel 0.1) on the circular vacuum tokamak, which `std/mean` (about `eps/sqrt(2)`) fails.
- `tests/mirror/test_turbulence.py` (from #263) pinned `std/mean`; it now pins the depth, `epsilon == field_line_b_modulation`, and `R0 == axis_arc_length / (2 pi)`.
- GKX side: its bridge test is stubbed and does not depend on the values. Its `geometry/booz_xform_bridge.py:455` still emits the `std/mean` form under the same key, which is a GKX follow-up.

## Docs

`vmex.core.turbulence` module notes, the `gk_closed_fieldline_geometry` docstring, `docs/explanation/mirror-gyrokinetics.rst` (new definitions block after the normalizations), `docs/explanation/mirror-geometry.rst` (the "not mirror ratios" paragraph), the plan ledger entry 31.4-R3, and the CHANGELOG.

## Tests

```
tests/mirror/test_turbulence.py   3 passed
tests/test_turbulence.py          17 passed, 2 skipped (pre-existing gkx eigenvector-floor gates)
ruff                              clean
sphinx -b dummy                   0 warnings
```

## Measured before / after

Same lines the tests use (`s_index=7`; shaped tokamak at `alpha=0.3`, `ntheta=128`); "before" is the pre-PR code on the same states.

| case | `epsilon` before (std/mean) | `epsilon` after (depth) | `sqrt(s) L_ref / R0` | `R0` before (= `L_ref`) | `R0` after | wout `Rmajor_p` |
|---|---|---|---|---|---|---|
| shaped finite-beta tokamak | 0.1744 | 0.2705 | 0.2890 | 2.299 m | 6.075 m | 6.075 m |
| circular vacuum tokamak (`R = 6`, `a = 2`) | 0.1560 | 0.2176 | 0.2205 | 2.000 m | 6.000 m | 6.000 m |
| closed racetrack mirror (test fixture) | 0.2429 | 0.2802 | n/a | 0.346 m | 3.100 m (`L_axis / 2 pi`) | n/a |

On the circular tokamak the depth sits 1.3% from the local `r / R0`, where `std/mean` was 29% low (it is about `eps / sqrt(2)` for a cosine-like modulation). On the mirror the depth is `(R_m - 1) / (R_m + 1)` for the field-line `R_m = 1.7785` exported next to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
