### PR TITLE
Focus the research plan on validated force balance and optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,30 @@
 # VMEX
 
 [![PyPI version](https://img.shields.io/pypi/v/vmex.svg)](https://pypi.org/project/vmex/)
-[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://github.com/uwplasma/vmex/blob/main/pyproject.toml)
-[![License](https://img.shields.io/github/license/uwplasma/vmex)](https://github.com/uwplasma/vmex/blob/main/LICENSE)
+[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg)](pyproject.toml)
+[![License](https://img.shields.io/github/license/uwplasma/vmex)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/uwplasma/vmex/ci.yml?branch=main&label=ci)](https://github.com/uwplasma/vmex/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/uwplasma/vmex/branch/main/graph/badge.svg)](https://codecov.io/gh/uwplasma/vmex)
 [![Docs](https://img.shields.io/readthedocs/vmex/latest?label=docs)](https://vmex.readthedocs.io/en/latest/)
 
-> **Rename note:** `vmec_jax` is now `vmex`; the deprecated `import vmec_jax` compatibility shim still ships and will be removed in a future minor release.
+VMEX computes stellarator and tokamak ideal-MHD equilibria in JAX. It reads
+VMEC input files, solves fixed- and free-boundary problems, and writes standard
+`wout_*.nc` files. Implicit derivatives connect equilibria to boundary, profile,
+and coil optimization.
 
-VMEX is a JAX implementation of VMEC for stellarator and tokamak ideal-MHD equilibria. It reads standard VMEC input files, solves fixed- and free-boundary problems, writes standard `wout_*.nc` files, and provides exact implicit derivatives of converged fixed-boundary equilibria for optimization.
+- **Use existing workflows:** VMEC input/output, multigrid continuation and hot restart.
+- **Design with gradients:** SciPy or JAX optimizers, scalar adjoints and residual Jacobians.
+- **Inspect the physics:** Boozer transforms, magnetic fields and spatial derivatives,
+  quasisymmetry, quasi-isodynamicity and stability diagnostics.
+- **Choose the hardware:** CPU or GPU execution, reusable compilation and independent-case ensembles.
+- **Connect coils:** ESSOS fields, NESTOR free boundary and finite-beta exterior fields.
 
 ![VMEX equilibria and diagnostics](docs/_static/figures/readme_equilibrium_showcase.webp)
+
+The [capability reference](https://vmex.readthedocs.io/en/latest/reference/capabilities.html)
+defines supported models and validation limits. VMEX's toroidal equilibrium
+model assumes nested flux surfaces; mirror and high-order polishing features
+have narrower validation scopes.
 
 ## Install
 
@@ -21,553 +34,187 @@ vmex --doctor
 vmex --test
 ```
 
-Python 3.10+ is supported. VMEX installs CPU JAX, SciPy, plotting, NetCDF, and `booz_xform_jax`; install an accelerator-enabled JAX wheel separately using the [JAX installation guide](https://docs.jax.dev/en/latest/installation.html). Optional integrations are `vmex[optimizers]` for JAXopt/Optax, `vmex[neoclassical]` for NEO_JAX effective ripple, `vmex[freeb]` for differentiable virtual casing, `vmex[coils]` for ESSOS, and `vmex[turbulence]` for GKX.
+Python 3.10–3.12 is tested. CPU JAX is included; for GPUs follow the
+[JAX installation guide](https://docs.jax.dev/en/latest/installation.html) and
+[VMEX GPU guide](https://vmex.readthedocs.io/en/latest/howto/run-on-gpu.html).
+Optional extras include `vmex[coils]` (ESSOS), `vmex[freeb]` (virtual casing),
+`vmex[neoclassical]` (effective ripple), and `vmex[optimizers]` (JAXopt/Optax).
+See [installation](https://vmex.readthedocs.io/en/latest/installation.html) for dependencies.
+The former package name, `vmec_jax`, remains a deprecated import shim.
 
-An editable source install remains connected to its checkout, so `pip install -e .` only needs to be repeated when packaging metadata or dependencies change—not after each `git fetch` or checkout.
+## Solve, plot and restart
 
-## Solve and inspect an equilibrium
-
-```python
-import vmex as vj
-
-inp = vj.VmecInput.from_file("input.circular_tokamak")
-result = vj.solve_multigrid(inp, verbose=True)
-wout = vj.wout_from_state(inp=inp, state=result.state,
-                           fsqr=result.fsqr, fsqz=result.fsqz, fsql=result.fsql,
-                           niter=result.iterations, converged=result.converged)
-vj.write_wout("wout_circular_tokamak.nc", wout)
-figures = vj.plot_wout("wout_circular_tokamak.nc", "figures")
-# The summary includes the relative radial force-error profile and its maximum.
-# That panel is O(1) noise for a vacuum case: read it only at finite pressure
-# or with net current.
-```
-
-The CLI provides the same workflow:
+With your own VMEC input file:
 
 ```console
-vmex input.circular_tokamak
-vmex --plot wout_circular_tokamak.nc
-vmex input.nearby --restart wout_circular_tokamak.nc
+vmex input.my_case --plot
+vmex --plot wout_my_case.nc
+vmex --booz wout_my_case.nc
+vmex input.nearby --restart wout_my_case.nc
 ```
 
-VMEX uses the input file's `NS_ARRAY`, `FTOL_ARRAY`, and `NITER_ARRAY`. `verbose=True` prints the VMEC iteration table; typed errors distinguish invalid inputs, Jacobian failures, non-convergence, and numerical failures.
-
-## Physics and interoperability
-
-VMEX includes VMEC pressure/current/iota profiles, multigrid continuation, NESTOR free boundary, mgrid and direct coil fields, Boozer transforms, QI/QS and maximum-J objectives, Mercier and ballooning diagnostics, bootstrap-current objectives, dimensional scaling, mirror equilibria, and standard wout/mout output. The [capability reference](https://vmex.readthedocs.io/en/latest/reference/capabilities.html) states the validation level and limitations of each path.
-
-VMEX outputs are intended for existing VMEC workflows: `wout_*.nc` files load in SIMSOPT, `booz_xform`, and other downstream tools. VMEC2000 compatibility and deliberate differences are documented in the [compatibility reference](https://vmex.readthedocs.io/en/latest/reference/vmec2000-compatibility.html).
-
-### Solver feature comparison
-
-This matrix was checked on 2026-08-11 against current [STELLOPT/VMEC2000](https://github.com/PrincetonUniversity/STELLOPT) and [VMEC++](https://github.com/proximafusion/vmecpp) sources. ✅ denotes a public path, ⚠️ a documented limitation, and ❌ no public path; the linked VMEX capability contract defines the validation scope.
-
-| Capability | VMEX | VMEC2000 | VMEC++ |
-|---|:---:|:---:|:---:|
-| fixed-boundary toroidal equilibria | ✅ | ✅ | ✅ |
-| 3-D NESTOR free boundary | ✅ | ✅ | ✅ |
-| free-boundary radial multigrid | ✅ | ✅ | ✅ |
-| free boundary from an in-memory field table | ✅ | ❌ | ✅ Python |
-| axisymmetric free-boundary tokamaks | ✅ | ✅ | ❌ |
-| non-stellarator-symmetric (`LASYM`) equilibria | ✅ | ✅ | ❌ |
-| fixed-boundary fallback when an mgrid file is missing | ✅ | ✅ | ❌ |
-| cubic and Akima spline profiles | ✅ | ✅ | ❌ |
-| INDATA / structured JSON input | ✅ / ✅ | ✅ / ❌ | ✅ / ✅ |
-| hot restart from a saved equilibrium | ✅ Python/CLI | ✅ CLI | ✅ Python |
-| typed zero-crash errors | ✅ | ❌ | ✅ |
-| built-in Boozer transform and plotting | ✅ | ❌ | ❌ |
-| input and WOUT dimensional scaling | ✅ | ❌ | ❌ |
-| GPU execution | ✅ | ❌ | ❌ |
-| exact fixed-boundary derivatives and optimizer interface | ✅ | ❌ | ❌ |
-| differentiable specified-boundary virtual-casing residual | ✅ | ❌ | ❌ |
-| 2-D block preconditioner | ✅ matrix-free | ✅ BCYCLIC | ❌ |
-| differentiable QI/QS, maximum-J, trapped-fraction, and stability objectives | ✅ | ❌ | ❌ |
-| self-consistent bootstrap-current workflows | ✅ | ❌ | ❌ |
-| open mirrors and stellarator–mirror hybrids | ⚠️ validated scopes | ❌ | ❌ |
-
-### Convergence parity
-
-On the bundled NFP=4 QH case at `ns=51`, VMEX follows VMEC2000 and VMEC++ through the full force-residual trace. Reproduce it with `python benchmarks/make_readme_figures.py --only convergence`; the benchmark discovers local solver installations or accepts `VMEX_XVMEC2000` and `VMEX_VMECPP_PY`, and caches the traces in `benchmarks/convergence_nfp4_ns51.json`.
-
-![VMEX, VMEC2000, and VMEC++ convergence trace](docs/_static/figures/readme_convergence.webp)
-
-VMEX reduces duplication by expressing spectral operators as vectorized JAX array programs and using the same equations for CPU, accelerators, and automatic differentiation. It also deliberately omits some legacy modes, so it carries both a different architecture and a narrower compatibility surface than the Fortran and C++ implementations.
-
-## Performance and parallelism
-
-JAX compilation is paid once per array structure and reused from a machine-local cache. Warm runs are the relevant measure for continuation, parameter scans, and optimization.
-
-![VMEX runtime comparison](docs/_static/figures/readme_runtime_compare.webp)
-
-Independent solves use `vj.parallel.solve_ensemble(inputs, workers=None)`. A single equilibrium already uses XLA's internal threading; ensemble workers are therefore bounded by both the number of cases and the CPUs made available by the host scheduler. Explicit `workers=1` gives a reproducible serial baseline, and GPU/device placement can be selected with `device=`.
-
-`benchmarks/optimization.py` profiles QI, QA, QH, QP, scalar objectives,
-SciPy/JAX contract agreement, finite differences, optimizer choices, and the
-`max_fsq_ratio` policy.
-
-## Magnetic field and derivatives
-
-Converged equilibria evaluate the field inside the LCFS, including spatial
-derivatives and exact VJPs in the originating optimization problem's degrees
-of freedom:
-
-```python
-import jax.numpy as jnp
-
-final_equilibrium = problem.equilibrium_from_x(result.x)
-final_equilibrium.set_points_xyz([[x, y, z]])
-
-B = final_equilibrium.B()
-absB = final_equilibrium.absB()
-gradB = final_equilibrium.gradB()
-gradgradB = final_equilibrium.gradgradB()
-gradgradgradB = final_equilibrium.gradgradgradB()
-
-dBdx = final_equilibrium.B_vjp(jnp.ones_like(B))
-dgradBdx = final_equilibrium.gradB_vjp(jnp.ones_like(gradB))
-d2Bdx = final_equilibrium.gradgradB_vjp(jnp.ones_like(gradgradB))
-d3Bdx = final_equilibrium.gradgradgradB_vjp(
-    jnp.ones_like(gradgradgradB))
-```
-
-Everything above is Cartesian, and each VJP returns one entry per
-`problem.dof_names`. `set_points_flux([[s, theta, phi]])` places interior points
-in flux coordinates (outputs stay Cartesian); `B` and its first three
-derivatives are valid on the magnetic axis via the regular spectral limit.
-Outside the plasma, `VmecExtender` adds the `virtual_casing_jax` plasma
-contribution to a supplied coil or MGRID field — virtual casing alone is not the total exterior field.
-
-![Poincare sections of the coil-only field next to the extended coil plus plasma field, whose exterior seeds resolve an island chain outside the plasma boundary](docs/_static/figures/readme_extender_exterior_islands.webp)
-
-Above, from `examples/vmex_fieldline_tracing_finite_beta.py`: Poincaré
-sections of the coil field alone (left) and of the extended field (right)
-for a finite-beta QA equilibrium. The pink points are field lines seeded
-just outside the boundary in the extended field — coils plus the
-virtual-casing plasma contribution — resolving the island chain outside the
-plasma; the coil field alone loses those lines before they return.
-
-Effective ripple is an optional in-memory diagnostic—no `boozmn` file is
-needed. `examples/epsilon_effective.py` computes and plots the conventional
-NEO transport quantity $\epsilon_{\mathrm{eff}}^{3/2}$.
-
-```python
-field = vj.VmecExtender.from_file(
-    "wout_example.nc", external_field=coils.B, nphi=32, ntheta=32
-)
-field.set_points([[1.8, 0.0, 0.0]])
-
-B = field.B()              # (n, 3), Cartesian
-modB = field.absB()        # (n,)
-gradB = field.gradB()      # (n, B_i, x_j)
-d2B = field.gradgradB()
-d3B = field.gradgradgradB()
-grad_modB = field.GradAbsB()
-```
-
-Install `vmex[freeb]` for the finite-beta path. Points must be outside the
-last closed flux surface, away from the source surface and external currents.
-MGRID queries must also remain inside the tabulated R-Z domain.
-The resulting vacuum region can contain islands or stochastic field lines;
-VMEX does not assume nested surfaces there.
-
-`equilibrium.exterior_field()` builds the plasma contribution from the live
-VMEX spectral state, rather than a materialized wout, so JAX derivatives with
-respect to the equilibrium boundary are retained for single-stage objectives.
-`examples/vmex_get_B_gradB.py` and `examples/free_boundary_essos_coils.py`
-are the runnable references; the docs' install page covers the ESSOS branch
-that exterior coil VJPs and field-line tracing currently need.
-
-The common CLI operations are:
-
-| Command | Result |
-|---|---|
-| `vmex input.X` | solve INDATA or JSON and write `wout_X.nc` |
-| `vmex input.X --plot` | solve and write the summary, cross-sections, automatic Boozer `|B|`, profiles, normalized force balance, and 3-D LCFS |
-| `vmex --plot wout_X.nc` | write the same complete plot set from an existing equilibrium |
-| `vmex --booz wout_X.nc` | additionally save a reusable standard `boozmn_X.nc` file |
-| `vmex input.X --restart wout_Y.nc` | hot-restart a fixed- or free-boundary solve from a saved equilibrium |
-| `vmex --scale input.X [B R]` | scale field and length by optional factors; without them target 5.7 T and 1.7 m |
-| `vmex --doctor` / `vmex --test` | inspect the installation / run the bundled quick start |
-
-See the [CLI reference](https://vmex.readthedocs.io/en/latest/reference/cli.html) for resolution, device, convergence, coil, plotting, and Boozer options.
-
-## Hot restart
-
-Pass a previous state or wout to initialize a nearby run. VMEX adapts the boundary and skips completed multigrid rungs when possible.
-
-```python
-base = vj.solve_multigrid(inp)
-nearby = vj.solve_multigrid(changed_input, initial_state=base.state)
-from_file = vj.solve_multigrid(changed_input, restart_from="wout_base.nc")
-```
-
-The CLI equivalent is `vmex input.changed --restart wout_base.nc`; a deck may instead set `RESTART_WOUT`. Optimization trial solves hot-restart automatically. See the [restart guide](https://vmex.readthedocs.io/en/latest/howto/restart-from-previous-run.html) for grid changes and validation rules.
-
-## Bring your own optimizer
-
-Objective tuples use `(function, target, weight)`, with `weight` multiplying the squared cost by default; a one-dimensional weight applies different penalties to profile rows, such as a stronger edge penalty. The resulting problem plugs into SciPy, JAXopt, Optax, or any optimizer you already use — VMEX supplies values, residuals, and exact derivatives, and stays out of the driver's way.
-
-```python
-from dataclasses import replace
-import jax.numpy as jnp
-import numpy as np
-from scipy.optimize import least_squares
-
-from vmex import optimize as opt
-from vmex.core.omnigenity import QIResidual
-
-max_mode = 5
-mpol = max(max_mode + 2, 5)
-inp = replace(inp, delt=0.5).change_resolution(
-    mpol=mpol, ntor=mpol, ntheta=2 * mpol + 6, nzeta=2 * mpol + 4)
-qi = QIResidual(np.linspace(0.1, 1.0, 6))
-
-def iota_floor(equilibrium_state, solver_context):
-    return jnp.maximum(
-        0.33 - jnp.abs(opt.mean_iota(equilibrium_state, solver_context)), 0.0)
-
-problem = opt.VmecProblem.from_tuples(inp, [
-    (qi, 0.0, 1.0),
-    (opt.aspect_ratio, 5.0, 0.005),
-    (iota_floor, 0.0, 10.0),
-], max_mode=max_mode, use_ess=True)
-
-result = least_squares(problem.residual, problem.x0,
-    jac=problem.residual_jac, x_scale=problem.scales, max_nfev=50, verbose=2)
-optimized_input = problem.input_from_x(result.x)
-optimized_equilibrium = problem.equilibrium_from_x(result.x)
-```
-
-VMEX implicitly differentiates the converged equilibrium by default. For a
-residual vector, `auto` checks each block-response column against the linearized
-VMEC equations. If any column fails, it recomputes the Jacobian with the reverse
-adjoint. Cost weights, hot restarts, and one-column batches are defaults.
-
-| Control | Purpose |
-|---|---|
-| `derivative_method="finite_difference"` | accept opaque host objectives |
-| `implicit_jacobian_method` | choose automatic, block, forward, or reverse response assembly |
-| `jacobian_batch_size` | trade first-compile memory for warm throughput |
-| `forward_ftol`, `forward_max_iterations` | set the final equilibrium solve controls |
-| `max_fsq_ratio` | bound `FSQ / ftol` before differentiation |
-| `workers` | parallelize finite differences, scans, and ensembles; `None` respects scheduler CPU limits |
-
-`problem.value_and_grad` and `problem.jax_value_and_grad` expose the same scalar contract. `problem.evaluate(x)` reports solve effort, failed trials, derivative fallbacks, `fsq`, `fsq_ratio`, and whether the implicit derivative was certified. The runnable examples show SciPy least squares, BFGS/L-BFGS-B, JAXopt, Optax Adam, QI/QS objectives, high-accuracy final solves, input/wout output, and plotting.
-
-Joint boundary/coil and coil-only free-boundary scripts are previews for the
-same ESSOS branch.
-
-## QA, QH, QP, and QI examples
-
-The scripts in `examples/optimization/` optimize QA (NFP=2), QH (NFP=4), QP (NFP=2), and QI (NFP=2) from simple seeds; each writes an optimized input, WOUT, and standard plots. Run `QA_optimization.py`, `QH_optimization.py`, `QP_optimization.py`, or `QI_optimization.py`, then `python examples/plot_optimized_families.py` to reproduce the composites below. Each column shows four toroidal cuts separated by `π/(2 NFP)`, the 3-D LCFS colored by `|B|`, and LCFS `|B|` in Boozer coordinates.
-
-`examples/optimization/stellarator_asymmetry/` contains matching vacuum and finite-beta examples with `LASYM=True`; each visibly seeds and optimizes the additional `RBS` and `ZBC` boundary families.
-
-![QA, QH, and QP optimization examples](docs/_static/figures/readme_optimization.webp)
-
-Validated QI inputs spanning NFP=1–4 are bundled in `examples/data/`; the same plotting script reads them directly.
-
-![QI equilibria at NFP 1 through 4](docs/_static/figures/readme_qi.webp)
-
-## Finite beta, free boundary, and mirrors
-
-`examples/free_boundary_essos_coils.py` holds the Landreman–Paul QA coil currents fixed while increasing beta and re-solving the NESTOR free boundary. The magnetic-axis displacement is the expected Shafranov shift.
-
-![Free-boundary beta ramp and Shafranov shift](docs/_static/figures/readme_essos_beta_scan.webp)
-
-VMEX also solves open-ended mirrors. `examples/mirror/mirror_fixed_boundary_nonaxisymmetric.py` compares an axisymmetric mirror with a non-axisymmetric rotating ellipse; `examples/mirror/mirror_free_boundary_beta_scan.py` continues an ESSOS-coil free boundary from 0% to 80% central beta. The latter plots the solved on-axis field against the long-thin relation `B/Bvac = sqrt(1-beta)` implied by `p + B²/(2 μ0) = Bvac²/(2 μ0)` — [Ryutov et al. 2011](https://doi.org/10.1063/1.3624763), Eq. 30. That is not a small-beta estimate: it is the leading term in `(a/L)²` and is exact in beta for any beta < 1, so the deviation to expect is the device aspect `(a/L)² ≈ 6%` for the shipped two-coil case, not a function of how large beta is. Mirror ratios and lengths are reported through one set of definitions (`R_m,axis` per leg, `R_m,LCFS`, `L_mirror,B`, `L_straight`) in `vmex.mirror.metrics`. The 0–10% lane is supported; higher-beta points remain clearly marked as extended validation pending refined-grid promotion.
-
-![Axisymmetric and rotating-ellipse fixed-boundary mirrors](docs/_static/figures/mirror_fixed_boundary_3d.webp)
-
-![Free-boundary mirror beta scan](docs/_static/figures/mirror_free_boundary_beta_scan.webp)
-
-Closed stellarator–mirror hybrids also expose a differentiable, equal-arc
-field-line contract for GKX: VMEX owns the Cartesian metric and drift
-calculation, and GKX converts the mapping to its generic flux-tube type. The
-interface accepts only a field line that closes on the periodic racetrack and
-makes no open-end, sheath, source, or loss-cone claim; the
-[model and equations](https://vmex.readthedocs.io/en/latest/explanation/mirror-gyrokinetics.html) spell out that boundary.
-
-```python
-from vmex.mirror import gk_closed_fieldline_geometry
-
-geometry = gk_closed_fieldline_geometry(
-    result.evaluated.state,
-    setup.discretization,
-    setup.axis,
-    axial_flux_derivative=AXIAL_FLUX_DERIVATIVE,
-    current_derivative=0.0,
-    ntheta=32,
-)
-```
-
-## Optional force-balance polishing
-
-Polishing is disabled by default. Ordinary `solve`, `solve_multigrid`,
-`solve_file`, CLI, and optimization calls run the established VMEC solve only.
-Enable the additional step explicitly when a smaller continuum force residual
-is needed.
-
-VMEC converges projected equations on a staggered radial mesh, so small
-`FSQR/FSQZ/FSQL` values do not by themselves guarantee a small continuum
-residual
-
-$$
-\mathbf F = \mathbf J \times \mathbf B - \nabla p , \qquad
-\epsilon_F = \frac{2 |\mathbf F|}{|\mathbf J \times \mathbf B| + |\nabla p| + F_{\mathrm{floor}}} .
-$$
-
-`eps_F` is the acceptance threshold, and it is **bounded above by 2 by construction**: since `|F| <= |JxB| + |grad p|` pointwise, no state can exceed 2 however badly it violates force balance. It reaches 2 wherever the denominator collapses, and in vacuum, where `grad p` is identically zero, it sits at 2 to machine precision wherever any current remains. A value near 2 reports a collapsed denominator, not a 200% force error, and two saturated states cannot be ranked against one another at all. This is not hypothetical on a shipped deck: on the bundled `input.solovev`, whose pressure peaks at 0.125 Pa, the certificate reports `eps_F` volume L2 `1.969` and Linf `2.000` - the ceiling - because `<|grad p|>` is `1.35e-1` Pa m<sup>-1</sup> against a magnetic pressure gradient of `8.03e3` Pa m<sup>-1</sup>. The same state's vacuum-safe normalized force error is `1.22e-2`, and its dimensional `<|F|>` is `4.00e1` N m<sup>-3</sup>: an ordinary, small residual that the pointwise metric had no way to express ([record](benchmarks/polish_force_error_solovev_2026-09-03.json)).
-
-Every certificate therefore also reports quantities that cannot saturate, over `s` in `[0.1, 0.99]` as well as over the whole domain: the volume-averaged relative force error `<|F|>/<|grad p|>` of Panici et al. (2023) (reported as `n/a` in vacuum, where it is undefined), the vacuum-safe `|F| / <|grad(B^2/2mu0)|>` that DESC's `ForceBalance` objective uses, the dimensional `<|F|>` in N m<sup>-3</sup>, and the near-axis/bulk/edge split of the residual. The CLI prints all of them beside `eps_F`, `PolishReport` carries them, and the benchmark artifacts record them. Quote one of those, never `eps_F` alone, when reporting a gain; the [certificate page](https://vmex.readthedocs.io/en/latest/explanation/high-order-force-balance.html) derives the bound.
-
-The optional step lifts a converged fixed-boundary state to axis-regular cubic
-B-splines, holds the boundary and profiles fixed, and reduces both physical
-force channels on an overdetermined collocation grid with matrix-free SOLVAX
-Gauss–Newton steps. VMEX accepts the result only after independent force,
-radial-refinement, and positive-Jacobian checks.
-
-Enable it in a VMEC-compatible input deck:
-
-```fortran
-!@VMEX POLISH = AUTO
-!@VMEX POLISH_TOL = 1.0E-3
-!@VMEX POLISH_MAX_ITER = 40
-&INDATA
-  ...
-/
-```
-
-VMEX reads the comments; VMEC2000 ignores them. `POLISH = AUTO` lifts the
-converged final stage to degree-3 clamped radial B-splines (about one span per
-two radial points, at most 32), returns at once if that lifted state already
-passes the independent certificate (volume L2 at or below `1.0E-2`), and
-otherwise runs up to 80 Gauss-Newton iterations at relative tolerance `1.0E-3`.
-`OFF` is the default.
-
-`AUTO` and `ON` differ in one further way. Before committing to the
-Gauss-Newton phase, `AUTO` times one of its linear products on your problem
-and your machine and multiplies by the iteration limits you configured. If
-that worst case is longer than `POLISH_BUDGET`, it prints what it measured,
-returns the equilibrium unpolished and uncertified, and names the knobs that
-change the decision; it never raises, because nothing was attempted. `ON`
-never measures and never declines.
-
-The default one-hour budget admits every case polishing is shipped and
-claimed on, all of which are axisymmetric, and declines a 3-D deck at
-production resolution — which matches the scope described below rather than
-contradicting it. Use `POLISH = ON`, or raise `POLISH_BUDGET`, to ask for one
-deliberately. The other directives map onto `PolishConfig`:
-
-| Directive | Meaning | Default |
-|---|---|---|
-| `POLISH = AUTO \| ON \| OFF` | polish once after the final fixed-boundary stage | `OFF` |
-| `POLISH_TOL` | Gauss-Newton relative tolerance (`tolerance`) | `1.0E-3` |
-| `POLISH_DEGREE = 3 \| 5 \| 7` | radial B-spline degree (`radial_degree`) | `3` |
-| `POLISH_SPANS` | radial spans of the polished basis (`radial_spans`) | resolution-derived, at most 32 |
-| `POLISH_MAX_ITER` | Gauss-Newton iteration cap (`max_nonlinear_iterations`) | `80` |
-| `POLISH_BUDGET` | wall-clock ceiling `AUTO` will commit to, seconds (`auto_budget_seconds`) | `3600` |
-| `POLISH_FAIL = ERROR \| FALLBACK \| WARN` | failed polish: raise, return unpolished, or warn | `ERROR` |
-
-The CLI mirrors every directive (`--polish`, `--polish-tol`, `--polish-degree`,
-`--polish-spans`, `--polish-max-iter`, `--polish-budget`, `--polish-fail`,
-`--no-polish`) with
-precedence `CLI flag > Python keyword > file directive > package default`; an
-explicit `polish_config` in Python wins over all scalar knobs. A CLI run
-announces each polish phase, prints one row per Gauss-Newton iteration, and
-closes with a certificate verdict that names any failed check.
-
-The same opt-in is available in Python:
+VMEX follows the deck's `NS_ARRAY`, `FTOL_ARRAY` and `NITER_ARRAY`.
+In Python:
 
 ```python
 import vmex as vj
 
-# Reads the !@VMEX directive; no directive means no polishing.
-result = vj.solve_file("input.my_case")
-
-# VmecInput contains physics only, so direct solves use an explicit flag.
 inp = vj.VmecInput.from_file("input.my_case")
-result = vj.solve_multigrid(inp, polish_force_balance="auto")
-print(result.polish_report.initial_normalized_l2)
-print(result.polish_report.final_normalized_l2)
+result = vj.solve_multigrid(inp, verbose=True)
+print(result.converged, result.fsqr, result.fsqz, result.fsql)
+wout = vj.wout_from_state(
+    inp=inp, state=result.state, fsqr=result.fsqr, fsqz=result.fsqz,
+    fsql=result.fsql, niter=result.iterations, converged=result.converged)
+vj.write_wout("wout_my_case.nc", wout)
 ```
 
-`opt.solve_equilibrium(..., polish_force_balance=True)` exposes the same final
-step. Leave it at its `False` default during ordinary optimization and enable it
-only for a final equilibrium if desired. The focused example shows the full
-before/after workflow:
+Pass `initial_state=result.state` for a nearby Python solve, or `restart_from=`
+for a saved WOUT. [Restart](https://vmex.readthedocs.io/en/latest/howto/restart-from-previous-run.html)
+and [CLI](https://vmex.readthedocs.io/en/latest/reference/cli.html) guides cover
+resolution changes, devices, profiles and output controls.
 
-```console
-vmex examples/data/input.shaped_tokamak_pressure_polished --plot
-python examples/force_balance_polishing.py
+## Differentiate and optimize
+
+Compute a boundary/profile derivative without differentiating through every
+forward iteration:
+
+```python
+import jax
+from vmex.core import implicit
+
+params = implicit.params_from_input(inp)
+gradient = jax.grad(lambda p: implicit.run(inp, p).aspect)(params)
 ```
 
-The comparison below applies the same independent force oracle to the
-exported equilibrium of each code - VMEX, VMEC2000, VMEC++, and DESC - on the
-bundled finite-pressure shaped tokamak; VMEX is the certified polished
-result. The two cases in it were selected because certified polishing
-improves them. It is therefore evidence that polishing can reduce the
-continuum residual on those cases and by how much, and it is not evidence of
-a general advantage: it says nothing about how often polishing helps, or
-about cases where it does not. Stellarator rows join as certified 3-D
-polishing becomes tractable (the compile-side work is in progress).
+For a simple boundary optimization, supply objectives and let SciPy choose the
+steps. Each tuple is `(function, target, cost_weight)`:
 
-![Finite-pressure tokamak and finite-beta stellarator force-balance comparisons](docs/_static/figures/readme_strong_force_comparison.webp)
+```python
+from scipy.optimize import least_squares
+from vmex import optimize as opt
 
-Below: the bundled shaped tokamak (`input.shaped_tokamak_pressure_polished`)
-before and after polishing, with the boundary and prescribed profiles
-untouched. The like-for-like measurement is the one taken on the lifted
-native state - the same spline basis, the same certificate nodes, before and
-after the correction - and it is recorded, with the deck hash, the commit and
-the exact command, in
-[`benchmarks/polish_force_error_2026-09-03.json`](benchmarks/polish_force_error_2026-09-03.json):
+problem = opt.VmecProblem.from_tuples(
+    inp, [(opt.aspect_ratio, 4.0, 1.0)], max_mode=1, use_ess=True)
+fit = least_squares(
+    problem.residual, problem.x0, jac=problem.residual_jac,
+    x_scale=problem.scales, max_nfev=20)
+problem.input_from_x(fit.x).to_indata("input.optimized")
+equilibrium = problem.equilibrium_from_x(fit.x)
+vj.write_wout("wout_optimized.nc", equilibrium.wout)
+```
 
-| quantity | before | after | ratio |
-|---|---|---|---|
-| `eps_F` volume L2 (bounded by 2) | `1.284e-2` | `1.803e-3` | 7.1x |
-| dimensional \|F\| volume L2, N m<sup>-3</sup> | `3.330e2` | `2.068e2` | 1.61x |
-| `<\|F\|>/<\|grad p\|>`, whole domain | `2.090e-3` | `1.586e-3` | 1.32x |
-| `<\|F\|>/<\|grad(B^2/2mu0)\|>`, whole domain | `2.374e-3` | `1.801e-3` | 1.32x |
-| `<\|F\|>/<\|grad p\|>`, `s` in `[0.1, 0.99]` | `1.658e-3` | `1.561e-3` | 1.06x |
-| \|F\| L2 near axis (`rho < 0.2`), N m<sup>-3</sup> | `9.773e2` | `6.718e1` | 14.5x |
-| \|F\| L2 bulk (`0.2 <= rho <= 0.8`) | `1.630e2` | `1.470e2` | 1.11x |
-| \|F\| L2 edge (`rho > 0.8`), N m<sup>-3</sup> | `4.089e2` | `2.844e2` | 1.44x |
+`problem.value_and_grad` supplies scalar objectives to BFGS/L-BFGS-B;
+`problem.jax_value_and_grad` supports JAX optimizers. `problem.evaluate(x)`
+reports solve effort and derivative status. Implicit derivatives describe the
+chosen discrete equilibrium equations: small linear residuals alone do not
+establish continuum accuracy. See the
+[gradient tutorial](https://vmex.readthedocs.io/en/latest/tutorials/first-gradient.html)
+and [optimization guide](https://vmex.readthedocs.io/en/latest/howto/optimize-a-boundary.html)
+for convergence checks, constraints, scaling and finite-difference verification.
 
-Read the last three rows first: the correction is concentrated near the
-magnetic axis, where it removes a factor of 14.5, and over the bulk of the
-plasma it is worth about 10%. The 7.1x in `eps_F` is largely that near-axis
-gain, because the pointwise denominator is smallest there and the metric is
-most sensitive to it; measured as a volume-averaged relative force error over
-the whole domain the improvement is 1.32x, and over `s` in `[0.1, 0.99]` it
-is 1.06x. Quote the row that answers the question being asked.
+![QA, QH and QP optimization examples](docs/_static/figures/readme_optimization.webp)
 
-Earlier versions of this section claimed "about 26-fold, from `5.05e-2` to
-`1.91e-3`". That number is not the polish gain: its two ends are the
-*exported* wouts of the figure below, written on different radial meshes -
-the unpolished export on the `ns = 31` solve mesh, the certified polished
-export on the `ns = 129` mesh that a certifiable reconstruction requires - so
-it multiplied the polish gain by an export-mesh reconstruction difference.
+## Examples for different applications
 
-The radial force-balance panel in `vmex --plot` summaries is VMEC's own
-discrete flux-surface average, which ordinary solves already minimize, so
-that panel does not show this gain.
-
-![Shaped-tokamak flux surfaces and independent force-error profiles before and after polishing](docs/_static/figures/readme_polish_summary.webp)
-
-The raw comparison data, source revisions, resolutions, timing boundaries, and
-certificate refinements are recorded in `benchmarks/`.
-
-### Where polishing is effective today
-
-Every case VMEX ships as a *certified* polish is axisymmetric (`NTOR = 0`).
-No 3-D deck has yet passed the independent certificate, and the reason is
-cost, not a discovered impossibility. The evidence, all of it in
-`benchmarks/polish3d_tuning.md` with the raw records beside it:
-
-| deck | resolution | Gauss-Newton budget spent | independent force L2 | certificate |
-|---|---|---|---|---|
-| `input.shaped_tokamak_pressure_polished` | `MPOL 5`, `NTOR 0`, `ns 31` | minutes | see the figure above | **certified** |
-| `input.nfp2_QA_smooth_beta` | `MPOL 5`, `NTOR 5`, `ns 25` | 40 iterations x 600 linear, 5 h 22 m | `3.43e4` -> `2.04e4` (-40%) | declined |
-| W7-X standard (not bundled) | `MPOL 10`, `NTOR 10`, `ns 51` | 6 iterations x 150 linear, 11 h 09 m | `4.33e6` -> `4.28e6` (-1.1%) | declined |
-
-Read the last two rows together. The 3-D QA case improves its independent
-force error substantially and still fails the certificate, so a large gain
-there is not yet a certified equilibrium. The W7-X row improved much less,
-but it was also given a far smaller budget: six Gauss-Newton iterations
-against the QA case's forty, and 150 linear iterations per step against 600.
-The two are therefore not a controlled comparison, and the W7-X row is
-evidence about **price**, not about futility - one Gauss-Newton iteration at
-`MPOL = NTOR = 10` costs about 1.75 h on a 36-core CPU, so a QA-like
-iteration count at that resolution is a multi-day run. Whether it would
-certify at that budget is not known; this README does not claim either way.
-
-Two consequences for anyone using the feature:
-
-- Polishing a production-resolution stellarator is not something to start
-  casually. `POLISH = AUTO` now prices the solve first and declines rather
-  than silently spending the night. Asking for it anyway is deliberate:
-  either raise `POLISH_BUDGET` past the reported prediction, or use
-  `POLISH = ON`, which never prices and never declines.
-- The certificate's `normalized_l2` is a *ratio* of the force error to the
-  local force scale. On a vacuum or near-vacuum deck - the W7-X standard
-  configuration among them - both terms of that scale vanish and the ratio
-  saturates at its ceiling of 2 regardless of how good the equilibrium is.
-  Use the dimensional `absolute_l2` on such decks, as the table above does.
-
-## Equilibrium and kinetic diagnostics
-
-`vmex --plot wout_X.nc` produces cross-sections, profiles, a 3-D LCFS, and
-the compact summaries below, including the relative radial force error and
-its maximum over solved surfaces, Mercier/Glasser stability, the second
-adiabatic invariant, and Boozer $|B|$. The radial force-error panel is
-meaningless for a vacuum case — with no pressure gradient and no net current
-its numerator and denominator are the same discretization noise, so it reads
-$O(1)$ regardless of solve quality. The
-[plotting guide](https://vmex.readthedocs.io/en/latest/howto/plot-diagnostics.html)
-defines every panel; `--booz` additionally saves a reusable `boozmn_*.nc`.
-
-The panel below is the bundled finite-pressure NFP=4 QI deck
-`examples/data/input.nfp4_QI_finite_beta` at `ns=51`, which reaches
-$\langle\beta\rangle=2.53\%$. Regenerate it with
-`python docs/_static/figures/sources/make_readme_diagnostics_figures.py`; the
-deck hash, the solved scalars, and the run's commit and versions are recorded
-in `docs/_static/figures/readme_diagnostics.json`.
-
-![Finite-pressure NFP=4 QI diagnostics](docs/_static/figures/readme_diagnostics_summary.webp)
-
-On a vacuum case the same panel reads differently, and the difference is
-physics rather than a plotting artifact: with `pres=0` VMEX adds no pressure
-floor, so `DWell` is exactly zero. `DMerc` can retain shear, current, and
-geodesic terms; for a current-free vacuum it reduces to the shear term and
-$D_R=0$, so a vacuum Mercier curve is not a finite-beta pressure margin.
-
-`QA_optimization_bootstrap.py`, `QH_optimization_bootstrap.py` and `QI_optimization_bootstrap.py` first fit a bootstrap-consistent seed, then optimize the boundary and a stage-refined current spline together against Redl, Mercier, and resistive-interchange targets. The QI variant uses `helicity_n=0`, since a quasi-isodynamic field carries no helical symmetry for the Redl isomorphism to shift; Redl is a fit to quasisymmetric calculations, so there it is an analytic estimate rather than a converged kinetic answer. Their controls are explained in the [objective reference](https://vmex.readthedocs.io/en/latest/reference/objectives.html#bootstrap-current-redl). `benchmarks/QA_bootstrap_selfconsistent.py` and `benchmarks/QH_bootstrap_selfconsistent.py` reproduce arXiv:2205.02914 against that paper's published equilibrium; the QA script also compares against the paper's stored SFINCS drift-kinetic curve (the QH SFINCS points are published only as a figure, so no QH comparison exists). Both need the paper's Zenodo archive on disk (`VMEX_ZENODO_2205_02914`).
-Each script also writes a direct Redl-versus-equilibrium bootstrap-current overlay (`bootstrap_comparison.png`, next to the run's outputs). In the vacuum QA example, setting `TRIAL_BETA` enables differentiable frozen-geometry pressure proxies for `DMerc` and `DR`; a finite-pressure re-solve remains the stability certificate.
-
-## Documentation and development
-
-The [documentation](https://vmex.readthedocs.io/) is organized as tutorials, task-focused how-to guides, API/reference pages, and numerical explanations. Start with:
-
-- [first equilibrium](https://vmex.readthedocs.io/en/latest/tutorials/first-equilibrium.html)
-- [first gradient](https://vmex.readthedocs.io/en/latest/tutorials/first-gradient.html)
-- [first optimization](https://vmex.readthedocs.io/en/latest/tutorials/first-optimization.html)
-- [optimization reference](https://vmex.readthedocs.io/en/latest/reference/optimization.html)
-- [objectives reference](https://vmex.readthedocs.io/en/latest/reference/objectives.html)
-- [parallel and HPC usage](https://vmex.readthedocs.io/en/latest/howto/parallel-ensembles.html)
-
-For development:
+The examples below run from a source checkout:
 
 ```console
 git clone https://github.com/uwplasma/vmex
 cd vmex
-pip install -e ".[dev]"
-pytest -q -m "not full and not weekly"
-python -m ruff check vmex tests examples benchmarks
+pip install -e .
+vmex examples/data/input.circular_tokamak --plot
+python examples/take_gradients.py
 ```
 
-See [contributing](https://vmex.readthedocs.io/en/latest/project/contributing.html) and the [test manifest](tests/manifest.json). Release notes are on [GitHub](https://github.com/uwplasma/vmex/releases). VMEX uses the MIT license.
+| Application | Runnable starting point |
+|---|---|
+| Tokamak or stellarator equilibrium | `vmex examples/data/input.circular_tokamak --plot`; replace the deck with one from [examples/data](examples/data/) |
+| QA, QH, QP or QI boundary design | [examples/optimization](examples/optimization/): `python examples/optimization/QA_optimization.py` and the corresponding QH/QP/QI scripts |
+| Asymmetric boundary design | [stellarator_asymmetry](examples/optimization/stellarator_asymmetry/) vacuum and finite-beta scripts |
+| Fields and spatial derivatives | `python examples/vmex_get_B_gradB.py` |
+| ESSOS coils and a free-boundary beta scan | `python examples/free_boundary_essos_coils.py` |
+| Finite-beta exterior field lines | `python examples/vmex_fieldline_tracing_finite_beta.py` |
+| Effective ripple | `python examples/epsilon_effective.py` |
+| Fixed-boundary open mirror | `python examples/mirror/mirror_fixed_boundary_nonaxisymmetric.py` |
+| Free-boundary mirror | `python examples/mirror/mirror_free_boundary_beta_scan.py` |
+| Research force-balance polishing | `python examples/force_balance_polishing.py` |
 
-## Getting support
+The optimization scripts expose resolutions, objective weights and iteration
+budgets near the top. Inspect those settings before a research run; advanced
+coil examples need the optional dependencies and versions in the
+[ESSOS guide](https://vmex.readthedocs.io/en/latest/howto/use-essos-fields-and-coils.html).
 
-Bug reports, feature requests, and questions all go to [GitHub issues](https://github.com/uwplasma/vmex/issues), which offers a template for each; include the input file and the output of `vmex --doctor`. [Troubleshooting](https://vmex.readthedocs.io/en/latest/howto/troubleshoot.html) covers non-convergence, NaNs, and device placement first. Contributions follow [CONTRIBUTING.md](CONTRIBUTING.md); participation is governed by the [code of conduct](CODE_OF_CONDUCT.md).
+## Fields, coils and free boundary
 
-## Roadmap
+The live equilibrium exposes Cartesian `B()`, `gradB()`, `gradgradB()` and
+`gradgradgradB()`, with corresponding VJPs in the originating problem's degrees
+of freedom. Use `set_points_xyz(...)` or `set_points_flux(...)` to select
+interior evaluation points.
 
-The detailed, phased plan lives in [plan.md](plan.md). In flight now:
+For an exterior field, `vj.VmecExtender.from_file("wout_my_case.nc",
+external_field=coils.B)` combines the plasma's virtual-casing contribution with
+the supplied coil field. Its points must be outside the plasma and away from
+source surfaces/currents; an MGRID field also has a finite tabulated domain.
+See [field and coil usage](https://vmex.readthedocs.io/en/latest/howto/use-essos-fields-and-coils.html).
 
-- Performance: the committed workflow baselines drive measured fixes to
-  compilation reuse, the polishing path's runtime, and chunked Boozer
-  transforms; regimes (cold, cache-reload, warm) are never mixed in one
-  number.
-- A pinned DESC `Gamma_c` oracle: `GammaC` evaluates DESC's form of the
-  Nemov proxy and is checked against drift-kinetic identities and its own
-  `wout` tables, but no test yet asserts its value against a number
-  computed by DESC's `GammaC` on a shared equilibrium.
-- Up-down asymmetric (LASYM) equilibria as a fully supported certified lane.
-- Promote the boundary-Schur free-boundary adjoint and coil-only
-  free-boundary single-stage optimization after their compile and GPU
-  memory costs come down.
-- Promote stellarator–mirror hybrids from extended validation, with
-  refinement studies, independent force checks, and optimization examples.
-- Downstream contracts: booz_xform_jax, NEO_JAX, and GKX consume VMEX
-  states differentiably, with cross-code parity tests.
+![Free-boundary beta ramp and Shafranov shift](docs/_static/figures/readme_essos_beta_scan.webp)
+
+Joint boundary/coil optimization and the boundary-Schur adjoint remain advanced
+workflows with substantial solve costs. Open mirrors support defined isotropic
+fixed/free-boundary cases; the shipped free-boundary 0–10% beta range is the
+supported range, while higher beta, anisotropy and periodic hybrids need further
+validation. See the [mirror guide](https://vmex.readthedocs.io/en/latest/howto/mirror-machines.html).
+
+## Accuracy and optional polishing
+
+A small VMEC `FSQR/FSQZ/FSQL` means the discrete solve converged. It does not
+by itself bound the continuous force error `J × B − ∇p`. Optional spline-based
+polishing is disabled by default and remains a research feature: recorded
+certified cases are axisymmetric; a generally accurate, affordable 3-D polished
+solve is still an open goal.
+
+```console
+vmex examples/data/input.shaped_tokamak_pressure_polished --polish auto --plot
+```
+
+`AUTO` estimates the Gauss–Newton work against `--polish-budget`; this is an
+admission estimate, not an enforced end-to-end timeout. Inspect
+`result.polish_report` when using Python. The legacy pointwise `eps_F` metric
+is bounded above by 2 by construction and can saturate in vacuum; read the
+dimensional and volume-normalized metrics with it.
+
+The [validation record](docs/explanation/validation.md) explains the measured
+near-axis improvement, failed 3-D attempts, native DESC comparison and export
+errors. The [polishing reference](https://vmex.readthedocs.io/en/latest/explanation/high-order-force-balance.html)
+defines the method and certificate. Exported-and-refitted WOUT comparisons
+measure reconstruction error as well as solver error.
+
+## Performance and parallel execution
+
+JAX compilation is reused for matching array structures. Measure first-call,
+cache-reload and warm costs separately, including refinement and gradients for
+optimization. CPU/GPU performance depends on resolution and workload; see
+[benchmark evidence](https://vmex.readthedocs.io/en/latest/explanation/validation.html)
+and [profiling tools](benchmarks/).
+
+`vj.parallel.solve_ensemble(inputs, workers=None)` distributes independent
+cases; `workers=1` provides a serial baseline. Set worker and device budgets
+using the [ensemble guide](https://vmex.readthedocs.io/en/latest/howto/parallel-ensembles.html).
+Multi-device kernel/AD tests do not yet establish a scalable distributed
+nonlinear equilibrium solve.
+
+## Documentation, development and citation
+
+Start with [your first equilibrium](https://vmex.readthedocs.io/en/latest/tutorials/first-equilibrium.html),
+then [your first optimization](https://vmex.readthedocs.io/en/latest/tutorials/first-optimization.html).
+The [API](https://vmex.readthedocs.io/en/latest/reference/api/basic.html),
+[VMEC compatibility](https://vmex.readthedocs.io/en/latest/reference/vmec2000-compatibility.html)
+and [troubleshooting](https://vmex.readthedocs.io/en/latest/howto/troubleshoot.html)
+pages cover research use.
+
+For development, install `pip install -e ".[dev]"` and run
+`python tools/preflight.py --static`; the [test manifest](tests/manifest.json)
+defines numerical suites. Report issues with the input deck and `vmex --doctor`
+output. See [contributing](CONTRIBUTING.md), [citation metadata](CITATION.cff),
+[license](LICENSE) and the [plan/logbook](plan.md). A new release will follow
+integration and validation of the agreed priorities.

--- a/benchmarks/review_20260905.json
+++ b/benchmarks/review_20260905.json
@@ -165,5 +165,638 @@
     "published_at": "2025-08-23T12:44:31Z",
     "tag_name": "v0.16",
     "target_commitish": "main"
+  },
+  "focused_review_20260906": {
+    "date": "2026-09-06",
+    "vmex_base": "ae0e410f6ecc9bc15b66472039f755fdd6dd3ef6",
+    "branch": "review/focused-plan-20260906",
+    "scope": "Planning and documentation only; no production numerical implementation. New execution probes are diagnostic, not paper-grade rankings or release approval.",
+    "environment": {
+      "cpu": "Apple M3 Max",
+      "memory_bytes": 38654705664,
+      "python": "3.11.14",
+      "jax": "0.9.2",
+      "jaxlib": "0.9.2",
+      "numpy": "2.4.6",
+      "scipy": "1.17.1",
+      "solvax": "0.20.0",
+      "precision": "float64",
+      "platform": "cpu",
+      "vmex_compilation_cache": "disabled",
+      "timing_limitations": "Shared host with unrelated work, single first/warm samples for same-deck comparison, no controlled CPU/GPU speedup result."
+    },
+    "repositories": {
+      "VMEX": "ae0e410f6ecc9bc15b66472039f755fdd6dd3ef6",
+      "SOLVAX": "5a49926992fe1a3aebac4b8b8cb098798e977c14",
+      "DESC": "ad105c5e525fbf26824d6cf9dde48775db0f8a2c",
+      "VMEC++": "07ef6710078e78e29ccabab0443cb3ec0ad7e375",
+      "GVEC": "c0dc66fe2b9faa147c76a728e5cd053ce693d472"
+    },
+    "open_vmex_prs": [
+      {
+        "baseRefName": "main",
+        "headRefOid": "db6092b7c4bd97fbeb6d29e927a0b15c175d140e",
+        "number": 277,
+        "title": "Require nonlinear stationarity for polished implicit derivatives",
+        "url": "https://github.com/uwplasma/vmex/pull/277"
+      },
+      {
+        "baseRefName": "main",
+        "headRefOid": "e1714014ebdd3a5804303503fbb16c397c8beb4c",
+        "number": 276,
+        "title": "Make the mirror, ESSOS, and extender examples write their figures as lossless WebP",
+        "url": "https://github.com/uwplasma/vmex/pull/276"
+      },
+      {
+        "baseRefName": "main",
+        "headRefOid": "308d39d5f511a321212e3b767b69d94ac2d94cf9",
+        "number": 274,
+        "title": "Revise the research plan after a second literature review",
+        "url": "https://github.com/uwplasma/vmex/pull/274"
+      },
+      {
+        "baseRefName": "main",
+        "headRefOid": "daf6e2dcf3e4f47dd1d6df29fa4f02893ff7766e",
+        "number": 266,
+        "title": "Coil-length target, the circular-coil seed result, and a profile of the optimizer",
+        "url": "https://github.com/uwplasma/vmex/pull/266"
+      }
+    ],
+    "pr277_ci": {
+      "run": 34005068178,
+      "job": 101410970180,
+      "head": "db6092b7c4bd97fbeb6d29e927a0b15c175d140e",
+      "passed": 226,
+      "failed": 1,
+      "seconds": 2519.45,
+      "failure": "test_collocation_polish_primal_and_derivatives: polish_report.least_squares_success False, physical converged True",
+      "python": "3.12",
+      "jax": "0.11.1",
+      "scipy": "1.18.1",
+      "numpy": "2.5.2",
+      "initial_gradient_norm": 136.207,
+      "disposition": "Unresolved CI/local discrepancy; do not merge as ready or relax stationarity based on local pass."
+    },
+    "local_tests": [
+      {
+        "checkout": "ae0e410f6ecc9bc15b66472039f755fdd6dd3ef6",
+        "command": "VMEX_COMPILATION_CACHE=disabled JAX_PLATFORMS=cpu python -m pytest -q tests/test_radial_basis.py tests/test_strong_force.py",
+        "passed": 67,
+        "seconds": 619.75,
+        "log": "main-physics-tests.log"
+      },
+      {
+        "checkout": "ae0e410f6ecc9bc15b66472039f755fdd6dd3ef6",
+        "command": "VMEX_COMPILATION_CACHE=disabled JAX_PLATFORMS=cpu python -m pytest -q tests/test_strong_force_solovev.py tests/test_implicit_grad.py -k 'not test_implicit_grad or test_solovev_gradients_vs_fd or test_adjoint_gmres_preconditioner_value'",
+        "passed": 9,
+        "deselected": 38,
+        "seconds": 148.21,
+        "log": "analytic-and-ad-tests.log"
+      },
+      {
+        "checkout": "db6092b7c4bd97fbeb6d29e927a0b15c175d140e",
+        "command": "VMEX_COMPILATION_CACHE=disabled JAX_PLATFORMS=cpu python -m pytest -q tests/test_polish_preconditioner.py -k 'collocation_polish_primal_and_derivatives or polish_stationarity'",
+        "passed": 26,
+        "deselected": 205,
+        "seconds": 219.7,
+        "log": "pr277-local.log"
+      },
+      {
+        "checkout": "07ef6710078e78e29ccabab0443cb3ec0ad7e375",
+        "backend": "vmecpp 0.7.3 wheel; not source-built main",
+        "command": "python -m pytest -q tests/test_hessian.py tests/test_adjoint.py",
+        "passed": 4,
+        "seconds": 1.79,
+        "log": "vmecpp-hessian-tests.log"
+      }
+    ],
+    "same_deck_comparison": {
+      "jax": "0.9.2",
+      "vmecpp": "0.7.3",
+      "vmex_path": "${VMEX}/vmex/__init__.py",
+      "vmecpp_path": "${VENV}/lib/python3.11/site-packages/vmecpp/__init__.py",
+      "jit_disabled": false,
+      "rows": [
+        {
+          "input": "input.shaped_tokamak_pressure_polished",
+          "sha256": "2e83e7641e2c63d2bb026390e34d32d9b09cd2fd28d304aecf0b0745045f86f4",
+          "vmex_converged": true,
+          "vmex_iterations": 158,
+          "vmex_fsq": [
+            9.375411796552367e-11,
+            6.119848008908331e-11,
+            2.4407821802681628e-11
+          ],
+          "vmecpp_ier_flag": 0,
+          "vmecpp_iterations": 159,
+          "vmecpp_fsq": [
+            9.37541233310576e-11,
+            6.119848019968397e-11,
+            2.4407821818223215e-11
+          ],
+          "seconds": {
+            "vmex_first": 3.3272795840000526,
+            "vmex_warm": 0.0421686250001585,
+            "vmecpp": 0.006919165999988763
+          },
+          "coefficient_differences": {
+            "rmnc": {
+              "vmex_shape": [
+                31,
+                5
+              ],
+              "vmecpp_shape": [
+                31,
+                5
+              ],
+              "relative_l2": 3.388590174867268e-16,
+              "max_abs": 2.220446049250313e-15
+            },
+            "zmns": {
+              "vmex_shape": [
+                31,
+                5
+              ],
+              "vmecpp_shape": [
+                31,
+                5
+              ],
+              "relative_l2": 1.156584822196693e-15,
+              "max_abs": 2.4494295480792516e-15
+            },
+            "lmns": {
+              "vmex_shape": [
+                31,
+                5
+              ],
+              "vmecpp_shape": [
+                31,
+                5
+              ],
+              "relative_l2": 2.93244128990317e-14,
+              "max_abs": 2.808864252301646e-14
+            },
+            "iotaf": {
+              "vmex_shape": [
+                31
+              ],
+              "vmecpp_shape": [
+                31
+              ],
+              "relative_l2": 3.753085609157598e-15,
+              "max_abs": 2.3092638912203256e-14
+            },
+            "presf": {
+              "vmex_shape": [
+                31
+              ],
+              "vmecpp_shape": [
+                31
+              ],
+              "relative_l2": 1.0660070821894576e-16,
+              "max_abs": 2.9103830456733704e-11
+            }
+          }
+        },
+        {
+          "input": "input.nfp2_QA_smooth_beta",
+          "sha256": "557d33b3a600fa9b81d81f1f4eed6bead36d61abef0eb1ffff8fb3b8d1dd4a64",
+          "vmex_converged": true,
+          "vmex_iterations": 730,
+          "vmex_fsq": [
+            9.894247158307834e-14,
+            4.7475443547452514e-14,
+            5.587326205366158e-14
+          ],
+          "vmecpp_ier_flag": 0,
+          "vmecpp_iterations": 775,
+          "vmecpp_fsq": [
+            9.996862792446534e-14,
+            6.007027019151356e-14,
+            5.603206959933447e-14
+          ],
+          "seconds": {
+            "vmex_first": 8.420759209000153,
+            "vmex_warm": 1.161815790999981,
+            "vmecpp": 0.25787162500000704
+          },
+          "coefficient_differences": {
+            "rmnc": {
+              "vmex_shape": [
+                25,
+                50
+              ],
+              "vmecpp_shape": [
+                25,
+                50
+              ],
+              "relative_l2": 3.732936976559003e-06,
+              "max_abs": 3.1080073362052565e-06
+            },
+            "zmns": {
+              "vmex_shape": [
+                25,
+                50
+              ],
+              "vmecpp_shape": [
+                25,
+                50
+              ],
+              "relative_l2": 1.7880280460449557e-05,
+              "max_abs": 3.312003597563116e-06
+            },
+            "lmns": {
+              "vmex_shape": [
+                25,
+                50
+              ],
+              "vmecpp_shape": [
+                25,
+                50
+              ],
+              "relative_l2": 0.00038726454467204446,
+              "max_abs": 6.796662270543347e-05
+            },
+            "iotaf": {
+              "vmex_shape": [
+                25
+              ],
+              "vmecpp_shape": [
+                25
+              ],
+              "relative_l2": 4.054778630175543e-07,
+              "max_abs": 4.565574504011849e-07
+            },
+            "presf": {
+              "vmex_shape": [
+                25
+              ],
+              "vmecpp_shape": [
+                25
+              ],
+              "relative_l2": 1.553093366253295e-16,
+              "max_abs": 3.637978807091713e-12
+            }
+          }
+        }
+      ],
+      "scope": "Two same-input smoke comparisons, cold and one warm VMEX sample; shared host under unrelated load, no speedup or continuous-force ranking."
+    },
+    "frozen_operator": {
+      "shape": [
+        156,
+        17
+      ],
+      "residual_norm": 12.489995996796798,
+      "gradient_norm": 89.20251409418425,
+      "jacobian_condition": 7150.573848549389,
+      "singular_values": [
+        34.94185465148362,
+        3.5934185374743395,
+        2.343999957220767,
+        2.0614192447375776,
+        1.8893087340990473,
+        1.4035189015197187,
+        1.0962741294250675,
+        0.6726947527725583,
+        0.6123781300017369,
+        0.42135188899319415,
+        0.30422738433880614,
+        0.2615315235139031,
+        0.22013352010258963,
+        0.14252905809619545,
+        0.01817030016117663,
+        0.016150359315831565,
+        0.004886580488721495
+      ],
+      "hessian_eigenvalues": [
+        3.2711793324360223e-05,
+        0.00014643846772689065,
+        0.00041277042208602327,
+        0.02034134041187037,
+        0.04862915108860733,
+        0.06832614577398041,
+        0.09257194705564925,
+        0.17736365937833998,
+        0.37582706735508364,
+        0.4520888848647182,
+        1.2012398962717075,
+        1.9704019256023448,
+        3.568012654959782,
+        4.250117548147724,
+        5.495819302348805,
+        12.915840433278222,
+        1220.700677003671
+      ],
+      "hessian_asymmetry": 1.1306507981820538e-16,
+      "relative_residual_curvature": 0.0002081201394247876,
+      "hvp_fd": [
+        {
+          "h": 0.001,
+          "relative_error": 3.883967206188094e-09
+        },
+        {
+          "h": 0.0001,
+          "relative_error": 5.165197383807448e-09
+        },
+        {
+          "h": 1e-05,
+          "relative_error": 6.215569608799817e-07
+        }
+      ],
+      "linear_solves": [
+        {
+          "method": "cg",
+          "damping": 0.001,
+          "iterations": 31,
+          "status": 0,
+          "relative_true_normal_residual": 1.1720406115611463e-09,
+          "relative_step_error": 1.2184025026611418e-08
+        },
+        {
+          "method": "diagonal-cg",
+          "damping": 0.001,
+          "iterations": 30,
+          "status": 0,
+          "relative_true_normal_residual": 2.6630358114620546e-09,
+          "relative_step_error": 2.7471211865860735e-08
+        },
+        {
+          "method": "lsmr",
+          "damping": 0.001,
+          "iterations": 35,
+          "status": 2,
+          "relative_true_normal_residual": 1.441091275168273e-13,
+          "relative_step_error": 9.537445639589702e-13
+        },
+        {
+          "method": "cg",
+          "damping": 1e-06,
+          "iterations": 36,
+          "status": 0,
+          "relative_true_normal_residual": 8.019260553513125e-09,
+          "relative_step_error": 7.768164716810475e-10
+        },
+        {
+          "method": "diagonal-cg",
+          "damping": 1e-06,
+          "iterations": 32,
+          "status": 0,
+          "relative_true_normal_residual": 4.653084203032371e-09,
+          "relative_step_error": 1.209934544264871e-08
+        },
+        {
+          "method": "lsmr",
+          "damping": 1e-06,
+          "iterations": 39,
+          "status": 2,
+          "relative_true_normal_residual": 2.709934288001117e-12,
+          "relative_step_error": 4.143064945240716e-11
+        }
+      ],
+      "elapsed_seconds": 66.68251699999996,
+      "scope": "Frozen current collocation functional at initial tiny Solovev lift; no nonlinear convergence, Cartesian metric, 3-D speedup, or solver promotion established."
+    },
+    "native_desc": {
+      "controls": {
+        "ftol": 1e-08,
+        "gtol": 1e-08,
+        "maxiter": 60,
+        "xtol": 1e-08
+      },
+      "cost": 1.157390594701348e-09,
+      "devices": [
+        "TFRT_CPU_0"
+      ],
+      "engine": "desc",
+      "input": "input.shaped_tokamak_pressure_polished.vmex.nc",
+      "iterations": 28,
+      "message": "`gtol` condition satisfied. (gtol=1.00e-08)",
+      "native_force_error": {
+        "mean_force_density": 9.01256834646453,
+        "mean_grad_magnetic_pressure": 98541.56674505181,
+        "mean_grad_pressure": 111822.96707843934,
+        "normalized_by_magnetic_pressure": 9.145956010403183e-05,
+        "normalized_by_pressure_gradient": 8.059675558548338e-05
+      },
+      "optimality": 8.383996226987486e-10,
+      "output_wout": "desc-shaped.nc",
+      "peak_rss_mib": 1979.984375,
+      "platform": "macOS-14.4.1-arm64-arm-64bit",
+      "representation": {
+        "L": 12,
+        "M": 6,
+        "N": 0,
+        "profile": "iota",
+        "spectral_indexing": "fringe",
+        "surfaces": 129
+      },
+      "schema": "vmex.external-equilibrium-run/2",
+      "source": {
+        "commit": "ad105c5e525fbf26824d6cf9dde48775db0f8a2c",
+        "dirty": false
+      },
+      "success": true,
+      "timing_seconds": {
+        "load": 7.899356542000078,
+        "save": 14.296006457999965,
+        "solve": 7.237265125000022,
+        "total": 29.600268417000052
+      },
+      "versions": {
+        "desc": "0.17.1+11.g2471d5504.dirty",
+        "jax": "0.9.2",
+        "python": "3.11.14"
+      },
+      "provenance_correction": "versions.desc is inherited installed-distribution metadata, not the executed source version; PYTHONPATH selected clean DESC ad105c5e525fbf26824d6cf9dde48775db0f8a2c. Source path/SHA identifies this run."
+    },
+    "gvec": {
+      "build": "GNU Fortran 13.4, OpenBLAS; Release, USE_OPENMP=OFF, LINK_GVEC_TO_NETCDF=OFF",
+      "example": "test-CI/examples/analytic_gs_elliptok/parameter.ini",
+      "configuration_changes": "For second run, only maxiter=3000 and ProjectName changed; default minimize_tol=1e-10 retained.",
+      "exit_code": 0,
+      "converged": false,
+      "reason": "maximum iteration count exceeded",
+      "iterations": 3000,
+      "last_force_channels": [
+        2.8735828531448e-09,
+        3.5846481016375e-09,
+        3.7509337244465e-08
+      ],
+      "reported_minimization_seconds": 3.47,
+      "reported_total_seconds": 4.08,
+      "scope": "Different analytic problem from VMEX decks; no matched native-force or speed ranking. Original 100-iteration run also capped."
+    },
+    "commands": {
+      "environment": "python -m venv --system-site-packages ${EVIDENCE}/venv; ${VENV}/bin/python -m pip install --no-deps vmecpp==0.7.3 adv-jax-math==1.2",
+      "desc": "PYTHONPATH=${DESC} JAX_PLATFORMS=cpu OMP_NUM_THREADS=1 ${VENV}/bin/python ${VMEX}/benchmarks/run_external_equilibrium.py desc --wout ${EVIDENCE}/input.shaped_tokamak_pressure_polished.vmex.nc --output-wout ${EVIDENCE}/desc-shaped.nc --report ${EVIDENCE}/desc-shaped.json --source-repo ${DESC} --L 12 --M 6 --N 0 --surfaces 129 --tolerance 1e-8 --maxiter 60",
+      "gvec_configure": "cmake -S ${GVEC} -B ${EVIDENCE}/gvec-build -DCMAKE_BUILD_TYPE=Release -DUSE_OPENMP=OFF -DLINK_GVEC_TO_NETCDF=OFF",
+      "gvec_build": "cmake --build ${EVIDENCE}/gvec-build --parallel 2",
+      "gvec_execute": "Copy the analytic_gs_elliptok parameter.ini and its referenced files from the pinned source into an output directory, apply the two declared parameter changes, then run ${EVIDENCE}/gvec-build/bin/gvec parameter-refined.ini there."
+    },
+    "reproduction_probes": {
+      "compare_vmex_vmecpp.py": {
+        "sha256": "3d2337fe622918b6d2204fe4bfed9365721655e9a69817e94923b5f91bbb3b66",
+        "command": "VMEX_COMPILATION_CACHE=disabled JAX_PLATFORMS=cpu OMP_NUM_THREADS=1 PYTHONPATH=${VMEX} ${VENV}/bin/python compare_vmex_vmecpp.py ${VMEX} ${EVIDENCE}",
+        "source": "import sys, json, time, hashlib, os\nfrom pathlib import Path\nimport numpy as np\nimport jax\njax.config.update(\"jax_enable_x64\", True)\nimport vmex as vj\nimport vmecpp\nfrom importlib.metadata import version\nrepo=Path(sys.argv[1]); dest=Path(sys.argv[2]); rows=[]\nfor name in [\"input.shaped_tokamak_pressure_polished\", \"input.nfp2_QA_smooth_beta\"]:\n    path=repo/\"examples/data\"/name\n    inp=vj.VmecInput.from_file(path)\n    vpp=vmecpp.VmecInput.from_file(path)\n    t=time.perf_counter(); cpp=vmecpp.run(vpp, max_threads=1, verbose=False); cpp_seconds=time.perf_counter()-t\n    t=time.perf_counter(); result=vj.solve_multigrid(inp, verbose=False, polish_force_balance=False); jax.block_until_ready(result.state); first=time.perf_counter()-t\n    t=time.perf_counter(); again=vj.solve_multigrid(inp, verbose=False, polish_force_balance=False); jax.block_until_ready(again.state); warm=time.perf_counter()-t\n    w=vj.wout_from_state(inp=inp,state=result.state,fsqr=result.fsqr,fsqz=result.fsqz,fsql=result.fsql,niter=result.iterations,converged=result.converged)\n    vj.write_wout(dest/(name+\".vmex.nc\"),w); cpp.wout.save(dest/(name+\".vmecpp.nc\"))\n    diffs={}\n    for key in [\"rmnc\",\"zmns\",\"lmns\",\"iotaf\",\"presf\"]:\n        a=np.asarray(getattr(w,key)); b=np.asarray(getattr(cpp.wout,key))\n        if a.shape!=b.shape and a.shape==b.T.shape:b=b.T\n        diffs[key]={\"vmex_shape\":list(a.shape),\"vmecpp_shape\":list(b.shape),\"relative_l2\":float(np.linalg.norm(a-b)/max(np.linalg.norm(b),1e-30)),\"max_abs\":float(np.max(np.abs(a-b)))}\n    row=dict(input=name,sha256=hashlib.sha256(path.read_bytes()).hexdigest(),vmex_converged=bool(result.converged),vmex_iterations=int(result.iterations),vmex_fsq=[float(result.fsqr),float(result.fsqz),float(result.fsql)],vmecpp_ier_flag=int(cpp.wout.ier_flag),vmecpp_iterations=int(cpp.wout.niter),vmecpp_fsq=[float(cpp.wout.fsqr),float(cpp.wout.fsqz),float(cpp.wout.fsql)],seconds=dict(vmex_first=first,vmex_warm=warm,vmecpp=cpp_seconds),coefficient_differences=diffs)\n    rows.append(row);print(json.dumps(row),flush=True)\n    (dest/\"same-deck-comparison.json\").write_text(json.dumps(dict(jax=jax.__version__,vmecpp=version(\"vmecpp\"),vmex_path=vj.__file__,vmecpp_path=vmecpp.__file__,jit_disabled=bool(jax.config.jax_disable_jit),rows=rows,scope=\"Two same-input smoke comparisons, cold and one warm VMEX sample; shared host under unrelated load, no speedup or continuous-force ranking.\"),indent=2))\n"
+      },
+      "frozen_operator.py": {
+        "sha256": "1f443a232c6a21418a3ea4e2585e1e0fa1707108f5a3f6c488b951261bf828b2",
+        "command": "VMEX_COMPILATION_CACHE=disabled JAX_PLATFORMS=cpu PYTHONPATH=${VMEX} python frozen_operator.py ${VMEX} ${EVIDENCE}/frozen-operator.json",
+        "source": "import importlib.util, sys, json, time\nfrom pathlib import Path\nimport jax\njax.config.update('jax_enable_x64',True)\nimport jax.numpy as jnp\nimport numpy as np\nfrom scipy.sparse.linalg import cg, lsmr, LinearOperator\nfrom vmex.core.polish import make_strong_structured_chart, strong_collocation_residual\nfrom vmex.core.polish_driver import _collocation_variable_scale\nrepo=Path(sys.argv[1]); out=Path(sys.argv[2]); started=time.perf_counter()\nspec=importlib.util.spec_from_file_location('polish_tests',repo/'tests/test_polish_preconditioner.py'); m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m)\nrt=m.small_strong_root.__wrapped__(m.small_adapter.__wrapped__())\nchart=make_strong_structured_chart(rt,balance_iterations=1,balance_probes=2)\nx=jnp.zeros(chart.size); r0=strong_collocation_residual(x,rt,chart); a=jnp.sqrt(jnp.mean(r0*r0)); D=_collocation_variable_scale(rt,chart,a,x,int(r0.size),2)\nr=lambda y: strong_collocation_residual(D*y,rt,chart)/a\nf=lambda y: .5*jnp.vdot(r(y),r(y))\nrr=np.asarray(r(x)); J=np.asarray(jax.jit(jax.jacfwd(r))(x)); H=np.asarray(jax.jit(jax.hessian(f))(x)); g=J.T@rr\ns=np.linalg.svd(J,compute_uv=False); eig=np.linalg.eigvalsh((H+H.T)/2)\nv=np.random.default_rng(4).normal(size=x.size);v/=np.linalg.norm(v)\nfd=[]\ngrad=jax.jit(jax.grad(f)); hv=H@v\nfor h in [1e-3,1e-4,1e-5]:\n z=(np.asarray(grad(x+h*v))-np.asarray(grad(x-h*v)))/(2*h)\n fd.append(dict(h=h,relative_error=float(np.linalg.norm(z-hv)/np.linalg.norm(hv))))\nrows=[]\nfor mu in [1e-3,1e-6]:\n A=J.T@J+mu*np.eye(x.size);b=-g\n ref=np.linalg.lstsq(np.vstack([J,np.sqrt(mu)*np.eye(x.size)]),np.r_[-rr,np.zeros(x.size)],rcond=None)[0]\n for label,M in [('cg',None),('diagonal-cg',LinearOperator(A.shape,matvec=lambda z:z/np.diag(A)))]:\n  count=[0]\n  def callback(z):count[0]+=1\n  z,status=cg(A,b,rtol=1e-8,atol=0,maxiter=10*x.size,M=M,callback=callback)\n  rows.append(dict(method=label,damping=mu,iterations=count[0],status=int(status),relative_true_normal_residual=float(np.linalg.norm(A@z-b)/np.linalg.norm(b)),relative_step_error=float(np.linalg.norm(z-ref)/np.linalg.norm(ref))))\n z=lsmr(J,-rr,damp=np.sqrt(mu),atol=1e-12,btol=1e-12,conlim=1e12,maxiter=10*x.size)\n rows.append(dict(method='lsmr',damping=mu,iterations=int(z[2]),status=int(z[1]),relative_true_normal_residual=float(np.linalg.norm(A@z[0]-b)/np.linalg.norm(b)),relative_step_error=float(np.linalg.norm(z[0]-ref)/np.linalg.norm(ref))))\nreport=dict(shape=list(J.shape),residual_norm=float(np.linalg.norm(rr)),gradient_norm=float(np.linalg.norm(g)),jacobian_condition=float(s[0]/s[-1]),singular_values=s.tolist(),hessian_eigenvalues=eig.tolist(),hessian_asymmetry=float(np.linalg.norm(H-H.T)/np.linalg.norm(H)),relative_residual_curvature=float(np.linalg.norm(H-J.T@J)/np.linalg.norm(H)),hvp_fd=fd,linear_solves=rows,elapsed_seconds=time.perf_counter()-started,scope='Frozen current collocation functional at initial tiny Solovev lift; no nonlinear convergence, Cartesian metric, 3-D speedup, or solver promotion established.')\nout.write_text(json.dumps(report,indent=2));print(json.dumps(report),flush=True)\n"
+      }
+    },
+    "failed_attempts": [
+      "First comparison harness passed unsupported keyword polish; corrected to polish_force_balance before obtaining measurements.",
+      "First fresh DESC run lacked adv_jax_math; installed 1.2 in isolated venv and reran successfully.",
+      "GVEC reached iteration cap at both 100 and 3000 iterations, despite exit code 0."
+    ],
+    "external_evidence": {
+      "local_directory": "${LOCAL_ROOT}/vmex-review-evidence-20260906",
+      "public_archive": null,
+      "note": "Essential results and probe sources are embedded here; native states and large build/runtime outputs remain outside git. A persistent public archive is required before publication."
+    },
+    "artifacts": [
+      {
+        "path": "analytic-and-ad-tests.log",
+        "bytes": 125,
+        "sha256": "56638b3646e264a80688ea5f088e04bb8539b2ba04256aaddc2b5b4ce92c0fdb"
+      },
+      {
+        "path": "desc-dependencies.log",
+        "bytes": 1036,
+        "sha256": "e042e3e27516c78290f68a9ca1c8562c74ed4a8f08d664188e09b603adb42333"
+      },
+      {
+        "path": "desc-shaped.log",
+        "bytes": 1344,
+        "sha256": "dd41e3a2be5c2a11e2ea15922ddc764b6b2ee70a6227af037446173879e6a8b6"
+      },
+      {
+        "path": "frozen-operator.log",
+        "bytes": 2426,
+        "sha256": "afd742e8a9c8331e553d7f4105859dca844abe0ef2c023a3765fb300c4fb9f95"
+      },
+      {
+        "path": "gvec-build.log",
+        "bytes": 8552,
+        "sha256": "ff2dc09e3d1a936c0c8e5e20c7fdcd2bdfb85111975cce0ffa8a33f0f0ef0986"
+      },
+      {
+        "path": "main-physics-tests.log",
+        "bytes": 111,
+        "sha256": "f73b0f48bf189b9b72a39c0429204b1a8a804c68f19c51b9583bcb3d82051b77"
+      },
+      {
+        "path": "performance-doc-tests.log",
+        "bytes": 99,
+        "sha256": "07b0afc728982e3d6e70ae417856dc95f7526fdd88768a8455655a7f10b578d4"
+      },
+      {
+        "path": "pr277-local.log",
+        "bytes": 127,
+        "sha256": "923fb53fc2f5a5ad033cc0df45920f5e344cd75572319a3226186a47fc358ce6"
+      },
+      {
+        "path": "pr277-polish-ci.log",
+        "bytes": 96991,
+        "sha256": "2effc09cadda35ca6f40c1c06ccc8bb81c12b9bb043ce7be9fafa0ca90fefca1"
+      },
+      {
+        "path": "same-deck-comparison.log",
+        "bytes": 2348,
+        "sha256": "d655a7886f03f2926c9348ee4a2b3f77759d021d8bf5f8d8637de7ad80f4781a"
+      },
+      {
+        "path": "vmecpp-hessian-tests.log",
+        "bytes": 98,
+        "sha256": "1dde2ec73bb2d1eac48a0b7a1add920157c690038c32f874102b48b2b20484f8"
+      },
+      {
+        "path": "vmecpp-install.log",
+        "bytes": 1528,
+        "sha256": "187e6c7863205e57c4fdc06c7501cd52a38a4c754955204a194c956e75b20e3a"
+      },
+      {
+        "path": "gvec-analytic/refined.log",
+        "bytes": 60118,
+        "sha256": "d435d383de5001a08e935d6c767f24061e268c50e624a8c8ccc12a336f5f44c2"
+      },
+      {
+        "path": "preflight-final.log",
+        "bytes": 4313,
+        "sha256": "0159268690c4a198cf75d43e73cea957b45c7fe0de73883a0c15f07d66a744a7"
+      },
+      {
+        "path": "figure-provenance-final.log",
+        "bytes": 98,
+        "sha256": "9646ce79c776ab25c6f0027f5d1456ee841bfea7e77306ea4e7c21bdec48ecb1"
+      },
+      {
+        "path": "linkcheck.log",
+        "bytes": 13082,
+        "sha256": "4da4c36402c99d25e99f1205d2bab877f7870fb57cdc826a30d5114ed2b5466d"
+      },
+      {
+        "path": "readme-workflow.log",
+        "bytes": 1302,
+        "sha256": "bbcacf66a1a376f4effc519676556ca421a64249cc4f573177cf876e401c2e00"
+      }
+    ],
+    "source_size_at_base": {
+      "vmex/core": {
+        "python_files": 58,
+        "python_text_lines": 52563
+      },
+      "vmex/mirror": {
+        "python_files": 14,
+        "python_text_lines": 9376
+      }
+    },
+    "planning_validation": {
+      "production_code_changed": false,
+      "preflight": {
+        "command": "python tools/preflight.py --static --docs",
+        "status": "passed",
+        "guards_passed": 59,
+        "guard_seconds": 9.45,
+        "components": [
+          "Ruff",
+          "mypy",
+          "docs prose/media",
+          "strict Sphinx HTML",
+          "manifest/performance/docs/API/packaging/coverage guards"
+        ]
+      },
+      "figures": {
+        "command": "python -m pytest -q tests/test_figure_provenance.py",
+        "passed": 7,
+        "seconds": 0.24
+      },
+      "performance_records": {
+        "command": "python -m pytest -q tests/test_performance_docs.py",
+        "passed": 19,
+        "seconds": 5.74,
+        "note": "Also included in the 59 preflight guards; not additional distinct tests."
+      },
+      "linkcheck": {
+        "command": "python -m sphinx -b linkcheck docs docs/_build/linkcheck",
+        "status": "passed"
+      },
+      "readme_workflow": {
+        "method": "Concatenate the three Python blocks from the new README; substitute the bundled circular-tokamak deck for input.my_case; write all outputs outside git. Run CPU, cache disabled, with a 300-second subprocess timeout.",
+        "equilibrium_converged": true,
+        "optimizer_success": true,
+        "optimizer_nfev": 3,
+        "optimizer_final_cost": 3.35539794755465e-30,
+        "scope": "Executable solve/gradient/optimization/export walkthrough; no additional scientific certification implied.",
+        "script_sha256": "c176072ab58d5ab55512150bd67f4966d91198d4fcf6c1473dc6a62d5fc18053"
+      },
+      "readme_targets": "All local links, current documentation page targets and directly named example scripts exist.",
+      "repair_log": [
+        "Initial strict Sphinx build rejected a relative Markdown link outside docs; changed it to the GitHub benchmark page.",
+        "The diagnostics-provenance guard initially required a beta number in README. Relocated the figure and measured beta to validation.md and redirected the same numeric/hash guard; no tolerance weakened."
+      ]
+    }
   }
 }

--- a/docs/_static/figures/figures.json
+++ b/docs/_static/figures/figures.json
@@ -63,9 +63,7 @@
       "hardware": "Apple M3 Max (arm64), macOS 14.4.1, CPU",
       "reproducible": "command",
       "bytes_verified": true,
-      "used_in": [
-        "README.md"
-      ],
+      "used_in": [],
       "note": "ESSOS two-loop coil set built from constants inside the example. The example calls vmex.mirror.output.plot_axisymmetric_beta_scan_summary with image_format=\"webp\", which writes this composite as lossless WebP straight into docs/_static/figures unless VMEX_EXAMPLES_CI=1 redirects it to results/. Needs the ESSOS optional dependency. Re-rendered on 2026-09-05 and re-derived by a second run that reproduced the bytes."
     },
     {
@@ -181,9 +179,7 @@
       "hardware": "Apple M3 Max (arm64), macOS 14.4.1, CPU",
       "reproducible": "command",
       "bytes_verified": true,
-      "used_in": [
-        "README.md"
-      ],
+      "used_in": [],
       "note": "The example writes its three-panel vmex_fieldline_tracing_finite_beta.png to the working directory and, outside the CI smoke run, crops the phi=0 Poincare panel pair from the same render into this file as lossless WebP, so the crop is no longer done by hand. Needs ESSOS branch rj/vmex-optimization-interfaces (uwplasma/ESSOS#58; run here at its merge commit 1b3210c). Re-rendered on 2026-09-05 and re-derived by a second run that reproduced the bytes."
     },
     {

--- a/docs/_static/figures/figures.json
+++ b/docs/_static/figures/figures.json
@@ -47,7 +47,6 @@
       "reproducible": "command",
       "bytes_verified": true,
       "used_in": [
-        "README.md",
         "docs/explanation/mirror-geometry.rst"
       ],
       "note": "Geometry is built from constants inside the example, not from a deck. The example calls vmex.mirror.output.plot_mirror_3d_pair with image_format=\"webp\", which writes this file as lossless WebP straight into docs/_static/figures unless VMEX_EXAMPLES_CI=1 redirects it to results/; the per-case plot_mout panels still go to results/. Re-rendered on 2026-09-05 and re-derived by a second run that reproduced the bytes."
@@ -105,7 +104,6 @@
       "bytes_verified": true,
       "note": "Plots the cached three-code trace, which dates from 2026-07-10; the `generated` date is the render. On a cache miss the generator re-solves and shells out to VMEC2000 and VMEC++, discovered locally or via VMEX_XVMEC2000 / VMEX_VMECPP_PY. Re-rendered in 2026-09 so the committed bytes match what the command produces.",
       "used_in": [
-        "README.md",
         "docs/explanation/validation.md",
         "docs/reference/performance.rst"
       ]
@@ -125,7 +123,7 @@
       "reproducible": "command",
       "bytes_verified": true,
       "used_in": [
-        "README.md"
+        "docs/explanation/validation.md"
       ],
       "note": "Regenerated from a bundled deck in 2026-09; the figure it replaced had no generator and no recorded input. The record file carries the deck hash, the solved scalars the README quotes, and the run's commit and versions."
     },
@@ -220,7 +218,7 @@
       "reproducible": "external-data",
       "bytes_verified": false,
       "used_in": [
-        "README.md"
+        "docs/explanation/validation.md"
       ],
       "note": "The four certificate and wout paths are supplied on the command line and are not committed. The record file carries this figure's sha256 and the before/after independent L2 the panel plots, and tests/test_performance_docs.py already guards both."
     },
@@ -262,9 +260,7 @@
       "hardware": null,
       "reproducible": "command",
       "bytes_verified": false,
-      "used_in": [
-        "README.md"
-      ],
+      "used_in": [],
       "note": "Unlike the sibling optimization figure, every QI deck it draws is bundled, so one command rebuilds it. Not re-rendered here (four solves), so its committed bytes predate the lossless-WebP change to the generator."
     },
     {
@@ -283,7 +279,6 @@
       "reproducible": "command",
       "bytes_verified": true,
       "used_in": [
-        "README.md",
         "docs/index.md"
       ],
       "note": "Regenerated in 2026-09 from the committed baselines. The previously committed pixels dated from 2026-07-07 and came from a pipeline no longer in the tree; its sidecar readme_runtime_compare.json/.csv were deleted so the figure has one provenance story. Hardware is a property of benchmarks/baseline.json, not of the render."
@@ -304,7 +299,7 @@
       "reproducible": "command",
       "bytes_verified": false,
       "used_in": [
-        "README.md"
+        "docs/explanation/validation.md"
       ],
       "note": "The renderer refuses to draw a source measured from a dirty tree or a failed external solve. tests/test_performance_docs.py already guards this figure's sha256 and every source hash."
     },

--- a/docs/explanation/validation.md
+++ b/docs/explanation/validation.md
@@ -12,16 +12,17 @@ gate", the page says so instead of implying coverage.
 
 ## The evidence hierarchy
 
-Not all agreement is worth the same. VMEX's evidence falls into five tiers,
-strongest first, and the rest of this page is organized by them.
+VMEX uses five complementary types of evidence. Each addresses a different
+question; none alone establishes accuracy for every supported model.
 
 1. **Analytic limits.** The answer is known in closed form, so agreement is
-   evidence about the code and nothing else. The mirror module's paraxial
-   and vacuum identities are here.
+   evidence about the implementation within that analytic model. The true
+   Solov'ev projection and mirror paraxial/vacuum identities are here.
 2. **An independent oracle.** A second implementation of the physics, written
    against a different discretization, scores the same equilibrium. VMEX's
-   continuum force-balance oracle is here, and it is the only tier that can
-   compare VMEX against other codes on a quantity none of them optimizes.
+   continuum force-balance oracle is here. Independence must be checked for
+   the specific derivative, representation and normalization under test;
+   analytic and native cross-code tests provide complementary checks.
 3. **Reference-code parity.** VMEC2000 is the reference implementation; VMEX
    reproduces its trajectory and its output file. This is the largest tier by
    test count, and its weakness is structural — it can only show that VMEX
@@ -153,51 +154,114 @@ Quote it by its measured maxima, never as "machine precision":
 `tests/test_performance_docs.py::test_fresh_deck_parity_artifact_is_provenanced_and_cited`
 guards the record's provenance and requires the docs to cite it by path.
 
-## The independent oracle, and the cross-code table
+## Continuous force, native states and WOUT reconstruction
 
-Reference-code parity cannot say whether VMEC2000 is right. For that VMEX
-carries a separate continuum evaluation of the residual
-$\mathbf{J} \times \mathbf{B} - \nabla p$ on a high-order B-spline lift of a
-converged state (`vmex.core.strong_force`), overintegrated to produce a
-certificate independent of the solver's own discretization. It is validated
-in its own right before it is used as a judge:
+`vmex.core.strong_force` evaluates Cartesian `J × B − ∇p` independently of
+VMEC's discrete force residual. Its current/field tests include analytic
+fields and a native DESC reference. The closed-form finite-pressure Solov'ev
+state in `tests/test_strong_force_solovev.py` additionally verifies radial
+and Fourier convergence: this tests representation and differentiation of a
+known equilibrium, not convergence of a VMEX solve to that equilibrium.
 
-- against an analytic constant-toroidal-field case, `rtol` `2e-12` on
-  $\mathbf{B}$ and `2e-11` on $\mathbf{J}$ and the force;
-- against DESC's pointwise current and force on a stored circular case,
-  `rtol=3e-13` on the Jacobian and field and `rtol=3e-10` on the current and
-  force components.
+### Cross-code reconstruction record
 
-Because the oracle is applied to *each code's exported equilibrium*, it gives
-the one genuinely comparable cross-code number. From
-`benchmarks/strong_force_comparison_m4.json`, normalized force-balance $L_2$:
+[`benchmarks/strong_force_comparison_m4.json`](../../benchmarks/strong_force_comparison_m4.json)
+contains the following historical values of pointwise-normalized force L2
+after each output has been sampled to WOUT and reconstructed by VMEX:
 
-| source | shaped tokamak, finite pressure | NFP=2 QA, finite beta |
+| WOUT source | shaped tokamak | NFP=2 QA |
 |---|---|---|
-| VMEX (certified polished) | **0.00179** | 0.52590 |
+| VMEX | 0.00179 | 0.52590 |
 | VMEC2000 | 0.01711 | 0.52518 |
 | VMEC++ | 0.01711 | 0.52518 |
 | DESC | 0.02962 | 0.87926 |
 
-Read both rows. On the tokamak, VMEX's polished state reaches roughly a
-tenth of the VMEC2000 and VMEC++ residual, which agree with each other to
-nine digits. **On the stellarator VMEX is not better** — 0.5259 against
-0.5252 is a tie, marginally on the wrong side, and only DESC is clearly
-worse. The stellarator row is published as a tie rather than omitted; the
-3-D production polish that would move it is not yet tractable. The polish
-gain itself is recorded as a before/after pair on the tokamak, `0.0505` to
-`0.0019`.
+These are **reconstruction measurements, not a ranking of native solvers**.
+The VMEX tokamak output includes polishing and a denser export mesh; the QA
+row does not demonstrate certified 3-D polishing. The original cases were
+selected for successful tokamak polishing, so they do not establish how often
+it helps on other configurations.
 
-The figure and every source hash are guarded by
-`tests/test_performance_docs.py::test_readme_strong_force_figure_matches_committed_sources`,
-and the renderer refuses to draw any source measured from a dirty tree or a
-failed external solve. That guard checks provenance and one ordering claim;
-it does not re-run the physics.
+![Historical WOUT reconstruction measurements](../_static/figures/readme_strong_force_comparison.webp)
+
+The separate [native DESC record](../../benchmarks/desc_native_vs_lifted_2026-09-03.json)
+reports `<|F|>/<|grad p|> = 4.01e-6` on DESC's own shaped-tokamak equilibrium.
+Exporting that state to 129 surfaces and fitting VMEX splines gives pointwise
+normalized L2 `7.13e-2`. Those two norms are different; their quotient is not
+an error amplification factor. They establish that the old table cannot be
+used to claim VMEX is more accurate than DESC. A solver comparison must
+independently refine each native representation and use the same physical
+norm, region, boundary, profiles and flux conventions.
+
+Figure/source hashes remain checked in
+`tests/test_performance_docs.py::test_validation_strong_force_figure_matches_committed_sources`.
+The checks preserve this historical record; they do not rerun the solvers or
+certify a native accuracy ordering.
+
+### What the tokamak polish actually improves
+
+The [same-native-state before/after record](../../benchmarks/polish_force_error_2026-09-03.json)
+uses the same basis and certificate quadrature on the shaped tokamak:
+
+| quantity | before | after | ratio |
+|---|---|---|---|
+| `eps_F` volume L2 (bounded by 2) | `1.284e-2` | `1.803e-3` | 7.1x |
+| dimensional \|F\| volume L2, N m<sup>-3</sup> | `3.330e2` | `2.068e2` | 1.61x |
+| `<\|F\|>/<\|grad p\|>`, whole domain | `2.090e-3` | `1.586e-3` | 1.32x |
+| `<\|F\|>/<\|grad(B^2/2mu0)\|>`, whole domain | `2.374e-3` | `1.801e-3` | 1.32x |
+| `<\|F\|>/<\|grad p\|>`, `s` in `[0.1, 0.99]` | `1.658e-3` | `1.561e-3` | 1.06x |
+| \|F\| L2 near axis (`rho < 0.2`), N m<sup>-3</sup> | `9.773e2` | `6.718e1` | 14.5x |
+| \|F\| L2 bulk (`0.2 <= rho <= 0.8`) | `1.630e2` | `1.470e2` | 1.11x |
+| \|F\| L2 edge (`rho > 0.8`), N m<sup>-3</sup> | `4.089e2` | `2.844e2` | 1.44x |
+
+
+The correction is strongest near the axis. The dimensional volume L2 improves
+1.61x, while the pressure-normalized volume mean improves 1.32x overall and
+1.06x in the stated bulk window. These are different scientific questions;
+the 7.1x pointwise-ratio improvement must never be quoted on its own.
+
+Earlier versions of this section quoted a 26-fold gain from WOUTs exported at
+31 and 129 radial surfaces. That mixed correction and reconstruction effects;
+it is withdrawn. The following historical summary contains those export views:
+
+![Shaped-tokamak geometry and exported force profiles](../_static/figures/readme_polish_summary.webp)
+
+### Vacuum normalization and unsuccessful attempts
+
+The pointwise `eps_F = 2|F|/(|J×B|+|grad p|+floor)` is bounded above by 2 by
+construction. It cannot rank near-vacuum states when it saturates. In the
+[bundled Solovev record](../../benchmarks/polish_force_error_solovev_2026-09-03.json),
+its volume L2 is `1.969`, with `<|grad p|>` = `1.35e-1` Pa/m compared with
+`<|grad(B²/2mu0)|>` = `8.03e3` Pa/m. The dimensional mean force is `4.00e1`
+N/m³ and magnetic-normalized L2 is `1.22e-2`. A zero magnetic-pressure gradient
+also makes that denominator unavailable; dimensional force and a declared
+fixed `B_ref²/(mu0 a_ref)` scale remain meaningful.
+
+[`benchmarks/polish3d_tuning.md`](https://github.com/uwplasma/vmex/blob/main/benchmarks/polish3d_tuning.md) records
+uncertified QA and W7-X attempts of 5 h 22 m and 11 h 09 m on the office CPU.
+Their budgets and normalizations differ, so these do not isolate an angular
+resolution floor or predict success with more iterations. No production 3-D
+polish has yet demonstrated the complete force, stationarity and derivative
+contract. The [method reference](high-order-force-balance.rst) explains the
+remaining functional/chart limitations.
+
+## Application record: finite-beta QI diagnostics
+
+The bundled `input.nfp4_QI_finite_beta` run reached **2.53% beta** at
+`ns=51` in 2,599 iterations. This is an equilibrium/diagnostic example, not
+a new optimization result or a continuous-force certificate. Its input,
+figure and solve provenance are recorded in
+[readme_diagnostics.json](../_static/figures/readme_diagnostics.json).
+
+![Finite-beta QI equilibrium diagnostics](../_static/figures/readme_diagnostics_summary.webp)
 
 ## Derivative certificates
 
-Gradients come from the implicit function theorem at the converged fixed
-point, so the question is whether the linear solve is the true derivative.
+Implicit gradients describe a converged discrete equilibrium. Their validity
+requires nonlinear convergence and a sufficiently accurate linear response
+solve. The tests below check particular cases; they do not guarantee that
+every returned state satisfies both conditions. The ordinary refinement
+fallback and polished nonlinear stationarity gate remain under review.
 
 **Fixed boundary** (`tests/test_implicit_grad.py`). Four adjoint gradients on
 `solovev` — `d(wb)/d(RBC)`, `d(aspect)/d(RBC)`, `d(wb)/d(phiedge)`,
@@ -221,10 +285,13 @@ example prints its adjoint-versus-finite-difference agreement and the test
 fails above `1e-4`. Documentation quotes that gate rather than a particular
 run's number.
 
-For solver-sensitive outputs — `iota`, `DMerc`, `jdotb`, `D_R` — a naive
-re-solving finite difference is not a valid reference at all, and can even
-sign-flip. The frozen-path check described in
-{doc}`/explanation/adjoint-gradients` is the reference there.
+For solver-sensitive outputs — `iota`, `DMerc`, `jdotb`, `D_R` — an
+insufficiently converged re-solving finite difference can be dominated by
+solver noise. The frozen-path checks in
+{doc}`/explanation/adjoint-gradients` isolate linearization consistency; they
+do not replace an independently converged perturbation study of the physical
+objective. That study needs a step-size convergence interval and explicit
+checks that perturbed solves remain on the same admissible branch.
 
 ## Free boundary: the ladder
 
@@ -337,9 +404,10 @@ a claim exists elsewhere.
 - **The 2D block preconditioner as a speed feature.** Its evidence is an
   iteration-count reduction and a `wb` agreement, not a wall-clock or memory
   win; it is opt-in for that reason.
-- **The oracle against an exact solution.** The independent oracle is
-  validated against an analytic constant-field case and against DESC, but
-  there is no analytic Solov'ev equilibrium in its validation set yet.
+- **Recovery of an analytic equilibrium.** The constant-field and true
+  Solov'ev projection tests validate the oracle and representation. They
+  do not establish that the nonlinear high-order solve recovers the analytic
+  state from a perturbed guess or solves a finite-beta 3-D case.
 - **`virtual_casing.py` and `turbulence.py`** are excluded from the coverage
   gate, because their finite-difference gradient tests are optional-dependency
   gated and skip in the core lane.

--- a/plan.md
+++ b/plan.md
@@ -555,8 +555,9 @@ Sphinx HTML, linkcheck, 59 guard tests and seven figure-provenance tests.
 The README Python solve/gradient/optimization/export walkthrough ran on the
 bundled circular tokamak and converged in three optimization evaluations.
 The standalone 19 performance-record tests also passed (included in the
-59 guards, not additional distinct tests). The final PR is recorded below
-before handoff. All authored commits use `rogeriojorge`.
+59 guards, not additional distinct tests). Planning commit `814af87a` is published in
+[PR #282](https://github.com/uwplasma/vmex/pull/282); CI/review are pending at
+handoff. No merge, release or production solver implementation was performed. All authored commits use `rogeriojorge`.
 
 Raw logs, native outputs, isolated environment and the two short review probes
 are in `/Users/rogeriojorge/local/vmex-review-evidence-20260906`; the compact

--- a/plan.md
+++ b/plan.md
@@ -1,1186 +1,608 @@
-# VMEX research and implementation plan
+# VMEX: focused research plan and execution logbook
 
-Reviewed 2026-09-05 UTC. This is the authoritative forward plan, replacing the
-August plan and its appended September ledger. Completed work is linked, open
-work has an owner and an acceptance gate, and unsuccessful experiments remain
-evidence rather than proposed defaults. Implementation status is recorded below;
-the remaining physics and distributed solver work is not yet implemented.
+Reviewed **2026-09-06** against main **`ae0e410f`**, version **0.8.1**.
+This replaces the previous A–J schedule and reconciles the proposals in
+[#274](https://github.com/uwplasma/vmex/pull/274). It is a planning change:
+no new equilibrium algorithm, derivative guarantee or performance result is
+being promoted. **Do not cut a release now.** Resolve the outstanding PRs and
+the important gates below before proposing a release.
 
-## Execution logbook
+## 1. Decision: fewer promises, stronger results
 
-- **Completed (2026-09-05 UTC):** scope missing-golden skips to external comparisons
-  in `tests/test_optimize.py`. Worktree `/Users/rogeriojorge/local/vmex-optimizer-tests`,
-  branch `test/optimizer-fixture-scope`, based on `6e365a6f` / PR #270.
-  Implementation `32ff7f3f`, [PR #273](https://github.com/uwplasma/vmex/pull/273). This is
-  a sibling of the stationarity work in `/Users/rogeriojorge/local/vmex-stationarity`.
-- **Reproducer:** #269 C3D job 101254672103 ran 62 passed / 37 skipped; #270
-  job 101254700521 ran 96 passed / 3 skipped. `GOLDEN_DIR=None` applied a
-  module-wide skip to all 34 optimizer tests, including local-deck and pure-API
-  tests. Combined coverage was 94.7978% vs 94.9718%, chiefly 35 optimizer lines
-  and 5 statephysics lines. Raw logs/coverage are outside git under
-  `vmex-review-evidence-20260905/pr269-coverage`, `pr270-coverage`, and the C3D logs.
-- **Fix:** remove the module-wide golden skip; `_golden_wout` skips just the
-  callers that actually require external fixtures. Keep the JIT fixture and
-  all coverage thresholds. With `VMEX_GOLDEN_DIR=/nonexistent-vmex-test-fixture`,
-  the focused selection `boundary_pack_roundtrip or ess_scale or
-  public_problem_factory_validation or qs_solovev_axisymmetric_sanity or
-  uncertified_jacobian` skipped all 6 tests before the fix; afterward 5 passed
-  and only the golden comparison skipped (12.33 s). Static preflight passed:
-  Ruff/mypy/prose plus 43 guard tests, 3 skips (14.07 s).
-- **Merge state:** #267 is ready for review; main requires one approving GitHub
-  review and none exists. Repository auto-merge is disabled. No bypass or merge
-  was performed. #269's coverage drop is not a passing badge; repeat CI after
-  this test-selection repair is integrated. Other required stack CI passed.
-- **Next:** await CI/review for #273, then return to `vmex-stationarity` for the nonlinear derivative gate and its
-  CPU/GPU checks. Keep both branches' results in the active plan before resuming
-  A's remaining acceptance, benchmark and admissibility tasks.
+Keep the VMEC-compatible solve as the reliable starting point for toroidal
+research. Concentrate implementation on **correct acceptance, a demonstrably
+better force-balance formulation, and time to a validated optimized design**.
+The high-order method deserves one bounded recovery experiment. It does not
+yet deserve an expanding family of solvers, coordinate systems or long runs.
 
-## 1. Outcome and order of work
+The strongest near-term product is a small, documented equilibrium and
+optimization API with trustworthy status and reproducible CPU/GPU evidence.
+The ambitious result remains accurate native 3-D force balance with useful
+implicit derivatives. Separate that research question from routine fixes:
+ordinary boundary optimization should not wait for distributed polishing,
+anisotropic mirrors or a replacement coordinate system.
 
-Keep the fast VMEC-compatible solve as the branch finder. Build one accurate,
-native high-order equilibrium path above it, with separately checked physical
-residuals and implicit derivatives. Make time and memory **to a stated accuracy
-and optimization result** the performance targets. Preserve standard VMEC I/O
-while letting research workflows retain native geometry and derivatives.
-
-The program must deliver:
-
-1. Reliable fixed- and free-boundary stellarator and tokamak equilibria, including
-   finite pressure, prescribed current, bootstrap workflows and LASYM.
-2. A high-order path that addresses VMEC's continuous force-balance error,
-   including the axis, with real radial/angular convergence and independent
-   comparisons against native DESC, VMEC2000, VMEC++ and, where available, GVEC.
-3. Certified derivatives and useful boundary/profile/coil optimization, measured
-   through the final feasible design rather than through a cheap isolated call.
-4. Measured CPU and GPU execution, independent-case parallelism, and genuine
-   sharding of force/derivative work across devices without accidental gathers.
-5. A coherent mirror program: isotropic foundations, consistent anisotropy,
-   free-boundary coupling, and periodic stellarator–mirror hybrids whose model
-   and limitations are explicit.
-6. A small, understandable API, student-to-research examples, organized
-   documentation, reproducible evidence and one or more publishable results.
-
-The critical path is **A → B → C → D → E → F** below. Documentation and measured
-slimming proceed with every change. Mirror research (H) and downstream work (G)
-have their own prerequisites; they do not block a well-supported toroidal
-release or the first methods paper. Do not launch another multi-day W7-X polish
-before the frozen-operator and physical-functional gates in C pass.
-
-| Work package | Scope and owner | Depends on | Completion evidence |
+| Priority | Deliverable | Owner | Exit decision |
 |---|---|---|---|
-| A | Acceptance, provenance and benchmark repairs — VMEX | current main | Failed roots/gradients cannot be labelled certified; honest stage records |
-| B | Physics oracle, conventions and native representation — VMEX | A | Analytic and manufactured tests; matched native cross-code metrics |
-| C | Recover a useful 3-D high-order solve — VMEX + SOLVAX | B | Frozen QA operator verified; certified finite-beta 3-D refinement |
-| D | Profile and reduce time/memory — respective kernel owners | A; C for polish claims | Cold/warm/gradient/time-to-accuracy results and trace-backed ablations |
-| E | CPU/GPU sharding and scaling — SOLVAX primitives, VMEX layouts | A, D; C for polish | Multi-device values/gradients, actual shard layouts and scaling curves |
-| F | Optimization and engineering examples — VMEX + ESSOS | A–D; E for scaling claims | Feasible before/after designs, independent validation, total cost |
-| G | Native consumers and confinement diagnostics — respective codes | B, F as appropriate | In-memory value/derivative parity and topology contracts |
-| H | Mirrors, anisotropy and hybrid optimization — VMEX + ESSOS | B, C foundations | Closure, interface, force, derivative and application certificates |
-| I | Documentation, API and slimming — VMEX | continuous | Shorter ownership paths, runnable tutorials and measured size/performance |
-| J | Releases and publications — maintainers | gates for each claimed scope | Archived inputs, environments, evidence, papers and verified claims |
-
-## 2. Review baseline and evidence limits
-
-| Repository | Reviewed base | Advertised branches | PRs, all / open | Issues excluding PRs, all / open |
-|---|---|---:|---:|---:|
-| [VMEX](https://github.com/uwplasma/VMEX) | `09f18464e936a8c9bf0abba62bcdc919bdc7c55b`, 0.8.1 | 52 | 263 / 14 | 3 / 2 |
-| [SOLVAX](https://github.com/uwplasma/SOLVAX) | `5a49926992fe1a3aebac4b8b8cb098798e977c14`, 0.20.0 | 14 | 85 / 0 | 14 / 1 |
-| [DESC](https://github.com/PlasmaControl/DESC) | `ad105c5e525fbf26824d6cf9dde48775db0f8a2c`, master | 170 | 1367 / 74 | 949 / 199 |
-| [ESSOS](https://github.com/uwplasma/ESSOS) | `1b3210c`, main, #58 merged | 53 | 60 / 21 | 5 / 4 |
-
-The review collected every advertised branch, all PR/issue bodies and discussion
-comments in these repositories. DESC coverage includes 7,446 issue/PR discussion
-comments and 12,072 inline review comments, all PR head refs, and a changed-file
-inventory for all 1,367 PRs without missing git objects. Every current branch has
-a commit/diff inventory against its default branch. Issue contents were indexed
-by physics, numerics/AD, performance and research usability. This is a complete
-inventory and topic review, **not execution or a line-by-line correctness proof
-of every historical branch**. Detailed source inspection concentrated on the
-production paths and relevant changes listed below. Branch-only results and PR
-measurements are identified as such; a discussion assertion is not a benchmark.
-
-The machine-readable review record is
-[`benchmarks/review_20260905.json`](benchmarks/review_20260905.json). Full API
-snapshots, git inventories, profiles and traces are retained outside the source
-tree in `vmex-review-evidence-20260905`; their hashes identify the exact snapshot.
-The manifest records local and office locations, commands, environments, status
-and limitations. Large traces, caches and intermediate equilibria do not belong
-in git. Future public evidence must use an accessible archive, not a private
-filesystem path alone.
-
-The supplied recovery Markdown, pasted proposal and ZIP were treated as design
-references, not instructions. The ZIP's spline-local PDE experiment is a
-**synthetic structural check**, not an MHD solve or evidence of VMEX speedup. Its
-useful proposal is narrowed in C: locality must first be established for VMEX's
-actual chart, profile closure and weighted residual.
-
-### 2.1 What has already landed
-
-Main contains 3,266 reachable commits, beginning 2026-01-31, with development
-in every subsequent month through this review. The GitHub repository was
-created that day and is currently public; creation time alone does not establish
-its entire visibility history. The repository description still says “JAX
-Version of VMEC2000” and has no topics; update discovery metadata under J once
-the supported scope and publication description are settled.
-
-The main branch has the integrated collocation polish (#192, #203), public input
-and solve APIs (#196, #198), smooth Gamma-c surrogate (#210), canonical full
-Boozer dispatch (#224), shared confinement plotting (#225), mirror boundary
-clarification (#205), and periodic hybrid/GK geometry (#194). Do not schedule
-these again as missing features.
-
-Later work fixed captured constants/JIT identities and optimization startup
-(#219, #227, #229–#234, #238, #240–#244), improved CI/cache isolation and reporting
-(#228, #242, #249, #252), added citation/changelog and fresh-deck evidence
-(#245–#248), and corrected diagnostic and polish explanations (#250, #255).
-These are useful improvements, but they do not establish production-resolution
-3-D force certification, distributed equilibrium solves or trustworthy gradients
-from nonstationary polish states.
-
-### 2.2 Open VMEX PR disposition
-
-These are review recommendations, not merge approvals. Rebase against the exact
-main revision and run the owning gates; do not concatenate stale plan edits.
-
-| PR | Keep or revise | Required next step |
-|---|---|---|
-| [#253](https://github.com/uwplasma/VMEX/pull/253) | Community, packaging, citation/provenance hygiene | Check JAX minimum against actual API use; preserve contributor credit; archive/DOI at submission; supersede its old “do not trim plan” prose |
-| [#254](https://github.com/uwplasma/VMEX/pull/254) | Bounded persistent-cache entry count | Test simultaneous writers, interrupted/hostile entries and mature-cache cost; do not claim CI lock contention was proved |
-| [#256](https://github.com/uwplasma/VMEX/pull/256) | Figure manifest, validation page and removal of unsupported numbers | Reconcile with #260/#264 and new measurements; keep failures in comparison tables; remove orphan media after reference checks |
-| [#257](https://github.com/uwplasma/VMEX/pull/257) | Public API coverage and useful docstrings | Resolve its discovered semantic defects through A/B/I; avoid presenting unused polish knobs as functional |
-| [#258](https://github.com/uwplasma/VMEX/pull/258) | Correct FFT tail mask and normalized Jacobian margin | Test signed FFT modes, Nyquist and union of tails; explain that sampled local orientation is not global injectivity |
-| [#259](https://github.com/uwplasma/VMEX/pull/259) | Native LASYM flag propagation | Check all sine/cosine families, Boozer and virtual casing, eager/JIT and explicit tracer metadata |
-| [#260](https://github.com/uwplasma/VMEX/pull/260) | Native DESC measurement | Compare identical norms, grids, units and region; do not compare its native L1/pressure ratio with VMEX's bounded L2 ratio |
-| [#261](https://github.com/uwplasma/VMEX/pull/261) | Chunked/checkpointed memory reduction and cost/progress reporting | Separate memory fix from unproved solver improvements; no certified 3-D claim from the W7-X run; C replaces speculative long reruns |
-| [#262](https://github.com/uwplasma/VMEX/pull/262) | Document NaN failure under JIT | Add the true-residual acceptance repair in A; document value plus status for transformed callers |
-| [#263](https://github.com/uwplasma/VMEX/pull/263) | Mirror model/metric audit | Scope axial-current rejection to the unsupported exterior; correct anisotropic oracle and exterior-BVP statements in H |
-| [#264](https://github.com/uwplasma/VMEX/pull/264) | Analytic Solov'ev oracle and LASYM audit | Extend native analytic refinement to B/C; do not halve `tcon` alone: the VMEC normalization changes must be considered together |
-| [#265](https://github.com/uwplasma/VMEX/pull/265) | Progress output and elimination of duplicate gradient calls | Do not promote `adjoint_fail="best_effort"` for certified optimization; a reported relative residual near 0.66 is a failed gradient |
-| [#266](https://github.com/uwplasma/VMEX/pull/266) | Profile ledger, physical scaling/bounds and coil-seed investigation | Stack after the safe parts of #265; pair tolerance comparisons with derivative/feasibility checks; C addresses the remaining polish bottleneck |
-| [#197](https://github.com/uwplasma/VMEX/pull/197) | Scalar-adjoint option after rebase | Preserve the measured startup/memory tradeoff and TRF's better objective per evaluation; consolidate duplicated example setup under I |
-
-The #266 QA polish experiment reports roughly 3,096 s and 16 GiB for three GN
-iterations, with all 1,800 available inner iterations consumed. The #261 W7-X
-experiment reports 11 h 09 min, 17.1 GB peak RSS and only about 1.1% improvement
-in dimensional L2 force, despite a much larger collocation-cost reduction. These
-are PR evidence on particular machines/settings, not results rerun by this
-review. They motivate fixing the functional, chart and linear system before
-increasing nonlinear budgets. The old conclusion that more iterations alone
-would settle effectiveness is superseded.
-
-The two open VMEX issues also have concrete owners. [#157](https://github.com/uwplasma/VMEX/issues/157)
-reports an undefined `runtime` in the GPU guide: I1 must make that snippet
-self-contained and execute it. [#211](https://github.com/uwplasma/VMEX/issues/211)
-reports a closed-hybrid strong-force plateau near 5e-3 despite weak residuals
-near 1e-16, and a seed-to-solved change in field modulation: H4 must resolve
-the physical admission criterion before downstream GKX claims are promoted.
-
-### 2.3 Measurements made during this review
-
-The stage audit attempted 16 workflows in a fresh process per workflow, with a
-300 s budget covering setup, first calls, three warm repeats and one profiled
-repeat. Local CPU: 12 completed, F7/F8/F10 timed out, F9 hit an ESSOS capability
-gate. Office GPU with CPU callback support: 10 completed, F3/F7/F8/F10/C1 timed
-out, F9 hit the same gate. F1 was measured separately in four cache/reuse regimes
-on both hosts. M2 was excluded because its supplied field is not solenoidal.
-“Completed” here means timing collection completed; it is not a physics verdict.
-
-Representative stage medians in seconds, with first-call compilation reported
-separately in the manifest:
-
-| Stage | Local M3 Max CPU | Office RTX A4000 execution |
-|---|---:|---:|
-| F2 multigrid solve | 0.239 | 0.808 |
-| F4 scalar gradient | 0.268 | 0.782 |
-| F5 full Jacobian at repeated parameters | 0.229 | 0.698 |
-| F11 LASYM gradient | 0.276 | 0.756 |
-| B1 one-surface Boozer transform | 0.088 | 0.292 |
-| B2 eight-surface Boozer transform | 0.431 | 1.303 |
-| F3 shaped-tokamak polished value | 15.119 | workflow timeout |
-
-These exploratory values include the shipped workflow's caches and placement
-policy; the hosts differ, and no controlled CPU/GPU speedup follows. F5's warm
-residual is about 1 ms because it can reuse the one-entry objective cache. That
-is why A/D require changed-parameter timing and actual call counts.
-
-F1 XProf traces expose 4,480 calls to each of two GPU tridiagonal pivot kernels
-per traced solve. A separate, same-office-host li383 ablation forced the imported
-SOLVAX tridiagonal backend to Thomas in a fresh process, without editing source:
-warm median 0.836 s (auto GPU) → 0.406 s (Thomas GPU); office CPU auto was 0.271 s.
-All used 123 iterations and passed the legacy tolerance. R/Z/lambda maximum
-coefficient differences between the GPU variants were below 8.4e-14. Cold solve
-times remained about 17.9/17.7 s on GPU and 7.7 s on office CPU. This is a
-promising small-case backend hypothesis, not a continuous-force certificate,
-large-resolution result or proposed unconditional default change.
-
-The review also reproduced R1's false acceptance of a true residual 1.0 with
-tolerance 1e-8 and of NaN when the solver flag was true. Targeted checks passed:
-22 SOLVAX tests, two analytic VMEX force/coordinate tests, static preflight
-(43 guards passed, three skipped) and strict Sphinx. E records the additional
-actual CPU/GPU sharding probes. Production physics and algorithms are unchanged
-by this plan revision.
-
-## 3. Findings that change the implementation priorities
-
-Paths and symbols below refer to the pinned main branch. Each finding has a
-work-package owner; none is closed merely by this plan.
-
-| ID | Finding and consequence | Owner |
-|---|---|---|
-| R1 | `polish_implicit._linear_report` accepts `solution.converged OR true_residual <= tolerance`. A solver flag can override a failed or nonfinite recomputed residual. | A |
-| R2 | The already-certified shortcut in `polish_legacy_solution` checks normalized L2 alone; normal acceptance can pass force/quadrature/Jacobian checks without least-squares stationarity. Physics and derivative acceptance are different contracts. | A |
-| R3 | `strong_collocation_residual_at_native` multiplies separate radial/helical magnitudes by `abs(sqrtg)` and a frozen denominator, without Gauss weights or the vector Gram cross term. Its least-squares cost is not the physical Cartesian volume L2 certificate. | B/C |
-| R4 | The production `make_strong_structured_chart` has independent constrained R and lambda directions; Z is not independently variable, and this chart rejects LASYM. The cylindrical Z-based gauge is singular at extrema of Z. Some m=1 mixing remains, so “every Z coefficient is frozen” is too broad. Reachability must be tested. | C |
-| R5 | `make_strong_root_layout` uses local-group SVDs of legacy restriction/prolongation. This can mix radial coefficients and restrict the correction to the legacy mesh image. Native spline support alone does not prove chart locality or h-refinement freedom. | B/C |
-| R6 | `apply_high_order_correction` changes geometry/lambda but holds lifted `phip`, `chip` and pressure tables fixed. Prescribed current (`NCURR=1`) and finite-gamma mass/pressure constraints require a separate consistency audit as geometry changes. | B/C |
-| R7 | `_gauss_newton_polish_lane` calls SOLVAX GN without `precond=` or physical `admissible=`. Legacy factors are built but not used by this lane. Exposed square-root controls do not describe production GN behavior. | A/C |
-| R8 | SOLVAX GN already supports a preconditioner and admissibility hook, but does not expose/use the inner true residual, convergence or breakdown state in its trial policy. Iteration counts alone cannot distinguish an acceptable inexact step from stagnation. | C, SOLVAX |
-| R9 | The continuous force kernel nests spatial `jacfwd` evaluations inside parameter AD. Repeated synthesis, residual linearization and stored intermediates create a large cost/memory target. | C/D |
-| R10 | `eps_F=2|F|/(|J×B|+|grad p|+floor)` is bounded and approaches 2 for nonzero vacuum force. `radial_refinement_difference` changes quadrature on the same state; it is not solve h/p convergence. | A/B |
-| R11 | Independent certificate nodes share the production force implementation. They test off-grid behavior, not implementation independence. A DESC WOUT re-lift tests the export/reconstruction chain, not native DESC accuracy. | B |
-| R12 | `parallel.solve_ensemble` provides CPU task parallelism; current VMEX has no demonstrated multi-device single-solve path. SOLVAX's sharded primitives do not establish VMEX end-to-end sharding. | E |
-| R13 | The profiler's generic warm fallback repeats only the first stage; new-parameter/new-shape variants exist only for F1. Repeated parameters can hit the one-entry objective cache. Compile log counts do not distinguish backend compilation from persistent-cache hits. | A/D |
-| R14 | Profiling C2 uses the hard Gamma-c path under a derivative-safe description. M2's purported two-loop field is `(0,0,B_axis(z))`, which is not divergence-free when B varies. These are invalid labels/physics for those benchmark claims. | A/G/H |
-| R15 | `tests/conftest.py` disables JIT globally. Ordinary unit-test success does not cover transformed failure handling, callback placement or compiled sharding. | A/E |
-| R16 | Documentation already has tutorial/how-to/explanation/reference directories, but duplicates API/solver narratives and carries historical status and comparison numbers. Reorganize ownership inside that structure instead of adding a second documentation tree. | I |
-
-Additional defects identified in #257 remain in the repair queue: public tuple
-annotation disagreement in `FunctionProblem.from_tuples`; progress missing for
-combined loss; inconsistent Euclidean/infinity “optimality”; parameterized
-surface construction bypassing validation; scaled WOUT profiles disagreeing
-with unchanged stored profile coefficients; plotting entry points bypassing the
-shared backend/style setup. Triage these by a reproducer, fix in their existing
-owner, and retain `doctor`'s documented exit semantics or add an explicit strict
-mode. Do not silently change a diagnostic command's exit behavior.
-
-## A. Repair acceptance and evidence first
-
-**Owner:** VMEX reports, tests and `benchmarks/profile_workflows.py`; SOLVAX owns
-only generic solve-result semantics. **Exit:** every status means what it says.
-
-- [x] Make a finite, recomputed **unpreconditioned** tangent/adjoint residual the
-  authoritative gate. A solver's flag may be diagnostic; it cannot override a
-  failed true residual. Test false-positive flags, NaN/Inf, zero RHS, iteration
-  exhaustion, eager behavior and real `jax.jit` behavior. Check solution and
-  operator/RHS finiteness as well as the norm.
-- [ ] Unify early return, normal completion, CLI, native export and resumed solve
-  acceptance. Distinguish `legacy_converged`, `physics_certified`,
-  `stationarity_certified`, and `derivative_certified` with explicit thresholds.
-  Reuse the existing report/result owners instead of adding parallel report APIs.
-- [ ] A physical certificate can accept a state before GN stationarity, but its
-  stationarity-based implicit derivative must then fail or refine first. Under
-  transformations return numerical values plus a usable status, with the host
-  boundary raising a typed error when requested. NaN is never optimization data.
-- [ ] Wire all physical invariants into trial admissibility: finite fields,
-  regular/positive-oriented geometry away from the axis, axis limits, boundary
-  and gauge constraints, profile/current closure and model-specific conditions.
-  Reject invalid trial geometries before expensive full evaluations where a
-  cheap conservative check is available. A sampled Jacobian is only a local test.
-- [ ] Audit each `PolishConfig` option against the actual public call graph.
-  Implement a meaningful control or deprecate it; remove unnecessary factor
-  construction. Rename reports inherited from the retired continuation lane.
-- [ ] Repair the profiler to time every named stage; implement meaningful changed
-  parameter/shape regimes per workflow or emit “unsupported” explicitly. Record
-  setup failure, dependency gate, nonconvergence, timeout, OOM and NaN separately,
-  and preserve partial stage output. A process exiting zero is not success.
-- [ ] Include physics and derivative status in every timing row. Fix C2's actual
-  objective and replace M2's field with full analytic/ESSOS Biot–Savart before
-  treating it as a physical benchmark. Add stage annotations around setup,
-  forward solve, refinement, linearization, adjoint, objective and certification.
-- [ ] Remove selected-winner requirements for README plots. Predeclare cases;
-  retain ties, losses and failures in the table. Separate native improvement,
-  export sampling and re-lift improvement. Retain the bounded diagnostic for
-  compatibility, but never make it the sole accuracy or promotion criterion.
-
-**Review measurement:** this revision profiles pinned main on the local M3 Max
-and office RTX A4000 environment with fresh-process limits. It records failures
-and incomplete runs, not paper-grade speedups. See the manifest for exact rows.
-F1 traces already show thousands of GPU tridiagonal pivot launches. This is a
-specific backend investigation for D, not evidence that all GPU solves are slow.
-
-## B. Specify the physics, representation and independent oracle
-
-**Owner:** VMEX `strong_force.py`, `polish.py`, `radial_basis.py`, profile/state
-owners, existing certificate and comparison benchmarks. **Exit:** the oracle
-passes exact solutions, and different codes are compared as the same problem.
-
-### B1. One conventions and constraints contract
-
-- [ ] Consolidate SI units, `MU0`, full/half mesh, normalized toroidal flux
-  `s=rho^2`, angular periodicity, physical phi versus NFP-scaled angle,
-  handedness/signgs, m/n ordering, lambda sign/scaling and WOUT conventions.
-  Cross-reference the source formulas and verified VMEC2000/VMEC++ descriptions.
-- [ ] State which flux/current/pressure quantities are independent for each
-  `NCURR`, gamma and free-boundary mode. Audit the lift and correction against
-  those invariants. For prescribed current, enforce/check Ampère loop integrals
-  while geometry changes; freezing iota is not the same problem. For gamma/mass
-  profiles, recompute the volume-dependent pressure law where required.
-- [ ] Preserve exact boundary constraints, axis regularity and coordinate gauge
-  in a native spline/Fourier space. Document `rho^|m| q_mn(s)` analyticity and
-  handle m=0/1 axis limits explicitly. Use one declared degree default and
-  precision/floor policy. Local basis support must survive constraint elimination.
-- [ ] Native state serialization must retain knots, degree, all parity families,
-  physical profiles/closure, units, topology and provenance. Version the schema,
-  validate shapes and round-trip fields/JVPs. Sample WOUT only for compatibility;
-  report export-grid dependence rather than silently discarding native accuracy.
-
-### B2. Norms and regions
-
-Let `F = curl(B)×B/mu0 - grad(p)` in Cartesian components, `dV` be the physical
-volume measure, and `V` the evaluation volume. Report, with SI units:
-
-- `F_L1 = integral |F| dV / V` and `F_L2 = sqrt(integral |F|^2 dV / V)`;
-- a declared pointwise maximum/percentiles and flux-surface RMS profiles;
-- pressure-normalized `F_L1 / <|grad p|>_V` for finite-pressure literature
-  comparisons, and an explicitly named magnetic-pressure-gradient normalization
-  when that denominator is nonzero;
-- a vacuum-safe fixed reference `F_ref = B_ref^2/(mu0 a_ref)` and `F_L2/F_ref`,
-  with B_ref/a_ref fixed for a comparison or optimization stage;
-- the existing bounded `eps_F` only as an additional diagnostic, with its floor
-  and saturation disclosed.
-
-Uniform fields can make even the magnetic-pressure-gradient denominator zero;
-use an unavailable status for that ratio and retain the dimensional/fixed-scale
-metrics. Do not introduce an arbitrary floor that changes cross-code rankings.
-Match L1 with L1 and L2 with L2; distinguish a mean of pointwise ratios from a
-ratio of means. Keep the legacy radial `equif` residual distinct from vector
-strong force and explain its vacuum limitation.
-
-Use the Panici comparison region `s in [0.1,0.99]` when reproducing that paper,
-**and** report full-volume, near-axis, bulk and edge results with exact region
-boundaries. Do not hide difficult regions to certify the whole equilibrium.
-A coordinate Jacobian vanishes at the axis by construction; check its regularized
-limit there rather than applying an impossible positive lower bound at rho=0.
-
-### B3. Verification hierarchy and benchmark cases
-
-| Level | Required problems | What it verifies |
-|---|---|---|
-| Exact/local | Uniform Cartesian B, toroidal vacuum B∝1/R, manufactured divergence-free fields, circular-coil on/off-axis field | Units, curl/divergence, coordinate transforms, derivatives and vacuum metrics |
-| Exact equilibrium | Analytic Solov'ev from #264, analytic theta-pinch, quartic-flux mirror | Force oracle against known nonzero pressure/current; no numerical “Solov'ev input” substituted for an exact solution |
-| Representation | h- and degree-refined splines; m=0/1 and higher parity; perturbed LASYM; exact knot insertion | Approximation order, regularity, reachability and independent off-grid derivatives |
-| Toroidal cross-code | Shaped tokamak; finite-beta QA; QH; LASYM finite-beta; high-aspect-ratio/near-axis case; harder W7-X case | Native force, profiles, geometry, current closure, convergence and failure boundaries |
-| Free boundary | Vacuum coil/plasma-off limit, analytic axisymmetric case, finite-beta direct-coil stellarator | Interface traction/B·n, vacuum coupling, branch-local response |
-| Mirror/hybrid | Isotropic fixed/free mirror; anisotropic fixed/free mirror; perturbed 3-D mirror; periodic hybrid | Topology-specific closure, interfaces, regularity and limits under H |
-| Application | Stable near-axis Mercier limit, QS metrics, transport/orbit validation and constrained optimization | Whether equilibrium accuracy matters to downstream science |
-
-- [ ] Evaluate force on shifted/oversampled quadrature distinct from solve nodes,
-  then increase evaluation quadrature until integration error is below the
-  claimed force improvement. Correct the signed-frequency angular tail mask.
-- [ ] Re-solve/re-polish after radial h, spline degree and angular refinement.
-  Record force, observables, current and gradient convergence separately. Rename
-  the present quadrature-only difference; retain it as an integration check.
-- [ ] Retain a slow independent evaluator using analytic derivatives or a
-  separately implemented coordinate calculation. Test the optimized kernel
-  against it before using the optimized kernel as a certificate. Manufactured
-  forcing verifies operators, not existence of a physical unforced equilibrium.
-- [ ] Compare native DESC spectral fields with native VMEX spline fields at
-  matched physical points or equivalent volume quadrature. Record interpolation,
-  flux-label correspondence and coordinate maps. WOUT comparisons form a
-  separate compatibility/reconstruction experiment, including export refinement.
-- [ ] Match boundary, NFP, pressure/current/iota specification, flux, beta, units,
-  symmetry and solution branch. Report scalar degrees of freedom, not just a
-  shared “resolution” name. Use each code's reasonable converged settings and
-  sweep its own resolution. Include conversion and initialization cost explicitly.
-- [ ] Retain VMEC trajectory/WOUT parity tests without confusing parity with
-  continuous equilibrium accuracy. Pin the existing harmonic/iteration tolerances
-  rather than describing them as machine precision.
-- [ ] Separate numerical failure from model limits: nested surfaces exclude
-  islands/stochastic regions, and ideal-MHD rational-surface singular currents
-  can prevent smooth spectral convergence. Use SIESTA/SPEC/HINT comparisons only
-  with their different topology/pressure models declared; do not promise that
-  high-order polishing repairs a physically nonexistent smooth nested solution.
-
-## C. Recover accurate and affordable 3-D force balance
-
-**Owners:** VMEX specifies the physical residual, chart, closure, local element
-blocks and acceptance. SOLVAX owns generic least-squares, factorizations,
-preconditioners, Krylov algorithms, globalization and implicit linear solves.
-
-### C1. Freeze one real linearization before designing the solver
-
-Start with the modest finite-beta QA case used in #266, then the exact tokamak
-and a modest LASYM case once C2 supports its chart. Save the native state,
-profiles, constraints, grid,
-scales, damping and random seeds in a bounded artifact. For
-`r(c)=weighted physical force`, define `A=dr/dc` and test:
-
-1. Directional finite differences over a step-size sweep and several directions;
-   JVP/VJP duality; comparison against a chunked explicit Jacobian.
-2. Matrix-free normal action against explicit `A.T @ A`, true residual and
-   predicted reduction. Check rank, singular values and identifiable/gauge modes.
-3. A trusted augmented QR/SVD solution of
-   `min_delta ||A delta + r||^2 + mu ||L delta||^2`, including the actual variable
-   scaling. Compare physical step, cost reduction and linear residual, not only
-   coefficient norms or Krylov recurrence residuals.
-4. One-factor-at-a-time ablations: old/new weighting, restricted/full R–Z chart,
-   frozen/consistent profiles, and no/structured preconditioner. This separates
-   unreachable force directions, poor conditioning and expensive kernel work.
-
-Use explicit matrices only where their measured memory is affordable. The
-attachment's 36,540×2,788 float64 Jacobian arithmetic is approximately 0.759 GiB
-for one matrix; AD tapes, QR workspace, copies and XLA temporaries add more.
-A matrix-size estimate is not a process/device-memory prediction.
-
-**Gate C1:** Jacobian/transpose tests pass; QR gives a trustworthy reference;
-the effect of each physics/chart change is measured; no unexplained rank or
-operator mismatch remains. An ineffective QR step redirects work to physics,
-representation or globalization instead of another Krylov variant.
-
-### C2. Optimize the intended physical functional
-
-Use Cartesian residual rows, or a mathematically equivalent positive metric
-factorization including all cross terms. A proposed row is
-
-`r_q = sqrt(w_q * abs(g_q) / V_ref) * F_cart(q) / F_ref`.
-
-Here `w_q` includes the full quadrature conversion for the chosen coordinates,
-`V_ref` and `F_ref` are fixed stage/comparison scales, and `g_q` is the physical
-Jacobian. Decide explicitly whether geometric weights vary within the nonlinear
-functional or are frozen during an outer reweighting step. Differentiate the
-chosen definition consistently; a frozen-weight derivative is not automatically
-the derivative of a public solve that recomputes weights for perturbed inputs.
-
-- [ ] Introduce independent admissible R, Z and lambda directions, with a regular
-  gauge based on displacement/constraint geometry rather than division by
-  `Z_theta`. Include all LASYM parity families rather than merely removing the
-  current symmetry guard. Test vertical shape errors and noncircular surfaces.
-- [ ] Construct constraints natively, without restricting every refined correction
-  to a low-order sample image. Verify exact boundary/axis constraints and the
-  dimension/rank of the admissible space at each h/p level.
-- [ ] Restore prescribed-current and finite-gamma closure from B1. Account for
-  induced profile derivatives in both the force Jacobian and implicit response.
-- [ ] Use continuation in pressure/current/resolution and regularized steps to
-  reach the intended branch. Report all residual blocks and physical invariants.
-
-### C3. Choose structured linear algebra from the actual operator
-
-For a local degree-d spline chart and local closure, each quadrature row touches
-at most d+1 radial basis functions. Then normal-matrix blocks couple radial
-indices separated by at most d. Verify this on **VMEX's** frozen matrix. Global
-profile constraints, integral normalizations or dense gauge elimination can
-break that property; retain their contribution as explicit borders/low-rank
-terms or revise the chart. Never discard off-band entries just to fit a solver.
-
-- [ ] Stream local Jacobian chunks `A_e`; accumulate local `A_e.T A_e` and
-  `A_e.T r_e` without retaining the full global Jacobian. Validate assembly
-  against C1, including cross-element scatter and its transpose under JIT.
-- [ ] For moderate angular width, compare banded/block factorizations and grouped
-  radial block-Thomas elimination (group d radial blocks to obtain a block
-  tridiagonal system). Estimate O(n_radial d b²) storage and factorization cost
-  before promotion; increasing angular width b can make dense blocks expensive.
-- [ ] Reuse SOLVAX's existing block factorization/transpose/Schur owners. Its
-  generic checked solves must report pivot quality, damping and the true residual.
-  Do not interpret clamped pivots as an exact SPD solve without certification.
-- [ ] For larger cases, benchmark a symmetric additive Schwarz approximation
-  built from the **actual** damped normal operator, with radial overlap,
-  angular/mode coupling and a spline coarse correction. Exact knot insertion
-  provides transfer when nested spaces apply; verify the transpose/coarse metric.
-- [ ] Compare normal-equation PCG with a right-preconditioned rectangular method
-  such as LSMR when conditioning warrants it. Normal equations square the
-  singular-value condition number. Right preconditioning requires a consistent
-  transpose and damping transformation; arbitrary left row scaling changes the
-  least-squares objective.
-- [ ] Wire the selected preconditioner into SOLVAX GN. Return inner convergence,
-  true residual, breakdown and prediction-quality diagnostics. Use an inexact
-  forcing policy appropriate to GN; tighten toward stationarity. Existing
-  Eisenstat–Walker support in Newton–Krylov is prior art, not already GN support.
-- [ ] Reuse the accepted-point linearization/preconditioner across rejected
-  damping trials when valid. Update/factor only changed terms; measure this
-  against memory retained by reusable linearization closures.
-
-The borrowed square-root `B B.T` preconditioner was measured ineffective in
-#261, with a separate 3-D scatter-transpose failure. The fused legacy constraint
-experiment was measured neutral and has a parity failure at larger mode counts.
-Keep their negative results; do not replay them without a new operator-based
-hypothesis. Do not add deflation, learned corrections, an optimizer zoo or
-another generic solver framework as the first remedy.
-
-**Gate C3:** on the fixed C1 problems, the promoted method matches the reference
-step/reduction to the declared conditioning-aware tolerance, passes transpose
-checks, and reduces total time/memory at matched quality. A working target is
-50–100 inner iterations at a fixed requested accuracy with bounded growth under
-refinement; this is a target to test, not a promised universal iteration count.
-Keep one production policy and a small reference path; delete losing experiments.
-
-### C4. Tensor kernels and nonlinear certification
-
-- [ ] Precompute spline/Fourier values and first/second spatial derivatives for
-  each static grid. Use separable/tensor contractions, local support and bounded
-  quadrature chunks. Retain parameter AD but avoid reconstructing spatial
-  `jacfwd` graphs point by point. Treat singular-axis limits analytically.
-- [ ] Checkpoint/rematerialize only where measured AD storage dominates. Record
-  residual/JVP/VJP time, compile time, executable temporary size, peak live
-  memory and rejected-trial work. Do not replace memory pressure with excessive
-  recomputation without a matched total-cost comparison.
-- [ ] Use the same constraint/chart/closure throughout continuation. Return the
-  best valid state plus explicit failure when the budget is exhausted; never
-  relabel an exhausted solve as certified by a bounded force ratio alone.
-- [ ] Add deterministic progress after setup and during expensive GN/linear
-  work, with elapsed cost and residual trends. Callback frequency must be bounded
-  and measured; a “cost estimate” is a range based on measured kernels and
-  requested budgets, not a prediction of time to convergence.
-- [ ] Require independent force reduction and h/p convergence on tokamak, QA,
-  QH and LASYM cases before increasing to W7-X production resolution. Fix a
-  public target grid/norm/accuracy band before each campaign; retain failed bands.
-
-### C5. Correct implicit differentiation of the promoted state
-
-For a zero root `G(x,p)=0`, use the appropriate full constrained Jacobian. For
-least-squares stationarity `g=A.T r=0`, the exact state Hessian includes
-`A.T A + sum_i r_i Hessian(r_i)`; GN alone is generally not the IFT operator at
-nonzero residual. Current `polish_implicit.py` retains this distinction.
-
-- [ ] Certify stationarity before IFT, including the same scales, profile closure
-  and gauge as the public solve. State how reweighting and active constraints
-  enter the differentiated problem.
-- [ ] Check full unpreconditioned tangent/adjoint residuals, duality, multi-step
-  directional finite differences and tolerance/refinement stability of gradients.
-  Use conditioning/residual estimates to tie inner tolerances to objective error.
-- [ ] Test the complete boundary → solve → polish → objective chain with both
-  recomputed and frozen reference data as explicitly distinct experiments.
-  Reject branch changes, topology events and rank loss as ordinary smooth steps.
-- [ ] For free-boundary Schur methods, freeze the same coupled root for the full
-  and block solve. Compare `K.T lambda - rhs` in the original system; a good
-  Schur residual or a different warm-start branch is not sufficient.
-
-## D. Profiling and performance program
-
-**Owners:** VMEX orchestration/physics; SOLVAX linear/nonlinear algorithms;
-BOOZ_XFORM_JAX transforms; ESSOS fields/coils/orbits. Profile before changing an
-owner. Extend the existing harness and retire overlapping scripts after parity.
-
-### D1. Measurement contract
-
-For each workflow run a fresh-process cold/empty-cache case, persistent-cache
-reload, warm same parameters, warm changed dynamic parameters, and changed
-static resolution. Treat objective memoization separately from compute reuse.
-Time and synchronize every value, gradient, Jacobian and validation stage with
-`block_until_ready`; distinguish compilation, lowering, cache lookup and actual
-backend compilation. Count calls to forward solve, refinement and adjoint to
-catch duplicate work and unexpected host callbacks.
-
-Record exact git and dependency revisions, input SHA256, command, x64, device
-model/count, CPU affinity/threads, driver/CUDA, selected device/sharding, problem
-size, seeds, tolerances, nonlinear/linear counts, achieved certificates and
-failures. Record host RSS and **device allocated/live/peak** memory separately;
-JAX reserved/preallocated memory is not live tensor memory. Annotate process-wide
-high-water marks so they are not misread as per-stage peaks.
-
-Use isolated runs on idle machines; record contention/thermal state and execution
-order. Repeat enough for median and spread (at least five measured warm runs and
-three fresh-process runs for publication), retain all samples, and include
-statistical uncertainty. A 300 s censored run is “timeout at 300 s,” not a slow
-successful solve. Do not compare M3 CPU with A4000 GPU as a controlled speedup;
-include an office CPU baseline on the same host and a proper GPU resolution sweep.
-
-### D2. Mandatory workload matrix
-
-| Family | Stages and sweeps |
+| P0 | Honest solve/derivative status and reconciled PRs | VMEX | Failed nonlinear or linear solves cannot silently supply certified gradients |
+| P1 | One physical force contract and a small benchmark matrix | VMEX | Native accuracy, discretization, reconstruction and solver error are distinguishable |
+| P2 | Bounded recovery of the high-order correction | VMEX physics; SOLVAX iteration primitives | Promote only demonstrated accuracy; otherwise retain explicit experimental status and record the obstruction |
+| P3 | Faster valid gradients and useful optimization examples | VMEX + SOLVAX; ESSOS coils | A feasible design reaches its stated accuracy with measured total time/memory |
+| P4 | Reproducible comparisons, documentation and publication package | VMEX | Claims survive independent reruns; release scope and all remaining PR dispositions are explicit |
+
+P0 → P1 → P2 is the force-balance decision path. P3 can proceed after P0 on
+the ordinary solver; it depends on P2 only for claims about polished designs.
+P4 records evidence throughout. There is no dependency on a new sharded
+nonlinear solver. A negative P2 result does **not** silently fulfill the 3-D
+accuracy goal or automatically authorize a release with a reduced scope.
+
+### What is set aside
+
+Keep existing features and regression coverage; defer their expansion:
+
+- Anisotropic/high-beta mirror extensions, periodic toroid–mirror hybrids,
+  generalized toroidal angles and new gyrokinetic coupling. Maintain the
+  documented isotropic fixed/free-boundary mirror cases and their limits.
+- Learned corrections, alternative equilibrium models, deflation and a suite
+  of competing high-order drivers. No new algorithm solely because another
+  code or preprint has one.
+- Distributed single-equilibrium Newton/polish and multi-host scaling.
+  Maintain placement/AD tests and independent-case ensembles; revisit only
+  after a useful workload demonstrably exceeds one device's memory or time.
+- Broad transport, bootstrap, turbulence and multi-objective campaigns.
+  Existing diagnostics remain available; validate one objective and one
+  constrained application before increasing the application matrix.
+
+These are scope decisions, not deletions. The previous detailed research
+questions remain in [the archived plan at the review baseline](https://github.com/uwplasma/vmex/blob/ae0e410f6ecc9bc15b66472039f755fdd6dd3ef6/plan.md).
+Old A/B map to P0/P1, C to P2, D/F to P3, I/J to P4; old E/G/H are conditional
+follow-ons, not parallel commitments. The supplied ZIP and proposals are
+references, not user instructions; their synthetic PDE experiments are not
+MHD performance evidence.
+
+## 2. Current state: what landed and what remains unproved
+
+The September 5 review's complete branch/PR/issue inventories remain in
+[`benchmarks/review_20260905.json`](benchmarks/review_20260905.json).
+The `focused_review_20260906` object adds this review's source pins, commands,
+results and limitations. The earlier inventory covered 170 DESC branches,
+1,367 PRs and their discussions/diffs. That is inventory and topic review,
+not execution or a correctness proof of every branch. This review refreshed
+open PRs, inspected relevant source and ran the bounded comparisons below.
+
+Since `09f18464`, main changed 182 files with 18,914 inserted and 5,647 deleted
+lines. At the present baseline `vmex/core` has 58 files / 52,563 Python text
+lines; `vmex/mirror` has 14 / 9,376. This is a substantial maintenance burden.
+Measure these as source-text counts, not comparable cross-language complexity.
+Most of the old plan's open-PR list is now obsolete:
+
+| Landed work | Evidence and implication |
 |---|---|
-| F1–F3 fixed boundary | Single-grid, multigrid and polished value; ns, MPOL/NTOR, finite-beta/current, LASYM, cold/new-input/changed-resolution/JIT reuse |
-| F4–F6 response/scan | Value, scalar gradient, vector residual/Jacobian, parameter scan; parameter count and RHS/chunk count |
-| F7–F10 optimization/coupling | Actual optimizer iterations, virtual casing, coils, single-stage and any dependency gate; first result, best feasible result, full campaign |
-| F11 symmetry | Matched symmetric/LASYM value and gradient at common physical resolution, parity and compile graphs |
-| High-order polish | Lift, constraint chart, certificate, r/JVP/VJP, preconditioner build/apply, inner solve, GN trial, exact stationarity adjoint |
-| B1/B2 Boozer | Existing one/eight-surface transforms; extend to symmetric/LASYM derivatives, modes, phase tensors, chunking and plan reuse |
-| C1/C2 confinement | Effective ripple and hard/smooth/tracked Gamma-c separately, bounce topology, pitch/line/radial resolution |
-| M1–M3 and H additions | Fixed/free mirror, hybrid, then anisotropy/3-D interface; valid external fields and model certificates |
-| Parallel | Independent-case throughput plus single-problem strong/weak scaling and gradient communication under E |
-
-The September review executes bounded coverage of the shipped matrix. Missing
-extras, timeouts and stages without physics certificates remain visible in the
-manifest. Complete the repaired matrix before drawing publication conclusions.
-
-### D3. Tool-driven investigation
-
-1. Use Python wall timing and cProfile for orchestration, repeats, cache lookup,
-   host synchronization and file I/O. Then label the dominant JAX regions.
-2. Capture JAX traces for XProf/TensorBoard and Perfetto. The current JAX docs
-   recommend XProf; TensorFlow is not required merely to profile JAX. Use
-   nonblocking trace capture and bounded trace windows.
-3. Inspect lowering/StableHLO/optimized HLO for captured constants, graph size,
-   repeated compilations, collectives, layout conversions and fusion boundaries.
-   Use compiled executable memory/cost analysis alongside the trace.
-4. On office GPUs use XProf kernel timelines; use Nsight Systems/Compute when
-   available and needed for launch latency, occupancy, bandwidth and roofline
-   analysis. Record unavailable tools instead of claiming kernel-level coverage
-   from Python-only timing. Host and device inclusive durations can overlap.
-5. Run one-change ablations at matched force/gradient accuracy. Save compact
-   summaries and hashes; archive raw XPlane/Perfetto/HLO files outside git.
-
-Priority investigations: tridiagonal backend/launch count on GPU; repeated
-Newton refinement and adjoint work in optimization; chart SVD and nested AD in
-polish; unused preconditioner setup; Boozer contraction/transpose memory;
-LASYM chunk policy; mature persistent-cache rescans; shared objective setup and
-callbacks. Static metadata may be cached; physical iterates must be dynamic
-arguments. Bound caches by bytes **and entries**, with a documented per-job
-location for shared filesystems; never routinely erase a user's global cache.
-
-**Promotion gate:** lower time to the same certified result and/or materially
-lower memory, no unexplained gradient/branch change, no compile-count regression,
-and a regression budget appropriate to the size of the improvement. A noisy
-5% microbenchmark difference is not a universal speed claim. Performance
-refactors should normally have nonpositive source/file growth, with justified
-exceptions for new capabilities and independent scientific tests.
-
-## E. Make parallelism and sharding real on CPU and GPU
-
-**Owner split:** VMEX chooses physical work partitions and reduction weights;
-SOLVAX preserves shardings and implements generic communication/solves. The
-current `shard_batch`, global inner products, PCG, structured solvers and Schur
-operators are foundations to reuse. No VMEX physics goes into SOLVAX.
-
-Review baseline: 22 targeted SOLVAX least-squares/sharding tests passed. An
-external probe also executed VMEX's actual strong-force row kernel and its
-parameter gradient on 1/2/4/8 emulated CPU devices and 1/2 real office GPUs.
-Values and gradients matched the single-device reference within the declared
-1e-10/2e-9 tolerances; the multi-device reverse kernel contains one all-reduce
-and no all-gather. Local shard shapes were inspected. This verifies a useful
-building block, not a distributed nonlinear equilibrium solver or a speedup.
-
-- [ ] Establish four distinct modes: one-device execution, CPU independent-case
-  ensembles, GPU independent-case ensembles, and one-problem multi-device work.
-  Report latency, throughput and memory for the appropriate mode. Bound CPU
-  workers against XLA internal threads; sweep workers/affinity to avoid
-  oversubscription and memory multiplication.
-- [ ] Start with independent equilibrium cases, then independent force/certificate
-  quadrature rows, Boozer surfaces and particle/field-line batches. Replicate
-  modest equilibrium coefficients and shard quadrature rows initially. Compute
-  local JVPs and globally sum VJP/normal contributions exactly once.
-- [ ] Derive the global weighted least-squares sum and adjoint reduction, including
-  any normalization by global volume. Test uneven/padded batches with masks;
-  never let padding change the physical norm or gradients.
-- [ ] Use explicit `NamedSharding`/mesh layouts and `shard_map` where manual
-  communication is needed, compatible with the pinned JAX version. Inspect
-  input, output and **intermediate** layouts/HLO; multiple visible devices or
-  `vmap` alone is not distributed execution.
-- [ ] Test runtime matrix/diagonal operands as well as RHS, scalar nonlinear
-  objectives, JVP/VJP duality and parameter gradients. This prevents constant
-  folding/replication from making a broken adjoint appear collective-free.
-- [ ] Extend SOLVAX CI on 2/4/8 emulated CPU devices; these test SPMD semantics,
-  not physical-node scaling. On office run 1/2 real RTX A4000 GPUs, inspect local
-  shards and peer topology, and compare single-device references within a
-  predeclared float64 tolerance at matched residual. Record HLO collectives and
-  measured communication bytes/time in both primal and reverse passes.
-- [ ] Remove hidden `device_get`, NumPy conversions and single-device callbacks
-  from the promoted sharded hot path. Current implicit callbacks may require
-  `JAX_PLATFORMS=cuda,cpu`; report actual placement and transfers. A host callback
-  stage must be marked as such until it is replaced or explicitly supported.
-- [ ] Introduce distributed radial/state decomposition only when replicated-state
-  memory or scaling warrants it, after C establishes local operators. Specify
-  halo/border/coarse communication and transpose semantics before implementing.
-- [ ] Publish strong scaling (fixed problem), weak scaling (fixed work/device),
-  efficiency `T1/(n*Tn)`, time-to-accuracy and memory/device. Include small cases
-  where communication makes two GPUs slower. Keep an explicit one-device fallback.
-
-**Exit:** one real VMEX equilibrium/optimization workflow and its gradient run
-correctly with the intended multi-device layouts on CPU and two GPUs; generic
-SOLVAX tests and a sharded field evaluator alone are intermediate milestones.
-Scaling claims are limited to measured hardware/workloads. Multi-node/MPI is a
-later extension, not implied by two devices on one host.
-
-## F. Optimization that produces useful physical designs
-
-**Owners:** VMEX equilibrium/objectives/constraints; SOLVAX generic algorithms;
-ESSOS coils, field evaluation, engineering objectives and orbit integration.
-
-### F1. One small optimization interface
-
-- [ ] Keep scalar `value_and_grad` and vector `residual_and_jacobian` routes
-  through one certified response/setup owner. Reuse the solve and linearization;
-  callbacks receive computed values rather than recomputing gradients.
-- [ ] Give every term a fixed physical or initial scale, units, target and
-  independently printed value. Do not silently renormalize away degraded field
-  strength, expanded volume or violated iota. Carry real bounds/constraints
-  through the optimizer; soft penalties do not guarantee feasibility.
-- [ ] Benchmark TRF/Gauss–Newton versus scalar quasi-Newton only on representative
-  dimensionalities and objective structure. Retain #197's documented tradeoff;
-  select a small default policy rather than eight duplicated driver families.
-- [ ] Use pressure/current/resolution continuation, tangent predictors and warm
-  starts with branch checks. Recycle generic linear spaces only while operator
-  drift/true residual remain acceptable. A looser forward solve must not merely
-  shift more work into root refinement and adjoints.
-- [ ] After derivative failure refine/retry or reject the outer trial and record
-  the reason. A line search cannot certify the direction computed from an
-  unconverged adjoint. Test the effect of tolerances on the final optimum and
-  engineering feasibility, not just gradient agreement at one point.
-- [ ] Record initial/best/final designs, every objective and constraint, gradient
-  norm definition, step acceptance, failures, physics certificates, compilation,
-  total wall time and memory. Save restartable small parameter/history artifacts.
-
-### F2. Application sequence
-
-| Application | Design and objectives | Required final validation |
-|---|---|---|
-| Student tokamak | A few boundary shape/profile variables; aspect ratio, elongation/triangularity, iota/current target | Analytic/Grad–Shafranov checks, current/force, FD gradient and feasible bounds |
-| QA/QH stellarator | Increasing boundary modes; QS, aspect ratio, iota, beta/current and geometric constraints | Native force/refinement, QS oracle, bootstrap consistency and ESSOS orbit check |
-| QI/omnigenity | Shared epsilon-effective, smooth Gamma-c and maximum-J terms, with weights visible | Hard Gamma-c, second-invariant/topology checks, transport and prompt losses |
-| LASYM stellarator | A physical asymmetric target/perturbation with both parity families | LASYM native/Boozer/virtual-casing parity and a scientifically useful before/after result |
-| Two-stage coils | Optimize boundary, then ESSOS coil curves/currents against required external normal field | Coil/plasma and coil/coil clearance, curvature/length, field-grid convergence and traced surfaces |
-| Single-stage finite beta | Coupled plasma/coil optimization using moving-boundary fields and virtual casing | Full coupled/root-adjoint certificate, feasibility and independently traced total field |
-| Mirror | Throat/length/shape/current and pressure parameters after H's closure gates | Mirror ratio/well geometry, force/interface, orbit/admissibility checks |
-| Periodic hybrid | Leg/return geometry, throat modulation, closure/iota and confinement, later coils | H's periodic model checks, explicit surface averages, ESSOS and applicable GKX/DKX validation |
-
-For coil cases, start from a seed with the required topology/iota and a measured
-normal-field error. ESSOS #58 is merged, but installed/released wheels must be
-capability-tested; the review's installed environment failed that test. Publish
-a compatible version or pinned reproducible environment before calling the
-example installable. ESSOS's latest GitHub release in this snapshot is v0.16
-(2025-08-23), so a merge on main must not be equated with that release. A
-circular-coil zero-iota seed is not evidence that no
-circular-coil arrangement can ever form a useful stellarator seed.
-
-Coil quadrature uses physical arclength/surface area. Check parameterization,
-quadrature and resolution invariance of squared flux, curvature/torsion,
-clearances and coil length. State whether a length term is a target or an upper
-bound and use the corresponding residual. Protect physical field/flux scale
-against normalized-objective degeneracy. Topological linking diagnostics are
-integer/discrete checks, not smooth shape gradients. Add perturbation/robustness
-runs for coil errors and profile changes after a deterministic design is valid.
-
-Coordinate ESSOS issues #14/#60 on named active/frozen coil DOFs and a stable
-dynamic-array/static-metadata representation. Verify active-set packing, parameter
-names and transpose scatter; do not implement a second coil-DOF owner in VMEX.
-Use its field batching/composition work (#15/#64) for repeated sampling. QFM
-surfaces (#17) can support seed/field validation, but an approximate QFM surface
-is not itself a certified ideal-MHD equilibrium.
-
-**Exit:** each promoted example reaches a declared feasible target with certified
-physics/derivatives, beats its own initial design on hard validation metrics,
-and reproduces on a clean documented installation. No promise that a confinement
-proxy proves zero particle loss or that a magnetic-well proxy proves stability.
-
-## G. Confinement and native downstream interfaces
-
-### G1. One full Boozer transform and shared diagnostic work
-
-The full transform is already dispatched to BOOZ_XFORM_JAX. Audit the optional
-lightweight symmetric path only for a measured selected-surface advantage. Keep
-it only with a clear accuracy/performance boundary; otherwise remove it.
-
-- [ ] Adopt `BoozerConfig`/`BoozerPlan` only with an available compatible release
-  or explicit research pin; distinguish installed 0.1.1 from unreleased APIs.
-- [ ] Reuse static mode/grid/transform tables and bounded chunks across surfaces,
-  objectives and summary plots. Compare separable/blocked contractions, streamed
-  modes and recomputing VJPs. Nonlinearly mapped angles are not generally a
-  plain FFT replacement.
-- [ ] Validate cosine/sine spectra, signs, surface ordering, analytic symmetry
-  limits, JVP/VJP and memory scaling against classic BOOZ_XFORM and native DESC
-  where the same quantities are defined. Warm-start nearby surfaces with explicit
-  ownership and residual checks; never leak state between unrelated equilibria.
-- [ ] Share Boozer/field-line inputs for epsilon-effective, Gamma-c and maximum-J
-  where the mathematics overlaps. Keep missing/invalid diagnostics as unavailable,
-  not zero. Plot both confinement profiles without a duplicate transform.
-
-### G2. Hard values and differentiable surrogates
-
-`GammaCSmooth` is shipped; the missing result is convergence of its optimization
-benefit to hard diagnostics. Preserve three semantic categories: hard physical
-Gamma-c, a smooth optimization surrogate, and a possible tracked-topology
-formulation. Implement tracked wells only if measured bias/branch behavior makes
-it useful; do not require three permanent public algorithms merely for symmetry.
-
-- [ ] Check hard Gamma-c against a pinned DESC/independent value, including
-  field-line/pitch/quadrature/radial refinement. Gamma-c squared is a least-squares
-  cost, not a general physical prompt-loss law.
-- [ ] Validate smooth values/gradients on analytic single-well, ordinary QA/QH
-  and multi-well near-event cases. Measure bias, temperature/resolution limits,
-  softmin tangencies and overflow. Do not report the surrogate as the hard value.
-- [ ] If tracking wells, retain brackets/IDs, match connectivity, implicitly
-  differentiate bounce roots and detect births, deaths, splits, merges and
-  ambiguous assignments. Refresh topology after accepted events; do not treat
-  those events as ordinary differentiable steps.
-- [ ] Validate epsilon-effective against NEO, maximum-J/second-invariant signs
-  and conventions, and bootstrap against the appropriate Redl/Sauter/Lin-Liu
-  formula and reference. Retain approximation/domain limitations (e.g. tokamak
-  fit used in stellarators); connect stronger physics tests to objectives.
-- [ ] Compare final optimized configurations using hard diagnostics, ESSOS
-  particle losses with sampling uncertainty, and DKX/SFINCS-compatible transport
-  where applicable. Use fixed random samples during smooth optimization and
-  independent samples for final validation.
-
-### G3. Native data contract, without an interface framework
-
-Use existing state/field/surface/Boozer adapter owners to define the smallest
-structural protocol needed by actual consumers. Carry arrays/pytrees and static
-metadata in memory; avoid WOUT/Boozmn/MOUT file round trips inside AD.
-
-| Consumer | VMEX provides | Consumer owns and validates |
-|---|---|---|
-| BOOZ_XFORM_JAX | Native geometry/field/profile tables, all parity, coordinates | Transform, nonlinear angles, spectra, chunking and transform derivatives |
-| VIRTUAL_CASING_JAX | Boundary position, normals, field/current and native derivatives | Singular/near-singular quadrature and external-field response |
-| ESSOS | Equilibrium field/boundary, dimensional sampling and certified response | Coils, Biot–Savart, orbit dynamics, loss estimators and engineering terms |
-| DKX | Fourier/Boozer geometry with conventions and radial derivatives | DKE, normalization, collisions and transport; closed-surface applicability |
-| GKX | Dimensional local mirror/hybrid/toroidal geometry | Gyrokinetic normalization, simulation and turbulence/eigenmode semantics |
-
-Each adapter declares topology, symmetry, pressure model, derivative support and
-whether sampling is exact or approximate. Preserve working file interfaces as
-external regression oracles. Do not relabel an open field line as a closed-surface
-DKE, or return fake toroidal quantities from a mirror. Check one end-to-end scalar
-derivative through every promoted chain, plus native/file parity. GKX's JAX floor
-is higher than the core review environment; test extras in separate environments.
-
-## H. Mirrors, anisotropy and periodic hybrids
-
-**Owner:** VMEX physical closure, topology and certificates; ESSOS external fields;
-SOLVAX generic coupled solves. This is a staged physics program, not an unchecked
-extension of toroidal labels.
-
-### H1. Harden the isotropic model and boundary contract
-
-- [ ] Retain fixed lateral geometry and through-flux end cuts. End cuts are
-  computational sections, not plasma–vacuum interfaces; do not impose lateral
-  total-pressure balance there. Audit simultaneous cut geometry/flux/lambda
-  constraints for compatibility and resulting end boundary layers.
-- [ ] On a free lateral surface require `B·n=0` and continuity of
-  `p + B²/(2mu0)`. Report each interface residual separately from interior force.
-- [ ] Reject net axial current only in entry points whose exterior cannot carry
-  its circulation, or implement the corresponding field/circuit with explicit
-  end-electrode/return-current assumptions. A fixed-boundary interior model can
-  support prescribed current under a stated end circuit; do not blanket-ban it.
-- [ ] Write the exterior Laplace/Neumann/decay BVP, numerical caps and BIE/Duffy
-  quadrature explicitly. A decaying exterior Neumann problem is not the interior
-  Neumann problem with an arbitrary constant gauge. Net physical magnetic flux
-  must still be zero; cap projection is a solenoidality consistency correction.
-- [ ] Validate full circular-coil fields on and off axis, quartic analytic flux,
-  long-thin two-coil limits along z at fixed flux, and force/divergence under
-  radial/axial/angular/end-collar refinement. Cite the exact Ågren–Savenko
-  potential used. `sqrt(1-beta)` is a long-thin estimate at its stated order,
-  not inherently a small-beta expansion or an exact finite-radius law.
-
-### H2. Consistent anisotropic closure before optimization
-
-For static, gyrotropic, flow-free MHD use
-
-`P = p_perp I + (p_parallel-p_perp) b b`, `J×B = div P`,
-
-`b·grad(p_parallel) = (p_parallel-p_perp) b·grad(log B)`.
-
-For profiles `p_parallel(s,B)`, enforce the Grad relation
-`p_perp = p_parallel - B partial_B p_parallel |_s`. Check the **full parallel
-projection** of `div P`; the isolated b-directed term in its expanded expression
-does not generally vanish by itself. Do not choose two unrelated radial
-pressure profiles where B varies along a mirror field line. DESC's tensor-force
-implementation can be cross-checked with a consistent profile closure; the
-problem is the selected closure, not all anisotropic DESC calculations.
-
-- [ ] Start with isotropic recovery and a consistent analytic Delta family.
-  Then add a polynomial mirror pressure family on its declared B domain, and
-  only then distribution moments/tabulated sloshing-ion models. Derive p_perp
-  from the same smooth p_parallel representation; preserve positivity and do not
-  hide a nonsmooth cutoff under AD. For tables test interpolation derivatives
-  and physical-domain boundaries as well as moment values.
-- [ ] Derive weak energy and boundary terms before coding. A candidate split is
-  `W = integral [B²/(2mu0) + p_th/(Gamma-1)] dV - integral p_hot,parallel(s,B) dV`,
-  with the thermal mass/volume law enforced. Handle isothermal/special gamma
-  cases separately; do not substitute an anisotropic pressure into the isotropic
-  energy formula. Verify first variations against the tensor force.
-- [ ] Check normalized firehose `sigma=1+mu0(p_perp-p_parallel)/B²` and closure
-  ellipticity `tau=1+(mu0/B) partial_B p_perp |_s`, both positive in the
-  admissible domain. Derive the principal symbol and analytic bi-Maxwellian
-  threshold as tests. Published sign/convention differences must be resolved
-  from that derivation, not copied blindly from one preprint. These conditions
-  are not proof of global interchange or kinetic stability.
-- [ ] CGL double-adiabatic invariants belong to a specified dynamical/stability
-  model; they do not by themselves specify a unique static equilibrium closure.
-- [ ] Test Cartesian manufactured tensor divergence, parallel integrability,
-  exact theta-pinch total pressure, energy/residual directional consistency,
-  isotropic value/residual/AD limit, and anisotropic long-thin mirror profiles.
-  Use published ANIMEC **toroidal** cases for that shared closure only; use
-  WHAM/Novatron/Pleiades-related data for mirrors with reproducible model inputs.
-
-### H3. Free boundary and 3-D mirrors
-
-Use actual ESSOS circular coils for the axisymmetric baseline. Continue from
-vacuum through low pressure, boundary release, pressure/anisotropy increase,
-and then small nonaxisymmetric coil/boundary perturbations. Remove the present
-axisymmetric gate only after the coupled solver and all geometry/quadrature
-operators retain full theta dependence.
-
-Include interior force, lateral B·n, anisotropic total-pressure balance
-`p_perp+B²/(2mu0)`, exterior response, cut constraints and any circuit unknowns
-in a separately scaled coupled system. Reuse SOLVAX Newton/PTC/Schur primitives;
-introduce pseudo-arclength only for a diagnosed fold. Validate plasma-off,
-isotropic and axisymmetric-on-a-multi-theta-grid limits, cap/rim quadrature,
-near-singular response, perturbation/FD and full coupled adjoints.
-
-MOUT/native outputs must retain anisotropic fields, external/plasma/total fields,
-coil and closure metadata, interface/force/divergence certificates and continuation
-history. Produce one axisymmetric anisotropic free-boundary coil case and one
-small but real nonaxisymmetric case before claiming general 3-D capability.
-
-### H4. Give the hybrid actual mirror wells and a valid optimization target
-
-The present hybrid is periodic and closed, with straight legs and curved
-returns; it has no open-end loss. Constant leg cross-sections do not create
-mirror throats inside the straight legs. Add smooth leg-radius/throat modulation
-and test it against the paraxial `B∝1/a²` limit before optimizing a leg mirror ratio.
-
-Define `R_m,axis` separately for each leg's well, `R_m,LCFS` separately, straight
-length by an explicit curvature threshold, and mirror length by the maxima
-bounding a |B| well. Do not export `std(B)/mean(B)` as a consumer's “epsilon”
-without matching its definition. Verify equal-arc remapping, periodic geometry,
-axis/section regularity, field-line closure, force and straight/toroidal limits.
-
-Reproduce #211 on a solved state, with pinned axis transition geometry, and
-separate axis representation, section rotation, quadrature and force-operator
-consistency under refinement. Compare local force near leg/return junctions with
-bulk error; derive the appropriate regularity/weak interface condition if a
-curvature discontinuity is retained. Do not simply relax the circular-limit
-threshold or infer acceptable strong force from downstream growth-rate
-convergence. Replace seed-based modulation assertions with solved-state physics
-tests and state which metrics a downstream consumer may admit.
-
-Optimize low-resolution geometry and mirror wells, then iota/closure, second
-invariant/QI quality, force refinement, coils and loss/transport/turbulence in
-stages. Use explicit surface quadrature or a justified ensemble of field lines
-where a single rational closed line cannot represent a surface average. Boozer
-coordinates may be valid while a single-line diagnostic is not.
-
-Final evidence includes before/after geometry, well/length profiles, iota,
-J-contours, force/refinement, actual coil feasibility and normal field, orbit
-loss uncertainty, and DKX/GKX quantities only within their model scope. Stability
-proxies and curvature integrals supplement, rather than replace, equilibrium
-and appropriate stability analysis.
-
-## I. Make the project easier to learn, maintain and install
-
-### I1. Documentation and README
-
-Keep the existing four-part documentation structure and give each fact one
-owner. Tutorials teach, how-to pages solve tasks, explanation pages derive
-physics/numerics, and reference pages specify APIs/options/status. Consolidate
-repeated “all of VMEX”, README and optimization/polish narratives with links and
-redirects. A public module index is useful; every internal helper need not be a
-user-facing API.
-
-- [ ] First path: install → doctor → bundled solve → inspect convergence and
-  force → first gradient → small optimization. Explain legacy residual,
-  continuous force and derivative certificate with one worked finite-beta case.
-- [ ] Keep source and wheel instructions consistent, state optional capabilities
-  and supported dependency ranges, and fail early with an actionable missing
-  capability/version message. Exercise minimal and full-extra installations.
-- [ ] Finish #257 exported API coverage, units/shapes/returns, examples and typed
-  failure semantics. Generate capability status from existing tested metadata;
-  include topology, LASYM, pressure/current model, native/export and AD scope.
-- [ ] Organize explanations into conventions/model, branch finder, high-order
-  force, differentiation, parallel execution, diagnostics and mirror physics.
-  Link algorithms to SOLVAX instead of copying its solver manual into VMEX.
-- [ ] Create one validation map linking claims → equations → tests → artifacts,
-  and one performance methodology/results page. State unsupported/experimental
-  behavior prominently, including polish stationarity, free-boundary branch
-  locality, Gamma-c topology and mirror end physics.
-- [ ] README: concise purpose; install and minimal runnable example; supported
-  capabilities; one representative scientific result; link to measured accuracy,
-  AD and performance tables; links to tutorials, research examples and citation.
-  Include cold startup as well as warm cost. Remove stale version/comparison
-  claims and use IFT/discretization-qualified derivative language.
-- [ ] Rebuild figures from a manifest recording generator, input/revision hashes,
-  units/norms, region, hardware, date and supporting JSON. Native DESC and WOUT
-  reconstruction must be labelled differently. Retire unsupported/orphan media
-  after link checks; keep representative losses/failures in the comparison data.
-- [ ] Verify scientific source/credit lineage before using “clean-room” or “port”
-  in public/paper text. Retain licenses, contributor credit and the existing
-  citation/changelog rather than inventing authors, ORCIDs or an unissued DOI.
-
-### I2. Deliberate examples, from students to research
-
-Reuse the existing example families listed in F2. Each example has a physical
-question, editable parameters at the top, visible construction/solve/objective
-steps, concise output, before/after diagnostics and a small saved configuration.
-Give fast teaching/CI and research settings with measured runtime/memory and
-optional dependencies. Keep ordinary Python easy to run and adapt; do not hide
-physical choices behind a generic launcher or many configuration layers.
-
-- [ ] Reuse the existing first equilibrium/gradient/optimization and coil scripts.
-  Avoid one file per optimizer, degree, device or scalar/vector variant.
-- [ ] Demonstrate boundary, pressure/current, solver tolerance, resolution,
-  device and optimizer choices where relevant, with their physical meaning.
-- [ ] Fast CI checks must test a real numerical invariant or improvement, not
-  only source-text presence. Research examples add hard diagnostics, refinement,
-  restartability and complete provenance without putting large arrays in git.
-- [ ] Student exercises: force versus solver tolerance; h/p refinement; FD versus
-  IFT gradient; parameter scaling; coil-field quadrature; model limits of mirrors.
-  Supply expected ranges and explanations for failure, not just a final figure.
-- [ ] Ask an external researcher/student to reproduce one installation and one
-  design workflow; record friction as issues and use it to simplify the path.
-
-### I3. Reduce code and file count through ownership
-
-The review measured roughly 58,073 text lines in 78 files under `vmex`, 40,993
-under tests, 11,495 under docs and 8,308 under examples. These are filesystem
-text counts, **not cloc implementation-line comparisons**. The old plan alone
-was 3,411 lines / 148,272 bytes. The largest implementation owners are
-`optimize.py`, `implicit.py`, `solver.py`, `freeboundary.py`, `polish.py`,
-`plotting.py`, `mirror/splines.py` and `polish_driver.py`.
-
-- [ ] Map public symbols/imports, duplicate equations, state packing, response
-  caches, optional imports and private cross-owner calls. Delete obsolete paths
-  after callers/tests migrate. Do not split a large module into many tiny files
-  merely to improve a line-count chart.
-- [ ] Consolidate scalar/vector response reports, failure/refinement policy,
-  boundary packing, free-boundary Schur orchestration and plotting diagnostics.
-  Share topology-independent spline basis code while retaining different topology
-  constraints. Keep canonical Boozer and coil algorithms in their owning codes.
-- [ ] Retire unused square-polish orchestration/controls after a migration window,
-  preserving only an independent reference if it is useful. Avoid two production
-  stacks with ambiguous names and partially implemented knobs.
-- [ ] For each refactor record net files/code/comments, import/startup time,
-  compilation count, warm value/gradient time, memory and numerical differences.
-  Prefer nonpositive LOC/file growth for refactors; do not delete independent
-  validation, readable equations or useful docstrings just to meet a quota.
-- [ ] Keep small inputs, manifests and summaries in git; archive large traces,
-  matrices, WOUT campaigns, videos and duplicate figures with hashes and download
-  instructions. Preserve the existing repository-size gate. Pruning means
-  removing unreferenced generated data, not rewriting history or deleting a
-  user's results without a separate decision.
-
-## J. Release and publication evidence
-
-### J1. Tests and release gates
-
-Use the existing test manifest and CI lane ownership. Fast tests cover equations,
-contracts and failure semantics; explicitly JIT-enabled integration tests cover
-compiled forward/AD behavior; optional/nightly/weekly lanes cover cross-code,
-GPU, higher resolution and costly applications. Keep deterministic input/seeds,
-record skips as capability gaps, and give expensive runs budgets plus partial
-reports. Coverage is useful but cannot substitute for a physics oracle.
-
-For each numerical change require the relevant exact/manufactured test,
-independent force/profile/observable check, derivative certificate and matched
-performance measurement. For sharding include actual multi-device execution.
-Run changed/owning tests first, then required repository checks. For documentation
-require strict Sphinx/navigation/link checks and runnable examples; no new test
-framework is needed for this plan edit.
-
-A release needs source/wheel installs, minimum/selected current dependency tests,
-optional-extra compatibility, CPU/GPU numerical tolerance policy, docs, changelog,
-capability status and reproducible small benchmark smoke. Use tolerances backed
-by observed numerical accuracy: floating-point/JIT fusion changes are not
-expected to be bit-identical across devices. Do not silently relax physics or
-AD tolerances to make a performance change pass.
-
-### J2. Papers with distinct scientific claims
-
-| Output | Main question and required result | Dependencies |
-|---|---|---|
-| Equilibrium/numerics paper, e.g. CPC/JCP/JPP | Can a VMEC-compatible branch finder plus local high-order solve reach accurate continuous force balance efficiently? Include analytic verification, native DESC/GVEC comparison, h/p behavior, current closure, time-to-accuracy, memory and negative cases. | A–D, B's mandatory smooth toroidal set; E only for distributed claims |
-| AD/optimization/performance paper | Do certified implicit gradients and distributed work reduce the cost of feasible stellarator/tokamak/coil design? Include parameter-count scaling, FD/IFT checks, adjoint residuals, compiler/kernel evidence and complete optimization histories. | C5–G, measured E |
-| Mirror/hybrid physics paper | What equilibria/designs become possible with a consistent anisotropic closure and coupled coils? Include exact limits, independent references, interface/closure certificates and scientifically meaningful optimized wells. | H and relevant F/G |
-| Optional JOSS software paper | Reusable software contribution, need, design, research use and community practice; no substitute for the numerical/physics papers. | Reproducible supported release and current journal eligibility |
-
-Predeclare the benchmark set and acceptance bands. Present accuracy/runtime/memory
-Pareto curves, success/failure coverage and confidence intervals. Compare native
-representations and exported compatibility separately. Show gradients versus
-number of design variables **including setup/compilation**, and speedups only at
-matched accuracy/hardware where a controlled comparison is possible. A single
-favorable row cannot support a global “faster and more accurate than DESC” claim.
-
-Archive release-tagged code, small inputs, exact environments, raw numerical
-results, figure scripts and optimized parameters with persistent identifiers at
-submission. Maintain CITATION.cff, contributor/ORCID information supplied by the
-authors, license/source credit, changelog, metadata, and an honest AI-assistance
-and verification disclosure. Add DOI/badges only when a record exists. Check the
-current journal's requirements at submission; JOSS currently includes public
-history/research-impact gates, not just an installation checklist. A DOI and
-external publication are later maintainer actions, not blockers to this plan.
-
-## 4. What to learn from DESC and other codes
-
-These are source-grounded implementation lessons and bounded reference roles.
-Open PRs are not shipped capabilities, and a closed branch may be stale even
-when its name sounds relevant. Exact inventories and head SHAs are in the review
-manifest/external snapshots.
-
-| Source | Lesson for VMEX and its boundary |
+| #253, #254, #256, #257 | Packaging, bounded cache entries, figure provenance and API docs landed; the prose still needs reconciliation with later measurements |
+| #258–#260, #264 | Tail/Jacobian diagnostics, native symmetry metadata, native DESC measurement and a true analytic Solov'ev oracle landed; these are useful foundations, not proof of a solved high-order equilibrium |
+| #261 (`189b75fb`) | Batching/rematerialization and priced AUTO admission reduce memory; recorded W7-X flat certificate 34.23 GiB → automatic 3.02 GiB, but chart setup still 15.44 GiB / 1,751 s; no affordable certified 3-D solve follows |
+| #262, #268–#270, #273 | Transformed derivative failure semantics, true linear residual, finite common-force certificate, input VJP and external-fixture skip repair landed; nonlinear stationarity is still a separate requirement |
+| #263, #272, #278, #280, #281 | Mirror audit, Gamma-c labeling, pressure scaling, nonsaturating force metrics and flux-tube conventions improved |
+| #197, #265 (`ae0e410f`) | Scalar-adjoint examples, optimizer progress and free-boundary workflow changes landed; useful optimization cost remains much larger than a warm primal call |
+
+### Open PR disposition at this review
+
+These are review recommendations, not merge approvals. Recheck the head and
+required CI/reviews immediately before any merge.
+
+| PR / reviewed head | Disposition and remaining work |
 |---|---|
-| DESC master force/basis/objectives | Regular Fourier–Zernike axis behavior, analytic derivatives, independent resolution controls and normalized objectives are useful. Its force component weighting is also not automatically the same as VMEX's proposed Cartesian volume L2; match metrics explicitly. |
-| DESC least-squares implementation | Current trust-region path supports QR/SVD/Cholesky choices; QR is the default examined here. A dense/reference factorization is valuable before scalable preconditioning, but need not become VMEX's large-case default. |
-| DESC #1773, `ku/shard`, and #1495, `yge/multigpu` | Sharding/MPI work is experimental and workload dependent. Inspect current diffs, dependency versions, collectives and AD; prior JAX compatibility failures and setup costs matter. Do not claim general multi-GPU speedup from the branch name. |
-| DESC #2170, #2267, #2281; issues #1686/#1872/#2171 | Sparse pullbacks, batching, releasing old Jacobian/factor buffers and shared value/gradient work guide D. Measure the complete derivative graph and avoid duplicate solves. |
-| DESC #2031, #2286; issues #1569/#2000/#2087 | Proximal/QR, chunked linearization and conditioning work remain relevant. Regularization changes sensitivity; the documented difficulty differentiating public `eq.solve` motivates testing VMEX's actual public composable chain. |
-| DESC #2304/#944, #2302/#2301 | Dynamic normalization and coil quadrature can change the optimization target or create resolution dependence. Include physical scales, parameterization and quadrature invariance in F. |
-| DESC #1877/#1876, `dp/lambda-resolution` | Near-axis iota/current and lambda/grid resolution require dedicated constraints and tests, not an assumption that spectral code is automatically exact. |
-| DESC #1848, mirror/anisotropy branches | Useful geometry and tensor-force prior art, still a research branch. Validate a consistent B-dependent pressure closure and the same open/periodic model before treating it as an oracle. |
-| DESC #2309, #2215, #1676, #994 and bounce work | Smooth J/topology objectives, available energy and omnigenity research guide G, with hard diagnostics and topology-event validation. |
-| DESC #2255/#2317 and documentation issues | Student workflows, scaling tutorials, reduced figure size and realistic runtime guidance belong in the main usability path. |
-| SOLVAX #98/#96/#86/#32/#66/#71/#28 | GN, Schur, forcing, recycling, sharded batch/operands and collective tests already exist in varying scope. Extend those owners; do not reimplement them in VMEX. Issue #74's large complex Arnoldi work is not a prerequisite for real GN polishing. |
-| ESSOS merged #58; open #61–#66 | Moving-boundary coil fields and optimization interfaces are on main; in-memory VMEC, combined fields, linking and winding-surface/objective repairs need release/source checks. Keep field/coil geometry and engineering quadrature in ESSOS. |
-| GVEC | Closest spline/Fourier equilibrium precedent: arbitrary-degree radial B-splines and flexible axes. Compare radial convergence, constraints and energy formulation; do not present B-splines alone as VMEX novelty. |
-| VMEC2000 and VMEC++ | Profile/normalization/constraint and free-boundary compatibility references. Refresh feature tables against pinned source; old abstract limitations may no longer describe current code. |
-| SIMSOPT | Clear parameterized examples, finite-beta single-stage objectives and coil engineering/robustness checks. Use it for independent objective/field oracles, not as a source of copied solver abstractions. |
-| SIESTA, SPEC, HINT; ANIMEC/Pleiades | Different topology or anisotropy assumptions bound the claim. Numerical agreement requires the same physical model; unsupported combinations must remain explicit. |
+| [#277](https://github.com/uwplasma/vmex/pull/277), `db6092b7` | Highest priority. Necessary nonlinear stationarity gate; local focused tests pass, but Linux e-polish CI fails the real-MHD `least_squares_success` assertion. Reproduce and explain before merging; do not relax the certificate to obtain a badge |
+| [#266](https://github.com/uwplasma/vmex/pull/266), `daf6e2dc` | Preserve its profiling and explicit coil target. CI passes at this snapshot. Review physical target/feasibility and gradient policy, refresh stale dependencies and correct the claim that iteration counts identify conditioning or that forward and transpose operators are identical |
+| [#276](https://github.com/uwplasma/vmex/pull/276), `e1714014` | CI passes; bounded format/output cleanup. Verify lossless output and figure hashes against its final head. It can be reviewed independently of force-balance research |
+| [#274](https://github.com/uwplasma/vmex/pull/274), `308d39d5` | This plan supersedes its proposed schedule. Preserve the useful bounded recovery and publication-scope decisions; do not merge two competing plans. Close as superseded after the replacement is accepted |
 
-## 5. Literature mapped to concrete work
+#274 adds roughly 477 lines to an already long plan. Some statements are too
+strong: Taylor-style stationarity tests already exist; a spectral projection
+tail is not a proven lower bound on achievable nonlinear force error; and a
+published resolution study cannot establish a universal W7-X error floor for
+a different representation, norm and pressure profile. Its proposed immediate
+0.8.2 tag conflicts with the requested release hold.
 
-Use primary papers, source/manuals and textbooks together. Record the exact
-version/equation and input data used for each new test. References below ground
-the program; they are not claims that every published result has been reproduced.
-The existing bibliography retains detailed diagnostic citations corrected in
-#250. Bibliographic metadata alone is not sufficient to implement an equation.
+### New local evidence
 
-| Reference | Required use |
+CPU: Apple M3 Max, 36 GiB, Python 3.11.14, JAX/jaxlib 0.9.2, float64.
+Compilation cache disabled for the VMEX probes. The host also had unrelated
+jobs: the following timings are diagnostic samples, **not speedup rankings**.
+
+| Execution | Result | What it establishes |
+|---|---|---|
+| Main radial basis + strong force suites | 67 passed, 619.75 s | Existing axis/force identities and rejection checks pass locally |
+| Analytic Solov'ev + selected ordinary implicit FD/preconditioner tests | 9 passed, 148.21 s | Closed-form projection/refinement and selected derivative consistency pass |
+| #277 nonlinear stationarity selection | 26 passed, 219.70 s | Local real-MHD fixture passes; portability unresolved: CI JAX 0.11.1 / Python 3.12 has 1 failed, 226 passed in 2,519.45 s |
+| Fresh VMEC++ source Hessian/adjoint tests against its 0.7.3 wheel | 4 passed, 1.79 s | HVP/adjoint examples work in this environment; the wheel is not a build of fresh main |
+| Same shaped-tokamak deck, VMEX / VMEC++ | Both converge; R/Z coefficient relative L2 below 1.2e-15, lambda below 3e-14 | Strong compatibility evidence on this case; iteration counts 158/159 |
+| Same finite-beta QA deck, VMEX / VMEC++ | Both converge; relative L2 R 3.73e-6, Z 1.79e-5, lambda 3.87e-4, iota 4.06e-7 | Small differences, not universal roundoff agreement; iterations 730/775 |
+| Fresh native DESC solve from the tokamak WOUT, L=12/M=6/N=0 | Converged in 28 iterations; native mean-force/mean-pressure-gradient 8.06e-5 | Actual native DESC execution; imported profiles/initialization and quadrature still need matching for a ranking |
+| Fresh GVEC source, analytic GS elliptical example | Builds/runs; force channels reach 2.87e-9, 3.58e-9, 3.75e-8 after 3,000 iterations but the configured stopping test remains unsatisfied | Source build and bounded execution succeeded; an exit code of zero and “successfully finished” are not convergence certificates |
+
+The VMEX first/warm and VMEC++ times were 3.33/0.0422/0.00692 s for the
+tokamak and 8.42/1.16/0.258 s for QA. These are two small cases, with one warm
+sample, one VMEC++ thread, and shared-host load. Retire blanket performance
+claims; neither these measurements nor previous selected runs establish a
+cross-code time-to-accuracy advantage. GVEC's example is a different problem
+and is not included in that timing comparison. No new GPU result is claimed.
+
+## 3. What the literature and source change about our choices
+
+### Native force accuracy must lead the comparison
+
+[Panici et al., DESC Part I](https://arxiv.org/abs/2203.17173) demonstrates why
+near-axis force accuracy and radial resolution affect quantities such as
+Mercier stability. Reproducing the VMEC discrete trajectory does not remove
+that issue. Use its force definitions and evaluation-region conventions as
+an explicit benchmark protocol, while also reporting the whole volume and
+the magnetic-pressure normalization for near-vacuum cases.
+
+The current validation page incorrectly ranked native DESC using an exported,
+refitted WOUT. The merged native DESC result is 4.01e-6 in its pressure-gradient
+ratio, whereas the refitted record is about 7.13e-2 in a different pointwise
+L2 metric. Dividing these is not a measured export amplification factor.
+This PR corrects that interpretation and preserves the historical numbers
+as reconstruction evidence in [validation](docs/explanation/validation.md).
+
+The recorded tokamak polish improves the bounded pointwise score 7.12 times,
+but dimensional volume L2 only 1.61 times and the full-volume pressure ratio
+1.32 times; near-axis dimensional L2 improves 14.5 times. These are different
+claims. A projected analytic Solov'ev reaches about 7.44e-10 geometric error
+with degree five and a force roundoff floor near 1e-10; that proves useful
+representational capacity, not that the nonlinear solver finds that state.
+
+### VMEC++ is a serious baseline, not a frozen historical comparator
+
+[The Numerics of VMEC++](https://arxiv.org/abs/2502.04374) documents the
+variational discretization, preconditioning and iteration machinery.
+Current source retains the damped VMEC-style iteration; its improvements
+include engineering of the implementation and the response interface.
+[0.7.2](https://github.com/proximafusion/vmecpp/releases/tag/v0.7.2) introduced
+the boundary-adjoint example; [0.7.3](https://github.com/proximafusion/vmecpp/releases/tag/v0.7.3)
+adds LFORBAL and restart fixes, LTO builds and x86 dispatch improvements.
+The tested Hessian product uses centered finite differences of analytic
+forces, not exact automatic differentiation. Its adjoint test independently
+reconverges perturbed equilibria. Adopt that verification discipline; do not
+infer that a public HVP means a globally robust Newton equilibrium solver.
+Pin a released binary as well as source and compare one-thread and OpenMP
+costs separately; the [validation repository](https://github.com/proximafusion/vmecpp-validation)
+is useful prior art for broad input compatibility.
+
+### DESC and GVEC suggest formulation and preconditioning work
+
+The fresh DESC checkout (`ad105c5e`) uses Fourier–Zernike regularity and a
+least-squares trust-region implementation whose default subproblem method is
+QR, with SVD/Cholesky alternatives. It is not evidence that replacing VMEX's
+CG with LSMR alone solves the physical problem. Relevant open work includes
+[#2286](https://github.com/PlasmaControl/DESC/pull/2286) on linearization reuse,
+[#1773](https://github.com/PlasmaControl/DESC/pull/1773) on sharding, and
+[#1877](https://github.com/PlasmaControl/DESC/pull/1877) on near-axis evaluation.
+Their branch status and claims remain separate from released behavior.
+
+[GVEC's theory](https://gvec.readthedocs.io/latest/user/theory.html) separates
+the geometry map, radial B-splines/Fourier representation and energy descent.
+The source at `c0dc66fe`, `src/functionals/mhd3d/mhd3d_evalfunc.F90`, constructs
+mode-separated banded radial preconditioners for both geometry fields and
+lambda. This is a concrete template for deriving an approximate VMEX
+operator, not justification for copying GVEC's whole coordinate framework.
+Its independently adjustable geometry components also motivate auditing
+VMEX's present correction chart before optimizing its linear algebra.
+
+## 4. P0 — make acceptance and PR integration reliable
+
+Owner: VMEX (`implicit.py`, `polish_driver.py`, `polish_implicit.py`, public
+optimization wrappers); SOLVAX owns generic true-residual reporting.
+
+1. Finish #277 with the actual failing Linux/JAX 0.11.1 context. Record
+   Python/JAX/SciPy versions, initial residual scaling, stopping reason and
+   attained stationarity. The local JAX 0.9.2 result is not sufficient.
+   Keep the tight real-MHD fixture; change an algorithm or justified stopping
+   definition only after identifying the discrepancy.
+2. Audit ordinary `implicit._refined_state` as well. It already applies a
+   matrix-free Newton/GCROT refinement, but the implementation explicitly
+   allows a best-effort nonroot to be returned. Gate derivative eligibility
+   on the actual nonlinear equation, admissible geometry and true linear
+   residual. Small adjoint residual alone cannot certify the implicit
+   derivative at an unconverged primal. Preserve value-only fallback with
+   explicit status where useful.
+3. For high-order least squares, distinguish physical force acceptance,
+   stationarity `g = Jᵀr`, and the true residual of the stationarity derivative
+   solve. All three are needed for a certified polished gradient. Host callers
+   and `jit`/`vmap` callers need consistent status; transformed NaN rejection
+   must not become a finite “best effort” gradient in an optimizer.
+4. Replace the CLI's misleading hard-ceiling description of AUTO. The code
+   prices anticipated Gauss–Newton work after setup; it does not interrupt
+   end-to-end execution at `--polish-budget`. Record setup, admitted work and
+   actual elapsed time separately; an enforced timeout would require a
+   separate, explicitly tested cancellation contract.
+
+**Gate:** real converged and failed-root cases under eager/JIT, including
+parameter updates and both derivative directions; true residuals recomputed
+outside iterative recurrences; no missing-fixture blanket skips. Preserve
+coverage and physics tolerances. Integrate #266/#276 only after their final
+review, and resolve #274 through this replacement rather than additive logs.
+
+## 5. P1 — define the physical problem and a small accuracy matrix
+
+Owner: VMEX. Reuse the existing certificate, analytic oracle and benchmark
+runner; consolidate them instead of adding another scoring implementation.
+
+### One comparison contract
+
+Record boundary, axis convention, NFP/LASYM, units, total toroidal flux,
+pressure and prescribed-iota/current functions, GAMMA/mass closure, radial
+coordinate and reference field/length. Hash the deck and native state. Compare
+physical functions, not just similarly named coefficient arrays. A projected
+state, a nonlinear solve and a WOUT reconstruction are different objects.
+
+Report Cartesian `F = J × B − ∇p` with converged quadrature: dimensional
+volume L1/L2/L∞, `mean(|F|)/mean(|∇p|)` where meaningful, magnetic-pressure
+normalization, and a fixed physical reference `B_ref²/(mu0 L_ref)` when a
+normalization vanishes. Include the axis neighborhood, bulk and edge, the
+whole volume, and an explicitly named literature window. State whether a
+window uses normalized flux `s` or `rho = sqrt(s)`; `[0.1,0.99]` means different
+regions in these coordinates. Never hide the axis by trimming it from the
+only quoted score. The bounded pointwise `eps_F ≤ 2` remains secondary.
+
+Certify on an off-grid mesh with independently evaluated derivatives and
+radial/angular refinement. Do not call two paths independent if they share
+the derivative or normalization being tested. Analytic identities and
+manufactured forcing test discretization; native cross-code comparison tests
+an actual equilibrium. Sampled Jacobian orientation does not prove global
+injectivity: also check boundary/interior geometry and crossing diagnostics.
+
+### Minimum matrix, expanded only when a gate needs it
+
+| Case | Purpose and acceptance evidence |
 |---|---|
-| Hirshman–Whitson (1983), [10.1063/1.864116](https://doi.org/10.1063/1.864116); Hirshman–Betancourt (1991), [10.1016/0021-9991(91)90267-O](https://doi.org/10.1016/0021-9991(91)90267-O) | VMEC variational/normalization and preconditioned-descent baseline, B/D |
-| Schilling, [The Numerics of VMEC++, arXiv:2502.04374v3](https://arxiv.org/abs/2502.04374v3) | Trace conventions, profiles, constraints and implementation heuristics to source, B |
-| Panici et al. (2023), [DESC Part I](https://doi.org/10.1017/S0022377823000272) | Native force, near-axis/stability and time-to-accuracy methodology, B/J; reproduce the defined norm and region |
-| Conlin et al. (2023), [DESC Part II](https://doi.org/10.1017/S0022377823000399); Dudt et al. (2023), [Part III](https://doi.org/10.1017/S0022377823000235) | Perturbation/continuation and constrained optimization baselines, C/F |
-| Hindenlang et al. (2026), [GVEC](https://doi.org/10.21105/joss.09670), [current manual](https://gvec.readthedocs.io/develop/index.html) | Spline/Fourier and flexible-axis prior art, constraints and comparison cases, B/C/H |
-| Hirshman et al. (2011), [SIESTA](https://doi.org/10.1063/1.3597155) | VMEC initialization followed by a different equilibrium method; distinguish topology/model from accuracy polishing |
-| Freidberg, [Ideal MHD](https://doi.org/10.1017/CBO9780511795046); Helander (2014), [Theory of plasma confinement in non-axisymmetric magnetic fields](https://doi.org/10.1088/0034-4885/77/8/087001) | Equilibrium/stability assumptions, nested-surface limits and confinement interpretation, B/F/H |
-| Fong–Saunders (2011), [LSMR](https://doi.org/10.1137/10079687X), [SOL implementation](https://web.stanford.edu/group/SOL/software/lsmr/) | Rectangular reference, conditioning, true residual and transpose requirements, C |
-| Eisenstat–Walker (1996), [10.1137/0917003](https://doi.org/10.1137/0917003); Kelley–Keyes (1998), [10.1137/S0036142996304796](https://doi.org/10.1137/S0036142996304796) | Inexact forcing and PTC where justified; retain exact terminal certificates, C/F |
-| Sangalli–Tani, [arXiv:1602.01636](https://arxiv.org/abs/1602.01636); Hofreither–Takacs, [arXiv:1607.05035](https://arxiv.org/abs/1607.05035); Kronbichler–Kormann, [10.1145/3325864](https://doi.org/10.1145/3325864) | Spline preconditioning, coarse spaces and tensor/matrix-free kernels; verify applicability to VMEX's operator, C/D |
-| Cooper et al. (1992), [10.1016/0010-4655(92)90002-G](https://doi.org/10.1016/0010-4655(92)90002-G); Cooper et al. (2009), [10.1016/j.cpc.2009.04.006](https://doi.org/10.1016/j.cpc.2009.04.006) | Anisotropic energy/free-boundary derivation and toroidal reference cases, H |
-| [Analysis of influences of pressure anisotropies on the 3-D MHD equilibrium in LHD](https://doi.org/10.1063/5.0033807), Eqs. 7–8 | Independent sigma/tau convention and sign checks for closure ellipticity, H2 |
-| Endrizzi et al. (2023), [WHAM physics basis](https://doi.org/10.1017/S0022377823000806); Frank et al. (2026), [10.1063/5.0306291](https://doi.org/10.1063/5.0306291), [preprint v4](https://arxiv.org/abs/2509.17288v4) | Mirror pressure moments, reconstruction, physical inputs and closure comparisons, H; verify source equation signs independently |
-| Lindvall et al., [Novatron: Equilibrium and Stability](https://arxiv.org/abs/2503.03387); Ryutov et al. (2011) and Ågren–Savenko (2004/2005), as indexed in mirror references | Polynomial closure, long-thin limits, potential tests and model-specific stability, H; identify exact equations before implementation |
-| Cary–Shasharina (1997), [10.1103/PhysRevLett.78.674](https://doi.org/10.1103/PhysRevLett.78.674); Nemov et al. (2008), [10.1063/1.2912456](https://doi.org/10.1063/1.2912456); Velasco et al. (2021), [10.1088/1741-4326/ac2994](https://doi.org/10.1088/1741-4326/ac2994) | Omnigenity, Gamma-c definitions and limits of prompt-loss proxies, G |
-| Unalmis et al., [differentiable bounce averaging](https://arxiv.org/abs/2412.01724), [published 2026](https://doi.org/10.1017/S0022377826101652); Ochs (2025), [multi-well domains](https://doi.org/10.1017/S002237782510069X) | Bounce quadrature/AD and topology handling, G |
-| Landreman–Paul (2022), [10.1103/PhysRevLett.128.035001](https://doi.org/10.1103/PhysRevLett.128.035001); Landreman–Jorge (2020), [10.1017/S002237782000121X](https://doi.org/10.1017/S002237782000121X) | QS objective and near-axis Mercier tests with correct equation conventions, B/F |
-| [Single-stage stellarator optimization](https://arxiv.org/abs/2302.10622), [SIMSOPT finite-beta example](https://github.com/hiddenSymmetries/simsopt/blob/master/docs/source/example_single_stage.rst) | Matched plasma/coil objectives and practical engineering examples, F |
-| JAX [benchmarking](https://docs.jax.dev/en/latest/benchmarking.html), [XProf/profiling](https://docs.jax.dev/en/latest/201/profiling.html), [shard_map](https://docs.jax.dev/en/latest/notebooks/shard_map.html), [AD and sharding](https://docs.jax.dev/en/latest/301/sharding-ad.html) | Synchronization, profiler interpretation, explicit reduction/transpose semantics and version-aware device work, D/E |
-| [JOSS review criteria](https://joss.readthedocs.io/en/latest/review_criteria.html), [submission requirements](https://joss.readthedocs.io/en/latest/submitting.html), [FAIR4RS](https://doi.org/10.15497/RDA00068) | Software/research evidence, attribution, reproducible archives and current submission gates, J |
+| Closed-form Solov'ev equilibrium from `test_strong_force_solovev.py` | Distinguish projection error from recovery of the same solution from perturbed coefficients; demonstrate radial h/p convergence, analytic axis derivatives and correct pressure/current conventions |
+| `input.shaped_tokamak_pressure_polished` | Baseline same-input VMEC++/VMEC2000 parity and native high-order force/gradient test; do not substitute a merely similarly named Solov'ev input |
+| `input.nfp2_QA_smooth_beta` | First genuine finite-beta 3-D recovery; native DESC with matched boundary/profiles and a quadrature-converged physical norm |
+| Existing vacuum and LASYM small decks | Vanishing-denominator behavior, orientation, Fourier families and ordinary implicit derivatives |
+| One prescribed-current deck and one small NESTOR/ESSOS case | Ordinary solver closure and free-boundary interface regression; admission to high-order polishing requires its own closure proof |
 
-Neural post-correction and deflation papers are later comparison/hypothesis
-sources, not substitutes for C's residual/chart verification. Reassess literature
-at each paper freeze; publication dates and arXiv versions matter.
+Start P2 with fixed boundary, stellarator symmetry, prescribed iota and
+GAMMA=0. Audit `phip`, `chip` and pressure updates before admitting NCURR=1 or
+finite-GAMMA/mass constraints. Freezing flux/profile arrays while geometry
+changes must not silently solve a different prescribed-current problem.
+Maintain those existing ordinary-solver features while high-order support
+remains narrower. W7-X is a later stress case, not the first recovery test.
 
-## 6. Migration from the old plan and execution discipline
+**Gate:** reproducible reference values with units/norms, convergence trends
+under independent quadrature and physical-profile agreement. Where a native
+DESC/GVEC adapter is missing, record the comparison as unavailable; do not
+fill it with the WOUT-relift score. Publication comparisons require native
+state archives as well as common interchange files.
 
-No unfinished physics goal is dropped by shortening the old ledger. Use this map
-when closing existing PR references; do not append another contradictory ledger.
+## 6. P2 — correct the formulation, then choose the solver
 
-| Previous requirement | New owner / status |
+### First question: are we minimizing the right functional in enough directions?
+
+In `core/polish.py::_strong_collocation_residual`, the current residual packs
+signed radial/helical force densities with `2*abs(sqrt_g)/normalization`.
+Squaring that vector is not the Cartesian volume L2 norm: the Jacobian is
+squared, Gauss weights are absent, and the physical vector metric/cross terms
+are not represented by simply summing component squares.
+
+Derive and implement a reference residual whose squared norm is
+`sum_q w_q |sqrt_g(q)| |F_cart(q)|² / F_ref²`. Use square-root quadrature/volume
+weights and a declared physical scaling. Geometry-dependent weights belong
+to the differentiated objective. A nonorthogonal two-component formulation
+must carry the full Gram metric; verify it against Cartesian evaluation.
+Use one residual definition for optimization, stationarity and its HVPs;
+preconditioning must not accidentally redefine the objective.
+
+`make_strong_structured_chart` retains R/lambda directions while eliminating
+Z directions as a coordinate gauge. Removing arbitrary vertical displacement
+by a poloidal reparameterization requires division by `Z_theta`, which can
+vanish. This is not a general global gauge proof. The current layout also
+comes through the prolongation/restriction image of the low-order state, so
+local B-splines do not automatically provide independent high-order freedom.
+
+Construct a tiny reference with independent native R/Z/lambda coefficients,
+fixed-boundary constraints, exact axis regularity and an explicit gauge
+quotient. Check rank, nullspaces and allowed perturbations as h/p increase.
+Simply adding every Z coefficient can introduce gauge singularity; simply
+removing them can discard physical directions. Compare the existing chart
+against this reference before designing a local preconditioner.
+
+### Coordinate decision
+
+| Option | Assessment and trigger |
 |---|---|
-| Integration, input/CLI polish, public results, export/native state | Landed baseline plus A/B1 hardening |
-| Performance phases 1–3; startup/cache/W7-X ledgers | A, C, D, E; old timings remain historical evidence |
-| Boozer, combined summary, Gamma-c phases 4–6 | Partly landed; G completes convergence and native reuse |
-| LASYM phase 7 | B/C/F; #264 rejects an isolated `tcon` halving |
-| Isotropic/anisotropic/free mirror and hybrid phases 8–11 | H, with explicit corrected closure/topology/metric contracts |
-| Native protocol and downstream phase 12 | G3, using existing owners and exact model boundaries |
-| Slimming/docs/examples phase 13 | I; no duplicated documentation tree or optimizer-file matrix |
-| Validation, figures, optimized configurations and release phase 14 | B/F/H/J; selected-winner figure policy removed |
-| 31.2 R1–R7 and recommendations | A/B/C; #260 native-DESC and #264 exact-Solov'ev work remain open |
-| 31.2 R4/R8/R9 explanations | Corrected by #255; verify against subsequent algorithm changes |
-| 31.3 diagnostic formulas/citations | #250 landed; hard independent values/refinement and scientific optimization remain G |
-| 31.4 mirror findings and spec sheet | H; corrected full parallel projection, closure eligibility and exterior-BVP interpretation |
-| 31.5 publication items | #245/#249 landed; #253/#256/#257 pending, I/J; DOI at submission |
-| 31.6 #197 decision | F/I preserve measured scalar/TRF tradeoff with fewer duplicated examples |
-| New source findings and profiling gaps | R1–R16 → A–I; tracked independently of earlier PR claims |
+| Existing `rho^|m| q(s)`, `s=rho²` | Retain first. `radial_basis.evaluate_regularized_mode` already implements this and analytic first/second axis limits. “Regularize the axis” alone is not a new remedy |
+| Normalize/localize the regular basis and its constraint elimination | First candidate if rank/conditioning identifies a basis problem. Compare equal function spaces and DOFs; knot spacing in s versus rho changes near-axis resolution |
+| Independent geometry components or a regular normal-displacement chart | Test against the full constrained reference. An off-axis normal parametrization still needs independent axis motion and a nonsingular axis limit |
+| Smooth polar center-splines | Conditional alternative if powers of rho or global constraints cause conditioning/locality failure; test a small basis replacement, not a second equilibrium framework |
+| Better nested-coordinate initialization | Conditional on poor Jacobian/admission at strongly shaped boundaries; separate initialization from the physical objective |
+| Generalized toroidal angle or a new global map | Defer for normal toroidal cases. Reconsider only when laboratory-angle geometry is the demonstrated limitation, with new gauge/axis constraints and AD costs budgeted |
 
-Implement the next open gate in dependency order. A numerical PR contains one
-physical or algorithmic hypothesis, a reproducer, the relevant independent
-checks, a compact performance comparison and an updated capability statement.
-A performance result is not complete while accuracy is unknown. A physics
-feature is not complete while its public usage and failure mode are unclear.
+[Jiang et al., smooth polar B-splines](https://arxiv.org/html/2601.17841v1),
+sections 3.1, 4.7 and 5.1, gives precise regularity and normalization machinery;
+it is a 2026 preprint and evidence for a testable basis construction, not a
+VMEX performance result. [Tecchiolli et al.](https://arxiv.org/html/2405.08173v1)
+(JPP, DOI 10.1017/S0022377824001119) constructs nested initial coordinates for
+strong shaping. [DESC #2282](https://github.com/PlasmaControl/DESC/pull/2282)
+introduces `phi = zeta + omega`; its unfinished axis/continuation work and
+additional unknowns argue against making it our critical path. Its racetrack
+comparison is not a matched-boundary proof that VMEX needs that coordinate.
 
-Update the affected checkbox/table and link the merged commit/artifact in place.
-Keep a compact execution logbook here with the active branch, checks, blockers
-and exact next action so an independent agent can resume. Link detailed history
-in git/PRs; keep this file focused on decisions still needed. Do not create a new report file for each experiment when the existing
-manifest can hold a record. Commits made for this work are authored by
-`rogeriojorge`; preserve existing contributors' authorship when incorporating
-their changes. Release publishing, external announcements and archival deposits
-are separate maintainer actions after their concrete artifacts are ready.
+### Would preconditioned Newton with matrix-free Hessian products help?
+
+Potentially, but there are three different operators:
+
+| Problem | Operator and implication |
+|---|---|
+| Ordinary discrete equilibrium `F(u,p)=0` | Newton uses `F_u v`; this need not equal a symmetric energy Hessian after scaling/constraints. Existing implicit refinement already uses this route. Better late refinement can reduce gradient cost but cannot remove the finite-difference continuum error |
+| High-order force least squares `min ½||r||²` | Gauss–Newton uses `JᵀJ`; exact stationarity Newton uses `H = JᵀJ + sum_i r_i ∇²r_i`. Existing polished implicit differentiation needs H. Away from small residuals H can be indefinite, so plain CG is not a general Newton solver |
+| Discrete energy minimization | An energy HVP is valid only after verifying that the differentiated constrained energy yields the intended force/closure equations. Do not substitute the current force vector for that proof |
+
+The current `polish_driver._gauss_newton_polish_lane` calls SOLVAX with variable
+scaling but does not pass a physics preconditioner or admissibility callback.
+This is a concrete gap. The previous BBT-style preconditioner targeted a
+different operator and did not demonstrate a useful 3-D result; reusing its
+name or factors is not a derivation.
+
+The new frozen **156×17** real-MHD probe, after current scaling, has
+`cond(J) ≈ 7.15e3`. At damping 1e-3, CG/diagonal-CG/LSMR took 31/30/35
+iterations. At 1e-6 they took 36/32/39. LSMR used tighter stopping controls,
+so these counts are not a fair runtime contest. All recovered the dense
+augmented least-squares step; exact-Hessian versus Gauss–Newton relative
+curvature was 2.08e-4, and a centered HVP difference reached 3.88e-9 relative
+error. This is a tiny initial Solov'ev lift using the **current** functional,
+not evidence of nonlinear 3-D convergence or a Newton advantage.
+
+[Knoll & Keyes, JFNK review](https://doi.org/10.1016/j.jcp.2003.08.010) motivates
+matrix-free products with problem-specific preconditioning and globalization.
+[Eisenstat & Walker](https://doi.org/10.1137/0917003) motivates adaptive inner
+accuracy, `||F + F_u delta|| ≤ eta ||F||`, rather than oversolving every step.
+[PETSc's SNES manual](https://petsc.org/main/manual/snes/) illustrates combining
+matrix-free operators with an explicit approximate preconditioner; it is
+prior art, not a proposed VMEX dependency.
+
+[LSMR](https://web.stanford.edu/group/SOL/software/lsmr/) provides a rectangular
+J/Jᵀ alternative without explicitly forming normal equations. It does not
+remove ill-conditioning. `cond(JᵀJ)=cond(J)²` does not imply CG needs that
+many iterations; nonlinear aggregate iteration counts exceeding the unknown
+count also do not estimate a condition number.
+
+### A bounded experiment with a decision, not a solver competition
+
+1. On the tiny analytic case, assemble J and the constrained reference H for
+   verification only. Compare JVP/VJP dot products, centered HVP differences,
+   spectrum/rank and augmented QR/SVD reference steps. Check the actual
+   nonlinear update on an independent physical certificate.
+2. Repeat at one affordable finite-beta QA resolution. Limit reference
+   matrix storage to 2 GiB and each diagnostic job to 10 minutes; reduce
+   resolution instead of silently exceeding those review budgets. Save a
+   failed or capped attempt as such.
+3. Only if the reference step is useful, derive **one** mode-block/banded
+   radial approximation from the corrected VMEX functional, including axis,
+   metric and closure terms. Reuse SOLVAX's existing Krylov/globalization
+   APIs; compare equal true residual and objective decrease, including
+   setup/update/memory. Compare CG and a rectangular solve only as needed to
+   isolate normal-equation accuracy. Test exact Newton only where measured
+   residual curvature or slow local convergence justifies its added cost.
+4. Use trust-region/line-search acceptance with geometry rejection and
+   adaptive forcing. Cap the initial nonlinear demonstration at 30 minutes
+   per small case, including setup; the experiment runner must enforce this
+   because AUTO currently does not. Record the final state and reason.
+5. Demonstrate actual recovery under at least three radial refinements and
+   two angular resolutions. Require lower independent dimensional and
+   normalized force, satisfied stationarity and constraints, and repeatable
+   derivatives. Freeze tolerances before the comparison. For the first QA
+   target, seek at least an order-of-magnitude physical-force improvement
+   over its converged ordinary solve; this is a proposed promotion target,
+   not an existing achievement or an assumed attainable universal threshold.
+
+**Decision:** if even a trusted constrained dense step cannot improve the
+independent force, investigate representation, closure or admissibility;
+stop tuning Krylov iterations. If it can, but the iterative solve cannot,
+fix preconditioning/linear accuracy. If both work but cost is excessive,
+profile the demonstrated bottleneck. If the bounded QA recovery fails,
+retain experimental status and publish the obstruction in this logbook.
+Do not launch W7-X or change the global coordinate model without that diagnosis.
+
+## 7. P3 — optimize the cost that researchers actually pay
+
+### Start with one ordinary QA optimization
+
+[#266's profile](https://github.com/uwplasma/vmex/pull/266) reports a 7.63 s
+value/gradient call with about 0.35 s in the VMEC loop, 3.86 s in Newton
+refinement and 3.06 s in the adjoint. A max-mode-2 QA run takes about 265 s
+including 29 s compilation, 205 s optimizer loop, 7 s finalization and 13 s
+plotting. Treat this as a case-specific profile; it makes refinement and
+response solves higher priority than accelerating the already cheap primal.
+Loosening the forward tolerance made that reported optimization slower.
+
+Reproduce one accepted optimization step with changed parameters, and then
+one complete run with fixed seed, objective scaling and feasibility criteria.
+Measure compile, primal, refinement, linearization, adjoint/Jacobian, rejected
+trials and plotting separately. Repeated identical parameters can hit memoized
+results and are not evidence of cheap changed-parameter gradients.
+
+Test existing linearization reuse, preconditioner update frequency and
+adaptive refinement first. Recycled forward Krylov vectors cannot be assumed
+to solve the adjoint: the operator is transposed and changes with state and
+parameters. Recompute the appropriate operator images, recertify the true
+residual and bound memory. SOLVAX already has GCROT machinery; extend a
+missing generic capability there only after a reproducible VMEX need.
+
+Use JAX/XProf traces, Perfetto and XLA/HLO inspection when stage timing points
+to compilation, transfers, allocations or kernels; use GPU counters only for
+a specific unresolved kernel question. Record synchronized measurements and
+trace overhead. An attractive kernel speedup that worsens total accepted
+optimization time does not pass.
+
+### Derivatives and applications
+
+Preserve existing FD and stationarity-Taylor tests. Add the missing test:
+independent nonlinear re-solves over a sequence of perturbations for boundary
+and profile directions, followed by objective Taylor remainders. Resolve
+both perturbed states more tightly than the derivative error being measured;
+show a convergence interval before roundoff/solver noise, and check branch
+continuity and geometry. Include eager/JIT and CPU/GPU once the CPU contract
+passes. Differentiate the actual accepted equilibrium equations, not a finite
+iteration history mislabeled as an exact equilibrium derivative.
+
+Use [Landreman & Paul, precise quasisymmetry](https://doi.org/10.1103/PhysRevLett.128.035001)
+as the first physics anchor: a reduced QA example for students, with a stated
+resolution gap to the paper, and a separate research budget for reproducing
+the physical target. Preserve QH/QP/QI scripts but share configuration/output
+logic only where it reduces duplication without hiding physics choices.
+One validated QA application precedes an exhaustive campaign.
+
+Then validate a tokamak shape/profile example and an ESSOS coil example.
+[Jorge et al., single-stage optimization](https://arxiv.org/abs/2302.10622)
+provides a concrete target for coupled plasma/coil objectives and independent
+field verification. Report coil length, curvature, separation, normal-field
+error, geometry and equilibrium accuracy alongside QS/QI. A lower weighted
+penalty with infeasible coils or an uncertified equilibrium is not success.
+For finite beta, include the plasma exterior contribution consistently.
+ESSOS owns Biot–Savart fields, coil geometry and their derivatives; VMEX owns
+equilibrium response, interface physics and acceptance. Do not duplicate coil
+kernels or move MHD closure into SOLVAX.
+
+**Gate:** cold re-evaluation of the final design, force/gradient/feasibility
+checks, preserved restart, readable convergence history and measured total
+CPU/GPU cost against the same accepted baseline. Choose a practical runtime
+budget from that baseline before optimizing; do not declare an unmeasured
+speedup target an achievement. The student example must finish in minutes
+on a documented CPU configuration; advanced settings must state their costs.
+
+## 8. P4 — evidence, parallelism, documentation and publication
+
+### Performance and parallelism
+
+Keep a small case manifest in the existing benchmark framework, using P1's
+inputs and P3's optimization. Compare VMEX, released VMEC++/VMEC2000 and native
+DESC at common physical tolerances and separately at common input resolution.
+GVEC joins numerical rankings only after a matched, converged native adapter.
+Pin source, executable/wheel hash, dependencies, CPU threads, GPU model,
+precision, input hash, status, DOFs, quadrature and all stopping criteria.
+
+Use fresh-process cold, disk-cache reload, warm same-shape **changed-parameter**,
+resolution-change and full optimized-design runs. Collect at least five warm
+samples and three independent complete runs when affordable; report spread,
+failures and censored timeouts. Separate profiling runs from timings. Archive
+peak host RSS and live/allocated device-memory measures with their definitions.
+The release comparison must use an otherwise idle host and matching thread
+budgets, not this review's shared-host samples.
+
+Run one-device CPU and `ssh office` GPU first. Then independent-case throughput
+with bounded CPU workers and one worker per GPU, checking oversubscription,
+compilation/cache races, deterministic outputs and aggregate memory. Reuse
+existing placement tests for correctness. Two host-device emulation tests do
+not demonstrate multi-GPU speedup; actual `NamedSharding` metadata alone does
+not prove a nonlinear iteration avoids gathers. A distributed equilibrium
+implementation is reconsidered only after its single-device bottleneck and
+communication budget are measured.
+
+### Documentation and deliberate code size
+
+This PR shortens the README around installation, solve/restart, gradients,
+optimization, scenario commands and supported features. Detailed numeric
+polish tables and failure records belong in `docs/explanation/validation.md`.
+The adjusted documentation tests preserve hashes, values and tolerance checks
+while allowing that relocation. Do not require a long benchmark essay on the
+landing page to retain scientific accountability.
+
+Continue with one owner per document: tutorials for learning; how-to pages
+for tasks; reference for API/model contracts; explanations for derivations;
+validation for measured evidence; this plan for unfinished work and decisions.
+Correct conflicting “exact gradient” and warm-primal performance language in
+other pages during P0/P3. Run examples with expected outputs and bounded
+budgets, including one beginner and one advanced workflow from a clean install.
+
+Track added/deleted source lines, file count, installed size and artifact
+bytes per implementation PR. Retire superseded residual/driver wrappers and
+duplicate tests only after behavior and failure coverage have an owner.
+Prefer extending existing modules and examples over new wrappers or framework
+layers. Keep compact numeric records and useful figures in git; put native
+states, traces, caches, generated intermediates and bulk benchmark output in
+a public, persistent archive. Delete unreferenced artifacts only after link,
+provenance and reproduction checks. Preserve scientific evidence when pruning.
+
+### Publication and release gates
+
+The first credible paper can center on VMEC compatibility, validated implicit
+responses, research optimization and measured execution on CPU/GPU. It still
+requires the P0/P1/P3/P4 evidence; current smoke tests are not a paper. A second
+high-order methods claim requires P2's solved finite-beta 3-D case, convergence
+and time-to-accuracy comparison. Do not inflate one incomplete story into
+several promised publications.
+
+Before proposing any release: every current PR is merged or explicitly
+superseded/deferred; important acceptance and application gates pass; any
+remaining 3-D limitation has an explicit scope decision; the supported
+Python/JAX matrix, source/wheel install, required CI, docs and examples pass.
+Freeze inputs, environments, traces and native states in an accessible archive,
+record licenses/citation metadata and regenerate claims from those records.
+There is no scheduled tag, automatic version bump or publication date here.
+
+## 9. Execution logbook and handoff
+
+**2026-09-06 — planning review, no production solver edits.** Branch
+`review/focused-plan-20260906`, worktree
+`/Users/rogeriojorge/local/vmex-focused-plan-20260906`, based on `ae0e410f`.
+Reconciled main and four open PRs, reviewed #274/#266 and relevant DESC changes,
+cloned VMEC++/GVEC/DESC, ran the tests and operator/comparison probes in §2/§6,
+rewrote this plan and the README, and corrected the native/WOUT interpretation
+on the validation page. Documentation validation passed: Ruff, mypy, prose/media checks, strict
+Sphinx HTML, linkcheck, 59 guard tests and seven figure-provenance tests.
+The README Python solve/gradient/optimization/export walkthrough ran on the
+bundled circular tokamak and converged in three optimization evaluations.
+The standalone 19 performance-record tests also passed (included in the
+59 guards, not additional distinct tests). The final PR is recorded below
+before handoff. All authored commits use `rogeriojorge`.
+
+Raw logs, native outputs, isolated environment and the two short review probes
+are in `/Users/rogeriojorge/local/vmex-review-evidence-20260906`; the compact
+results and probe sources are embedded in the existing review JSON so this
+plan remains usable without that filesystem. Fresh external source pins:
+VMEC++ `07ef6710078e78e29ccabab0443cb3ec0ad7e375`, GVEC
+`c0dc66fe2b9faa147c76a728e5cd053ce693d472`, DESC
+`ad105c5e525fbf26824d6cf9dde48775db0f8a2c`; SOLVAX remains
+`5a49926992fe1a3aebac4b8b8cb098798e977c14`. DESC distribution metadata came
+from an inherited environment and was stale; the executed source path/SHA
+identify the actual checkout. No other user's dirty checkout was changed.
+
+Reproduction commands, from the VMEX checkout (review probes use float64):
+
+```bash
+VMEX_COMPILATION_CACHE=disabled JAX_PLATFORMS=cpu python -m pytest -q \
+  tests/test_radial_basis.py tests/test_strong_force.py
+VMEX_COMPILATION_CACHE=disabled JAX_PLATFORMS=cpu python -m pytest -q \
+  tests/test_strong_force_solovev.py tests/test_implicit_grad.py \
+  -k 'not test_implicit_grad or test_solovev_gradients_vs_fd or test_adjoint_gmres_preconditioner_value'
+# In a detached worktree at PR #277 head db6092b7:
+VMEX_COMPILATION_CACHE=disabled JAX_PLATFORMS=cpu python -m pytest -q \
+  tests/test_polish_preconditioner.py \
+  -k 'collocation_polish_primal_and_derivatives or polish_stationarity'
+```
+
+The review JSON contains commands for the pinned VMEC++ tests, same-deck
+comparison, frozen operator, native DESC runner and GVEC build/capped solve.
+It preserves failed attempts and environment limitations. Do not promote a
+result based only on a process exit code or a private raw-log path.
+
+**Next implementation PRs, in order:**
+
+1. Resolve #277's CI failure and audit ordinary nonlinear derivative
+   eligibility (P0); update the status contract and affected examples.
+2. Complete the native physical-force/profile contract and the small
+   constrained chart/functional reference (P1/P2). Make the recovery decision
+   from that evidence before a new solver, coordinate rewrite or W7-X run.
+3. Improve the measured refinement/response bottleneck on one accepted QA
+   optimization (P3), using SOLVAX only for genuinely generic algorithm work.
+
+After each implementation change, append one compact entry here: exact
+base/head and PR, owning gate, command/environment, attained numerical result,
+time/memory, limitation/failure and next action. Update the priority's status
+in place. Keep abandoned experiments as evidence with a stop reason, rather
+than appending new work packages. A resumed agent should first read this
+section, check dirty worktrees and current remote PR status, then continue the
+first unmet gate. Do not rerun the full historical inventory or a multi-day
+polish unless new evidence justifies it.

--- a/tests/test_figure_provenance.py
+++ b/tests/test_figure_provenance.py
@@ -169,7 +169,7 @@ def test_preconditioner_table_matches_its_measurement(manifest: dict) -> None:
 
 
 def test_diagnostics_figure_matches_its_recorded_solve(manifest: dict) -> None:
-    """The regenerated README diagnostics panel names the deck it plots."""
+    """The diagnostics panel and validation page match the recorded solve."""
     record = json.loads((FIGURE_DIR / "readme_diagnostics.json").read_text())
     assert record["schema"] == "vmex.readme-diagnostics-figures/1"
     assert record["provenance"]["measurement_dirty"] is False
@@ -182,10 +182,10 @@ def test_diagnostics_figure_matches_its_recorded_solve(manifest: dict) -> None:
         deck = ROOT / case["deck"]
         assert deck.is_file()
         assert hashlib.sha256(deck.read_bytes()).hexdigest() == case["deck_sha256"]
-        # the README quotes the beta this solve reached
+        # The detailed validation page quotes the beta this solve reached.
         beta = case["scalars"]["betatotal"]
-        readme = (ROOT / "README.md").read_text()
-        assert f"{100 * beta:.2f}" in readme, (
-            f"README does not quote the measured beta {100 * beta:.2f}% "
+        evidence = (ROOT / "docs/explanation/validation.md").read_text()
+        assert f"{100 * beta:.2f}" in evidence, (
+            f"Validation page does not quote the measured beta {100 * beta:.2f}% "
             f"for {case['key']}"
         )

--- a/tests/test_performance_docs.py
+++ b/tests/test_performance_docs.py
@@ -317,7 +317,7 @@ def test_cross_code_certificates_are_clean_and_comparable() -> None:
     assert normalized["VMEX"] < 0.2 * normalized["VMEC2000"]
 
 
-def test_readme_strong_force_figure_matches_committed_sources() -> None:
+def test_validation_strong_force_figure_matches_committed_sources() -> None:
     metadata = json.loads(
         (ROOT / "benchmarks" / "strong_force_comparison_m4.json").read_text()
     )
@@ -340,6 +340,7 @@ def test_readme_strong_force_figure_matches_committed_sources() -> None:
             assert hashlib.sha256(path.read_bytes()).hexdigest() == source["sha256"]
     tokamak = cases["shaped_tokamak_pressure"]["sources"]
     assert set(tokamak) == {"VMEX", "VMEC2000", "VMEC++", "DESC"}
+    # Preserve the recorded reconstruction ordering; this is not native DESC.
     assert tokamak["VMEX"]["normalized_l2"] < tokamak["DESC"]["normalized_l2"]
 
     stellarator = cases["nfp2_QA_finite_beta"]["sources"]
@@ -350,11 +351,11 @@ def test_readme_strong_force_figure_matches_committed_sources() -> None:
     assert representation["L"] >= 16
     assert representation["M"] >= 10 and representation["N"] >= 10
     assert desc["metrics"]["radial_refinement_difference"] < 1.0e-3
-    # No timing-ratio claims: the README figure policy is accuracy only;
-    # runtime evidence lives in benchmarks/baselines, not in guards.
-    readme = (ROOT / "README.md").read_text()
-    assert metadata["figure"] in readme
-    assert metadata["summary_figure"] in readme
+    # Historical WOUT reconstruction records, not a native solver ranking.
+    # Runtime evidence lives in benchmarks/baselines, not in these guards.
+    evidence = (ROOT / "docs/explanation/validation.md").read_text()
+    assert metadata["figure"].removeprefix("docs/") in evidence
+    assert metadata["summary_figure"].removeprefix("docs/") in evidence
     assert metadata["summary_independent_l2"]["after"] < (
         metadata["summary_independent_l2"]["before"]
     )
@@ -391,7 +392,7 @@ def test_fresh_deck_parity_artifact_is_provenanced_and_cited() -> None:
 
 
 #: The two committed polish force-error records: the shaped tokamak whose
-#: before/after pair the README quotes, and the bundled solovev deck that
+#: before/after pair the validation page quotes, and the bundled solovev deck that
 #: shows what ``eps_F`` looks like when its denominator has collapsed.
 POLISH_FORCE_ERROR_RECORDS = (
     "polish_force_error_2026-09-03.json",
@@ -399,11 +400,11 @@ POLISH_FORCE_ERROR_RECORDS = (
 )
 
 
-def _readme_number(value: float, digits: int = 3) -> str:
-    """Format a measurement the way the README prints it.
+def _prose_number(value: float, digits: int = 3) -> str:
+    """Format a measurement the way the validation page prints it.
 
     ``f"{v:.3e}"`` pads the exponent (``1.284e-02``); prose writes
-    ``1.284e-2``.  Comparing through one formatter keeps the README pinned
+    ``1.284e-2``.  Comparing through one formatter keeps the prose pinned
     to the artifact digit for digit without dictating its typography.
     """
     mantissa, exponent = f"{value:.{digits}e}".split("e")
@@ -487,31 +488,31 @@ def test_solovev_record_shows_the_certificate_at_its_ceiling() -> None:
     assert scales["relative_force_error"] > 100.0
     assert scales["magnetic_normalized_l2"] < 0.1
 
-    readme = (ROOT / "README.md").read_text()
-    assert POLISH_FORCE_ERROR_RECORDS[1] in readme
-    assert f"`{block['pointwise_eps_f']['normalized_l2']:.3f}`" in readme
-    assert f"`{_readme_number(scales['magnetic_normalized_l2'], 2)}`" in readme
-    assert f"`{_readme_number(scales['volume_average_force'], 2)}`" in readme
-    assert f"`{_readme_number(scales['volume_average_grad_pressure'], 2)}`" in readme
+    evidence = (ROOT / "docs/explanation/validation.md").read_text()
+    assert POLISH_FORCE_ERROR_RECORDS[1] in evidence
+    assert f"`{block['pointwise_eps_f']['normalized_l2']:.3f}`" in evidence
+    assert f"`{_prose_number(scales['magnetic_normalized_l2'], 2)}`" in evidence
+    assert f"`{_prose_number(scales['volume_average_force'], 2)}`" in evidence
+    assert f"`{_prose_number(scales['volume_average_grad_pressure'], 2)}`" in evidence
     assert (
-        f"`{_readme_number(scales['volume_average_magnetic_pressure_gradient'], 2)}`"
-        in readme
+        f"`{_prose_number(scales['volume_average_magnetic_pressure_gradient'], 2)}`"
+        in evidence
     )
 
 
-def test_readme_polish_gain_matches_the_committed_record() -> None:
-    """The README's polish table must be the record, digit for digit.
+def test_validation_polish_gain_matches_the_committed_record() -> None:
+    """The validation page's polish table must be the record, digit for digit.
 
     Every row is read straight out of the artifact at the precision the
-    README prints, so the table cannot drift from the measurement, and the
+    validation page prints, so the table cannot drift from the measurement, and the
     withdrawn "26-fold" claim cannot come back.
     """
     record = json.loads(
         (ROOT / "benchmarks" / POLISH_FORCE_ERROR_RECORDS[0]).read_text()
     )
-    readme = (ROOT / "README.md").read_text()
-    assert POLISH_FORCE_ERROR_RECORDS[0] in readme
-    assert "26-fold" not in readme.split("Earlier versions of this section")[0]
+    evidence = (ROOT / "docs/explanation/validation.md").read_text()
+    assert POLISH_FORCE_ERROR_RECORDS[0] in evidence
+    assert "26-fold" not in evidence.split("Earlier versions of this section")[0]
 
     initial = record["initial_certificate"]["normalizations"]
     final = record["final_certificate"]["normalizations"]
@@ -531,10 +532,10 @@ def test_readme_polish_gain_matches_the_committed_record() -> None:
     ]
     for before, after in quoted:
         for value in (before, after):
-            assert f"`{_readme_number(value)}`" in readme, value
+            assert f"`{_prose_number(value)}`" in evidence, value
         ratio = before / after
         assert (
-            f"{ratio:.2f}x" in readme or f"{ratio:.1f}x" in readme
+            f"{ratio:.2f}x" in evidence or f"{ratio:.1f}x" in evidence
         ), ratio
 
 
@@ -547,8 +548,10 @@ def test_readme_states_the_certificate_ceiling_and_its_selection() -> None:
     readme = (ROOT / "README.md").read_text()
     assert "bounded above by 2 by construction" in readme
     assert "demonstrably wins" not in readme
-    assert "not evidence of\na general advantage" in readme
-    assert "were selected because certified polishing\nimproves them" in readme
+    assert "docs/explanation/validation.md" in readme
+    evidence = (ROOT / "docs/explanation/validation.md").read_text()
+    assert "not a ranking of native solvers" in evidence
+    assert "selected for successful tokamak polishing" in evidence
     page = (
         ROOT / "docs" / "explanation" / "high-order-force-balance.rst"
     ).read_text()


### PR DESCRIPTION
The previous plan schedules too many dependent research directions, and the README repeats detailed benchmark prose while the validation page still confuses native force accuracy with WOUT reconstruction. This planning PR replaces that schedule with gated priorities, retains a concise user-facing README, and corrects those evidence claims. It does not change production numerical code or cut a release.

The new plan prioritizes nonlinear/linear derivative acceptance, a common physical force contract, a bounded high-order recovery experiment, and faster validated optimization. It evaluates matrix-free Newton/Hessian products, the existing axis-regular basis and correction chart, DESC's QR/regularity work, and GVEC's radial preconditioning. Generalized coordinates, mirror extensions and distributed nonlinear solves are deferred until a measured obstruction justifies them. Sources, source pins, decision criteria, stop conditions, remaining PR dispositions and a resumable logbook are in `plan.md`.

This supersedes the proposed schedule in #274; review this replacement before closing that PR. #277 remains blocked by its Linux e-polish failure despite the focused local pass. #266 and #276 have separate review requirements recorded in the plan. No PR is merged by this change.

Validation and evidence:

- Main: 67 radial-basis/strong-force tests and 9 analytic/selected implicit-response tests pass. PR #277: 26 focused tests pass locally; its failing CI result is preserved.
- Fresh VMEC++ source HVP/adjoint tests against the 0.7.3 wheel: 4 pass. Both VMEX and VMEC++ converge on two identical input decks. A native DESC solve converges. Fresh GVEC builds and runs, but its example reaches the iteration cap; it is not reported as converged.
- A frozen 156×17 MHD operator probe checks conditioning, reference least-squares steps and Hessian products. These shared-host samples establish no general speedup or 3-D accuracy claim. Compact measurements, commands and probe sources are appended to the existing review JSON without changing its historical data.
- Ruff, mypy, prose/media checks, strict Sphinx HTML, linkcheck, 59 documentation/API guards and 7 figure-provenance tests pass. The README's Python solve/gradient/optimization/export workflow completes on the circular tokamak; optimization converges in 3 evaluations.

The README goes from 573 to 220 lines. Detailed numeric/figure evidence moves to the validation page; its hash/value guards move with it without weaker scientific tolerances. Large traces, native outputs and external builds remain outside git. Release and publication claims remain conditional on the plan's important gates.
