### PR TITLE
Bound PR test tiers and verify JAX compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,7 @@ jobs:
             selector: pr-mirror-field
             parallel: ""
           - lane: mirror-spline
-            selector: pr-physics-mirror-spline
-            parallel: ""
-          - lane: mirror-output
-            selector: pr-physics-mirror-output
+            selector: pr-mirror-spline
             parallel: ""
     steps:
       - uses: actions/checkout@v7.0.1
@@ -228,7 +225,7 @@ jobs:
             selector: pr-parity-c2
             parallel: "-n 4"
           - lane: misc
-            selector: pr-examples pr-external pr-full-only pr-gradient pr-mirror-spline
+            selector: pr-examples pr-external pr-full-only pr-gradient
             parallel: "-n 4"
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_tests == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -199,41 +199,15 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_tests == 'true'
     runs-on: ubuntu-latest
-    # The primary-lane partition is the whole pull-request suite; these
-    # jobs are the part no other job was running, and they define the CI
-    # attempt's wall clock, so the partition is rebalanced when a lane
-    # outgrows the others.  Lane c1 (then pr-parity-c1 + c3 + d) had grown
-    # to 44m36s -- double the next-longest job -- with almost all of the
-    # weight in the c3/d implicit-campaign modules (test_optimize.py alone
-    # carries ~31 minutes of call time), so those now run as their own
-    # job.  Lane a's 32m24s at -n 2 was the next ceiling; only the
-    # pr-parity-a1 selector carries the free-boundary modules whose
-    # concurrent solves exhaust the runner at -n 4 (killed mid-run at
-    # 32m10s, twice, on two different pull requests), so a1 keeps -n 2 by
-    # itself and a2+b run at -n 4.  The c3d lane then became the ceiling at
-    # 34 minutes green (43-44 under runner load, which kept tipping a
-    # 45-minute budget into a timeout-cancel), with two thirds of its call
-    # time in two modules: test_polish_preconditioner.py (~44 minutes of
-    # call time; every polish test builds a chart and certifies) and
-    # test_run_options.py (~16 minutes, mostly the polish directive).
-    # Those two ran as lane e, which dropped the longest parity lane to
-    # roughly 20 minutes.  The polish tests then grew again (#269's real
-    # Solov'ev correction at 705 s, #261's AUTO pricing and heartbeat tests
-    # run real polishes) and lane e reached 25 minutes on main and timed
-    # out at 55 on #261, so test_run_options.py (~20 minutes of call time,
-    # three polish-directive solves) is lane f on its own.  The budget stays at 55: it is a cap, not a reservation, and
-    # the 2026-08-31 timeout plague is not worth re-running to save a
-    # number nobody reads.
-    timeout-minutes: 55
+    # Real polish and free-boundary adjoint solves run in Nightly. Keep the
+    # PR partition bounded; a timeout is a failure, never a passing benchmark.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
         include:
           - lane: a-free
             selector: pr-parity-a1
-            # -n 2, not 4: this selector carries the free-boundary modules
-            # (test_freeboundary_implicit alone has two ~8-minute tests),
-            # and four concurrent free-boundary solves exhaust the runner.
             parallel: "-n 2"
           - lane: a-core
             selector: pr-parity-a2 pr-parity-b
@@ -329,6 +303,32 @@ jobs:
           path: coverage.device
           retention-days: 3
 
+  jax-compatibility:
+    name: Stationarity contract (JAX ${{ matrix.jax }})
+    needs: changes
+    if: needs.changes.outputs.run_tests == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        jax: ["0.9.2", "0.11.1"]
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install tested numerical versions
+        run: python -m pip install . pytest "jax==${{ matrix.jax }}" "jaxlib==${{ matrix.jax }}"
+      - name: Record environment and exercise eager and compiled certificates
+        env:
+          JAX_ENABLE_X64: "1"
+          JAX_PLATFORMS: cpu
+        run: |
+          python -m pip freeze
+          pytest -q -m "not full and not weekly" tests/test_polish_linear.py --durations=10
+
   changed-coverage:
     name: Changed executable lines (>= 95%)
     runs-on: ubuntu-latest
@@ -385,7 +385,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    needs: [changes, quality, fast, physics, parity, device, changed-coverage]
+    needs: [changes, quality, fast, physics, parity, device, jax-compatibility, changed-coverage]
     steps:
       - name: Require every review gate
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -132,7 +132,9 @@ jobs:
         run: python -m pip install . pytest "jax==${{ matrix.jax }}" "jaxlib==${{ matrix.jax }}"
       - name: Fetch the free-boundary reference fixture
         if: matrix.selector == 'full-free-boundary-adjoint'
-        run: python tools/fetch_assets.py --bundle reference-nc
+        run: |
+          python tools/fetch_assets.py --bundle ncsx-mgrid
+          test -f examples/data/mgrid_ncsx_c09r00_small.nc
       - name: Run retained nonlinear contracts
         env:
           RUN_FULL: "1"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,7 @@ permissions:
   contents: read
 
 env:
+  VMEX_COMPILATION_CACHE: disabled
   JAX_ENABLE_X64: "1"
   LC_ALL: C.UTF-8
   LANG: C.UTF-8
@@ -97,5 +98,50 @@ jobs:
         with:
           name: test-report-optional
           path: test-report-*.json
