### PR TITLE
Restore JIT state between solver test modules

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -256,7 +256,7 @@ research with the figure as its honest status.
 Owner: VMEX (`implicit.py`, `polish_driver.py`, `polish_implicit.py`, the
 public optimization wrappers, CI); SOLVAX owns generic true-residual reporting.
 
-1. **Stale claims, one PR — implemented locally; review pending.** Remove the withdrawn 26-fold number from
+1. **Stale claims, one PR — implemented in [#284](https://github.com/uwplasma/vmex/pull/284); CI/review pending.** Remove the withdrawn 26-fold number from
    `CHANGELOG.md`; remove or generate the three artifacts `performance.rst`
    cites; point the two benchmark records and three test docstrings at the
    P letters; extend `tools/check_docs_prose.py` to scan `.rst` pages and
@@ -272,7 +272,7 @@ public optimization wrappers, CI); SOLVAX owns generic true-residual reporting.
    stationarity at the derivative gate's 1e-8 bar and lets the derivative call
    be the check; SOLVAX's 1e-10 flag is a solver metric. Keep the tight
    real-MHD fixture.
-3. **CI tiering to a 25-minute PR ceiling.** Every test that runs a polish or
+3. **CI tiering to a 25-minute PR ceiling — JIT isolation implemented; tiering pending.** Every test that runs a polish or
    a free-boundary implicit adjoint moves to `full`; `test_polish_preconditioner.py`
    splits into Gauss-Newton (PR), homotopy (nightly) and linear (PR);
    `test_run_options.py` exercises directive parsing against a mocked driver
@@ -634,3 +634,16 @@ named pytest”; its Python also lacks pip and the copied directory has no git
 metadata. This is not a JAX numerical reproduction. Next: review/merge P0.1,
 then P0.3 test isolation/tiering; prepare an isolated pinned office environment
 for P0.2 rather than treating the incomplete saved run as evidence.