+          if-no-files-found: warn
+          retention-days: 7
+
+  nonlinear-contracts:
+    name: ${{ matrix.selector }} (JAX ${{ matrix.jax }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include:
+          - selector: full-polish-gn
+            jax: "0.11.1"
+          - selector: full-polish-homotopy
+            jax: "0.11.1"
+          - selector: full-polish-linear
+            jax: "0.9.2"
+          - selector: full-polish-linear
+            jax: "0.11.1"
+          - selector: full-run-options
+            jax: "0.11.1"
+          - selector: full-free-boundary-adjoint
+            jax: "0.11.1"
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install tested numerical versions
+        run: python -m pip install . pytest "jax==${{ matrix.jax }}" "jaxlib==${{ matrix.jax }}"
+      - name: Run retained nonlinear contracts
+        env:
+          RUN_FULL: "1"
+          JAX_PLATFORMS: cpu
+        run: |
+          python -m pip freeze
+          FILES="$(python tools/test_manifest.py select ${{ matrix.selector }})"
+          pytest -q $FILES --durations=20 --vmex-report=nonlinear-report.json
+      - uses: actions/upload-artifact@v7.0.1
+        if: always()
+        with:
+          name: nonlinear-${{ matrix.selector }}-${{ matrix.jax }}
+          path: nonlinear-report.json
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -130,6 +130,9 @@ jobs:
           cache: pip
       - name: Install tested numerical versions
         run: python -m pip install . pytest "jax==${{ matrix.jax }}" "jaxlib==${{ matrix.jax }}"
+      - name: Fetch the free-boundary reference fixture
+        if: matrix.selector == 'full-free-boundary-adjoint'
+        run: python tools/fetch_assets.py --bundle reference-nc
       - name: Run retained nonlinear contracts
         env:
           RUN_FULL: "1"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -130,6 +130,12 @@ jobs:
           cache: pip
       - name: Install tested numerical versions
         run: python -m pip install . pytest "jax==${{ matrix.jax }}" "jaxlib==${{ matrix.jax }}"
+      - name: Add XLA compile headroom
+        run: |
+          sudo fallocate -l 12G /mnt/vmex-swap
+          sudo chmod 600 /mnt/vmex-swap
+          sudo mkswap /mnt/vmex-swap
+          sudo swapon /mnt/vmex-swap
       - name: Fetch the free-boundary reference fixture
         if: matrix.selector == 'full-free-boundary-adjoint'
         run: |

--- a/docs/project/contributing.rst
+++ b/docs/project/contributing.rst
@@ -46,8 +46,8 @@ JAX compatibility and test tiers
 
 The stationarity contract is checked on Python 3.12 with JAX/JAXlib 0.9.2
 and 0.11.1, using identical float64 tolerances. These are tested numerical
-versions; the broader package dependency bounds do not certify every
-intermediate release. The PR matrix exercises eager and compiled linear
+versions for the core install; optional integrations can require newer JAX.
+The broader package dependency bounds do not certify every intermediate release. The PR matrix exercises eager and compiled linear
 certificates; Nightly runs the tight real-MHD derivative and rejected-root
 cases on both versions. Update the pair deliberately after reproducing failures,
 with environment and attained residuals recorded in ``plan.md``.

--- a/docs/project/contributing.rst
+++ b/docs/project/contributing.rst
@@ -31,15 +31,38 @@ The workflows obtain their selectors from the manifest:
 - ``CI`` is the stable pull-request gate. It runs fast API checks and
   representative fixed-boundary, free-boundary/NESTOR, mirror, device, and AD
   paths. Changed executable lines must be at least 95% covered.
-- ``Nightly`` owns the complete integration/oracle matrix and aggregate
-  package coverage. Its matrices leave hosted capacity for pull-request
-  checks.
-- ``Weekly high resolution`` owns campaigns that exceed the 150-minute cold
-  nightly budget.
+- ``Nightly`` runs optimization and optional integrations, plus the retained
+  nonlinear polish, homotopy, file-directive and free-boundary adjoint checks.
+  A full-suite ownership entry alone does not schedule a test: its selector
+  must also appear in a workflow.
+- ``Weekly high resolution`` runs the selected high-resolution campaigns.
 - ``Trusted GPU physics`` is an explicit self-hosted dispatch.
 
 Use ``pytest --vmex-report=report.json`` to record the 50 slowest tests and all
 skip reasons with the same metadata.
+
+JAX compatibility and test tiers
+--------------------------------
+
+The stationarity contract is checked on Python 3.12 with JAX/JAXlib 0.9.2
+and 0.11.1, using identical float64 tolerances. These are tested numerical
+versions; the broader package dependency bounds do not certify every
+intermediate release. The PR matrix exercises eager and compiled linear
+certificates; Nightly runs the tight real-MHD derivative and rejected-root
+cases on both versions. Update the pair deliberately after reproducing failures,
+with environment and attained residuals recorded in ``plan.md``.
+
+PR physics and parity jobs have a 25-minute timeout. Actual successful job
+times establish the runtime gate. ``full`` marks retain expensive checks for
+scheduled runs; they do not weaken assertions. Run either tier locally::
+
+  VMEX_COMPILATION_CACHE=disabled pytest -q -m "not full and not weekly" tests/test_polish_linear.py
+  RUN_FULL=1 VMEX_COMPILATION_CACHE=disabled pytest -q tests/test_polish_linear.py
+
+Use the restoring ``_module_jit_enabled`` fixture when a module needs compiled
+solves; an unscoped ``jax.config.update`` can change later tests. Directive
+parsing and precedence use a mocked driver; one real unpolished solve/export
+check remains in PR CI and the polished file workflow runs in Nightly.
 
 Reference assets
 ----------------

--- a/plan.md
+++ b/plan.md
@@ -639,7 +639,7 @@ residual scale 6.83505). CI's failure remains unreproduced. The repaired selecti
 locally (JAX 0.9.2, 228.87 s) and on office (0.11.1, 365.96 s); static checks passed. Raw logs:
 `vmex-review-evidence-20260906/{277-repair-*,office-277-*}.log`; RSS unmeasured.
 
-**2026-09-06, P0.3/P0.2 tiering.** Worktree `vmex-ci-tiers`, branch `fix/phase1-ci-tiers`,
+**2026-09-06, #286 / P0.3/P0.2 tiering (base #277).** Worktree `vmex-ci-tiers`, branch `fix/phase1-ci-tiers`,
 integrates #277/#284/#285 at `2ae2a716`; split and CI implementation at `0bfab61d`. GN retains its
 module; linear and homotopy checks move to two modules, sharing the existing fixtures. Real polish
 and free-boundary adjoint integrations are full-marked and scheduled explicitly; option

--- a/plan.md
+++ b/plan.md
@@ -583,41 +583,35 @@ python tools/preflight.py --static
 
 ## 12. Execution logbook
 
-Format for each entry: date, PR (base and head), owning gate, command and
-environment, result with units, time and memory, limitation or failure, next
-action. Abandoned experiments stay as evidence with their stop reason.
-Update the gate's status in place; do not append work packages.
+Format for each entry: date, PR (base and head), owning gate, command and environment, result with
+units, time and memory, limitation or failure, next action. Abandoned experiments stay as evidence
+with their stop reason. Update the gate's status in place; do not append work packages.
 
-**2026-09-05.** Twenty-one PRs merged in plan order (#267–#270, #264, #263,
-#262, #260, #258, #259, #254, #253, #256, #257, #261, #197, #280, #272, #278,
-#273, #281, #265); #271 was auto-closed by its base-branch deletion and
-reopened as #281. Facts learned: the compilation-cache entry scaling
-(`LRUCache.put` rescans the directory: 0.028 ms per entry) is bounded by #254;
-the W7-X flat certificate (34.23 GiB) is replaced by the batched one (3.24
-GiB certificate, 16.6 GiB chart); the LASYM `tcon` audit closed in VMEX's
-favour; the certificate diagnostics `angular_spectral_tail` and
-`nestedness_margin` were redefined by #258; the baseline guard is pinned by
-norms with a 1e-10 relative and 1e-12 absolute floor (#280).
+**2026-09-05.** Twenty-one PRs merged in plan order (#267–#270, #264, #263, #262, #260, #258, #259,
+#254, #253, #256, #257, #261, #197, #280, #272, #278, #273, #281, #265); #271 was auto-closed by its
+base-branch deletion and reopened as #281. Facts learned: the compilation-cache entry scaling
+(`LRUCache.put` rescans the directory: 0.028 ms per entry) is bounded by #254; the W7-X flat
+certificate (34.23 GiB) is replaced by the batched one (3.24 GiB certificate, 16.6 GiB chart); the
+LASYM `tcon` audit closed in VMEX's favour; the certificate diagnostics `angular_spectral_tail` and
+`nestedness_margin` were redefined by #258; the baseline guard is pinned by norms with a 1e-10
+relative and 1e-12 absolute floor (#280).
 
-**2026-09-06, #282 probes** (Apple M3 Max, JAX 0.9.2, cache disabled): the
-same-deck VMEC++ 0.7.3 parity, native DESC solve, frozen 156×17 operator and
-capped GVEC run of §2; raw logs in `vmex-review-evidence-20260906` outside
-git, compact results in `focused_review_20260906`. The README went from 573
-to 220 lines and the validation page separated native force accuracy from
-WOUT reconstruction. #277's CI failure (run 34005068178) preserved.
+**2026-09-06, #282 probes** (Apple M3 Max, JAX 0.9.2, cache disabled): the same-deck VMEC++ 0.7.3
+parity, native DESC solve, frozen 156×17 operator and capped GVEC run of §2; raw logs in
+`vmex-review-evidence-20260906` outside git, compact results in `focused_review_20260906`. The
+README went from 573 to 220 lines and the validation page separated native force accuracy from WOUT
+reconstruction. #277's CI failure (run 34005068178) preserved.
 
-**2026-09-06, consolidation.** #266 and #276 merged; #282 rebased over #276's
-figure manifest and merged; #283's plan rebased onto it and rewritten as this
-document; #274 closed. Local lane runs on clean main (fast plus seven physics
-lanes, all green) recorded in §2; the parity-lane log was lost with the
-session's task directory and those lanes are rerun in Phase 1's tiering PR.
-Office was unreachable; the recovered #277 evidence is recorded below.
+**2026-09-06, consolidation.** #266 and #276 merged; #282 rebased over #276's figure manifest and
+merged; #283's plan rebased onto it and rewritten as this document; #274 closed. Local lane runs on
+clean main (fast plus seven physics lanes, all green) recorded in §2; the parity-lane log was lost
+with the session's task directory and those lanes are rerun in Phase 1's tiering PR. Office was
+unreachable; the recovered #277 evidence is recorded below.
 
-**2026-09-06, P0.1/P0.3.** #284 (`417fb4fc`, base `2a0d4356`) implements
-the documentation gates: 73 guards and strict Sphinx passed. #285 (`40c1792b`,
-base #284) restores JIT state in four modules: 73 tests passed in 396.88 s;
-the regression fails on the parent. #284 CI passed; reviews/#285 CI await; retarget #285
-before deleting #284's branch. The tiering entry below continues this work.
+**2026-09-06, P0.1/P0.3.** #284 (`417fb4fc`, base `2a0d4356`) implements the documentation gates: 73
+guards and strict Sphinx passed. #285 (`40c1792b`, base #284) restores JIT state in four modules: 73
+tests passed in 396.88 s; the regression fails on the parent. #284 CI passed; reviews/#285 CI await;
+retarget #285 before deleting #284's branch. The tiering entry below continues this work.
 
 **2026-09-06, Phase 1 / P0.1–P0.3.** All-state PR inventory identifies #283
 as this plan's authority. #284 (`417fb4fc`, base main `2a0d4356`) implements
@@ -636,23 +630,32 @@ both XLA flags disabled it passed in 313.34 s (17 iterations, stationarity
 2.598e-9, reference 138.346, residual scale 6.83505). CI's failure remains
 unreproduced. The repaired selection passed 27 cases locally (JAX 0.9.2,
 228.87 s) and on office (0.11.1, 365.96 s); static checks passed. Raw logs:
+
+**2026-09-06, #277 / P0.2.** Main and this plan merged at `068b2cbc`; assertion repair pushed at
+`6371a36b`, without changing tolerances. The old office log only lacked pytest. On clean `db6092b7`,
+Python 3.12.13 / JAX 0.11.1 / SOLVAX 0.20, the original tight MHD test passed in 333.88 s; with both
+XLA flags disabled it passed in 313.34 s (17 iterations, stationarity 2.598e-9, reference 138.346,
+residual scale 6.83505). CI's failure remains unreproduced. The repaired selection passed 27 cases
+locally (JAX 0.9.2, 228.87 s) and on office (0.11.1, 365.96 s); static checks passed. Raw logs:
 `vmex-review-evidence-20260906/{277-repair-*,office-277-*}.log`; RSS unmeasured.
 
-**2026-09-06, P0.3/P0.2 tiering.** Worktree `vmex-ci-tiers`, branch
-`fix/phase1-ci-tiers`, integrates #277/#284/#285 at `2ae2a716`; split and CI
-implementation at `0bfab61d`. GN retains its module; linear and homotopy
-checks move to two modules, sharing the existing fixtures. Real polish and
-free-boundary adjoint integrations are full-marked and scheduled explicitly;
-option parsing/precedence and failure routing use mocks with one real PR
-solve/export. Assertions and physics tolerances are retained. All 1,962
-original cases survive the move; collection is 1,973 with 11 new cases.
-Eleven manifest guards passed in 9.89 s; PR/nightly matrices pin Python 3.12
-and JAX 0.9.2/0.11.1;
-PR physics/parity timeouts are 25 minutes. A timeout edit is not runtime
-proof. Campaign-class a1 routing and measured hosted limits remain open.
-Local PR selection: 253 passed, 22 full cases deselected, 375.30 s;
-76 guards passed in 18.00 s plus strict Sphinx/Ruff/mypy; all 64 original
-polish bodies are unchanged. Full homotopy: 12 passed in 385.24 s locally;
-office linear/MHD: 96 passed in 406.44 s on JAX 0.11.1. Logs are in
-`vmex-phase1-ci-evidence`; office 0.9.2 and local full options runs continue. An initial local options run was interrupted to enable its real solve
-with the restoring JIT fixture; it is not a passing observation. No peak RSS or performance ranking is claimed. Next: publish after remaining checks, then hosted CI/review and parent merges. P1/E1 and the release remain on hold.
+**2026-09-06, P0.3/P0.2 tiering.** Worktree `vmex-ci-tiers`, branch `fix/phase1-ci-tiers`,
+integrates #277/#284/#285 at `2ae2a716`; split and CI implementation at `0bfab61d`. GN retains its
+module; linear and homotopy checks move to two modules, sharing the existing fixtures. Real polish
+and free-boundary adjoint integrations are full-marked and scheduled explicitly; option
+parsing/precedence and failure routing use mocks with one real PR solve/export. Assertions and
+physics tolerances are retained. All 1,962 original cases survive; collection is 1,974 with 12 new
+cases. Twelve manifest guards passed in 10.81 s; PR/nightly matrices pin Python 3.12/JAX
+0.9.2/0.11.1; PR physics/parity timeouts are 25 minutes. A timeout edit is not runtime proof.
+Campaign-class a1 routing and measured hosted limits remain open. Local PR selection: 253 passed, 22
+full cases deselected, 375.30 s; 76 guards passed in 18.00 s plus strict Sphinx/Ruff/mypy; all 64
+original polish bodies are unchanged. Full homotopy: 12 passed/385.24 s; full options: 41
+passed/102.23 s. Office linear/MHD: 96 passed on each version (0.11.1: 406.44 s; 0.9.2: 577.27 s),
+same Python 3.12. Consolidated mirror: 57 passed in 331.74 s. Parent #284 misc took 27.7 min: remove
+its duplicate mirror suite and fold the output job into physics (one fewer job). Revised misc: 74
+passed/273.04 s; its 11 skips are explicitly disabled live VMEC2000 tests. Full GN on office and
+full adjoints locally run with 30-minute caps; the verified reference-nc bundle supplies NCSX,
+preventing a missing-asset skip. Logs: `vmex-phase1-ci-evidence`. The initial options run was
+interrupted for the scoped JIT fix; no peak RSS or performance ranking is claimed. Next: publish
+after remaining checks, then hosted CI/review and parent merges. P1/E1 and the release remain on
+hold.

--- a/plan.md
+++ b/plan.md
@@ -651,11 +651,13 @@ Campaign-class a1 routing and measured hosted limits remain open. Local PR selec
 full cases deselected, 375.30 s; 76 guards passed in 18.00 s plus strict Sphinx/Ruff/mypy; all 64
 original polish bodies are unchanged. Full homotopy: 12 passed/385.24 s; full options: 41
 passed/102.23 s. Office linear/MHD: 96 passed on each version (0.11.1: 406.44 s; 0.9.2: 577.27 s),
-same Python 3.12. Consolidated mirror: 57 passed in 331.74 s. Parent #284 misc took 27.7 min: remove
-its duplicate mirror suite and fold the output job into physics (one fewer job). Revised misc: 74
-passed/273.04 s; its 11 skips are explicitly disabled live VMEC2000 tests. Full GN on office and
-full adjoints locally run with 30-minute caps; the verified reference-nc bundle supplies NCSX,
-preventing a missing-asset skip. Logs: `vmex-phase1-ci-evidence`. The initial options run was
-interrupted for the scoped JIT fix; no peak RSS or performance ranking is claimed. Next: publish
-after remaining checks, then hosted CI/review and parent merges. P1/E1 and the release remain on
-hold.
+same Python 3.12. The shape-rejection test then moved back to GN to reuse its fixture: final PR
+linear selection is 93 passed/7.21 s (2 MHD cases full), with all test bodies retained. Consolidated
+mirror: 57 passed in 331.74 s. Parent #284 misc took 27.7 min: remove its duplicate mirror suite and
+fold the output job into physics (one fewer job). Revised misc: 74 passed/273.04 s; its 11 skips are
+explicitly disabled live VMEC2000 tests. Full GN on office and full adjoints locally run with
+30-minute caps; the first asset assertion stopped before tests because reference-nc lacks NCSX.
+Corrected Nightly to ncsx-mgrid with a file assertion and manifest-linked guard; the full adjoint
+run then started. Logs: `vmex-phase1-ci-evidence`. The initial options run was interrupted for the
+scoped JIT fix; no peak RSS or performance ranking is claimed. Next: publish after remaining checks,
+then hosted CI/review and parent merges. P1/E1 and the release remain on hold.

--- a/plan.md
+++ b/plan.md
@@ -173,14 +173,14 @@ does not interrupt. Fixed boundary, stellarator symmetry, prescribed iota,
 GAMMA = 0 until the closure audit in P1 admits more. Failed and capped
 attempts are saved as such.
 
-- **E1, functional consistency (one day).** For random chart directions v,
-  compare `⟨∂W/∂c, v⟩` from reverse-mode AD with `−∫ F_cart · (∂x/∂c v) √g`
-  from the certificate's own Cartesian force at the same quadrature; check
-  the strong residual's Jacobian against the same object by JVP/VJP duality;
-  run the chart rank and gauge-quotient audit on the same tiny reference.
-  Pass: 1e-10 relative agreement on Solov'ev and the shaped tokamak. Fail:
-  the energy route stops and the reason (closure term, boundary term, gauge)
-  is recorded.
+- **E1, functional consistency (one day).** Compare AD `dW[c]v` with complete
+  virtual work, including lambda (or displacement at fixed field-line labels),
+  closure and boundary terms. Fixed-angle `∂x/∂c v` alone misses lambda work;
+  see the [VMEC variation](https://princetonuniversity.github.io/STELLOPT/VMEC.html#theory).
+  On Solov'ev and the shaped tokamak, separate quadrature-refinement error
+  from the 1e-10 AD/JVP/VJP consistency bar; audit rank and the gauge quotient.
+  An unexplained, quadrature-converged work mismatch stops the energy route;
+  diagnose missing terms or quadrature first, before interpreting solver failure.
 - **E2, dense reference step (one week).** Assemble `J` and the constrained
   reference `H` on the frozen tokamak and one affordable finite-beta QA
   linearization; compare spectrum and rank, augmented QR/SVD reference steps
@@ -263,7 +263,7 @@ public optimization wrappers, CI); SOLVAX owns generic true-residual reporting.
    numbers in `CHANGELOG.md`, and add a cited-path existence test for
    `benchmarks/` references. Add README ≤ 300 and CHANGELOG ≤ 200 line caps to
    the same gate.
-2. **JAX policy and #277 — assertion repair tested on both versions; CI/matrix pending.** Test the floor (0.9.2, the machines we own) and
+2. **JAX policy and #277 — assertion repair tested; version matrix under validation.** Test the floor (0.9.2, the machines we own) and
    the head (0.11.x, CI); tolerances backed by observed accuracy; no
    cross-version bit claims. Bisect #277's assertion on the office box under
    `~/vmex_sweep/env-0.8.0` (JAX 0.11.1) with `--xla_cpu_use_xnnpack=false`
@@ -272,7 +272,7 @@ public optimization wrappers, CI); SOLVAX owns generic true-residual reporting.
    stationarity at the derivative gate's 1e-8 bar and lets the derivative call
    be the check; SOLVAX's 1e-10 flag is a solver metric. Keep the tight
    real-MHD fixture.
-3. **CI tiering to a 25-minute PR ceiling — JIT isolation implemented; tiering pending.** Every test that runs a polish or
+3. **CI tiering — implementation under validation; hosted ceiling unproved.** Every test that runs a polish or
    a free-boundary implicit adjoint moves to `full`; `test_polish_preconditioner.py`
    splits into Gauss-Newton (PR), homotopy (nightly) and linear (PR);
    `test_run_options.py` exercises directive parsing against a mocked driver
@@ -611,10 +611,13 @@ figure manifest and merged; #283's plan rebased onto it and rewritten as this
 document; #274 closed. Local lane runs on clean main (fast plus seven physics
 lanes, all green) recorded in §2; the parity-lane log was lost with the
 session's task directory and those lanes are rerun in Phase 1's tiering PR.
-The office workstation was unreachable at the end of the day, so the JAX
-0.11.1 reproduction of #277's assertion (`~/vmex277/run277b.log`) is the
-first thing Phase 1 reads. No production code was changed.
+Office was unreachable; the recovered #277 evidence is recorded below.
 
+**2026-09-06, P0.1/P0.3.** #284 (`417fb4fc`, base `2a0d4356`) implements
+the documentation gates: 73 guards and strict Sphinx passed. #285 (`40c1792b`,
+base #284) restores JIT state in four modules: 73 tests passed in 396.88 s;
+the regression fails on the parent. #284 CI passed; reviews/#285 CI await; retarget #285
+before deleting #284's branch. The tiering entry below continues this work.
 
 **2026-09-06, Phase 1 / P0.1–P0.3.** All-state PR inventory identifies #283
 as this plan's authority. #284 (`417fb4fc`, base main `2a0d4356`) implements
@@ -625,25 +628,31 @@ new subprocess regression fails on the unchanged parent. Both passed CI and merg
 merge; branch bases were retained. Tiering, module
 splitting, parsing mocks and the 25-minute lane gate remain unfinished.
 
-**2026-09-06, #277 / P0.2.** Merged main's authoritative plan into the
-stationarity branch (`068b2cbc`, numerical polish source unchanged). The old
-office log contains only missing pytest, not a failed solve. An isolated
-Python 3.12.13 / JAX 0.11.1 / SOLVAX 0.20 environment on office reproduced
-neither the original assertion failure nor a tolerance problem at `db6092b7`:
-the tight MHD test passed unmodified in 333.88 s; with both XLA flags above
-disabled it passed in 313.34 s, reporting 17 iterations, scaled stationarity
-2.598e-9, initial reference 138.346 and residual scale 6.83505. Both physical
-acceptance and internal solver success were true. This is not a flag bisect
-or a diagnosis of CI run 34005068178. The repaired test checks the public
-finite stationarity norm against its reported tolerance and retains tangent,
-adjoint, custom-VJP, Boozer and Taylor checks; solver/derivative tolerances
-and the tight fixture are unchanged. Local JAX 0.9.2: 27 selected tests passed
-in 228.87 s. Command: cache disabled, CPU, pytest on the polish module with
-`-k 'collocation_polish_primal_and_derivatives or polish_stationarity or physics_accepted_polish_can_fail_derivative_stationarity'`.
-Office JAX 0.11.1: the same 27 tests passed in 365.96 s on `db6092b7`
-plus the identical test patch. Static preflight, strict Sphinx and 59 guards
-passed (guards: 12.12 s); final-head CI and required review remain pending.
-Raw logs: `vmex-review-evidence-20260906/{277-repair-*,office-277-*}.log`
-outside git. RSS was not measured; these test times are not benchmark claims.
-Next: merge #277 after CI/review, then finish CI tiering/JAX matrix;
-P1 and E1 have not started, and the release hold remains.
+**2026-09-06, #277 / P0.2.** Main and this plan merged at `068b2cbc`;
+assertion repair pushed at `6371a36b`, without changing tolerances. The old
+office log only lacked pytest. On clean `db6092b7`, Python 3.12.13 / JAX
+0.11.1 / SOLVAX 0.20, the original tight MHD test passed in 333.88 s; with
+both XLA flags disabled it passed in 313.34 s (17 iterations, stationarity
+2.598e-9, reference 138.346, residual scale 6.83505). CI's failure remains
+unreproduced. The repaired selection passed 27 cases locally (JAX 0.9.2,
+228.87 s) and on office (0.11.1, 365.96 s); static checks passed. Raw logs:
+`vmex-review-evidence-20260906/{277-repair-*,office-277-*}.log`; RSS unmeasured.
+
+**2026-09-06, P0.3/P0.2 tiering.** Worktree `vmex-ci-tiers`, branch
+`fix/phase1-ci-tiers`, integrates #277/#284/#285 at `2ae2a716`; split and CI
+implementation at `0bfab61d`. GN retains its module; linear and homotopy
+checks move to two modules, sharing the existing fixtures. Real polish and
+free-boundary adjoint integrations are full-marked and scheduled explicitly;
+option parsing/precedence and failure routing use mocks with one real PR
+solve/export. Assertions and physics tolerances are retained. All 1,962
+original cases survive the move; collection is 1,973 with 11 new cases.
+Eleven manifest guards passed in 9.89 s; PR/nightly matrices pin Python 3.12
+and JAX 0.9.2/0.11.1;
+PR physics/parity timeouts are 25 minutes. A timeout edit is not runtime
+proof. Campaign-class a1 routing and measured hosted limits remain open.
+Local PR selection: 253 passed, 22 full cases deselected, 375.30 s;
+76 guards passed in 18.00 s plus strict Sphinx/Ruff/mypy; all 64 original
+polish bodies are unchanged. Full homotopy: 12 passed in 385.24 s locally;
+office linear/MHD: 96 passed in 406.44 s on JAX 0.11.1. Logs are in
+`vmex-phase1-ci-evidence`; office 0.9.2 and local full options runs continue. An initial local options run was interrupted to enable its real solve
+with the restoring JIT fixture; it is not a passing observation. No peak RSS or performance ranking is claimed. Next: publish after remaining checks, then hosted CI/review and parent merges. P1/E1 and the release remain on hold.

--- a/plan.md
+++ b/plan.md
@@ -608,28 +608,7 @@ clean main (fast plus seven physics lanes, all green) recorded in §2; the parit
 with the session's task directory and those lanes are rerun in Phase 1's tiering PR. Office was
 unreachable; the recovered #277 evidence is recorded below.
 
-**2026-09-06, P0.1/P0.3.** #284 (`417fb4fc`, base `2a0d4356`) implements the documentation gates: 73
-guards and strict Sphinx passed. #285 (`40c1792b`, base #284) restores JIT state in four modules: 73
-tests passed in 396.88 s; the regression fails on the parent. #284 CI passed; reviews/#285 CI await;
-retarget #285 before deleting #284's branch. The tiering entry below continues this work.
-
-**2026-09-06, Phase 1 / P0.1–P0.3.** All-state PR inventory identifies #283
-as this plan's authority. #284 (`417fb4fc`, base main `2a0d4356`) implements
-P0.1: withdrawn-claim, RST prose, root line-cap and cited-path guards;
-73 preflight guards and strict Sphinx passed. #285 (`40c1792b`, base #284)
-restores JIT state in four test modules: 73 tests passed in 396.88 s and the
-new subprocess regression fails on the unchanged parent. Both passed CI and merged on 2026-09-07 with user-authorized admin
-merge; branch bases were retained. Tiering, module
-splitting, parsing mocks and the 25-minute lane gate remain unfinished.
-
-**2026-09-06, #277 / P0.2.** Main and this plan merged at `068b2cbc`;
-assertion repair pushed at `6371a36b`, without changing tolerances. The old
-office log only lacked pytest. On clean `db6092b7`, Python 3.12.13 / JAX
-0.11.1 / SOLVAX 0.20, the original tight MHD test passed in 333.88 s; with
-both XLA flags disabled it passed in 313.34 s (17 iterations, stationarity
-2.598e-9, reference 138.346, residual scale 6.83505). CI's failure remains
-unreproduced. The repaired selection passed 27 cases locally (JAX 0.9.2,
-228.87 s) and on office (0.11.1, 365.96 s); static checks passed. Raw logs:
+**2026-09-06, Phase 1 / P0.1 and P0.3 isolation.** #284 (`417fb4fc`, base `2a0d4356`) implements P0.1: the withdrawn-claim removal, RST prose scanning, root line caps and cited-path guards; 73 preflight guards and strict Sphinx passed. #285 (`40c1792b`, base #284) restores JIT state in four test modules: 73 tests passed in 396.88 s and the new subprocess regression fails on the unchanged parent. Both passed CI and merged on 2026-09-07 under the plan's admin-merge rule; their branch bases were retained for the stack. Tiering, module splitting, parsing mocks and the 25-minute lane gate continue in #286.
 
 **2026-09-06, #277 / P0.2.** Main and this plan merged at `068b2cbc`; assertion repair pushed at
 `6371a36b`, without changing tolerances. The old office log only lacked pytest. On clean `db6092b7`,

--- a/plan.md
+++ b/plan.md
@@ -648,16 +648,19 @@ physics tolerances are retained. All 1,962 original cases survive; collection is
 cases. Twelve manifest guards passed in 10.81 s; PR/nightly matrices pin Python 3.12/JAX
 0.9.2/0.11.1; PR physics/parity timeouts are 25 minutes. A timeout edit is not runtime proof.
 Campaign-class a1 routing and measured hosted limits remain open. Local PR selection: 253 passed, 22
-full cases deselected, 375.30 s; 76 guards passed in 18.00 s plus strict Sphinx/Ruff/mypy; all 64
-original polish bodies are unchanged. Full homotopy: 12 passed/385.24 s; full options: 41
+full cases deselected, 375.30 s; 77 final guards passed in 17.94 s plus strict Sphinx/Ruff/mypy; all
+64 original polish bodies are unchanged. Full homotopy: 12 passed/385.24 s; full options: 41
 passed/102.23 s. Office linear/MHD: 96 passed on each version (0.11.1: 406.44 s; 0.9.2: 577.27 s),
 same Python 3.12. The shape-rejection test then moved back to GN to reuse its fixture: final PR
-linear selection is 93 passed/7.21 s (2 MHD cases full), with all test bodies retained. Consolidated
-mirror: 57 passed in 331.74 s. Parent #284 misc took 27.7 min: remove its duplicate mirror suite and
-fold the output job into physics (one fewer job). Revised misc: 74 passed/273.04 s; its 11 skips are
-explicitly disabled live VMEC2000 tests. Full GN on office and full adjoints locally run with
-30-minute caps; the first asset assertion stopped before tests because reference-nc lacks NCSX.
-Corrected Nightly to ncsx-mgrid with a file assertion and manifest-linked guard; the full adjoint
-run then started. Logs: `vmex-phase1-ci-evidence`. The initial options run was interrupted for the
-scoped JIT fix; no peak RSS or performance ranking is claimed. Next: publish after remaining checks,
-then hosted CI/review and parent merges. P1/E1 and the release remain on hold.
+linear selection is 93 passed/7.21 s locally, 16.24/18.98 s on office head/floor (2 MHD cases full),
+with all test bodies retained. Consolidated mirror: 57 passed in 331.74 s. Parent #284 misc took
+27.7 min: remove its duplicate mirror suite and fold the output job into physics (one fewer job).
+Revised misc: 74 passed/273.04 s; its 11 skips are explicitly disabled live VMEC2000 tests. The
+interpreted GN run was stopped after 115 passes/1413.93 s to try scoped JIT; it is incomplete.
+Compiled GN passed 124/579.02 s on office `~/vmex-ci-final` (`32f01c0c`); the local JAX 0.9.2 run
+passed 124/349.79 s. Full adjoints passed 15/932.33 s with no skips; the first asset assertion
+stopped before tests because reference-nc lacks NCSX. Corrected Nightly to ncsx-mgrid with a file
+assertion and manifest-linked guard; the rerun passed. Logs: `vmex-phase1-ci-evidence`. The initial
+options run was interrupted for the scoped JIT fix; no peak RSS or performance ranking is claimed.
+Next: hosted CI/runtime and coverage gates, required review, then parent merges; retarget this
+branch before deleting #277’s branch. P1/E1 and the release remain on hold.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,11 @@ ignore = ["E402", "E501", "E702"]
 [tool.ruff.lint.per-file-ignores]
 # The docstring contract is on the package's public surface only.
 "tests/**" = ["D"]
+# The split polish modules import shared fixtures with the `as` re-export
+# idiom and take them as test parameters; F811 for that pattern is a
+# false positive that only some ruff versions report.
+"tests/test_polish_homotopy.py" = ["D", "F811"]
+"tests/test_polish_linear.py" = ["D", "F811"]
 "examples/**" = ["D"]
 "benchmarks/**" = ["D"]
 "tools/**" = ["D"]

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -40,7 +40,7 @@
     ["tests/test_forces_residuals.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-d-f0"]],
     ["tests/test_fourier_transforms.py", "equilibrium", "unit", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "pr-fast", "full-core-d-f0"]],
     ["tests/test_freeboundary.py", "free-boundary", "integration", "slow", "cpu-gpu", "golden", "vmec2000", ["pr-parity-a1", "full-core-fb-a"]],