+
+**2026-09-07, Phase 1 / P0.3 isolation.** Based on P0.1 commit `417fb4fc`
+(PR #284), branch `fix/phase1-test-isolation`, worktree
+`/Users/rogeriojorge/local/vmex-test-isolation`. Four modules now use the
+existing restoring JIT fixture; removed their unscoped configuration writes.
+A subprocess regression checks restoration between real test modules. The
+unmodified parent fails the session-end restoration probe; the fix passes.
+CPU/JAX 0.9.2, cache disabled: the four complete PR module selections passed
+73 tests, 2 full tests deselected, in 396.88 s; manifest guards 9 passed in
+13.38 s; static preflight: 71 passed/3 unbuilt-HTML skips; RSS unmeasured. Logs: `vmex-review-evidence-20260906/jit-*.log`.
+No test moved to nightly and no tolerance changed; the 25-minute lane target
+remains unproved. Isolate this correction before measuring the tiering change.
+Next: finish P0.3 selector/tiering work and the office P0.2 reproduction.

--- a/tests/test_cli_freeboundary.py
+++ b/tests/test_cli_freeboundary.py
@@ -34,6 +34,8 @@ from vmex.core.errors import (
 from vmex.core.mgrid import read_mgrid
 from vmex.core.wout import read_wout
 
+pytestmark = pytest.mark.usefixtures("_module_jit_enabled")
+
 DATA_DIR = Path(__file__).resolve().parents[1] / "examples" / "data"
 DECK = DATA_DIR / "input.cth_like_free_bdy_lasym_small"
 MGRID = DATA_DIR / "mgrid_cth_like_lasym_small.nc"
@@ -42,13 +44,6 @@ SOLOVEV_DECK = DATA_DIR / "input.solovev"
 
 #: EXTCUR of the golden deck (HF, TVF).
 DECK_EXTCUR = (-12.0, -2.55)
-
-
-@pytest.fixture(autouse=True)
-def _enable_jit():
-    """Full solves need JIT (the repo conftest disables it for unit tests)."""
-    jax.config.update("jax_disable_jit", False)
-    yield
 
 
 def _run_cli(argv: list[str]) -> tuple[int, str]:
@@ -62,7 +57,6 @@ def _run_cli(argv: list[str]) -> tuple[int, str]:
 @pytest.fixture(scope="module")
 def freeb_cli(tmp_path_factory) -> tuple[int, str, Path]:
     """One capped ``LFULL3D1OUT=T`` free-boundary run (shared)."""
-    jax.config.update("jax_disable_jit", False)
     workdir = tmp_path_factory.mktemp("cli_freeb")
     deck = workdir / DECK.name
     text, count = re.subn(

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -60,7 +60,6 @@ def solovev_eq() -> opt.Equilibrium:
 
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
     cache = CACHE_DIR / "solovev_state.npz"
-    jax.config.update("jax_disable_jit", False)  # tests/conftest disables jit globally
     if cache.exists():
         data = np.load(cache)
         state = SpectralState(**{k: jax.numpy.asarray(data[k]) for k in _STATE_FIELDS})
@@ -326,7 +325,6 @@ def test_l_grad_b(solovev_eq):
     """LgradB objective: finiteness, jit parity, grid convergence, pins
     (recorded 2026-07-09, x64 CPU: golden nfp4_QH 0.3238956855163282 m,
     cached solovev 2.2782393147008424 m ~ minor-radius scale)."""
-    jax.config.update("jax_disable_jit", False)
     gqh = _golden_wout("nfp4_QH_warm_start")
     val = float(opt.l_grad_b(gqh))
     assert np.isfinite(val) and 0.0 < val < 100.0
@@ -379,7 +377,6 @@ def test_qi_regression_pin_and_jit(solovev_eq):
     residual amplifies convergence-path drift (~1e-4 between BLAS/jit
     configurations)."""
     pytest.importorskip("booz_xform_jax")
-    jax.config.update("jax_disable_jit", False)
     booz = opt.boozer_modes_from_wout(solovev_eq.wout, surfaces=[0.5, 1.0],
                                       mboz=8, nboz=8)
     out = opt.quasi_isodynamic_residual(
@@ -464,7 +461,6 @@ def test_least_squares_smoke(solovev_eq):
     the initial aspect is ~3.118, the target 4.0, and a handful of
     finite-difference trust-region steps must strictly reduce the cost.
     """
-    jax.config.update("jax_disable_jit", False)
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
     aspect0 = float(opt.aspect_ratio(solovev_eq.state, solovev_eq.runtime))
     cost0 = 0.5 * (aspect0 - 4.0) ** 2
@@ -489,7 +485,6 @@ def test_least_squares_implicit_smoke(solovev_eq):
     boundary plus one linearized-KKT solve for all dofs — gradient cost
     ~O(1 equilibrium solve) independent of the dof count.
     """
-    jax.config.update("jax_disable_jit", False)
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
     aspect0 = float(opt.aspect_ratio(solovev_eq.state, solovev_eq.runtime))
     cost0 = 0.5 * (aspect0 - 4.0) ** 2
@@ -503,7 +498,6 @@ def test_least_squares_implicit_smoke(solovev_eq):
 
 def test_minimize_scalarized_implicit_smoke(solovev_eq):
     """L-BFGS-B lowers the same cost with a finite reverse gradient."""
-    jax.config.update("jax_disable_jit", False)
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
     x0 = opt.pack_boundary(inp, 1)
     cost0 = 0.5 * (float(opt.aspect_ratio(
@@ -531,7 +525,6 @@ def test_scipy_bfgs_scalar_lane_completes_and_descends():
     this 2-dof problem: BFGS 3.89e-01 -> 1.55e-06 in 3 iterations (6
     evaluations), L-BFGS-B -> 3.64e-05 in 2; bounds carry ample margin.
     """
-    jax.config.update("jax_disable_jit", False)
     import scipy.optimize
 
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
@@ -587,7 +580,6 @@ def test_from_loss_honors_bound_scalar_method_literally():
     literally, and vector or non-traceable losses must be rejected with
     actionable errors before any optimizer sees them.
     """
-    jax.config.update("jax_disable_jit", False)
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
     qs = opt.QuasisymmetryRatioResidual(SURFACES, 1, -1)
 
@@ -624,7 +616,6 @@ def test_certified_trial_guards_reject_stale_or_missing_memo(monkeypatch):
 
     from vmex.core import implicit as implicit_module
 
-    jax.config.update("jax_disable_jit", False)
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
     inp = inp.change_resolution(mpol=3, ntor=0, ntheta=12, nzeta=4)
     inp = dataclasses.replace(
@@ -701,7 +692,6 @@ def test_least_squares_implicit_jac_chunking(solovev_eq):
     (:func:`solvax.chunk_map`), so the Jacobian at the initial boundary must
     be identical.  ``max_nfev=1`` keeps it cheap; solovev has 2 dofs so
     ``jac_chunk_size=1`` is a real 2-chunk pass."""
-    jax.config.update("jax_disable_jit", False)
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
     obj = [(opt.aspect_ratio, 4.0, 1.0)]
     # explicit None pins the unchunked reference (default is "auto")
@@ -819,7 +809,6 @@ def test_least_squares_implicit_jac_solver_block(monkeypatch):
     jvp probes, one :func:`solvax.block_thomas_factor`, GMRES-certified
     columns) must agree with the per-dof GMRES path to the solver tolerance
     (``adjoint_tol = 1e-6``)."""
-    jax.config.update("jax_disable_jit", False)
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
     inp = inp.change_resolution(
         mpol=3, ntor=0, ntheta=12, nzeta=4,
@@ -1227,7 +1216,6 @@ def test_least_squares_implicit_warm_start_modes(solovev_eq):
     restart: ``warm_start`` only changes each trial's initial guess, never
     the fixed point, so the optimizer walks the same trust-region path;
     ``solve_stats`` exposes the effort totals the R25.4 benchmark compares."""
-    jax.config.update("jax_disable_jit", False)
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
     obj = [(opt.aspect_ratio, 4.0, 1.0)]
     ref = opt.least_squares(obj, inp, max_mode=1, jac="implicit",
@@ -1249,7 +1237,6 @@ def test_least_squares_max_mode_schedule():
     """Staged max_mode continuation: two ultra-short stages chain through
     result.input; the second starts from — and does not regress — the
     first stage's boundary."""
-    jax.config.update("jax_disable_jit", False)
     inp = VmecInput.from_file(DATA_DIR / "input.solovev")
     res = opt.least_squares([(opt.aspect_ratio, 4.0, 1.0)], inp,
                             max_mode=(1, 1), max_nfev=2, diff_step=1e-4,

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -7,7 +7,6 @@ import re
 from pathlib import Path
 from types import SimpleNamespace
 
-import jax
 import numpy as np
 import pytest
 
@@ -26,6 +25,8 @@ from vmex.core.scaling import (
     scale_wout,
 )
 from vmex.core.wout import _preset_array, read_wout, wout_from_state, write_wout
+
+pytestmark = pytest.mark.usefixtures("_module_jit_enabled")
 
 DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
 
@@ -128,7 +129,6 @@ def test_mgrid_scaling_distinguishes_per_ampere_and_raw_tables():
 
 @pytest.fixture(scope="module")
 def finite_beta_similarity():
-    jax.config.update("jax_disable_jit", False)
     inp = VmecInput.from_file(DATA / "input.nfp2_QA_finite_beta")
     inp = dataclasses.replace(
         inp,

--- a/tests/test_test_manifest.py
+++ b/tests/test_test_manifest.py
@@ -160,3 +160,28 @@ def test_workflow_selects_manifest_lanes() -> None:
     assert "timeout-minutes: 45" in nightly
     for stale in ("A1_FILES=", "C2_FILES=", "core-a-c)"):
         assert stale not in "".join(workflows.values())
+
+
+def test_solver_modules_restore_jit_between_modules(tmp_path: Path) -> None:
+    """Exercise real module setup/teardown in one worker, where leaks matter."""
+    plugin = tmp_path / "jit_restoration_probe.py"
+    plugin.write_text(
+        "import jax, pytest\n"
+        "@pytest.hookimpl(wrapper=True)\n"
+        "def pytest_runtest_teardown(item, nextitem):\n"
+        "    result = yield\n"
+        "    if nextitem is None or nextitem.module is not item.module:\n"
+        "        assert jax.config.jax_disable_jit, item.nodeid\n"
+        "    return result\n"
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), env.get("PYTHONPATH", "")])
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-p", "jit_restoration_probe",
+         "tests/test_scaling.py::test_input_scaling_changes_only_dimensional_quantities",
+         "tests/test_cli_freeboundary.py::test_free_boundary_default_raises_before_wout",
+         "tests/test_optimize.py::test_public_problem_factory_validation"],
+        cwd=ROOT, env=env, text=True, capture_output=True, timeout=120,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "3 passed" in result.stdout

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -28,6 +28,8 @@ from vmex.core import cli
 from vmex.core.tracing import essos_vmec_field, trace_alphas
 from vmex.core.wout import read_wout
 
+pytestmark = pytest.mark.usefixtures("_module_jit_enabled")
+
 DATA_DIR = Path(__file__).resolve().parents[1] / "examples" / "data"
 SOLOVEV_DECK = DATA_DIR / "input.solovev"
 
@@ -36,17 +38,9 @@ TRACE_KWARGS = dict(
 )
 
 
-@pytest.fixture(autouse=True)
-def _enable_jit():
-    """Tracing needs JIT (the repo conftest disables it for unit tests)."""
-    jax.config.update("jax_disable_jit", False)
-    yield
-
-
 @pytest.fixture(scope="module")
 def solovev_wout(tmp_path_factory) -> Path:
     """One quiet CLI solve of the solovev deck, shared by the tests below."""
-    jax.config.update("jax_disable_jit", False)
     outdir = tmp_path_factory.mktemp("trace_wout")
     buffer = io.StringIO()
     with contextlib.redirect_stdout(buffer):
@@ -57,7 +51,6 @@ def solovev_wout(tmp_path_factory) -> Path:
 
 @pytest.fixture(scope="module")
 def traced(solovev_wout):
-    jax.config.update("jax_disable_jit", False)
     return trace_alphas(solovev_wout, **TRACE_KWARGS)
 
 


### PR DESCRIPTION
Implements the JIT-isolation portion of Phase 1 / P0.3, stacked on #284. Four solver test modules changed the process-wide JIT setting without restoring it, making subsequent tests depend on module order. They now reuse the existing restoring module fixture; redundant configuration writes are removed.

A subprocess regression exercises real module setup/teardown in one worker and checks restoration between modules. A separate negative control against the unchanged parent fails with the leaked configuration; the corrected checkout passes.

Validation: all four affected PR module selections pass (73 tests, 2 full tests deselected, 396.88 s, CPU/JAX 0.9.2, persistent compilation cache disabled); nine manifest guards pass; static preflight passes with 71 guards and three skips because the local HTML tree was not built. The four-module smoke also exercises the ESSOS tracing fixture. No numerical tolerance or test tier changed.

The plan/logbook records results and limitations. CI tiering and the 25-minute per-lane target remain pending; separating isolation first makes their baseline independent of leaked JIT state. Retarget this PR to main before deleting #284's branch after its merge. No release.