-    ["tests/test_freeboundary_implicit.py", "free-boundary", "ad", "slow", "cpu-gpu", "none", "fd", ["pr-parity-a1", "full-core-fb-a"]],
+    ["tests/test_freeboundary_implicit.py", "free-boundary", "ad", "slow", "cpu-gpu", "none", "fd", ["pr-parity-a1", "full-free-boundary-adjoint"]],
     ["tests/test_virtual_casing_api.py", "virtual-casing", "unit", "fast", "cpu", "none", "none", ["pr-parity-a1", "full-core-fb-a"]],
     ["tests/test_virtual_casing_physics.py", "virtual-casing", "ad", "medium", "cpu-gpu", "reference-nc", "fd", ["pr-parity-a1", "optional", "full-core-fb-a"]],
     ["tests/test_freeboundary_linear.py", "free-boundary", "ad", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-a1", "full-core-fb-a"]],
@@ -82,8 +82,10 @@
     ["tests/test_performance_docs.py", "infrastructure", "unit", "fast", "cpu", "none", "golden", ["pr-parity-c2", "full-core-n-s"]],
     ["tests/test_plot_summary.py", "diagnostics", "integration", "medium", "cpu", "none", "analytic", ["pr-parity-c2", "pr-fast", "full-core-n-s"]],
     ["tests/test_plotting_boozer.py", "diagnostics", "integration", "medium", "cpu", "golden", "external", ["pr-parity-c2", "full-core-n-s"]],
-    ["tests/test_polish_preconditioner.py", "equilibrium", "ad", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-e", "full-core-n-s"]],
-    ["tests/test_run_options.py", "equilibrium", "unit", "medium", "cpu", "none", "analytic", ["pr-parity-f", "full-core-n-s"]],
+    ["tests/test_polish_preconditioner.py", "equilibrium", "ad", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-e", "full-polish-gn"]],
+    ["tests/test_polish_linear.py", "equilibrium", "ad", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-e", "full-polish-linear"]],
+    ["tests/test_polish_homotopy.py", "equilibrium", "ad", "slow", "cpu-gpu", "none", "analytic", ["pr-full-only", "full-polish-homotopy"]],
+    ["tests/test_run_options.py", "equilibrium", "unit", "medium", "cpu", "none", "analytic", ["pr-parity-f", "full-run-options"]],
     ["tests/test_profile_workflows.py", "performance", "unit", "fast", "cpu", "none", "none", ["pr-parity-c1", "pr-fast", "full-core-n-s"]],
     ["tests/test_postprocess_currents.py", "diagnostics", "oracle", "medium", "cpu-gpu", "golden", "vmec2000", ["pr-parity-c2", "full-core-n-s"]],
     ["tests/test_preconditioner.py", "equilibrium", "unit", "medium", "cpu-gpu", "none", "analytic", ["pr-parity-c2", "pr-fast", "full-core-n-s"]],
@@ -175,7 +177,9 @@
       "tests/test_plotting_boozer.py"
     ],
     "pr-free-boundary-adjoint": [
-      "tests/test_freeboundary_implicit.py::test_free_boundary_current_gradient_matches_resolve_finite_difference"
+      "tests/test_freeboundary_linear.py",
+      "tests/test_freeboundary_implicit.py::test_host_adjoint_best_effort_warns_instead_of_raising",
+      "tests/test_freeboundary_implicit.py::test_free_boundary_host_adjoint_rejects_a_false_solver_success"
     ],
     "pr-implicit-response-a": [
       "tests/test_input_profiles.py::test_change_resolution_preserves_representable_coefficients",

--- a/tests/test_freeboundary_implicit.py
+++ b/tests/test_freeboundary_implicit.py
@@ -170,6 +170,7 @@ def test_free_boundary_host_adjoint_rejects_a_false_solver_success(monkeypatch):
                           jnp.ones(2), cfg)
 
 
+@pytest.mark.full
 def test_free_boundary_current_gradient_matches_resolve_finite_difference():
     """The implicit coil-current response agrees with two independent solves."""
     inp = lasym_free_input(DATA)
@@ -307,6 +308,7 @@ def test_free_boundary_pressure_gradient_matches_resolve_finite_difference():
         derivative, finite_difference, rtol=1.0e-1, atol=1.0e-7)
 
 
+@pytest.mark.full
 def test_boundary_schur_adjoint_reproduces_the_coupled_gcrot_gradient():
     """Both adjoint solvers invert the same converged plasma-vacuum Jacobian.
 
@@ -454,6 +456,7 @@ def _flat(tree):
     return jnp.concatenate([jnp.ravel(leaf) for leaf in jax.tree.leaves(tree)])
 
 
+@pytest.mark.full
 def test_free_boundary_gradient_is_certified_factor_by_factor():
     """A certificate whose tolerances come from arithmetic, not solver noise.
 
@@ -584,6 +587,7 @@ def test_free_boundary_gradient_is_certified_factor_by_factor():
     assert abs(forward_side - adjoint_side) / abs(adjoint_side) < 1.0e-6
 
 
+@pytest.mark.full
 def test_free_boundary_root_reproducibility_bounds_the_gradient():
     """Two entry points, two roots, and the gradient amplifies the gap.
 

--- a/tests/test_polish_homotopy.py
+++ b/tests/test_polish_homotopy.py
@@ -1,0 +1,565 @@
+"""Polish homotopy contracts; nonlinear integration stays in the full suite."""
+
+from __future__ import annotations
+
+import dataclasses
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from vmex.core.errors import (
+    StrongForceContinuationError,
+)
+from vmex.core.polish import (
+    apply_high_order_correction,
+    make_strong_structured_chart,
+    strong_root_rank,
+    strong_root_residual,
+)
+from vmex.core.polish_driver import (
+    PolishConfig,
+    _IdentityPreconditioner,
+    _arclength_to_target,
+    _bordered_preconditioner,
+    _branch_tangent,
+    _build_mode_block_preconditioner,
+    _continuation_precondition,
+    _low_inverse,
+    _normalized_low_residual_norm,
+    _ptc_config,
+    _residual_evaluations,
+    _supports_keyword,
+    polish_strong_root,
+)
+
+jax.config.update("jax_enable_x64", True)
+
+from tests.test_polish_preconditioner import (
+    DATA,
+    _tree_dot, small_adapter as small_adapter, small_strong_root as small_strong_root,
+)
+
+pytestmark = pytest.mark.full
+
+
+def test_solvax_continuation_api_compatibility_helpers():
+    def legacy_preconditioner(state, rhs, dtau):
+        del state, dtau
+        return rhs
+
+    def parameterized_preconditioner(state, rhs, dtau, parameter):
+        del state, dtau, parameter
+        return rhs
+
+    assert not _supports_keyword(legacy_preconditioner, "parameter")
+    assert _supports_keyword(parameterized_preconditioner, "parameter")
+    np.testing.assert_array_equal(
+        legacy_preconditioner(None, jnp.ones((2,)), None), jnp.ones((2,))
+    )
+    np.testing.assert_array_equal(
+        parameterized_preconditioner(None, jnp.ones((2,)), None, None),
+        jnp.ones((2,)),
+    )
+    assert _residual_evaluations(
+        SimpleNamespace(nonlinear_steps=3, residual_evaluations=9)
+    ) == 9
+    assert _residual_evaluations(SimpleNamespace(nonlinear_steps=3)) == 4
+    assert _residual_evaluations(SimpleNamespace(steps=2)) == 3
+    assert not _supports_keyword(1, "parameter")
+
+
+def test_parameterized_continuation_preconditioner_switches_at_half(monkeypatch):
+    rhs = jnp.asarray([1.0, -2.0])
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._low_inverse", lambda value, runtime: 2.0 * value
+    )
+    block = SimpleNamespace(apply=lambda value, alpha, dtau: 3.0 * value)
+    np.testing.assert_array_equal(
+        _continuation_precondition(rhs, 0.25, 1.0, SimpleNamespace(), block),
+        2.0 * rhs,
+    )
+    np.testing.assert_array_equal(
+        _continuation_precondition(rhs, 0.75, 1.0, SimpleNamespace(), block),
+        3.0 * rhs,
+    )
+    np.testing.assert_array_equal(
+        _continuation_precondition(
+            rhs, 0.25, 1.0, SimpleNamespace(), block, SimpleNamespace()
+        ),
+        3.0 * rhs,
+    )
+    identity = _IdentityPreconditioner()
+    np.testing.assert_array_equal(identity.apply(rhs), rhs)
+    np.testing.assert_array_equal(
+        _continuation_precondition(
+            rhs,
+            0.25,
+            1.0,
+            SimpleNamespace(),
+            identity,
+        ),
+        rhs,
+    )
+
+
+def test_arclength_crossing_runs_target_correction_and_counts_work(monkeypatch):
+    zero = jnp.zeros((2,))
+    target_vector = jnp.asarray([0.25, -0.5])
+
+    def corrector(
+        residual,
+        initial,
+        *,
+        tangent,
+        predictor,
+        config,
+        admissible,
+        parameterized_precond,
+    ):
+        del residual, initial, config
+        assert bool(admissible(*predictor))
+        np.testing.assert_array_equal(
+            parameterized_precond(predictor, predictor, 1.0, tangent, predictor)[0],
+            predictor[0],
+        )
+        return SimpleNamespace(
+            x=predictor,
+            steps=2,
+            linear_iterations=3,
+            residual_evaluations=4,
+            converged=True,
+            linear_converged=True,
+        )
+
+    def target(residual, initial, *, precond, admissible, config):
+        del residual, initial, config
+        assert bool(admissible(target_vector))
+        np.testing.assert_array_equal(precond(target_vector, target_vector, 1.0), target_vector)
+        return SimpleNamespace(
+            x=target_vector,
+            steps=5,
+            linear_iterations=6,
+            residual_evaluations=7,
+            converged=True,
+            linear_converged=True,
+        )
+
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._solvax_continuation_api",
+        lambda: (None, None, None, corrector, target),
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._ptc_config", lambda config, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._branch_tangent",
+        lambda *args, **kwargs: (jnp.zeros_like(zero), jnp.asarray(1.0)),
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._apply_bordered_preconditioner",
+        lambda state, rhs, dtau, tangent, runtime, block, chart=None: rhs,
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._low_inverse", lambda rhs, runtime: rhs
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver.strong_root_residual",
+        lambda vector, runtime, alpha: vector + alpha,
+    )
+    result = _arclength_to_target(
+        zero,
+        0.95,
+        SimpleNamespace(layout=SimpleNamespace(size=2), operator_balance=1.0),
+        PolishConfig(max_arclength_steps=1, arclength_step=0.1),
+        lambda vector, alpha: jnp.all(jnp.isfinite(vector)) & jnp.isfinite(alpha),
+        None,
+        None,
+    )
+    np.testing.assert_array_equal(result[0], target_vector)
+    assert result[1:] == (1.0, 1, 7, 9, 11)
+
+
+def test_bordered_tangent_uses_previous_orientation(monkeypatch):
+    zero = jnp.zeros((2,))
+    previous = (jnp.asarray([-1.0, -1.0]), jnp.asarray(-1.0))
+
+    def fake_gmres(operator, rhs, *, precond, **kwargs):
+        del kwargs
+        physical, normalization = operator(rhs)
+        assert physical.shape == zero.shape
+        assert np.isfinite(float(normalization))
+        for actual, expected in zip(
+            jax.tree.leaves(precond(rhs)), jax.tree.leaves(rhs), strict=True
+        ):
+            np.testing.assert_array_equal(actual, expected)
+        return SimpleNamespace(
+            x=(jnp.asarray([0.5, 0.25]), jnp.asarray(0.5)),
+            converged=True,
+            residual_norm=jnp.asarray(0.0),
+            iterations=1,
+        )
+
+    monkeypatch.setattr("vmex.core.polish_driver.gmres", fake_gmres)
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._bordered_preconditioner",
+        lambda *args, **kwargs: lambda state, rhs, dtau: rhs,
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver.strong_root_residual",
+        lambda vector, runtime, alpha: vector + alpha * jnp.ones_like(vector),
+    )
+    tangent = _branch_tangent(
+        zero,
+        0.5,
+        SimpleNamespace(),
+        PolishConfig(),
+        previous,
+        None,
+    )
+    np.testing.assert_allclose(
+        jnp.vdot(tangent[0], tangent[0]).real + tangent[1] ** 2,
+        1.0,
+        rtol=2.0e-13,
+    )
+    assert float(jnp.vdot(tangent[0], previous[0]) + tangent[1] * previous[1]) > 0.0
+
+
+def test_square_strong_root_endpoint_jvp_boundary_and_rank(small_strong_root):
+    runtime = small_strong_root
+    zero = jnp.zeros((runtime.layout.size,), dtype=jnp.float64)
+    radial_matrix = runtime.native.radial_basis.basis_matrix(runtime.radial_nodes**2)
+    assert runtime.radial_nodes.size > runtime.native.radial_basis.size
+    assert runtime.theta.size >= 4 * int(np.max(np.abs(runtime.native.m))) + 5
+    assert runtime.zeta.size == 1
+    for mode, mode_m in enumerate(np.asarray(runtime.native.m)):
+        regularized_matrix = (
+            runtime.radial_nodes[:, None] ** abs(int(mode_m)) * radial_matrix
+        )
+        np.testing.assert_allclose(
+            runtime.radial_fit[mode] @ regularized_matrix,
+            np.eye(runtime.native.radial_basis.size),
+            rtol=5.0e-10,
+            atol=5.0e-10,
+        )
+    low_endpoint = strong_root_residual(zero, runtime, 0.0)
+    strong_endpoint = strong_root_residual(zero, runtime, 1.0)
+    # The alpha = 0 endpoint is legacy_residual(x0) - legacy_defect: two
+    # evaluations of one nonlinear function in two separately compiled
+    # programs.  XLA does not promise bit-identical fusion across programs or
+    # platforms, so the cancellation bottoms out at round-off (measured
+    # 2.8e-14 on the Linux CI runner, exact zero on arm64).  The bound is the
+    # cancellation floor of the row-scaled O(1) residual, not a physics
+    # tolerance.
+    np.testing.assert_allclose(low_endpoint, 0.0, atol=1.0e-12)
+    assert strong_endpoint.shape == zero.shape
+    assert np.all(np.isfinite(np.asarray(strong_endpoint)))
+    # The initial force RMS is divided by the measured low-inverse stiffness.
+    np.testing.assert_allclose(
+        jnp.linalg.norm(strong_endpoint),
+        np.sqrt(runtime.layout.size) / runtime.operator_balance,
+        rtol=3.0e-13,
+    )
+    assert float(runtime.operator_balance) >= 1.0
+    assert runtime.coordinate_scale.shape == zero.shape
+    assert runtime.equation_scale.shape == zero.shape
+    assert np.all(np.asarray(runtime.coordinate_scale) > 0.0)
+    assert np.all(np.asarray(runtime.equation_scale) > 0.0)
+    assert runtime.strong_block_sign.shape == (3,)
+    np.testing.assert_array_equal(jnp.abs(runtime.strong_block_sign), 1.0)
+
+    probe = jnp.linspace(-0.01, 0.015, runtime.layout.size)
+    low_probe = strong_root_residual(probe, runtime, 0.0)
+    strong_probe = strong_root_residual(probe, runtime, 1.0)
+    alpha = 0.37
+    np.testing.assert_allclose(
+        strong_root_residual(probe, runtime, alpha),
+        low_probe + alpha * (strong_probe - low_probe),
+        rtol=2.0e-13,
+        atol=2.0e-13,
+    )
+
+    direction = jnp.linspace(-0.2, 0.3, runtime.layout.size)
+    _, tangent = jax.jvp(
+        lambda value: strong_root_residual(value, runtime, 1.0),
+        (zero,),
+        (direction,),
+    )
+    step = 2.0e-5
+    finite_difference = (
+        strong_root_residual(step * direction, runtime, 1.0)
+        - strong_root_residual(-step * direction, runtime, 1.0)
+    ) / (2.0 * step)
+    np.testing.assert_allclose(tangent, finite_difference, rtol=2.0e-6, atol=2.0e-7)
+
+    correction = runtime.layout.unpack(0.01 * direction)
+    corrected = apply_high_order_correction(runtime.native, correction)
+    for name in ("R_cos", "R_sin", "Z_cos", "Z_sin"):
+        np.testing.assert_array_equal(
+            np.asarray(getattr(corrected, name)[:, -1]),
+            np.asarray(getattr(runtime.native, name)[:, -1]),
+        )
+    assert corrected.source.endswith("strong-root correction")
+
+    rank, singular_values = strong_root_rank(runtime, relative_tolerance=1.0e-8)
+    assert rank == runtime.layout.size
+    assert float(singular_values[-1]) > 0.0
+
+
+def test_low_vector_preconditioner_is_finite_on_native_coordinates(
+    small_strong_root,
+):
+    runtime = small_strong_root
+    zero = jnp.zeros((runtime.layout.size,), dtype=jnp.float64)
+    direction = jnp.linspace(-0.1, 0.2, runtime.layout.size)
+    _, response = jax.jvp(
+        lambda value: strong_root_residual(value, runtime, 0.0),
+        (zero,),
+        (direction,),
+    )
+    recovered = _low_inverse(response, runtime)
+    assert np.all(np.isfinite(np.asarray(recovered)))
+    assert float(jnp.linalg.norm(recovered)) > 0.0
+    assert float(jnp.linalg.norm(recovered)) < 10.0 * float(
+        jnp.linalg.norm(direction)
+    )
+
+
+def test_scaled_low_inverse_and_transpose_are_exact_duals(small_strong_root):
+    runtime = small_strong_root
+    left = runtime.transfer.restrict(
+        runtime.layout.unpack(jnp.linspace(-0.2, 0.1, runtime.layout.size))
+    )
+    right = runtime.transfer.restrict(
+        runtime.layout.unpack(jnp.linspace(0.3, -0.15, runtime.layout.size))
+    )
+    forward = runtime.low_preconditioner.solve_scaled(left)
+    transpose = runtime.low_preconditioner.solve_scaled_transpose(right)
+    np.testing.assert_allclose(
+        _tree_dot(forward, right),
+        _tree_dot(left, transpose),
+        rtol=3.0e-12,
+        atol=3.0e-12,
+    )
+
+
+def test_arclength_tangent_and_bordered_preconditioner_are_finite(
+    small_strong_root,
+):
+    runtime = small_strong_root
+    zero = jnp.zeros((runtime.layout.size,), dtype=jnp.float64)
+    block_preconditioner = _build_mode_block_preconditioner(runtime)
+    direction = jnp.linspace(-0.15, 0.25, runtime.layout.size)
+    _, response = jax.jvp(
+        lambda value: strong_root_residual(value, runtime, 1.0),
+        (zero,),
+        (direction,),
+    )
+    recovered = block_preconditioner.apply(response, 1.0)
+    np.testing.assert_allclose(recovered, direction, rtol=3.0e-8, atol=3.0e-8)
+    _, pullback = jax.vjp(
+        lambda value: strong_root_residual(value, runtime, 1.0), zero
+    )
+    transpose_response = pullback(direction)[0]
+    transpose_recovered = block_preconditioner.apply_transpose(
+        transpose_response, 1.0
+    )
+    np.testing.assert_allclose(
+        transpose_recovered, direction, rtol=3.0e-8, atol=3.0e-8
+    )
+    tangent = _branch_tangent(
+        zero,
+        0.0,
+        runtime,
+        PolishConfig(),
+        None,
+        block_preconditioner,
+    )
+    np.testing.assert_allclose(
+        jnp.vdot(tangent[0], tangent[0]).real + tangent[1] ** 2,
+        1.0,
+        rtol=2.0e-13,
+    )
+    assert float(tangent[1]) > 0.0
+    rhs = (jnp.linspace(-0.2, 0.3, runtime.layout.size), jnp.asarray(0.4))
+    corrected = _bordered_preconditioner(
+        runtime, tangent, block_preconditioner
+    )((zero, 0.0), rhs, 1.0e6)
+    assert corrected[0].shape == zero.shape
+    assert np.all(np.isfinite(np.asarray(corrected[0])))
+    assert np.isfinite(float(corrected[1]))
+
+
+def test_polish_driver_records_bounded_unpolished_return(
+    small_strong_root, monkeypatch
+):
+    class InitialCertificate:
+        normalized_l2 = jnp.asarray(2.0)
+        radial_refinement_difference = jnp.asarray(0.0)
+        minimum_signed_jacobian = jnp.asarray(0.5)
+        # the driver now reports the non-saturating window normalizations
+        # beside eps_F, so a stand-in certificate has to carry them
+        window_normalizations = SimpleNamespace(
+            volume_average_force=jnp.asarray(1.0),
+            relative_force_error=jnp.asarray(1.0),
+            magnetic_relative_force_error=jnp.asarray(1.0),
+            s_min=0.1, s_max=0.99,
+        )
+
+    config = PolishConfig(
+        max_continuation_stages=1,
+        alpha_initial_step=1.0e-3,
+        alpha_min_step=1.0e-3,
+        alpha_max_step=1.0e-3,
+        max_nonlinear_iterations=12,
+        preconditioner="legacy",
+        use_pseudo_arclength=True,
+        fail_policy="return_unpolished",
+    )
+
+    def fail_tangent(*args, **kwargs):
+        del args, kwargs
+        raise StrongForceContinuationError("test tangent failure")
+
+    def endpoint(residual, initial, **kwargs):
+        del residual, kwargs
+        return SimpleNamespace(
+            x=initial,
+            steps=2,
+            linear_iterations=3,
+            residual_evaluations=4,
+            converged=True,
+            linear_converged=True,
+        )
+
+    def continuation(residual, initial, *, accept_stage, **kwargs):
+        del residual, kwargs
+        alpha = 1.0e-3
+        accept_stage(initial, alpha, None)
+        stage = SimpleNamespace(
+            nonlinear_steps=5,
+            linear_iterations=6,
+            residual_evaluations=7,
+            accepted=True,
+        )
+        return SimpleNamespace(
+            x=initial,
+            alpha=alpha,
+            steps=(stage,),
+            converged=False,
+        )
+
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._solvax_continuation_api",
+        lambda: (lambda **kwargs: object(), None, continuation, None, endpoint),
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._ptc_config", lambda config, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        "vmex.core.polish_driver._arclength_to_target", fail_tangent
+    )
+    chart = make_strong_structured_chart(small_strong_root)
+    result = polish_strong_root(
+        small_strong_root,
+        config=config,
+        initial_certificate=InitialCertificate(),
+        chart=chart,
+    )
+    report = result.polish_report
+    assert not report.converged
+    assert report.termination_reason == "pseudo-arclength-tangent-failed"
+    assert report.final_alpha == pytest.approx(1.0e-3)
+    assert report.continuation_accepted == 1
+    assert report.continuation_rejected == 0
+    assert report.nonlinear_iterations > 0
+    assert report.linear_iterations > 0
+    assert report.minimum_signed_jacobian > 0.0
+    np.testing.assert_array_equal(result.correction, 0.0)
+    assert result.native_equilibrium is small_strong_root.native
+
+
+def test_legacy_polish_announces_refinement_and_certificate_phases():
+    """The legacy driver's setup phases each emit a notice before starting.
+
+    Small solovev case; the raw lift never certifies at the default bar, so
+    the run passes through every phase (refinement, initial certificate,
+    preconditioner/root-runtime build) into one bounded Gauss-Newton step.
+    """
+    from vmex import VmecInput
+    from vmex.core.polish_driver import polish_legacy_solution
+    from vmex.core.solver import resolution_from_input, solve
+
+    inp = VmecInput.from_file(
+        str(DATA / "input.solovev")
+    ).change_resolution(mpol=3, ntor=0, ntheta=12, nzeta=4)
+    inp = dataclasses.replace(
+        inp, ns_array=np.asarray([5]), ftol_array=np.asarray([1.0e-9]),
+        niter_array=np.asarray([2000]),
+    )
+    result = solve(inp)
+    lines: list[str] = []
+
+    def capture(text="", **kwargs):
+        lines.append(str(text))
+
+    polish_legacy_solution(
+        inp,
+        resolution_from_input(inp, ns=5),
+        result.state,
+        config=PolishConfig(
+            max_nonlinear_iterations=1,
+            collocation_scale_probes=2,
+            fail_policy="return_unpolished",
+        ),
+        verbose=True,
+        emit=capture,
+    )
+    text = "\n".join(lines)
+    assert "refining the converged state" in text
+    assert "evaluating the initial force certificate" in text
+    assert "building the polish preconditioner and root runtime" in text
+    # eps_F alone is unreadable on a low-beta case: the console must name
+    # its ceiling and print the measures that can actually move.
+    assert "EPS-F is bounded by 2 by construction" in text
+    assert "<|F|>  [N m^-3]" in text
+    assert "<|F|>/<|grad B^2/2mu0|>" in text
+    assert "|F| L2 near axis [N m^-3]" in text
+    assert "(volume averages over s in [0.10, 0.99])" in text
+
+
+def test_polish_ptc_stopping_is_invariant_to_positive_residual_scaling():
+    tolerance = 2.0e-7
+    config = _ptc_config(PolishConfig(tolerance=tolerance), residual_scale=3.0e-4)
+    rescaled = _ptc_config(
+        PolishConfig(tolerance=tolerance), residual_scale=7.0 * 3.0e-4
+    )
+    assert config.rtol == tolerance
+    assert config.atol == pytest.approx(tolerance * 3.0e-4)
+    assert rescaled.atol == pytest.approx(7.0 * config.atol)
+
+
+def test_low_endpoint_check_ignores_numerical_row_equilibration():
+    residual = jnp.asarray([2.0e-9, -6.0e-9])
+    runtime = SimpleNamespace(
+        equation_scale=jnp.asarray([2.0, 3.0]),
+        layout=SimpleNamespace(size=2),
+    )
+    rescaled_runtime = SimpleNamespace(
+        equation_scale=7.0 * runtime.equation_scale,
+        layout=runtime.layout,
+    )
+    expected = jnp.linalg.norm(residual / runtime.equation_scale) / jnp.sqrt(2.0)
+    np.testing.assert_allclose(
+        _normalized_low_residual_norm(residual, runtime),
+        expected,
+        rtol=2.0e-13,
+    )
+    np.testing.assert_allclose(
+        _normalized_low_residual_norm(7.0 * residual, rescaled_runtime),
+        expected,
+        rtol=2.0e-13,
+    )
+

--- a/tests/test_polish_linear.py
+++ b/tests/test_polish_linear.py
@@ -366,25 +366,6 @@ def test_collocation_certification_error_retains_both_failure_gates():
     assert error.radial_refinement > error.radial_refinement_tolerance
 
 
-def test_implicit_polish_rejects_mismatched_inputs(small_strong_root):
-    chart = make_strong_structured_chart(small_strong_root)
-    good = PolishContext(
-        small_strong_root,
-        chart,
-        jnp.zeros((chart.size,)),
-        jnp.ones((chart.size,)),
-    )
-    bad = good._replace(correction=jnp.zeros((chart.size + 1,)))
-    with pytest.raises(ValueError, match="correction has shape"):
-        collocation_polish_tangent(bad, small_strong_root.native)
-    with pytest.raises(ValueError, match="correction has shape"):
-        collocation_polish_adjoint(bad, small_strong_root.native)
-    with pytest.raises(ValueError, match="native_tangent"):
-        collocation_polish_tangent(good, jnp.asarray(0.0))
-    with pytest.raises(ValueError, match="polished_cotangent"):
-        collocation_polish_adjoint(good, jnp.asarray(0.0))
-    with pytest.raises(ValueError, match="native must have"):
-        implicit_collocation_polished_state(jnp.asarray(0.0), good)
 
 
 @pytest.mark.full

--- a/tests/test_polish_linear.py
+++ b/tests/test_polish_linear.py
@@ -1,0 +1,591 @@
+"""Polish linear contracts; nonlinear integration stays in the full suite."""
+
+from __future__ import annotations
+
+import dataclasses
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from vmex.core.errors import (
+    StrongForceCertificationError,
+    StrongForceLinearSolveError,
+)
+from vmex.core.omnigenity import boozer_spectrum_high_order
+from vmex.core.polish import (
+    make_strong_structured_chart,
+)
+from vmex.core.polish_driver import (
+    PolishConfig,
+    PolishContext,
+    polish_collocation_least_squares,
+)
+from vmex.core.polish_implicit import (
+    PolishLinearConfig,
+    PolishLinearReport,
+    _checked_solution,
+    _linear_report,
+    _solve_linear,
+    _collocation_stationarity,
+    _tree_norm as _implicit_tree_norm,
+    collocation_polish_adjoint,
+    collocation_polish_tangent,
+    implicit_collocation_polished_state,
+)
+
+jax.config.update("jax_enable_x64", True)
+
+from tests.test_polish_preconditioner import (
+    _random_like, _tree_dot, _tree_norm, small_adapter as small_adapter, small_strong_root as small_strong_root,
+)
+
+
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({"rtol": 0.0}, "rtol"),
+        ({"atol": -1.0}, "atol"),
+        ({"restart": 0}, "restart"),
+        ({"max_restarts": 0}, "max_restarts"),
+        ({"fail_policy": "ignore"}, "fail_policy"),
+        ({"stationarity_rtol": 0.0}, "stationarity_rtol"),
+        ({"stationarity_rtol": np.inf}, "stationarity_rtol"),
+        ({"stationarity_atol": -1.0}, "stationarity_atol"),
+        ({"stationarity_atol": np.nan}, "stationarity_atol"),
+    ],
+)
+def test_polish_linear_config_validation(updates, message):
+    with pytest.raises(ValueError, match=message):
+        PolishLinearConfig(**updates)
+
+
+def test_polish_linear_failure_policy_is_explicit():
+    value = jnp.ones((2,))
+    report = PolishLinearReport(
+        residual_norm=jnp.asarray(2.0),
+        tolerance=jnp.asarray(1.0),
+        iterations=jnp.asarray(3),
+        converged=jnp.asarray(False),
+    )
+    with pytest.raises(StrongForceLinearSolveError, match="did not converge"):
+        _checked_solution(value, report, PolishLinearConfig(), "test")
+    result = _checked_solution(
+        value,
+        report,
+        PolishLinearConfig(fail_policy="nan"),
+        "test",
+    )
+    assert np.isnan(result).all()
+    assert _implicit_tree_norm((jnp.asarray([3.0, 4.0]),)) == pytest.approx(5.0)
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+@pytest.mark.parametrize(
+    ("rhs", "value", "applied", "flag", "accepted"),
+    [
+        (1.0, 0.0, 0.0, True, False),
+        (1.0, 0.0, 0.0, False, False),
+        (1.0, 1.0, 1.0, False, True),
+        (1.0, np.nan, 1.0, True, False),
+        (1.0, np.inf, 1.0, True, False),
+        (np.nan, 1.0, 1.0, True, False),
+        (np.inf, 1.0, 1.0, True, False),
+        (1.0, 1.0, np.nan, True, False),
+        (1.0, 1.0, np.inf, True, False),
+        (1.0e200, 1.0e200, 1.0e200, True, False),
+        (1.0, 1.0e200, 1.0e200, True, False),
+        (0.0, 0.0, 0.0, False, True),
+        (0.0, 1.0e-12, 1.0e-12, False, True),
+        (0.0, 1.0e-9, 1.0e-9, True, False),
+    ],
+)
+def test_polish_linear_true_certificate(compiled, rhs, value, applied, flag, accepted):
+    def report_for(rhs, value, applied):
+        return _linear_report(
+            lambda _: applied,
+            rhs,
+            SimpleNamespace(x=value, converged=flag, iterations=jnp.asarray(30)),
+            PolishLinearConfig(),
+        )
+
+    with jax.disable_jit(False):
+        report = (jax.jit(report_for) if compiled else report_for)(
+            *[jnp.asarray([item, item]) for item in (rhs, value, applied)]
+        )
+    assert bool(report.converged) == accepted
+    assert int(report.iterations) == 30
+
+
+@pytest.mark.parametrize("policy", ["raise", "nan"])
+def test_polish_linear_compiled_failure_returns_nan_and_status(policy):
+    config = PolishLinearConfig(fail_policy=policy)
+
+    def checked(value):
+        report = _linear_report(
+            lambda x: x, jnp.ones(1),
+            SimpleNamespace(x=value, converged=True, iterations=jnp.asarray(1)),
+            config,
+        )
+        return _checked_solution(value, report, config, "tangent"), report
+
+    with jax.disable_jit(False):
+        value, report = jax.jit(checked)(jnp.zeros(1))
+    assert not bool(report.converged)
+    assert bool(jnp.all(jnp.isnan(value)))
+
+
+@pytest.mark.parametrize("transpose", [False, True])
+@pytest.mark.parametrize("compiled", [False, True])
+def test_polish_linear_krylov_true_residual(transpose, compiled):
+    matrix = jnp.asarray([[4.0, 1.0], [-2.0, 3.0]])
+    if transpose:
+        matrix = matrix.T
+    rhs = jnp.asarray([2.0, -1.0])
+
+    def solve(rhs):
+        return _solve_linear(
+            lambda x: matrix @ x, rhs, lambda x: x / 4.0,
+            PolishLinearConfig(), "adjoint" if transpose else "tangent",
+        )
+
+    with jax.disable_jit(False):
+        value, report = (jax.jit(solve) if compiled else solve)(rhs)
+    assert bool(report.converged)
+    np.testing.assert_allclose(value, np.linalg.solve(matrix, rhs), atol=1.0e-11)
+    assert float(jnp.linalg.norm(rhs - matrix @ value)) <= float(report.tolerance)
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_polish_linear_iteration_exhaustion(compiled):
+    matrix = jnp.asarray([[4.0, 1.0], [-2.0, 3.0]])
+    rhs = jnp.asarray([2.0, -1.0])
+
+    def solve(rhs):
+        return _solve_linear(
+            lambda x: matrix @ x, rhs, lambda x: x,
+            PolishLinearConfig(restart=1, max_restarts=1, fail_policy="nan"),
+            "tangent",
+        )
+
+    with jax.disable_jit(False):
+        value, report = (jax.jit(solve) if compiled else solve)(rhs)
+    assert not bool(report.converged)
+    assert float(report.residual_norm) > float(report.tolerance)
+    assert bool(jnp.all(jnp.isnan(value)))
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_polish_vjp_uses_primal_native_input(monkeypatch, compiled):
+    """An analytic stationary root detects reuse of a stale native parameter."""
+    from vmex.core import polish_implicit as pi
+
+    @dataclasses.dataclass(frozen=True, eq=False)
+    class Runtime:
+        native: jax.Array
+
+    # g(c,q)=c-q^2=0, output=q+c, hence d(output)/dq=1+2q.
+    # Keep the actual adjoint/Krylov/custom-VJP chain; replace only the physics.
+    runtime = Runtime(jnp.asarray([1.0]))
+    context = PolishContext(runtime, SimpleNamespace(size=1), jnp.ones(1), jnp.ones(1))
+    monkeypatch.setattr(pi, "_collocation_stationarity", lambda c, q, runtime, chart: c - q*q)
+    monkeypatch.setattr(pi, "_collocation_corrected_state", lambda q, c, runtime, chart: q + c)
+
+    def objective(q):
+        stationary = context._replace(correction=jax.lax.stop_gradient(q*q))
+        return jnp.sum(implicit_collocation_polished_state(q, stationary))
+
+    with jax.disable_jit(False):
+        derivative = jax.grad(objective)
+        if compiled:
+            derivative = jax.jit(derivative)
+        # One compiled function must handle changed native data correctly.
+        for q in (1.0, 2.0, -0.5):
+            np.testing.assert_allclose(
+                derivative(jnp.asarray([q])), [1.0 + 2.0*q], atol=1.0e-11)
+
+
+@pytest.fixture
+def analytic_stationarity_context(monkeypatch):
+    from vmex.core import polish_implicit as pi
+
+    @dataclasses.dataclass(frozen=True, eq=False)
+    class Runtime:
+        native: jax.Array
+
+    # r=[c^2-q,c] has a nonzero-residual stationary root c=sqrt(q-1/2).
+    # Its exact Hessian is 4q-2, whereas the GN approximation is 4q-1.
+    monkeypatch.setattr(pi, "strong_collocation_residual_at_native",
+                        lambda c, q, runtime, chart: jnp.concatenate((c*c-q, c)))
+    monkeypatch.setattr(pi, "_collocation_corrected_state", lambda q, c, runtime, chart: q+c)
+    return PolishContext(Runtime(jnp.asarray([1.5])), SimpleNamespace(size=1),
+                         jnp.ones(1), jnp.asarray([3.0]), 2.0, 1.0)
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_polish_stationary_nonzero_residual_derivatives(analytic_stationarity_context, compiled):
+    context = analytic_stationarity_context
+
+    def responses(q):
+        root = jnp.sqrt(q-0.5)
+        current = context._replace(
+            runtime=dataclasses.replace(context.runtime, native=q), correction=root)
+        tangent = collocation_polish_tangent(current, jnp.ones_like(q))
+        adjoint = collocation_polish_adjoint(current, jnp.ones_like(q))
+        custom = jax.grad(lambda native: jnp.sum(implicit_collocation_polished_state(
+            native, context._replace(correction=root))))(q)
+        return tangent, adjoint, custom
+
+    with jax.disable_jit(False):
+        evaluate = jax.jit(responses) if compiled else responses
+        for q in (1.5, 4.5):
+            tangent, adjoint, custom = evaluate(jnp.asarray([q]))
+            expected = 1.0 + 0.5/np.sqrt(q-0.5)
+            for result in (tangent, adjoint):
+                assert bool(result.report.converged)
+                assert bool(result.report.stationarity_converged)
+                assert bool(result.report.linear_converged)
+                assert float(result.report.stationarity_norm) <= float(result.report.stationarity_tolerance)
+            for actual in (tangent.native_tangent, adjoint.native_cotangent, custom):
+                np.testing.assert_allclose(actual, expected, atol=1.0e-10)
+
+
+@pytest.mark.parametrize("mode", ["tangent", "adjoint", "vjp"])
+@pytest.mark.parametrize("compiled", [False, True])
+@pytest.mark.parametrize("policy", ["raise", "nan"])
+def test_polish_nonstationary_derivative_failure(analytic_stationarity_context, mode, compiled, policy):
+    context = analytic_stationarity_context
+    config = PolishLinearConfig(fail_policy=policy)
+
+    def response(correction):
+        current = context._replace(correction=correction)
+        if mode == "vjp":
+            return jax.grad(lambda native: jnp.sum(implicit_collocation_polished_state(
+                native, current, config)))(current.runtime.native)
+        function = collocation_polish_tangent if mode == "tangent" else collocation_polish_adjoint
+        result = function(current, jnp.ones(1), config=config)
+        return result[0], result.report
+
+    with jax.disable_jit(False):
+        evaluate = jax.jit(response) if compiled else response
+        if not compiled and policy == "raise":
+            with pytest.raises(StrongForceCertificationError) as failure:
+                evaluate(jnp.asarray([1.1]))
+            assert failure.value.stationarity_norm == pytest.approx(0.3465)
+            assert failure.value.stationarity_norm > failure.value.stationarity_tolerance
+        else:
+            result = evaluate(jnp.asarray([1.1]))
+            value = result if mode == "vjp" else result[0]
+            assert bool(jnp.all(jnp.isnan(value)))
+            if mode != "vjp":
+                report = result[1]
+                assert not bool(report.converged)
+                assert not bool(report.stationarity_converged)
+                assert not bool(report.linear_converged)
+                assert int(report.iterations) == 0
+                assert float(report.stationarity_norm) == pytest.approx(0.3465)
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("residual_scale", v) for v in (0.0, -1.0, np.nan, np.inf)]
+    + [("stationarity_reference", v) for v in (-1.0, np.nan, np.inf)]
+    + [("variable_scale", jnp.asarray([v])) for v in (0.0, -1.0, np.nan, np.inf)]
+    + [("correction", jnp.asarray([np.nan]))],
+)
+def test_polish_stationarity_rejects_invalid_scaling(analytic_stationarity_context, compiled, field, value):
+    from vmex.core.polish_implicit import _stationarity_certificate
+
+    context = analytic_stationarity_context._replace(**{field: value})
+    certificate = lambda g: _stationarity_certificate(g, context, PolishLinearConfig())  # noqa: E731
+    with jax.disable_jit(False):
+        result = (jax.jit(certificate) if compiled else certificate)(jnp.zeros(1))
+    assert not bool(result[2])
+
+
+def test_polish_stationarity_scaling_and_shapes(analytic_stationarity_context):
+    from vmex.core.polish_implicit import _stationarity_certificate
+
+    context = analytic_stationarity_context._replace(variable_scale=jnp.asarray([2.0]), residual_scale=4.0)
+    config = PolishLinearConfig(stationarity_atol=1.0)
+    norm, tolerance, valid = _stationarity_certificate(jnp.asarray([8.0]), context, config)
+    assert float(norm) == 1.0
+    assert float(tolerance) == 1.0
+    assert bool(valid)
+    assert not bool(_stationarity_certificate(jnp.asarray([8.001]), context, config)[2])
+    for gradient in (jnp.asarray([np.nan]), jnp.asarray([np.inf])):
+        assert not bool(_stationarity_certificate(gradient, context, config)[2])
+    with pytest.raises(ValueError, match="scalars"):
+        _stationarity_certificate(jnp.ones(1), context._replace(residual_scale=jnp.ones(1)), config)
+    with pytest.raises(ValueError, match="shape"):
+        _stationarity_certificate(jnp.ones(1), context._replace(variable_scale=jnp.ones(2)), config)
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+@pytest.mark.parametrize("policy", ["raise", "nan"])
+def test_stationary_polish_reports_a_failed_linear_solve(compiled, policy):
+    from vmex.core.polish_implicit import _solve_stationary_linear
+
+    matrix = jnp.asarray([[4.0, 1.0], [-2.0, 3.0]])
+    config = PolishLinearConfig(restart=1, max_restarts=1, fail_policy=policy)
+
+    def solve(rhs):
+        return _solve_stationary_linear(
+            lambda x: matrix @ x, rhs, lambda x: x, config, "tangent",
+            (jnp.asarray(0.0), jnp.asarray(1.0e-8), jnp.asarray(True)))
+
+    with jax.disable_jit(False):
+        evaluate = jax.jit(solve) if compiled else solve
+        if not compiled and policy == "raise":
+            with pytest.raises(StrongForceLinearSolveError):
+                evaluate(jnp.asarray([2.0, -1.0]))
+        else:
+            value, report = evaluate(jnp.asarray([2.0, -1.0]))
+            assert bool(report.stationarity_converged)
+            assert not bool(report.linear_converged)
+            assert not bool(report.converged)
+            assert int(report.iterations) > 0
+            assert bool(jnp.all(jnp.isnan(value)))
+
+
+def test_collocation_certification_error_retains_both_failure_gates():
+    error = StrongForceCertificationError(
+        "not certified",
+        solver_converged=True,
+        normalized_l2=0.2,
+        tolerance=0.1,
+        radial_refinement=0.03,
+        radial_refinement_tolerance=0.01,
+    )
+
+    assert error.solver_converged
+    assert error.normalized_l2 > error.tolerance
+    assert error.radial_refinement > error.radial_refinement_tolerance
+
+
+def test_implicit_polish_rejects_mismatched_inputs(small_strong_root):
+    chart = make_strong_structured_chart(small_strong_root)
+    good = PolishContext(
+        small_strong_root,
+        chart,
+        jnp.zeros((chart.size,)),
+        jnp.ones((chart.size,)),
+    )
+    bad = good._replace(correction=jnp.zeros((chart.size + 1,)))
+    with pytest.raises(ValueError, match="correction has shape"):
+        collocation_polish_tangent(bad, small_strong_root.native)
+    with pytest.raises(ValueError, match="correction has shape"):
+        collocation_polish_adjoint(bad, small_strong_root.native)
+    with pytest.raises(ValueError, match="native_tangent"):
+        collocation_polish_tangent(good, jnp.asarray(0.0))
+    with pytest.raises(ValueError, match="polished_cotangent"):
+        collocation_polish_adjoint(good, jnp.asarray(0.0))
+    with pytest.raises(ValueError, match="native must have"):
+        implicit_collocation_polished_state(jnp.asarray(0.0), good)
+
+
+@pytest.mark.full
+def test_physics_accepted_polish_can_fail_derivative_stationarity(small_strong_root):
+    chart = make_strong_structured_chart(small_strong_root, balance_iterations=1, balance_probes=2)
+    with jax.disable_jit(False):
+        result = polish_collocation_least_squares(
+            small_strong_root, chart=chart,
+            config=PolishConfig(tolerance=2.0, validation_tolerance=10.0,
+                                radial_refinement_tolerance=10.0, collocation_scale_probes=2,
+                                max_nonlinear_iterations=1))
+        assert result.polish_report.converged
+        # This loose solver bar accepts the initial point, whose exact gradient
+        # is not within the default derivative stationarity threshold.
+        assert result.polish_report.nonlinear_iterations == 0
+        with pytest.raises(StrongForceCertificationError, match="stationary"):
+            collocation_polish_tangent(result.context, _random_like(small_strong_root.native, 51))
+
+
+@pytest.mark.full
+def test_collocation_polish_primal_and_derivatives(small_strong_root):
+    # Compile this numerical integration explicitly; the suite disables JIT.
+    with jax.disable_jit(False):
+        chart = make_strong_structured_chart(
+            small_strong_root, balance_iterations=1, balance_probes=2
+        )
+        result = polish_collocation_least_squares(
+            small_strong_root,
+            chart=chart,
+            config=PolishConfig(
+                tolerance=1.0e-10,
+                validation_tolerance=10.0,
+                radial_refinement_tolerance=10.0,
+                collocation_scale_probes=2,
+                max_nonlinear_iterations=40,
+                fail_policy="return_unpolished",
+            ),
+        )
+        assert result.correction.shape == (small_strong_root.layout.size,)
+        assert result.polish_report.least_squares_success is not None
+        assert result.polish_report.variable_scale_probes == 2
+        assert result.context is not None
+        assert result.polish_report.converged
+        # The 1e-10 primal stopping flag is not derivative eligibility.
+        # Check the public stationarity and linear certificates below.
+        assert result.polish_report.nonlinear_iterations > 0
+
+        native_tangent = _random_like(small_strong_root.native, 51)
+        output_cotangent = _random_like(small_strong_root.native, 52)
+        linear_config = PolishLinearConfig(
+            rtol=2.0e-10,
+            atol=2.0e-11,
+            restart=chart.size,
+            max_restarts=5,
+        )
+        tangent = collocation_polish_tangent(
+            result.context, native_tangent, config=linear_config
+        )
+        adjoint = collocation_polish_adjoint(
+            result.context, output_cotangent, config=linear_config
+        )
+        assert bool(tangent.report.converged)
+        assert bool(adjoint.report.converged)
+        assert bool(tangent.report.stationarity_converged)
+        assert bool(adjoint.report.stationarity_converged)
+        for report in (tangent.report, adjoint.report):
+            assert np.isfinite(float(report.stationarity_norm))
+            assert float(report.stationarity_norm) <= float(report.stationarity_tolerance)
+        np.testing.assert_allclose(tangent.report.stationarity_norm,
+                                   result.polish_report.least_squares_optimality, rtol=1.0e-4, atol=1.0e-8)
+        np.testing.assert_allclose(
+            _tree_dot(output_cotangent, tangent.native_tangent),
+            _tree_dot(adjoint.native_cotangent, native_tangent),
+            rtol=2.0e-5,
+            atol=2.0e-6,
+        )
+
+        def objective(native):
+            polished = implicit_collocation_polished_state(
+                native, result.context, linear_config
+            )
+            return _tree_dot(polished, output_cotangent)
+
+        custom_gradient = jax.grad(objective)(small_strong_root.native)
+        difference = jax.tree.map(
+            jnp.subtract, custom_gradient, adjoint.native_cotangent
+        )
+        assert _tree_norm(difference) <= 2.0e-5 * max(
+            _tree_norm(adjoint.native_cotangent), 1.0
+        )
+
+        polished = implicit_collocation_polished_state(
+            small_strong_root.native,
+            result.context,
+            linear_config,
+        )
+
+        def boozer_objective(native):
+            spectrum = boozer_spectrum_high_order(
+                native,
+                surfaces=[0.49],
+                mboz=4,
+                nboz=2,
+                ntheta=12,
+                nzeta=8,
+            )
+            return jnp.sum(spectrum["bmnc_b"][:, 1:] ** 2)
+
+        boozer_cotangent = jax.grad(boozer_objective)(polished)
+        boozer_adjoint = collocation_polish_adjoint(
+            result.context,
+            boozer_cotangent,
+            config=linear_config,
+        )
+        boozer_gradient = jax.grad(
+            lambda native: boozer_objective(
+                implicit_collocation_polished_state(
+                    native,
+                    result.context,
+                    linear_config,
+                )
+            )
+        )(small_strong_root.native)
+        boozer_difference = jax.tree.map(
+            jnp.subtract,
+            boozer_gradient,
+            boozer_adjoint.native_cotangent,
+        )
+        assert _tree_norm(boozer_difference) <= 2.0e-5 * max(
+            _tree_norm(boozer_adjoint.native_cotangent),
+            1.0,
+        )
+
+        base_stationarity = _collocation_stationarity(
+            result.context.correction,
+            small_strong_root.native,
+            result.context.runtime,
+            result.context.chart,
+        )
+
+        def stationarity_remainder(step):
+            perturbed_native = jax.tree.map(
+                lambda value, direction: value + step * direction,
+                small_strong_root.native,
+                native_tangent,
+            )
+            perturbed_correction = (
+                result.context.correction + step * tangent.correction_tangent
+            )
+            return jnp.linalg.norm(
+                _collocation_stationarity(
+                    perturbed_correction,
+                    perturbed_native,
+                    result.context.runtime,
+                    result.context.chart,
+                )
+                - base_stationarity
+            )
+
+        coarse = stationarity_remainder(2.0e-5)
+        fine = stationarity_remainder(1.0e-5)
+        assert fine < 0.35 * coarse
+
+
+def test_polish_derivative_failure_is_nan_under_tracing_and_raises_outside():
+    """``fail_policy="raise"`` cannot raise on a traced convergence flag.
+
+    Outside jit the policy raises; under jit the flag is a tracer, so both
+    policies return NaN. The docstring says so, and this pins it: a jitted
+    gradient that fails comes back as NaN, never as an exception.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    from vmex.core.polish_implicit import (
+        PolishLinearConfig, PolishLinearReport, StrongForceLinearSolveError,
+        _checked_solution,
+    )
+
+    def report(converged):
+        return PolishLinearReport(
+            residual_norm=jnp.asarray(1.0), tolerance=jnp.asarray(1.0e-8),
+            iterations=jnp.asarray(30), converged=converged)
+
+    value = jnp.ones(3)
+    raising = PolishLinearConfig(fail_policy="raise")
+
+    # eager, failed: the documented exception
+    with pytest.raises(StrongForceLinearSolveError):
+        _checked_solution(value, report(jnp.asarray(False)), raising, "tangent")
+    # eager, converged: the value passes through
+    ok = _checked_solution(value, report(jnp.asarray(True)), raising, "tangent")
+    assert bool(jnp.all(ok == value))
+
+    # traced, failed: NaN, no exception, whatever the policy says.  The
+    # conftest disables jit suite-wide, so ask for it explicitly here --
+    # which is also why the interpreted suite never exercised this path.
+    def traced(flag):
+        return _checked_solution(value, report(flag), raising, "tangent")
+
+    with jax.disable_jit(False):
+        assert bool(jnp.all(jnp.isnan(jax.jit(traced)(jnp.asarray(False)))))
+        assert bool(jnp.all(jax.jit(traced)(jnp.asarray(True)) == value))
+

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -1,4 +1,4 @@
-"""High/low transfer and stored raw-block preconditioner tests."""
+"""Gauss-Newton, physical-chart and export contracts."""
 
 from __future__ import annotations
 

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -45,11 +45,16 @@ from vmex.core.polish import (
 )
 from vmex.core.polish_driver import (
     PolishConfig,
+    PolishContext,
     _build_mode_block_preconditioner,
     _solve_low_inverse,
     polish_collocation_least_squares,
     polish_strong_root,
     polished_wout_ns,
+)
+from vmex.core.polish_implicit import (
+    collocation_polish_tangent, collocation_polish_adjoint,
+    implicit_collocation_polished_state,
 )
 from vmex.core.strong_force import (
     FORCE_ERROR_MEASURE_LABELS,
@@ -718,6 +723,28 @@ def test_physical_chart_adapters_and_validation(small_strong_root, monkeypatch):
     )
     with pytest.raises(ValueError, match="stellarator symmetry"):
         make_strong_structured_chart(asymmetric)
+
+
+def test_implicit_polish_rejects_mismatched_inputs(small_strong_root):
+    chart = make_strong_structured_chart(small_strong_root)
+    good = PolishContext(
+        small_strong_root,
+        chart,
+        jnp.zeros((chart.size,)),
+        jnp.ones((chart.size,)),
+    )
+    bad = good._replace(correction=jnp.zeros((chart.size + 1,)))
+    with pytest.raises(ValueError, match="correction has shape"):
+        collocation_polish_tangent(bad, small_strong_root.native)
+    with pytest.raises(ValueError, match="correction has shape"):
+        collocation_polish_adjoint(bad, small_strong_root.native)
+    with pytest.raises(ValueError, match="native_tangent"):
+        collocation_polish_tangent(good, jnp.asarray(0.0))
+    with pytest.raises(ValueError, match="polished_cotangent"):
+        collocation_polish_adjoint(good, jnp.asarray(0.0))
+    with pytest.raises(ValueError, match="native must have"):
+        implicit_collocation_polished_state(jnp.asarray(0.0), good)
+
 
 
 @pytest.mark.parametrize("route", ["legacy", "continuation", "continuation-final", "collocation"])

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -15,16 +15,12 @@ from vmex.core import implicit
 from vmex.core import solver
 from vmex.core.errors import (
     StrongForceCertificationError,
-    StrongForceContinuationError,
-    StrongForceLinearSolveError,
 )
 from vmex.core.input import VmecInput
-from vmex.core.omnigenity import boozer_spectrum_high_order
 from vmex.core.polish import (
     HighOrderCorrection,
     PreconditionerRefreshPolicy,
     PreconditionerSnapshot,
-    apply_high_order_correction,
     build_low_order_preconditioner,
     build_strong_physical_block_preconditioner,
     build_strong_mode_block_preconditioner,
@@ -49,34 +45,11 @@ from vmex.core.polish import (
 )
 from vmex.core.polish_driver import (
     PolishConfig,
-    PolishContext,
-    _IdentityPreconditioner,
-    _arclength_to_target,
-    _bordered_preconditioner,
-    _branch_tangent,
     _build_mode_block_preconditioner,
-    _continuation_precondition,
-    _low_inverse,
-    _normalized_low_residual_norm,
     _solve_low_inverse,
-    _ptc_config,
-    _residual_evaluations,
-    _supports_keyword,
     polish_collocation_least_squares,
     polish_strong_root,
     polished_wout_ns,
-)
-from vmex.core.polish_implicit import (
-    PolishLinearConfig,
-    PolishLinearReport,
-    _checked_solution,
-    _linear_report,
-    _solve_linear,
-    _collocation_stationarity,
-    _tree_norm as _implicit_tree_norm,
-    collocation_polish_adjoint,
-    collocation_polish_tangent,
-    implicit_collocation_polished_state,
 )
 from vmex.core.strong_force import (
     FORCE_ERROR_MEASURE_LABELS,
@@ -86,511 +59,6 @@ from vmex.core.strong_force import (
 jax.config.update("jax_enable_x64", True)
 
 DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
-
-
-@pytest.mark.parametrize(
-    ("updates", "message"),
-    [
-        ({"rtol": 0.0}, "rtol"),
-        ({"atol": -1.0}, "atol"),
-        ({"restart": 0}, "restart"),
-        ({"max_restarts": 0}, "max_restarts"),
-        ({"fail_policy": "ignore"}, "fail_policy"),
-        ({"stationarity_rtol": 0.0}, "stationarity_rtol"),
-        ({"stationarity_rtol": np.inf}, "stationarity_rtol"),
-        ({"stationarity_atol": -1.0}, "stationarity_atol"),
-        ({"stationarity_atol": np.nan}, "stationarity_atol"),
-    ],
-)
-def test_polish_linear_config_validation(updates, message):
-    with pytest.raises(ValueError, match=message):
-        PolishLinearConfig(**updates)
-
-
-def test_polish_linear_failure_policy_is_explicit():
-    value = jnp.ones((2,))
-    report = PolishLinearReport(
-        residual_norm=jnp.asarray(2.0),
-        tolerance=jnp.asarray(1.0),
-        iterations=jnp.asarray(3),
-        converged=jnp.asarray(False),
-    )
-    with pytest.raises(StrongForceLinearSolveError, match="did not converge"):
-        _checked_solution(value, report, PolishLinearConfig(), "test")
-    result = _checked_solution(
-        value,
-        report,
-        PolishLinearConfig(fail_policy="nan"),
-        "test",
-    )
-    assert np.isnan(result).all()
-    assert _implicit_tree_norm((jnp.asarray([3.0, 4.0]),)) == pytest.approx(5.0)
-
-
-@pytest.mark.parametrize("compiled", [False, True])
-@pytest.mark.parametrize(
-    ("rhs", "value", "applied", "flag", "accepted"),
-    [
-        (1.0, 0.0, 0.0, True, False),
-        (1.0, 0.0, 0.0, False, False),
-        (1.0, 1.0, 1.0, False, True),
-        (1.0, np.nan, 1.0, True, False),
-        (1.0, np.inf, 1.0, True, False),
-        (np.nan, 1.0, 1.0, True, False),
-        (np.inf, 1.0, 1.0, True, False),
-        (1.0, 1.0, np.nan, True, False),
-        (1.0, 1.0, np.inf, True, False),
-        (1.0e200, 1.0e200, 1.0e200, True, False),
-        (1.0, 1.0e200, 1.0e200, True, False),
-        (0.0, 0.0, 0.0, False, True),
-        (0.0, 1.0e-12, 1.0e-12, False, True),
-        (0.0, 1.0e-9, 1.0e-9, True, False),
-    ],
-)
-def test_polish_linear_true_certificate(compiled, rhs, value, applied, flag, accepted):
-    def report_for(rhs, value, applied):
-        return _linear_report(
-            lambda _: applied,
-            rhs,
-            SimpleNamespace(x=value, converged=flag, iterations=jnp.asarray(30)),
-            PolishLinearConfig(),
-        )
-
-    with jax.disable_jit(False):
-        report = (jax.jit(report_for) if compiled else report_for)(
-            *[jnp.asarray([item, item]) for item in (rhs, value, applied)]
-        )
-    assert bool(report.converged) == accepted
-    assert int(report.iterations) == 30
-
-
-@pytest.mark.parametrize("policy", ["raise", "nan"])
-def test_polish_linear_compiled_failure_returns_nan_and_status(policy):
-    config = PolishLinearConfig(fail_policy=policy)
-
-    def checked(value):
-        report = _linear_report(
-            lambda x: x, jnp.ones(1),
-            SimpleNamespace(x=value, converged=True, iterations=jnp.asarray(1)),
-            config,
-        )
-        return _checked_solution(value, report, config, "tangent"), report
-
-    with jax.disable_jit(False):
-        value, report = jax.jit(checked)(jnp.zeros(1))
-    assert not bool(report.converged)
-    assert bool(jnp.all(jnp.isnan(value)))
-
-
-@pytest.mark.parametrize("transpose", [False, True])
-@pytest.mark.parametrize("compiled", [False, True])
-def test_polish_linear_krylov_true_residual(transpose, compiled):
-    matrix = jnp.asarray([[4.0, 1.0], [-2.0, 3.0]])
-    if transpose:
-        matrix = matrix.T
-    rhs = jnp.asarray([2.0, -1.0])
-
-    def solve(rhs):
-        return _solve_linear(
-            lambda x: matrix @ x, rhs, lambda x: x / 4.0,
-            PolishLinearConfig(), "adjoint" if transpose else "tangent",
-        )
-
-    with jax.disable_jit(False):
-        value, report = (jax.jit(solve) if compiled else solve)(rhs)
-    assert bool(report.converged)
-    np.testing.assert_allclose(value, np.linalg.solve(matrix, rhs), atol=1.0e-11)
-    assert float(jnp.linalg.norm(rhs - matrix @ value)) <= float(report.tolerance)
-
-
-@pytest.mark.parametrize("compiled", [False, True])
-def test_polish_linear_iteration_exhaustion(compiled):
-    matrix = jnp.asarray([[4.0, 1.0], [-2.0, 3.0]])
-    rhs = jnp.asarray([2.0, -1.0])
-
-    def solve(rhs):
-        return _solve_linear(
-            lambda x: matrix @ x, rhs, lambda x: x,
-            PolishLinearConfig(restart=1, max_restarts=1, fail_policy="nan"),
-            "tangent",
-        )
-
-    with jax.disable_jit(False):
-        value, report = (jax.jit(solve) if compiled else solve)(rhs)
-    assert not bool(report.converged)
-    assert float(report.residual_norm) > float(report.tolerance)
-    assert bool(jnp.all(jnp.isnan(value)))
-
-
-@pytest.mark.parametrize("compiled", [False, True])
-def test_polish_vjp_uses_primal_native_input(monkeypatch, compiled):
-    """An analytic stationary root detects reuse of a stale native parameter."""
-    from vmex.core import polish_implicit as pi
-
-    @dataclasses.dataclass(frozen=True, eq=False)
-    class Runtime:
-        native: jax.Array
-
-    # g(c,q)=c-q^2=0, output=q+c, hence d(output)/dq=1+2q.
-    # Keep the actual adjoint/Krylov/custom-VJP chain; replace only the physics.
-    runtime = Runtime(jnp.asarray([1.0]))
-    context = PolishContext(runtime, SimpleNamespace(size=1), jnp.ones(1), jnp.ones(1))
-    monkeypatch.setattr(pi, "_collocation_stationarity", lambda c, q, runtime, chart: c - q*q)
-    monkeypatch.setattr(pi, "_collocation_corrected_state", lambda q, c, runtime, chart: q + c)
-
-    def objective(q):
-        stationary = context._replace(correction=jax.lax.stop_gradient(q*q))
-        return jnp.sum(implicit_collocation_polished_state(q, stationary))
-
-    with jax.disable_jit(False):
-        derivative = jax.grad(objective)
-        if compiled:
-            derivative = jax.jit(derivative)
-        # One compiled function must handle changed native data correctly.
-        for q in (1.0, 2.0, -0.5):
-            np.testing.assert_allclose(
-                derivative(jnp.asarray([q])), [1.0 + 2.0*q], atol=1.0e-11)
-
-
-@pytest.fixture
-def analytic_stationarity_context(monkeypatch):
-    from vmex.core import polish_implicit as pi
-
-    @dataclasses.dataclass(frozen=True, eq=False)
-    class Runtime:
-        native: jax.Array
-
-    # r=[c^2-q,c] has a nonzero-residual stationary root c=sqrt(q-1/2).
-    # Its exact Hessian is 4q-2, whereas the GN approximation is 4q-1.
-    monkeypatch.setattr(pi, "strong_collocation_residual_at_native",
-                        lambda c, q, runtime, chart: jnp.concatenate((c*c-q, c)))
-    monkeypatch.setattr(pi, "_collocation_corrected_state", lambda q, c, runtime, chart: q+c)
-    return PolishContext(Runtime(jnp.asarray([1.5])), SimpleNamespace(size=1),
-                         jnp.ones(1), jnp.asarray([3.0]), 2.0, 1.0)
-
-
-@pytest.mark.parametrize("compiled", [False, True])
-def test_polish_stationary_nonzero_residual_derivatives(analytic_stationarity_context, compiled):
-    context = analytic_stationarity_context
-
-    def responses(q):
-        root = jnp.sqrt(q-0.5)
-        current = context._replace(
-            runtime=dataclasses.replace(context.runtime, native=q), correction=root)
-        tangent = collocation_polish_tangent(current, jnp.ones_like(q))
-        adjoint = collocation_polish_adjoint(current, jnp.ones_like(q))
-        custom = jax.grad(lambda native: jnp.sum(implicit_collocation_polished_state(
-            native, context._replace(correction=root))))(q)
-        return tangent, adjoint, custom
-
-    with jax.disable_jit(False):
-        evaluate = jax.jit(responses) if compiled else responses
-        for q in (1.5, 4.5):
-            tangent, adjoint, custom = evaluate(jnp.asarray([q]))
-            expected = 1.0 + 0.5/np.sqrt(q-0.5)
-            for result in (tangent, adjoint):
-                assert bool(result.report.converged)
-                assert bool(result.report.stationarity_converged)
-                assert bool(result.report.linear_converged)
-                assert float(result.report.stationarity_norm) <= float(result.report.stationarity_tolerance)
-            for actual in (tangent.native_tangent, adjoint.native_cotangent, custom):
-                np.testing.assert_allclose(actual, expected, atol=1.0e-10)
-
-
-@pytest.mark.parametrize("mode", ["tangent", "adjoint", "vjp"])
-@pytest.mark.parametrize("compiled", [False, True])
-@pytest.mark.parametrize("policy", ["raise", "nan"])
-def test_polish_nonstationary_derivative_failure(analytic_stationarity_context, mode, compiled, policy):
-    context = analytic_stationarity_context
-    config = PolishLinearConfig(fail_policy=policy)
-
-    def response(correction):
-        current = context._replace(correction=correction)
-        if mode == "vjp":
-            return jax.grad(lambda native: jnp.sum(implicit_collocation_polished_state(
-                native, current, config)))(current.runtime.native)
-        function = collocation_polish_tangent if mode == "tangent" else collocation_polish_adjoint
-        result = function(current, jnp.ones(1), config=config)
-        return result[0], result.report
-
-    with jax.disable_jit(False):
-        evaluate = jax.jit(response) if compiled else response
-        if not compiled and policy == "raise":
-            with pytest.raises(StrongForceCertificationError) as failure:
-                evaluate(jnp.asarray([1.1]))
-            assert failure.value.stationarity_norm == pytest.approx(0.3465)
-            assert failure.value.stationarity_norm > failure.value.stationarity_tolerance
-        else:
-            result = evaluate(jnp.asarray([1.1]))
-            value = result if mode == "vjp" else result[0]
-            assert bool(jnp.all(jnp.isnan(value)))
-            if mode != "vjp":
-                report = result[1]
-                assert not bool(report.converged)
-                assert not bool(report.stationarity_converged)
-                assert not bool(report.linear_converged)
-                assert int(report.iterations) == 0
-                assert float(report.stationarity_norm) == pytest.approx(0.3465)
-
-
-@pytest.mark.parametrize("compiled", [False, True])
-@pytest.mark.parametrize(
-    ("field", "value"),
-    [("residual_scale", v) for v in (0.0, -1.0, np.nan, np.inf)]
-    + [("stationarity_reference", v) for v in (-1.0, np.nan, np.inf)]
-    + [("variable_scale", jnp.asarray([v])) for v in (0.0, -1.0, np.nan, np.inf)]
-    + [("correction", jnp.asarray([np.nan]))],
-)
-def test_polish_stationarity_rejects_invalid_scaling(analytic_stationarity_context, compiled, field, value):
-    from vmex.core.polish_implicit import _stationarity_certificate
-
-    context = analytic_stationarity_context._replace(**{field: value})
-    certificate = lambda g: _stationarity_certificate(g, context, PolishLinearConfig())  # noqa: E731
-    with jax.disable_jit(False):
-        result = (jax.jit(certificate) if compiled else certificate)(jnp.zeros(1))
-    assert not bool(result[2])
-
-
-def test_polish_stationarity_scaling_and_shapes(analytic_stationarity_context):
-    from vmex.core.polish_implicit import _stationarity_certificate
-
-    context = analytic_stationarity_context._replace(variable_scale=jnp.asarray([2.0]), residual_scale=4.0)
-    config = PolishLinearConfig(stationarity_atol=1.0)
-    norm, tolerance, valid = _stationarity_certificate(jnp.asarray([8.0]), context, config)
-    assert float(norm) == 1.0
-    assert float(tolerance) == 1.0
-    assert bool(valid)
-    assert not bool(_stationarity_certificate(jnp.asarray([8.001]), context, config)[2])
-    for gradient in (jnp.asarray([np.nan]), jnp.asarray([np.inf])):
-        assert not bool(_stationarity_certificate(gradient, context, config)[2])
-    with pytest.raises(ValueError, match="scalars"):
-        _stationarity_certificate(jnp.ones(1), context._replace(residual_scale=jnp.ones(1)), config)
-    with pytest.raises(ValueError, match="shape"):
-        _stationarity_certificate(jnp.ones(1), context._replace(variable_scale=jnp.ones(2)), config)
-
-
-@pytest.mark.parametrize("compiled", [False, True])
-@pytest.mark.parametrize("policy", ["raise", "nan"])
-def test_stationary_polish_reports_a_failed_linear_solve(compiled, policy):
-    from vmex.core.polish_implicit import _solve_stationary_linear
-
-    matrix = jnp.asarray([[4.0, 1.0], [-2.0, 3.0]])
-    config = PolishLinearConfig(restart=1, max_restarts=1, fail_policy=policy)
-
-    def solve(rhs):
-        return _solve_stationary_linear(
-            lambda x: matrix @ x, rhs, lambda x: x, config, "tangent",
-            (jnp.asarray(0.0), jnp.asarray(1.0e-8), jnp.asarray(True)))
-
-    with jax.disable_jit(False):
-        evaluate = jax.jit(solve) if compiled else solve
-        if not compiled and policy == "raise":
-            with pytest.raises(StrongForceLinearSolveError):
-                evaluate(jnp.asarray([2.0, -1.0]))
-        else:
-            value, report = evaluate(jnp.asarray([2.0, -1.0]))
-            assert bool(report.stationarity_converged)
-            assert not bool(report.linear_converged)
-            assert not bool(report.converged)
-            assert int(report.iterations) > 0
-            assert bool(jnp.all(jnp.isnan(value)))
-
-
-def test_collocation_certification_error_retains_both_failure_gates():
-    error = StrongForceCertificationError(
-        "not certified",
-        solver_converged=True,
-        normalized_l2=0.2,
-        tolerance=0.1,
-        radial_refinement=0.03,
-        radial_refinement_tolerance=0.01,
-    )
-
-    assert error.solver_converged
-    assert error.normalized_l2 > error.tolerance
-    assert error.radial_refinement > error.radial_refinement_tolerance
-
-
-def test_solvax_continuation_api_compatibility_helpers():
-    def legacy_preconditioner(state, rhs, dtau):
-        del state, dtau
-        return rhs
-
-    def parameterized_preconditioner(state, rhs, dtau, parameter):
-        del state, dtau, parameter
-        return rhs
-
-    assert not _supports_keyword(legacy_preconditioner, "parameter")
-    assert _supports_keyword(parameterized_preconditioner, "parameter")
-    np.testing.assert_array_equal(
-        legacy_preconditioner(None, jnp.ones((2,)), None), jnp.ones((2,))
-    )
-    np.testing.assert_array_equal(
-        parameterized_preconditioner(None, jnp.ones((2,)), None, None),
-        jnp.ones((2,)),
-    )
-    assert _residual_evaluations(
-        SimpleNamespace(nonlinear_steps=3, residual_evaluations=9)
-    ) == 9
-    assert _residual_evaluations(SimpleNamespace(nonlinear_steps=3)) == 4
-    assert _residual_evaluations(SimpleNamespace(steps=2)) == 3
-    assert not _supports_keyword(1, "parameter")
-
-
-def test_parameterized_continuation_preconditioner_switches_at_half(monkeypatch):
-    rhs = jnp.asarray([1.0, -2.0])
-    monkeypatch.setattr(
-        "vmex.core.polish_driver._low_inverse", lambda value, runtime: 2.0 * value
-    )
-    block = SimpleNamespace(apply=lambda value, alpha, dtau: 3.0 * value)
-    np.testing.assert_array_equal(
-        _continuation_precondition(rhs, 0.25, 1.0, SimpleNamespace(), block),
-        2.0 * rhs,
-    )
-    np.testing.assert_array_equal(
-        _continuation_precondition(rhs, 0.75, 1.0, SimpleNamespace(), block),
-        3.0 * rhs,
-    )
-    np.testing.assert_array_equal(
-        _continuation_precondition(
-            rhs, 0.25, 1.0, SimpleNamespace(), block, SimpleNamespace()
-        ),
-        3.0 * rhs,
-    )
-    identity = _IdentityPreconditioner()
-    np.testing.assert_array_equal(identity.apply(rhs), rhs)
-    np.testing.assert_array_equal(
-        _continuation_precondition(
-            rhs,
-            0.25,
-            1.0,
-            SimpleNamespace(),
-            identity,
-        ),
-        rhs,
-    )
-
-
-def test_arclength_crossing_runs_target_correction_and_counts_work(monkeypatch):
-    zero = jnp.zeros((2,))
-    target_vector = jnp.asarray([0.25, -0.5])
-
-    def corrector(
-        residual,
-        initial,
-        *,
-        tangent,
-        predictor,
-        config,
-        admissible,
-        parameterized_precond,
-    ):
-        del residual, initial, config
-        assert bool(admissible(*predictor))
-        np.testing.assert_array_equal(
-            parameterized_precond(predictor, predictor, 1.0, tangent, predictor)[0],
-            predictor[0],
-        )
-        return SimpleNamespace(
-            x=predictor,
-            steps=2,
-            linear_iterations=3,
-            residual_evaluations=4,
-            converged=True,
-            linear_converged=True,
-        )
-
-    def target(residual, initial, *, precond, admissible, config):
-        del residual, initial, config
-        assert bool(admissible(target_vector))
-        np.testing.assert_array_equal(precond(target_vector, target_vector, 1.0), target_vector)
-        return SimpleNamespace(
-            x=target_vector,
-            steps=5,
-            linear_iterations=6,
-            residual_evaluations=7,
-            converged=True,
-            linear_converged=True,
-        )
-
-    monkeypatch.setattr(
-        "vmex.core.polish_driver._solvax_continuation_api",
-        lambda: (None, None, None, corrector, target),
-    )
-    monkeypatch.setattr(
-        "vmex.core.polish_driver._ptc_config", lambda config, **kwargs: object()
-    )
-    monkeypatch.setattr(
-        "vmex.core.polish_driver._branch_tangent",
-        lambda *args, **kwargs: (jnp.zeros_like(zero), jnp.asarray(1.0)),
-    )
-    monkeypatch.setattr(
-        "vmex.core.polish_driver._apply_bordered_preconditioner",
-        lambda state, rhs, dtau, tangent, runtime, block, chart=None: rhs,
-    )
-    monkeypatch.setattr(
-        "vmex.core.polish_driver._low_inverse", lambda rhs, runtime: rhs
-    )
-    monkeypatch.setattr(
-        "vmex.core.polish_driver.strong_root_residual",
-        lambda vector, runtime, alpha: vector + alpha,
-    )
-    result = _arclength_to_target(
-        zero,
-        0.95,
-        SimpleNamespace(layout=SimpleNamespace(size=2), operator_balance=1.0),
-        PolishConfig(max_arclength_steps=1, arclength_step=0.1),
-        lambda vector, alpha: jnp.all(jnp.isfinite(vector)) & jnp.isfinite(alpha),
-        None,
-        None,
-    )
-    np.testing.assert_array_equal(result[0], target_vector)
-    assert result[1:] == (1.0, 1, 7, 9, 11)
-
-
-def test_bordered_tangent_uses_previous_orientation(monkeypatch):
-    zero = jnp.zeros((2,))
-    previous = (jnp.asarray([-1.0, -1.0]), jnp.asarray(-1.0))
-
-    def fake_gmres(operator, rhs, *, precond, **kwargs):
-        del kwargs
-        physical, normalization = operator(rhs)
-        assert physical.shape == zero.shape
-        assert np.isfinite(float(normalization))
-        for actual, expected in zip(
-            jax.tree.leaves(precond(rhs)), jax.tree.leaves(rhs), strict=True
-        ):
-            np.testing.assert_array_equal(actual, expected)
-        return SimpleNamespace(
-            x=(jnp.asarray([0.5, 0.25]), jnp.asarray(0.5)),
-            converged=True,
-            residual_norm=jnp.asarray(0.0),
-            iterations=1,
-        )
-
-    monkeypatch.setattr("vmex.core.polish_driver.gmres", fake_gmres)
-    monkeypatch.setattr(
-        "vmex.core.polish_driver._bordered_preconditioner",
-        lambda *args, **kwargs: lambda state, rhs, dtau: rhs,
-    )
-    monkeypatch.setattr(
-        "vmex.core.polish_driver.strong_root_residual",
-        lambda vector, runtime, alpha: vector + alpha * jnp.ones_like(vector),
-    )
-    tangent = _branch_tangent(
-        zero,
-        0.5,
-        SimpleNamespace(),
-        PolishConfig(),
-        previous,
-        None,
-    )
-    np.testing.assert_allclose(
-        jnp.vdot(tangent[0], tangent[0]).real + tangent[1] ** 2,
-        1.0,
-        rtol=2.0e-13,
-    )
-    assert float(jnp.vdot(tangent[0], previous[0]) + tangent[1] * previous[1]) > 0.0
 
 
 def _tree_dot(left, right):
@@ -876,87 +344,6 @@ def test_factor_refresh_policy_reports_every_trigger():
 def test_factor_refresh_policy_rejects_invalid_thresholds(field, value, message):
     with pytest.raises(ValueError, match=message):
         PreconditionerRefreshPolicy(**{field: value})
-
-
-def test_square_strong_root_endpoint_jvp_boundary_and_rank(small_strong_root):
-    runtime = small_strong_root
-    zero = jnp.zeros((runtime.layout.size,), dtype=jnp.float64)
-    radial_matrix = runtime.native.radial_basis.basis_matrix(runtime.radial_nodes**2)
-    assert runtime.radial_nodes.size > runtime.native.radial_basis.size
-    assert runtime.theta.size >= 4 * int(np.max(np.abs(runtime.native.m))) + 5
-    assert runtime.zeta.size == 1
-    for mode, mode_m in enumerate(np.asarray(runtime.native.m)):
-        regularized_matrix = (
-            runtime.radial_nodes[:, None] ** abs(int(mode_m)) * radial_matrix
-        )
-        np.testing.assert_allclose(
-            runtime.radial_fit[mode] @ regularized_matrix,
-            np.eye(runtime.native.radial_basis.size),
-            rtol=5.0e-10,
-            atol=5.0e-10,
-        )
-    low_endpoint = strong_root_residual(zero, runtime, 0.0)
-    strong_endpoint = strong_root_residual(zero, runtime, 1.0)
-    # The alpha = 0 endpoint is legacy_residual(x0) - legacy_defect: two
-    # evaluations of one nonlinear function in two separately compiled
-    # programs.  XLA does not promise bit-identical fusion across programs or
-    # platforms, so the cancellation bottoms out at round-off (measured
-    # 2.8e-14 on the Linux CI runner, exact zero on arm64).  The bound is the
-    # cancellation floor of the row-scaled O(1) residual, not a physics
-    # tolerance.
-    np.testing.assert_allclose(low_endpoint, 0.0, atol=1.0e-12)
-    assert strong_endpoint.shape == zero.shape
-    assert np.all(np.isfinite(np.asarray(strong_endpoint)))
-    # The initial force RMS is divided by the measured low-inverse stiffness.
-    np.testing.assert_allclose(
-        jnp.linalg.norm(strong_endpoint),
-        np.sqrt(runtime.layout.size) / runtime.operator_balance,
-        rtol=3.0e-13,
-    )
-    assert float(runtime.operator_balance) >= 1.0
-    assert runtime.coordinate_scale.shape == zero.shape
-    assert runtime.equation_scale.shape == zero.shape
-    assert np.all(np.asarray(runtime.coordinate_scale) > 0.0)
-    assert np.all(np.asarray(runtime.equation_scale) > 0.0)
-    assert runtime.strong_block_sign.shape == (3,)
-    np.testing.assert_array_equal(jnp.abs(runtime.strong_block_sign), 1.0)
-
-    probe = jnp.linspace(-0.01, 0.015, runtime.layout.size)
-    low_probe = strong_root_residual(probe, runtime, 0.0)
-    strong_probe = strong_root_residual(probe, runtime, 1.0)
-    alpha = 0.37
-    np.testing.assert_allclose(
-        strong_root_residual(probe, runtime, alpha),
-        low_probe + alpha * (strong_probe - low_probe),
-        rtol=2.0e-13,
-        atol=2.0e-13,
-    )
-
-    direction = jnp.linspace(-0.2, 0.3, runtime.layout.size)
-    _, tangent = jax.jvp(
-        lambda value: strong_root_residual(value, runtime, 1.0),
-        (zero,),
-        (direction,),
-    )
-    step = 2.0e-5
-    finite_difference = (
-        strong_root_residual(step * direction, runtime, 1.0)
-        - strong_root_residual(-step * direction, runtime, 1.0)
-    ) / (2.0 * step)
-    np.testing.assert_allclose(tangent, finite_difference, rtol=2.0e-6, atol=2.0e-7)
-
-    correction = runtime.layout.unpack(0.01 * direction)
-    corrected = apply_high_order_correction(runtime.native, correction)
-    for name in ("R_cos", "R_sin", "Z_cos", "Z_sin"):
-        np.testing.assert_array_equal(
-            np.asarray(getattr(corrected, name)[:, -1]),
-            np.asarray(getattr(runtime.native, name)[:, -1]),
-        )
-    assert corrected.source.endswith("strong-root correction")
-
-    rank, singular_values = strong_root_rank(runtime, relative_tolerance=1.0e-8)
-    assert rank == runtime.layout.size
-    assert float(singular_values[-1]) > 0.0
 
 
 def test_physical_chart_eliminates_only_the_linear_coordinate_gauge(
@@ -1333,200 +720,6 @@ def test_physical_chart_adapters_and_validation(small_strong_root, monkeypatch):
         make_strong_structured_chart(asymmetric)
 
 
-def test_implicit_polish_rejects_mismatched_inputs(small_strong_root):
-    chart = make_strong_structured_chart(small_strong_root)
-    good = PolishContext(
-        small_strong_root,
-        chart,
-        jnp.zeros((chart.size,)),
-        jnp.ones((chart.size,)),
-    )
-    bad = good._replace(correction=jnp.zeros((chart.size + 1,)))
-    with pytest.raises(ValueError, match="correction has shape"):
-        collocation_polish_tangent(bad, small_strong_root.native)
-    with pytest.raises(ValueError, match="correction has shape"):
-        collocation_polish_adjoint(bad, small_strong_root.native)
-    with pytest.raises(ValueError, match="native_tangent"):
-        collocation_polish_tangent(good, jnp.asarray(0.0))
-    with pytest.raises(ValueError, match="polished_cotangent"):
-        collocation_polish_adjoint(good, jnp.asarray(0.0))
-    with pytest.raises(ValueError, match="native must have"):
-        implicit_collocation_polished_state(jnp.asarray(0.0), good)
-
-
-def test_low_vector_preconditioner_is_finite_on_native_coordinates(
-    small_strong_root,
-):
-    runtime = small_strong_root
-    zero = jnp.zeros((runtime.layout.size,), dtype=jnp.float64)
-    direction = jnp.linspace(-0.1, 0.2, runtime.layout.size)
-    _, response = jax.jvp(
-        lambda value: strong_root_residual(value, runtime, 0.0),
-        (zero,),
-        (direction,),
-    )
-    recovered = _low_inverse(response, runtime)
-    assert np.all(np.isfinite(np.asarray(recovered)))
-    assert float(jnp.linalg.norm(recovered)) > 0.0
-    assert float(jnp.linalg.norm(recovered)) < 10.0 * float(
-        jnp.linalg.norm(direction)
-    )
-
-
-def test_scaled_low_inverse_and_transpose_are_exact_duals(small_strong_root):
-    runtime = small_strong_root
-    left = runtime.transfer.restrict(
-        runtime.layout.unpack(jnp.linspace(-0.2, 0.1, runtime.layout.size))
-    )
-    right = runtime.transfer.restrict(
-        runtime.layout.unpack(jnp.linspace(0.3, -0.15, runtime.layout.size))
-    )
-    forward = runtime.low_preconditioner.solve_scaled(left)
-    transpose = runtime.low_preconditioner.solve_scaled_transpose(right)
-    np.testing.assert_allclose(
-        _tree_dot(forward, right),
-        _tree_dot(left, transpose),
-        rtol=3.0e-12,
-        atol=3.0e-12,
-    )
-
-
-def test_arclength_tangent_and_bordered_preconditioner_are_finite(
-    small_strong_root,
-):
-    runtime = small_strong_root
-    zero = jnp.zeros((runtime.layout.size,), dtype=jnp.float64)
-    block_preconditioner = _build_mode_block_preconditioner(runtime)
-    direction = jnp.linspace(-0.15, 0.25, runtime.layout.size)
-    _, response = jax.jvp(
-        lambda value: strong_root_residual(value, runtime, 1.0),
-        (zero,),
-        (direction,),
-    )
-    recovered = block_preconditioner.apply(response, 1.0)
-    np.testing.assert_allclose(recovered, direction, rtol=3.0e-8, atol=3.0e-8)
-    _, pullback = jax.vjp(
-        lambda value: strong_root_residual(value, runtime, 1.0), zero
-    )
-    transpose_response = pullback(direction)[0]
-    transpose_recovered = block_preconditioner.apply_transpose(
-        transpose_response, 1.0
-    )
-    np.testing.assert_allclose(
-        transpose_recovered, direction, rtol=3.0e-8, atol=3.0e-8
-    )
-    tangent = _branch_tangent(
-        zero,
-        0.0,
-        runtime,
-        PolishConfig(),
-        None,
-        block_preconditioner,
-    )
-    np.testing.assert_allclose(
-        jnp.vdot(tangent[0], tangent[0]).real + tangent[1] ** 2,
-        1.0,
-        rtol=2.0e-13,
-    )
-    assert float(tangent[1]) > 0.0
-    rhs = (jnp.linspace(-0.2, 0.3, runtime.layout.size), jnp.asarray(0.4))
-    corrected = _bordered_preconditioner(
-        runtime, tangent, block_preconditioner
-    )((zero, 0.0), rhs, 1.0e6)
-    assert corrected[0].shape == zero.shape
-    assert np.all(np.isfinite(np.asarray(corrected[0])))
-    assert np.isfinite(float(corrected[1]))
-
-
-def test_polish_driver_records_bounded_unpolished_return(
-    small_strong_root, monkeypatch
-):
-    class InitialCertificate:
-        normalized_l2 = jnp.asarray(2.0)
-        radial_refinement_difference = jnp.asarray(0.0)
-        minimum_signed_jacobian = jnp.asarray(0.5)
-        # the driver now reports the non-saturating window normalizations
-        # beside eps_F, so a stand-in certificate has to carry them
-        window_normalizations = SimpleNamespace(
-            volume_average_force=jnp.asarray(1.0),
-            relative_force_error=jnp.asarray(1.0),
-            magnetic_relative_force_error=jnp.asarray(1.0),
-            s_min=0.1, s_max=0.99,
-        )
-
-    config = PolishConfig(
-        max_continuation_stages=1,
-        alpha_initial_step=1.0e-3,
-        alpha_min_step=1.0e-3,
-        alpha_max_step=1.0e-3,
-        max_nonlinear_iterations=12,
-        preconditioner="legacy",
-        use_pseudo_arclength=True,
-        fail_policy="return_unpolished",
-    )
-
-    def fail_tangent(*args, **kwargs):
-        del args, kwargs
-        raise StrongForceContinuationError("test tangent failure")
-
-    def endpoint(residual, initial, **kwargs):
-        del residual, kwargs
-        return SimpleNamespace(
-            x=initial,
-            steps=2,
-            linear_iterations=3,
-            residual_evaluations=4,
-            converged=True,
-            linear_converged=True,
-        )
-
-    def continuation(residual, initial, *, accept_stage, **kwargs):
-        del residual, kwargs
-        alpha = 1.0e-3
-        accept_stage(initial, alpha, None)
-        stage = SimpleNamespace(
-            nonlinear_steps=5,
-            linear_iterations=6,
-            residual_evaluations=7,
-            accepted=True,
-        )
-        return SimpleNamespace(
-            x=initial,
-            alpha=alpha,
-            steps=(stage,),
-            converged=False,
-        )
-
-    monkeypatch.setattr(
-        "vmex.core.polish_driver._solvax_continuation_api",
-        lambda: (lambda **kwargs: object(), None, continuation, None, endpoint),
-    )
-    monkeypatch.setattr(
-        "vmex.core.polish_driver._ptc_config", lambda config, **kwargs: object()
-    )
-    monkeypatch.setattr(
-        "vmex.core.polish_driver._arclength_to_target", fail_tangent
-    )
-    chart = make_strong_structured_chart(small_strong_root)
-    result = polish_strong_root(
-        small_strong_root,
-        config=config,
-        initial_certificate=InitialCertificate(),
-        chart=chart,
-    )
-    report = result.polish_report
-    assert not report.converged
-    assert report.termination_reason == "pseudo-arclength-tangent-failed"
-    assert report.final_alpha == pytest.approx(1.0e-3)
-    assert report.continuation_accepted == 1
-    assert report.continuation_rejected == 0
-    assert report.nonlinear_iterations > 0
-    assert report.linear_iterations > 0
-    assert report.minimum_signed_jacobian > 0.0
-    np.testing.assert_array_equal(result.correction, 0.0)
-    assert result.native_equilibrium is small_strong_root.native
-
-
 @pytest.mark.parametrize("route", ["legacy", "continuation", "continuation-final", "collocation"])
 @pytest.mark.parametrize(
     ("field", "value", "accepted"),
@@ -1654,6 +847,7 @@ def test_polish_certificate_routes(monkeypatch, route, field, value, accepted):
         assert result.polish_report.radial_refinement_tolerance == 0.001
 
 
+@pytest.mark.full
 def test_polish_driver_skips_an_already_certified_state(small_strong_root):
     class InitialCertificate:
         normalized_l2 = jnp.asarray(1.0e-9)
@@ -1682,55 +876,7 @@ def test_polish_driver_skips_an_already_certified_state(small_strong_root):
     np.testing.assert_array_equal(result.correction, 0.0)
 
 
-def test_legacy_polish_announces_refinement_and_certificate_phases():
-    """The legacy driver's setup phases each emit a notice before starting.
-
-    Small solovev case; the raw lift never certifies at the default bar, so
-    the run passes through every phase (refinement, initial certificate,
-    preconditioner/root-runtime build) into one bounded Gauss-Newton step.
-    """
-    from vmex import VmecInput
-    from vmex.core.polish_driver import polish_legacy_solution
-    from vmex.core.solver import resolution_from_input, solve
-
-    inp = VmecInput.from_file(
-        str(DATA / "input.solovev")
-    ).change_resolution(mpol=3, ntor=0, ntheta=12, nzeta=4)
-    inp = dataclasses.replace(
-        inp, ns_array=np.asarray([5]), ftol_array=np.asarray([1.0e-9]),
-        niter_array=np.asarray([2000]),
-    )
-    result = solve(inp)
-    lines: list[str] = []
-
-    def capture(text="", **kwargs):
-        lines.append(str(text))
-
-    polish_legacy_solution(
-        inp,
-        resolution_from_input(inp, ns=5),
-        result.state,
-        config=PolishConfig(
-            max_nonlinear_iterations=1,
-            collocation_scale_probes=2,
-            fail_policy="return_unpolished",
-        ),
-        verbose=True,
-        emit=capture,
-    )
-    text = "\n".join(lines)
-    assert "refining the converged state" in text
-    assert "evaluating the initial force certificate" in text
-    assert "building the polish preconditioner and root runtime" in text
-    # eps_F alone is unreadable on a low-beta case: the console must name
-    # its ceiling and print the measures that can actually move.
-    assert "EPS-F is bounded by 2 by construction" in text
-    assert "<|F|>  [N m^-3]" in text
-    assert "<|F|>/<|grad B^2/2mu0|>" in text
-    assert "|F| L2 near axis [N m^-3]" in text
-    assert "(volume averages over s in [0.10, 0.99])" in text
-
-
+@pytest.mark.full
 def test_collocation_polish_announces_each_phase(small_strong_root):
     """Every silent setup phase emits a notice before it starts.
 
@@ -1769,6 +915,7 @@ def test_collocation_polish_announces_each_phase(small_strong_root):
     assert summary.count(" -> ") >= len(FORCE_ERROR_MEASURE_LABELS)
 
 
+@pytest.mark.full
 def test_normalization_fields_report_both_ends_of_the_window_averages():
     """``PolishReport`` must carry a pair that can move, not only eps_F.
 
@@ -1811,165 +958,6 @@ def test_normalization_fields_report_both_ends_of_the_window_averages():
     )
 
 
-def test_physics_accepted_polish_can_fail_derivative_stationarity(small_strong_root):
-    chart = make_strong_structured_chart(small_strong_root, balance_iterations=1, balance_probes=2)
-    with jax.disable_jit(False):
-        result = polish_collocation_least_squares(
-            small_strong_root, chart=chart,
-            config=PolishConfig(tolerance=2.0, validation_tolerance=10.0,
-                                radial_refinement_tolerance=10.0, collocation_scale_probes=2,
-                                max_nonlinear_iterations=1))
-        assert result.polish_report.converged
-        # This loose solver bar accepts the initial point, whose exact gradient
-        # is not within the default derivative stationarity threshold.
-        assert result.polish_report.nonlinear_iterations == 0
-        with pytest.raises(StrongForceCertificationError, match="stationary"):
-            collocation_polish_tangent(result.context, _random_like(small_strong_root.native, 51))
-
-
-def test_collocation_polish_primal_and_derivatives(small_strong_root):
-    # Compile this numerical integration explicitly; the suite disables JIT.
-    with jax.disable_jit(False):
-        chart = make_strong_structured_chart(
-            small_strong_root, balance_iterations=1, balance_probes=2
-        )
-        result = polish_collocation_least_squares(
-            small_strong_root,
-            chart=chart,
-            config=PolishConfig(
-                tolerance=1.0e-10,
-                validation_tolerance=10.0,
-                radial_refinement_tolerance=10.0,
-                collocation_scale_probes=2,
-                max_nonlinear_iterations=40,
-                fail_policy="return_unpolished",
-            ),
-        )
-        assert result.correction.shape == (small_strong_root.layout.size,)
-        assert result.polish_report.least_squares_success is not None
-        assert result.polish_report.variable_scale_probes == 2
-        assert result.context is not None
-        assert result.polish_report.converged
-        # The 1e-10 primal stopping flag is not derivative eligibility.
-        # Check the public stationarity and linear certificates below.
-        assert result.polish_report.nonlinear_iterations > 0
-
-        native_tangent = _random_like(small_strong_root.native, 51)
-        output_cotangent = _random_like(small_strong_root.native, 52)
-        linear_config = PolishLinearConfig(
-            rtol=2.0e-10,
-            atol=2.0e-11,
-            restart=chart.size,
-            max_restarts=5,
-        )
-        tangent = collocation_polish_tangent(
-            result.context, native_tangent, config=linear_config
-        )
-        adjoint = collocation_polish_adjoint(
-            result.context, output_cotangent, config=linear_config
-        )
-        assert bool(tangent.report.converged)
-        assert bool(adjoint.report.converged)
-        assert bool(tangent.report.stationarity_converged)
-        assert bool(adjoint.report.stationarity_converged)
-        for report in (tangent.report, adjoint.report):
-            assert np.isfinite(float(report.stationarity_norm))
-            assert float(report.stationarity_norm) <= float(report.stationarity_tolerance)
-        np.testing.assert_allclose(tangent.report.stationarity_norm,
-                                   result.polish_report.least_squares_optimality, rtol=1.0e-4, atol=1.0e-8)
-        np.testing.assert_allclose(
-            _tree_dot(output_cotangent, tangent.native_tangent),
-            _tree_dot(adjoint.native_cotangent, native_tangent),
-            rtol=2.0e-5,
-            atol=2.0e-6,
-        )
-
-        def objective(native):
-            polished = implicit_collocation_polished_state(
-                native, result.context, linear_config
-            )
-            return _tree_dot(polished, output_cotangent)
-
-        custom_gradient = jax.grad(objective)(small_strong_root.native)
-        difference = jax.tree.map(
-            jnp.subtract, custom_gradient, adjoint.native_cotangent
-        )
-        assert _tree_norm(difference) <= 2.0e-5 * max(
-            _tree_norm(adjoint.native_cotangent), 1.0
-        )
-
-        polished = implicit_collocation_polished_state(
-            small_strong_root.native,
-            result.context,
-            linear_config,
-        )
-
-        def boozer_objective(native):
-            spectrum = boozer_spectrum_high_order(
-                native,
-                surfaces=[0.49],
-                mboz=4,
-                nboz=2,
-                ntheta=12,
-                nzeta=8,
-            )
-            return jnp.sum(spectrum["bmnc_b"][:, 1:] ** 2)
-
-        boozer_cotangent = jax.grad(boozer_objective)(polished)
-        boozer_adjoint = collocation_polish_adjoint(
-            result.context,
-            boozer_cotangent,
-            config=linear_config,
-        )
-        boozer_gradient = jax.grad(
-            lambda native: boozer_objective(
-                implicit_collocation_polished_state(
-                    native,
-                    result.context,
-                    linear_config,
-                )
-            )
-        )(small_strong_root.native)
-        boozer_difference = jax.tree.map(
-            jnp.subtract,
-            boozer_gradient,
-            boozer_adjoint.native_cotangent,
-        )
-        assert _tree_norm(boozer_difference) <= 2.0e-5 * max(
-            _tree_norm(boozer_adjoint.native_cotangent),
-            1.0,
-        )
-
-        base_stationarity = _collocation_stationarity(
-            result.context.correction,
-            small_strong_root.native,
-            result.context.runtime,
-            result.context.chart,
-        )
-
-        def stationarity_remainder(step):
-            perturbed_native = jax.tree.map(
-                lambda value, direction: value + step * direction,
-                small_strong_root.native,
-                native_tangent,
-            )
-            perturbed_correction = (
-                result.context.correction + step * tangent.correction_tangent
-            )
-            return jnp.linalg.norm(
-                _collocation_stationarity(
-                    perturbed_correction,
-                    perturbed_native,
-                    result.context.runtime,
-                    result.context.chart,
-                )
-                - base_stationarity
-            )
-
-        coarse = stationarity_remainder(2.0e-5)
-        fine = stationarity_remainder(1.0e-5)
-        assert fine < 0.35 * coarse
-
 @pytest.mark.parametrize(
     ("updates", "message"),
     [
@@ -1998,40 +986,6 @@ def test_polish_config_validation(updates, message):
         PolishConfig(**updates)
 
 
-def test_polish_ptc_stopping_is_invariant_to_positive_residual_scaling():
-    tolerance = 2.0e-7
-    config = _ptc_config(PolishConfig(tolerance=tolerance), residual_scale=3.0e-4)
-    rescaled = _ptc_config(
-        PolishConfig(tolerance=tolerance), residual_scale=7.0 * 3.0e-4
-    )
-    assert config.rtol == tolerance
-    assert config.atol == pytest.approx(tolerance * 3.0e-4)
-    assert rescaled.atol == pytest.approx(7.0 * config.atol)
-
-
-def test_low_endpoint_check_ignores_numerical_row_equilibration():
-    residual = jnp.asarray([2.0e-9, -6.0e-9])
-    runtime = SimpleNamespace(
-        equation_scale=jnp.asarray([2.0, 3.0]),
-        layout=SimpleNamespace(size=2),
-    )
-    rescaled_runtime = SimpleNamespace(
-        equation_scale=7.0 * runtime.equation_scale,
-        layout=runtime.layout,
-    )
-    expected = jnp.linalg.norm(residual / runtime.equation_scale) / jnp.sqrt(2.0)
-    np.testing.assert_allclose(
-        _normalized_low_residual_norm(residual, runtime),
-        expected,
-        rtol=2.0e-13,
-    )
-    np.testing.assert_allclose(
-        _normalized_low_residual_norm(7.0 * residual, rescaled_runtime),
-        expected,
-        rtol=2.0e-13,
-    )
-
-
 def test_public_solver_rejects_unknown_polish_mode_before_solving():
     inp = VmecInput.from_file(DATA / "input.solovev")
     with pytest.raises(ValueError, match="False, True, or 'auto'"):
@@ -2049,6 +1003,7 @@ def test_public_solver_resolves_polish_keywords_only():
         solver._resolve_force_balance_polish(inp, False, True)
 
 
+@pytest.mark.full
 def test_public_solver_auto_corrects_a_lift_that_fails_quadrature(monkeypatch):
     from vmex.core import strong_force
 
@@ -2166,6 +1121,7 @@ def test_polished_wout_ns_covers_reconstruction_and_the_native_basis():
     assert polished_wout_ns(wide, solve_ns=31) == 181
 
 
+@pytest.mark.full
 def test_polished_wout_export_certifies_near_the_native_state(tmp_path):
     pytest.importorskip("netCDF4")
     import vmex as vj
@@ -2229,6 +1185,7 @@ _BOUNDED_POLISH = dict(
 )
 
 
+@pytest.mark.full
 def test_auto_declines_a_solve_it_priced_above_its_budget():
     """AUTO must measure the cost and refuse to spend past its ceiling.
 
@@ -2399,6 +1356,7 @@ def test_progress_callbacks_are_inert_without_an_active_reporter():
     assert quiet.lines == 1
 
 
+@pytest.mark.full
 def test_declined_auto_does_not_warn_under_the_warn_fail_policy(tmp_path):
     """``POLISH_FAIL = WARN`` reports failures, and a decline is not one."""
 
@@ -2419,42 +1377,4 @@ def test_declined_auto_does_not_warn_under_the_warn_fail_policy(tmp_path):
         warnings.simplefilter("error", RuntimeWarning)
         result = solve_file(path, write_wout=False)
     assert result.polish_report.termination_reason == "auto-declined-cost"
-def test_polish_derivative_failure_is_nan_under_tracing_and_raises_outside():
-    """``fail_policy="raise"`` cannot raise on a traced convergence flag.
 
-    Outside jit the policy raises; under jit the flag is a tracer, so both
-    policies return NaN. The docstring says so, and this pins it: a jitted
-    gradient that fails comes back as NaN, never as an exception.
-    """
-    import jax
-    import jax.numpy as jnp
-
-    from vmex.core.polish_implicit import (
-        PolishLinearConfig, PolishLinearReport, StrongForceLinearSolveError,
-        _checked_solution,
-    )
-
-    def report(converged):
-        return PolishLinearReport(
-            residual_norm=jnp.asarray(1.0), tolerance=jnp.asarray(1.0e-8),
-            iterations=jnp.asarray(30), converged=converged)
-
-    value = jnp.ones(3)
-    raising = PolishLinearConfig(fail_policy="raise")
-
-    # eager, failed: the documented exception
-    with pytest.raises(StrongForceLinearSolveError):
-        _checked_solution(value, report(jnp.asarray(False)), raising, "tangent")
-    # eager, converged: the value passes through
-    ok = _checked_solution(value, report(jnp.asarray(True)), raising, "tangent")
-    assert bool(jnp.all(ok == value))
-
-    # traced, failed: NaN, no exception, whatever the policy says.  The
-    # conftest disables jit suite-wide, so ask for it explicitly here --
-    # which is also why the interpreted suite never exercised this path.
-    def traced(flag):
-        return _checked_solution(value, report(flag), raising, "tangent")
-
-    with jax.disable_jit(False):
-        assert bool(jnp.all(jnp.isnan(jax.jit(traced)(jnp.asarray(False)))))
-        assert bool(jnp.all(jax.jit(traced)(jnp.asarray(True)) == value))

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -1377,4 +1377,3 @@ def test_declined_auto_does_not_warn_under_the_warn_fail_policy(tmp_path):
         warnings.simplefilter("error", RuntimeWarning)
         result = solve_file(path, write_wout=False)
     assert result.polish_report.termination_reason == "auto-declined-cost"
-

--- a/tests/test_polish_preconditioner.py
+++ b/tests/test_polish_preconditioner.py
@@ -62,6 +62,7 @@ from vmex.core.strong_force import (
 )
 
 jax.config.update("jax_enable_x64", True)
+pytestmark = pytest.mark.usefixtures("_module_jit_enabled")
 
 DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
 

--- a/tests/test_run_options.py
+++ b/tests/test_run_options.py
@@ -26,6 +26,8 @@ from vmex.core.run_options import (
     strip_vmex_json,
 )
 
+pytestmark = pytest.mark.usefixtures("_module_jit_enabled")
+
 DATA = Path(__file__).resolve().parents[1] / "examples" / "data"
 
 
@@ -246,6 +248,7 @@ def test_public_python_polish_defaults_are_explicitly_off():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.full
 def test_solve_file_runs_and_writes_wout(tmp_path):
     import vmex as vj
 
@@ -296,7 +299,7 @@ def test_unpolished_wout_stays_bit_identical_to_the_plain_state_write(tmp_path):
     assert written.read_bytes() == reference.read_bytes()
 
 
-def test_solve_file_rejects_polish_on_a_free_boundary_deck(tmp_path):
+def test_solve_file_rejects_polish_on_a_free_boundary_deck(tmp_path, monkeypatch):
     source = tmp_path / "input.freeb"
     # MGRID_FILE must name something: readin.f (and VmecInput) force
     # LFREEB = F when it is 'NONE', which would silently reroute this deck to
@@ -310,16 +313,20 @@ def test_solve_file_rejects_polish_on_a_free_boundary_deck(tmp_path):
 
     with pytest.raises(ValueError, match="fixed-boundary.*file"):
         vj.solve_file(source, write_wout=False)
-    # --no-polish equivalent: the Python keyword overrides the directive, so
-    # the gate no longer fires.  The deck then proceeds into the free-boundary
-    # ladder and fails there for its own reason (no usable mgrid), which is
-    # the point: the rejection above is the polish gate, not deck validation.
-    with pytest.raises(Exception) as info:
-        vj.solve_file(source, polish=False, write_wout=False,
-                      niter_array=np.array([3]))
-    assert "polishing requires" not in str(info.value)
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+    from vmex.core import multigrid
+
+    result = SimpleNamespace(polish_report=None)
+    driver = Mock(return_value=result)
+    monkeypatch.setattr(multigrid, "solve_free_boundary_multigrid", driver)
+    assert vj.solve_file(source, polish=False, write_wout=False) is result
+    driver.assert_called_once()
+    assert driver.call_args.args[0].lfreeb
 
 
+
+@pytest.mark.full
 def test_solve_file_polish_directive_activates_polishing(tmp_path):
     """One documented input runs the whole flow: directive -> polished wout.
 
@@ -357,3 +364,53 @@ def test_solve_file_polish_directive_activates_polishing(tmp_path):
     # really came from the file.
     plain = vj.solve_file(physics, outdir=tmp_path, polish_config=config)
     assert plain.polish_report is None
+
+
+@pytest.mark.parametrize("mode", ["AUTO", ".TRUE.", ".FALSE."])
+@pytest.mark.parametrize("override", [None, False])
+def test_solve_file_directives_reach_driver_once(tmp_path, monkeypatch, mode, override):
+    """Parsing and Python precedence need no nonlinear solve."""
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+    from vmex.core import multigrid
+
+    path = tmp_path / "input.directives"
+    path.write_text(f"!@VMEX POLISH = {mode}\n!@VMEX POLISH_TOL = 2e-5\n"
+                    + (DATA / "input.solovev").read_text())
+    result = SimpleNamespace(polish_report=None)
+    driver = Mock(return_value=result)
+    monkeypatch.setattr(multigrid, "solve_multigrid", driver)
+    assert multigrid.solve_file(path, polish=override, write_wout=False) is result
+    driver.assert_called_once()
+    expected = {"AUTO": "auto", ".TRUE.": True, ".FALSE.": False}[mode]
+    assert driver.call_args.kwargs["polish_force_balance"] == (
+        expected if override is None else override)
+    assert driver.call_args.kwargs["polish_config"].tolerance == 2e-5
+
+
+@pytest.mark.parametrize("policy,reason,warns", [
+    ("WARN", "nonlinear-failed", True),
+    ("WARN", "auto-declined-cost", False),
+    ("FALLBACK", "nonlinear-failed", False),
+])
+def test_solve_file_failed_polish_never_resolves(tmp_path, monkeypatch, policy, reason, warns):
+    import warnings
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+    from vmex.core import multigrid
+
+    path = tmp_path / "input.failure"
+    path.write_text(f"!@VMEX POLISH = AUTO\n!@VMEX POLISH_FAIL = {policy}\n"
+                    + (DATA / "input.solovev").read_text())
+    result = SimpleNamespace(polish_report=SimpleNamespace(
+        converged=False, termination_reason=reason))
+    driver = Mock(return_value=result)
+    monkeypatch.setattr(multigrid, "solve_multigrid", driver)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert multigrid.solve_file(path, write_wout=False) is result
+    assert len(caught) == int(warns)
+    if warns:
+        assert "polishing failed" in str(caught[0].message)
+    driver.assert_called_once()
+    assert driver.call_args.kwargs["polish_config"].fail_policy == "return_unpolished"

--- a/tests/test_run_options.py
+++ b/tests/test_run_options.py
@@ -393,7 +393,7 @@ def test_solve_file_directives_reach_driver_once(tmp_path, monkeypatch, mode, ov
     ("WARN", "auto-declined-cost", False),
     ("FALLBACK", "nonlinear-failed", False),
 ])
-def test_solve_file_failed_polish_never_resolves(tmp_path, monkeypatch, policy, reason, warns):
+def test_solve_file_failed_polish_does_not_repeat_the_solve(tmp_path, monkeypatch, policy, reason, warns):
     import warnings
     from types import SimpleNamespace
     from unittest.mock import Mock

--- a/tests/test_test_manifest.py
+++ b/tests/test_test_manifest.py
@@ -195,6 +195,11 @@ def test_deferred_nonlinear_contracts_have_scheduled_jobs() -> None:
         assert lane in _invoked_lanes()
         assert f"selector: {lane}" in nightly
     assert 'RUN_FULL: "1"' in nightly
+    bundles = json.loads((ROOT / "assets/manifest.json").read_text())["bundles"]
+    ncsx = next(bundle["name"] for bundle in bundles
+                if "examples/data/mgrid_ncsx_c09r00_small.nc" in bundle["common_paths"])
+    assert f"tools/fetch_assets.py --bundle {ncsx}" in nightly
+    assert "test -f examples/data/mgrid_ncsx_c09r00_small.nc" in nightly
     ci = (ROOT / ".github/workflows/ci.yml").read_text()
     assert 'jax: ["0.9.2", "0.11.1"]' in ci
     assert "device, jax-compatibility, changed-coverage]" in ci

--- a/tests/test_test_manifest.py
+++ b/tests/test_test_manifest.py
@@ -112,7 +112,7 @@ def _invoked_lanes() -> set[str]:
     text = "\n".join(
         path.read_text() for path in sorted((ROOT / ".github" / "workflows").glob("*.yml")))
     invoked: set[str] = set()
-    for value in re.findall(r"^\s*selector:\s*(.+?)\s*$", text, re.M):
+    for value in re.findall(r"^\s*(?:-\s*)?selector:\s*(.+?)\s*$", text, re.M):
         invoked.update(value.split())          # a matrix value may list several
     invoked |= set(re.findall(r"test_manifest\.py select ([a-z][A-Za-z0-9-]*)", text))
     return invoked
@@ -185,3 +185,40 @@ def test_solver_modules_restore_jit_between_modules(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "3 passed" in result.stdout
+
+
+def test_deferred_nonlinear_contracts_have_scheduled_jobs() -> None:
+    nightly = (ROOT / ".github/workflows/nightly.yml").read_text()
+    for lane in ("full-polish-gn", "full-polish-linear", "full-polish-homotopy",
+                 "full-run-options", "full-free-boundary-adjoint"):
+        assert test_manifest.select(lane)
+        assert lane in _invoked_lanes()
+        assert f"selector: {lane}" in nightly
+    assert 'RUN_FULL: "1"' in nightly
+    ci = (ROOT / ".github/workflows/ci.yml").read_text()
+    assert 'jax: ["0.9.2", "0.11.1"]' in ci
+    assert "device, jax-compatibility, changed-coverage]" in ci
+
+
+def test_nonlinear_integrations_are_full_but_linear_contracts_remain_in_pr() -> None:
+    env = os.environ.copy()
+    env.pop("RUN_FULL", None)
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", "-m", "full",
+         "tests/test_polish_preconditioner.py", "tests/test_polish_linear.py",
+         "tests/test_polish_homotopy.py", "tests/test_run_options.py",
+         "tests/test_freeboundary_implicit.py"],
+        cwd=ROOT, env=env, capture_output=True, text=True, timeout=120)
+    assert result.returncode == 0, result.stdout + result.stderr
+    nodes = {line for line in result.stdout.splitlines() if "::" in line}
+    for node in (
+        "tests/test_polish_linear.py::test_collocation_polish_primal_and_derivatives",
+        "tests/test_polish_linear.py::test_physics_accepted_polish_can_fail_derivative_stationarity",
+        "tests/test_polish_preconditioner.py::test_auto_declines_a_solve_it_priced_above_its_budget",
+        "tests/test_polish_preconditioner.py::test_public_solver_auto_corrects_a_lift_that_fails_quadrature",
+        "tests/test_run_options.py::test_solve_file_polish_directive_activates_polishing",
+        "tests/test_freeboundary_implicit.py::test_free_boundary_current_gradient_matches_resolve_finite_difference",
+    ):
+        assert node in nodes
+    assert not any("::test_polish_linear_true_certificate" in node for node in nodes)
+    assert not any("::test_solve_file_directives_reach_driver_once" in node for node in nodes)

--- a/tests/test_test_manifest.py
+++ b/tests/test_test_manifest.py
@@ -222,3 +222,13 @@ def test_nonlinear_integrations_are_full_but_linear_contracts_remain_in_pr() -> 
         assert node in nodes
     assert not any("::test_polish_linear_true_certificate" in node for node in nodes)
     assert not any("::test_solve_file_directives_reach_driver_once" in node for node in nodes)
+
+
+def test_mirror_primary_suite_runs_once_in_physics() -> None:
+    ci = (ROOT / ".github/workflows/ci.yml").read_text()
+    physics, parity = ci.split("  physics:", 1)[1].split("  parity:", 1)
+    assert "selector: pr-mirror-spline" in physics
+    assert "pr-mirror-spline" not in parity
+    # The complete primary selector includes the former separate output job.
+    assert set(test_manifest.select("pr-physics-mirror-output")) <= set(
+        test_manifest.select("pr-mirror-spline"))


### PR DESCRIPTION
PR checks currently mix short contracts with repeated nonlinear solves; the earlier polish lane took 43.4 minutes. This change keeps the fast contracts in PR CI, schedules the real nonlinear checks explicitly, and tests polish stationarity on pinned JAX 0.9.2 and 0.11.1 with Python 3.12.

- Split the existing polish module into Gauss–Newton, linear derivative and homotopy modules. Share the existing fixtures. All 64 original test function bodies are unchanged, and collection preserves all 1,962 original cases after mapping moved names.
- Mark real polish and free-boundary adjoint integrations `full` and add explicit Nightly selectors, including the specific `ncsx-mgrid` asset fetch and a file assertion. Keep the tight MHD derivative and rejected-root checks on both JAX versions. PR linear checks keep eager and compiled failure/status tests.
- Exercise file directive parsing, precedence and failed-polish routing with a mocked driver; keep one real unpolished solve/export in PR CI and retain the polished file integration in Nightly. Use restoring JIT state for this module and the Gauss–Newton suite.
- Remove the duplicate mirror suite from the 27.7-minute misc lane, folding mirror-output into the complete mirror physics job (one fewer job).
- Add routing guards and enforce a 25-minute timeout for PR physics/parity jobs. This is a budget to validate on hosted runners, not a claim that every lane is already below it. Retain the existing 95% changed-line and 90% mirror coverage thresholds.
- Correct contributor documentation about scheduled versus merely manifest-owned tests. Keep plan.md as the authoritative logbook. Clarify E1's virtual-work audit to include lambda, closure/boundary terms and quadrature refinement before interpreting a discrepancy as solver failure, citing the VMEC formulation.

Validation:
- Local JAX 0.9.2 PR selection: 253 passed, 22 full cases deselected, 375.30 s.
- Full linear suite, office Python 3.12/JAX 0.11.1: 96 passed, 406.44 s.
- Full linear suite, office Python 3.12/JAX 0.9.2: 96 passed, 577.27 s.
- Full homotopy suite, local JAX 0.9.2: 12 passed, 385.24 s.
- Full file-directive suite: 41 passed, 102.23 s. Consolidated mirror job: 57 passed, 331.74 s.
- Revised misc parity selection: 74 passed, 11 opt-in live-VMEC2000 skips, 273.04 s. The skip reasons were checked separately.
- After moving the physical shape-rejection test back to GN to reuse its fixture, the final PR linear selection passed 93 tests in 7.21 s locally and 16.24/18.98 s on office head/floor; two MHD cases remain full. The earlier full linear counts include the moved shape test.
- Full Gauss–Newton suite with restoring JIT on office JAX 0.11.1: 124 passed, 579.02 s; the same full suite passed locally on JAX 0.9.2 in 349.79 s. The interpreted attempt was interrupted after 115 passes/1413.93 s; it is incomplete evidence.
- Full free-boundary adjoints locally: 15 passed, 932.33 s, no skips, with the verified NCSX bundle.
- Static preflight: Ruff, mypy, strict Sphinx and 77 guards passed (guards: 17.94 s). Twelve manifest guards passed; YAML parsed and all original nodes survived the move. Collection adds twelve routing/directive cases.

This branch integrates #277, #284 and #285; it is stacked on #277 until the parent work is merged. Original #277 CI failure remains unreproduced; no numerical tolerances or production solver code are changed by the tiering commits. Peak RSS and performance rankings are not claimed. Parent PRs #277, #284 and #285 now have successful CI. #277 and #284 still require an approving review. This PR’s hosted runtime/coverage evidence and required reviews remain merge gates. Campaign-class a1 routing and hosted nightly validation remain unfinished. Retarget this PR before deleting #277’s branch. No release is proposed. Commits are authored by rogeriojorge.
