### PR TITLE
E2: compare full RZ and structured dense force-reference steps

### DIFF
--- a/benchmarks/e2_dense_reference.py
+++ b/benchmarks/e2_dense_reference.py
@@ -30,7 +30,7 @@ from scipy.linalg import lstsq
 import vmex
 from benchmarks._provenance import assert_repo_vmex, git_state
 from benchmarks.e1_functional_consistency import shaped_state
-from vmex.core.polish import _physical_equation_basis, apply_high_order_correction
+from vmex.core.polish import _flatten_high, _physical_equation_basis, apply_high_order_correction
 from vmex.core.profiles import MU0
 from vmex.core.radial_basis import _span_quadrature
 from vmex.core.strong_force import _basic_fields, _point_force, certify_strong_force
@@ -56,6 +56,7 @@ def experiment(native, layout, steps, order, angles, damping):
                           for theta in np.arange(angles) * 2 * np.pi / angles])
     weights = jnp.asarray(np.repeat(weights, angles) * (2 * np.pi)**2 / angles)
     zero = jnp.zeros(layout.size)
+    coefficient_map = np.asarray(jax.jacfwd(lambda vector: _flatten_high(layout.unpack(vector)))(zero))
 
     def state(vector):
         return apply_high_order_correction(native, layout.unpack(vector))
@@ -66,8 +67,9 @@ def experiment(native, layout, steps, order, angles, damping):
         return jacobian, force
 
     jacobian, _ = fields(zero)
-    # Freeze the reference volume measure. Scaling is explicit column-L2
-    # equilibration below, not a claim to reproduce production Ruiz scaling.
+    # Freeze the reference volume measure. Equilibration is not production
+    # Ruiz scaling. Damping acts in physical spline coefficients: the local
+    # SVD layout basis can rotate between BLAS versions without changing it.
     volume_weights = weights * jnp.abs(jacobian)
     measure = jnp.sqrt(volume_weights / jnp.sum(volume_weights))
     residual = jax.jit(lambda vector: (measure[:, None] * fields(vector)[1]).reshape(-1))
@@ -102,12 +104,15 @@ def experiment(native, layout, steps, order, angles, damping):
         history = []
         for iteration in range(steps):
             r = np.asarray(residual(jnp.asarray(vector)))
-            J = (J0 if iteration == 0 else np.asarray(jac(jnp.asarray(vector)))) @ basis
+            full_J = J0 if iteration == 0 else np.asarray(jac(jnp.asarray(vector)))
+            J = full_J @ basis
             column_norm = np.linalg.norm(J, axis=0)
             scale = 1 / np.maximum(column_norm, max(float(column_norm.max()) * 1e-12, 1e-30))
             scaled = J * scale
-            augmented = np.vstack((scaled, np.sqrt(damping) * np.eye(basis.shape[1])))
-            rhs = np.concatenate((-r, np.zeros(basis.shape[1])))
+            physical_norm = np.linalg.norm(full_J @ coefficient_map.T, axis=0)
+            penalty = physical_norm[:, None] * (coefficient_map @ basis)
+            augmented = np.vstack((scaled, np.sqrt(damping) * penalty * scale))
+            rhs = np.concatenate((-r, np.zeros(coefficient_map.shape[0])))
             started = time.perf_counter()
             y, _, rank, _ = lstsq(augmented, rhs, lapack_driver="gelsd")
             qr, _, _, _ = lstsq(augmented, rhs, lapack_driver="gelsy")
@@ -145,7 +150,8 @@ def experiment(native, layout, steps, order, angles, damping):
         results["charts"][name] = {"coordinates": basis.shape[1], "history": history,
                                   "final_certificate": final,
                                   "absolute_l2_improvement": initial["absolute_l2"] / final["absolute_l2"],
-                                  "final_coordinates": vector.tolist()}
+                                  "final_coordinates": vector.tolist(),
+                                  "final_physical_correction": (coefficient_map @ vector).tolist()}
     results["verification_passed"] = (
         results["jacobian_fd_relative"] < 1e-6
         and results["full_energy_hessian"]["symmetry_relative"] < 1e-10

--- a/benchmarks/e2_dense_reference.py
+++ b/benchmarks/e2_dense_reference.py
@@ -1,0 +1,201 @@
+"""E2 fixed-profile dense reference: full R/Z versus the structured subspace.
+
+Uses the actual constrained layout from E1. Both runs start from the same
+shaped-tokamak seed with frozen flux and pressure profiles (GAMMA=0). This
+is a bounded diagnostic, not a production solver or a fixed-current solve.
+Augmented least squares uses SciPy's independent GELSD/GELSY implementations:
+https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.lstsq.html
+"""
+
+from __future__ import annotations
+
+import argparse
+from importlib.metadata import version
+import json
+from pathlib import Path
+import platform
+import resource
+import signal
+import sys
+import time
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from scipy.linalg import lstsq
+
+import vmex
+from benchmarks._provenance import assert_repo_vmex, git_state
+from benchmarks.e1_functional_consistency import shaped_state
+from vmex.core.polish import _physical_equation_basis, apply_high_order_correction
+from vmex.core.profiles import MU0
+from vmex.core.radial_basis import _span_quadrature
+from vmex.core.strong_force import _basic_fields, _point_force, certify_strong_force
+
+
+def certificate(state):
+    report = certify_strong_force(state, angular_multiplier=4, radial_order_increment=8)
+    return {name: float(getattr(report, name)) for name in (
+        "absolute_l2", "absolute_linf", "normalized_l2", "near_axis_l2",
+        "bulk_l2", "edge_l2", "minimum_signed_jacobian", "radial_refinement_difference")}
+
+
+def spectrum(matrix):
+    singular = np.linalg.svd(matrix, compute_uv=False)
+    return {"shape": list(matrix.shape), "bytes": matrix.nbytes,
+            "rank_rtol_1e-10": int(np.sum(singular > singular[0] * 1e-10)),
+            "singular_values": singular.tolist()}
+
+
+def experiment(native, layout, steps, order, angles, damping):
+    rho, weights = _span_quadrature(np.sqrt(native.radial_basis.breakpoints), order)
+    points = jnp.asarray([(r, theta, 0.0) for r in rho
+                          for theta in np.arange(angles) * 2 * np.pi / angles])
+    weights = jnp.asarray(np.repeat(weights, angles) * (2 * np.pi)**2 / angles)
+    zero = jnp.zeros(layout.size)
+
+    def state(vector):
+        return apply_high_order_correction(native, layout.unpack(vector))
+
+    @jax.jit
+    def fields(vector):
+        jacobian, _, _, force, *_ = jax.vmap(lambda point: _point_force(state(vector), point))(points)
+        return jacobian, force
+
+    jacobian, _ = fields(zero)
+    # Freeze the reference volume measure. Scaling is explicit column-L2
+    # equilibration below, not a claim to reproduce production Ruiz scaling.
+    volume_weights = weights * jnp.abs(jacobian)
+    measure = jnp.sqrt(volume_weights / jnp.sum(volume_weights))
+    residual = jax.jit(lambda vector: (measure[:, None] * fields(vector)[1]).reshape(-1))
+    jac = jax.jit(jax.jacfwd(residual))
+
+    def energy(vector):
+        def density(point):
+            _, g, _, _, B, p = _basic_fields(state(vector), point)
+            return (jnp.vdot(B, B) / (2 * MU0) - p) * jnp.abs(g)
+        return weights @ jax.vmap(density)(points)
+
+    estimated_bytes = (len(points) * 3 * layout.size + layout.size**2) * 8
+    if estimated_bytes > 2 * 1024**3:
+        raise MemoryError("E2 reference matrices exceed the 2 GiB plan budget")
+    started = time.perf_counter()
+    J0 = np.asarray(jac(zero))
+    H = np.asarray(jax.jit(jax.hessian(energy))(zero))
+    build_seconds = time.perf_counter() - started
+    direction = jnp.cos(jnp.arange(layout.size)) / np.sqrt(layout.size)
+    finite_difference = np.asarray((residual(1e-6 * direction) - residual(-1e-6 * direction)) / 2e-6)
+    jv = J0 @ np.asarray(direction)
+    initial = certificate(native)
+    results = {"initial_certificate": initial, "reference_build_seconds": build_seconds,
+               "reference_matrix_bytes": estimated_bytes,
+               "jacobian_fd_relative": float(np.linalg.norm(jv - finite_difference) / np.linalg.norm(jv)),
+               "full_jacobian": spectrum(J0), "full_energy_hessian": {
+                   "symmetry_relative": float(np.linalg.norm(H - H.T) / np.linalg.norm(H)),
+                   "eigenvalues": np.linalg.eigvalsh((H + H.T) / 2).tolist()}, "charts": {}}
+    for name, basis in (("full_RZ", np.eye(layout.size)),
+                        ("structured", _physical_equation_basis(layout))):
+        vector = np.zeros(layout.size)
+        history = []
+        for iteration in range(steps):
+            r = np.asarray(residual(jnp.asarray(vector)))
+            J = (J0 if iteration == 0 else np.asarray(jac(jnp.asarray(vector)))) @ basis
+            column_norm = np.linalg.norm(J, axis=0)
+            scale = 1 / np.maximum(column_norm, max(float(column_norm.max()) * 1e-12, 1e-30))
+            scaled = J * scale
+            augmented = np.vstack((scaled, np.sqrt(damping) * np.eye(basis.shape[1])))
+            rhs = np.concatenate((-r, np.zeros(basis.shape[1])))
+            started = time.perf_counter()
+            y, _, rank, _ = lstsq(augmented, rhs, lapack_driver="gelsd")
+            qr, _, _, _ = lstsq(augmented, rhs, lapack_driver="gelsy")
+            solve_seconds = time.perf_counter() - started
+            step = basis @ (scale * y)
+            cost = float(np.vdot(r, r) / 2)
+            trials = []
+            accepted = False
+            for fraction in (1.0, 0.5, 0.25, 0.125, 0.0625):
+                candidate = jnp.asarray(vector + fraction * step)
+                g, force = fields(candidate)
+                valid = bool(jnp.all(jnp.isfinite(force)) & jnp.all(native.jacobian_sign * g > 0))
+                trial_cost = float(jnp.vdot(residual(candidate), residual(candidate)) / 2) if valid else None
+                trials.append({"fraction": fraction, "admissible_on_solve_grid": valid, "cost": trial_cost})
+                if valid and trial_cost < cost:
+                    vector = np.asarray(candidate)
+                    accepted = True
+                    break
+            equation_defect = augmented.T @ (augmented @ y - rhs)
+            record = {"iteration": iteration, "cost": cost, "accepted": accepted,
+                      "column_scale": scale.tolist(), "scaled_jacobian": spectrum(scaled),
+                      "augmented_rank": int(rank), "qr_svd_step_relative": float(
+                          np.linalg.norm(qr - y) / max(np.linalg.norm(y), 1e-30)),
+                      "augmented_optimality_relative": float(np.linalg.norm(equation_defect) /
+                          max(np.linalg.norm(augmented.T @ rhs), 1e-30)),
+                      "true_linear_residual_norm": float(np.linalg.norm(J @ (scale * y) + r)),
+                      "predicted_full_step_cost": float(np.linalg.norm(J @ (scale * y) + r)**2 / 2),
+                      "factorizations_seconds": solve_seconds, "trials": trials}
+            history.append(record)
+            print(json.dumps({"chart": name, "iteration": iteration, "cost": cost,
+                              "accepted": accepted, "last_trial": trials[-1]}), flush=True)
+            if not accepted:
+                break
+        final = certificate(state(jnp.asarray(vector)))
+        results["charts"][name] = {"coordinates": basis.shape[1], "history": history,
+                                  "final_certificate": final,
+                                  "absolute_l2_improvement": initial["absolute_l2"] / final["absolute_l2"],
+                                  "final_coordinates": vector.tolist()}
+    results["verification_passed"] = (
+        results["jacobian_fd_relative"] < 1e-6
+        and results["full_energy_hessian"]["symmetry_relative"] < 1e-10
+        and all(np.isfinite(list(chart["final_certificate"].values())).all()
+                and chart["final_certificate"]["minimum_signed_jacobian"] > 0
+                and all(record["qr_svd_step_relative"] < 1e-9
+                        and record["augmented_optimality_relative"] < 1e-9
+                        for record in chart["history"])
+                for chart in results["charts"].values()))
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--steps", type=int, default=3)
+    parser.add_argument("--order", type=int, default=6)
+    parser.add_argument("--angles", type=int, default=24)
+    parser.add_argument("--damping", type=float, default=1e-3)
+    args = parser.parse_args()
+    if not jax.config.x64_enabled or not 1 <= args.steps <= 5 or not 4 <= args.order <= 12 or not 16 <= args.angles <= 64:
+        parser.error("require float64, steps 1..5, order 4..12, angles 16..64")
+    if not np.isfinite(args.damping) or args.damping <= 0:
+        parser.error("damping must be finite and positive")
+    def expired(*_):
+        raise TimeoutError("E2 600 s diagnostic budget")
+    signal.signal(signal.SIGALRM, expired)
+    signal.alarm(600)
+    provenance = git_state(ROOT)
+    provenance.update(vmex_module=assert_repo_vmex(vmex.__file__, ROOT),
+                      python=platform.python_version(), platform=platform.system(),
+                      versions={name: version(name) for name in ("jax", "jaxlib", "scipy", "numpy", "solvax")},
+                      device=str(jax.devices()[0]), precision="float64")
+    started = time.perf_counter()
+    output = {"_provenance": provenance, "case": "shaped tokamak, frozen iota/pressure, GAMMA=0",
+              "settings": {k: v for k, v in vars(args).items() if k != "output"}}
+    try:
+        output["result"] = experiment(*shaped_state(), args.steps, args.order, args.angles, args.damping)
+        output["status"] = "completed diagnostic; QA and nonlinear convergence not established"
+        if not output["result"]["verification_passed"]:
+            raise RuntimeError("E2 reference consistency or geometry check failed")
+    except Exception as error:
+        output["status"] = f"{type(error).__name__}: {error}"
+        raise
+    finally:
+        output["seconds"] = time.perf_counter() - started
+        output["peak_rss_MiB"] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / (
+            1024**2 if platform.system() == "Darwin" else 1024)
+        args.output.write_text(json.dumps(output, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/plan.md
+++ b/plan.md
@@ -185,9 +185,9 @@ attempts are saved as such.
   reference `H`, retaining independent R/Z, on the frozen tokamak and one affordable finite-beta QA
   linearization; compare spectrum and rank, augmented QR/SVD reference steps
   with the actual scaling, and the physical step, cost reduction and linear
-  residual, not only coefficient norms. This is DESC's solver, not only a
-  diagnostic: at ≤ 3,000 unknowns the Jacobian is under 1 GiB and the
-  factorization takes seconds on the office box. Pass: the independent
+  residual, not only coefficient norms. Budget residual rows × coordinates ×
+  dtype size plus factorization workspace; 3,000 unknowns alone do not bound
+  Jacobian memory. Measure assembly/factorization costs rather than extrapolating. Pass: the independent
   certificate improves by an order of magnitude on the QA target. Fail: the
   obstruction is representation, reachability or closure; no Krylov work
   follows.
@@ -198,8 +198,10 @@ attempts are saved as such.
   acceptance with geometry rejection, and the strong certificate as judge.
   Pass: the certified tokamak value at fewer than 50 Hessian products per
   step and fewer than 20 steps, and h/p convergence on Solov'ev at the
-  degree's order. Kill: an indefinite Hessian on a case VMEC converges, or
-  no 5× reduction in operator applications against E2's dense step.
+  degree's order. Diagnose negative curvature at a certified stable equilibrium;
+  an indefinite off-root Hessian alone is not a kill rule (see the
+  [trust-region reference](https://docs.scipy.org/doc/scipy/tutorial/optimize.html)).
+  Kill on failed force/geometry convergence or no 5× operator reduction against E2.
 
 **Decision tree.** If even the trusted dense step cannot improve the
 independent force, investigate representation, closure or admissibility and
@@ -614,33 +616,36 @@ reference 138.346, residual scale 6.83505). CI's failure remains unreproduced. T
 (JAX 0.9.2, 228.87 s) and on office (0.11.1, 365.96 s); static checks passed. Raw logs:
 `vmex-review-evidence-20260906/{277-repair-*,office-277-*}.log`; RSS unmeasured.
 
-**2026-09-06, #286 / P0.3/P0.2 tiering.** Worktree `vmex-ci-tiers`, branch `fix/phase1-ci-tiers`, initial base #277; integration
-`2ae2a716`, implementation `0bfab61d`. GN/linear/homotopy split shares fixtures; real nonlinear/adjoint cases run explicitly in
-Nightly; option routing uses mocks plus one real PR solve/export. All 1,962 original cases and 64 polish bodies retained; 1,974
-collected with 12 new cases. Twelve manifest guards passed/10.81 s; final preflight 77/17.94 s plus Sphinx/Ruff/mypy. Local PR
-selection 253/375.30 s (22 deselected); full homotopy 12/385.24 s; full options 41/102.23 s; full adjoints 15/932.33 s, no
-skips. NCSX requires ncsx-mgrid, not reference-nc: initial file assertion stopped correctly, corrected fetch then passed, with
-manifest-linked guard. Office full linear: 96 passes on Python 3.12/JAX 0.11.1 (406.44 s) and 0.9.2 (577.27 s). Shape-rejection
-test then returned to GN for fixture reuse: final PR linear 93 passes (2 full deselections), local 7.21 s, office 16.24/18.98 s.
-Interpreted GN stopped incomplete after 115 passes/1413.93 s; scoped-JIT GN passed 124/579.02 s on office `~/vmex-ci-final` at
-`32f01c0c`, local 124/349.79 s. Initial options run also interrupted for JIT repair. Mirror consolidated: 57/331.74 s; revised
-misc 74/273.04 s, 11 opt-in live-VMEC2000 skips. CI run 34080867732 passed on `d58223b4`: polish 5.37 min versus parent 43.4,
-misc 24.58 versus 27.7, c2 22.60; all jobs <25 min. Both JAX gates passed; coverage skipped for test/docs-only delta. No RSS or
-solver-performance ranking claimed. Raw logs: `vmex-phase1-ci-evidence`. #286 retargeted to main, integrated #277 at `98049a1a`,
-resolving only logbook conflicts. Integration CI and Nightly 34132378608 pending; campaign-class a1 routing remains open.
+**2026-09-06, #286 / CI tiering.** `fix/phase1-ci-tiers` in `vmex-ci-tiers`, initially base #277; integration `2ae2a716`, split
+`0bfab61d`, scoped-JIT GN `32f01c0c`. All 1,962 original cases/64 polish bodies retained; 1,974 collected. GN/linear/homotopy
+share fixtures, nonlinear cases explicitly scheduled; option routing mocked with one real PR solve/export. Final static/docs: 77
+guards/17.94 s. Local full homotopy 12/385.24 s, options 41/102.23 s, adjoints 15/932.33 s without skips. NCSX asset assertion
+found the wrong bundle; corrected to ncsx-mgrid with a manifest-linked guard. Office linear/MHD: 96 passes on both JAX versions
+(406.44/577.27 s); one test returned to GN for fixture reuse. Final PR linear: 93 passes/7.21 s locally, 16.24/18.98 s office.
+Interpreted GN stopped at 115/1413.93 s; compiled GN 124/579.02 s office, 349.79 s local. Raw results/stopped attempts:
+`vmex-phase1-ci-evidence`. CI 34080867732 on `d58223b4` passed: polish 5.37 min versus 43.4, misc 24.58 versus 27.7, c2 22.60;
+every PR job <25 min, both JAX gates green. No solver speedup claimed. Retargeted to main and merged #277 `98049a1a`, resolving
+only logbook conflicts; integration CI/Nightly 34132378608 remain pending.
 
-**2026-09-07, E1 and cleanup.** `research/e1-functional-consistency`, base #286 `6a4d560f`;
-`benchmarks/e1_functional_consistency.py` at `b17352c1`: independent complete virtual work, fixed boundary/profiles and GAMMA=0,
-deliberately off-root. Clean CPU/JAX 0.9.2: order 4/8/12 work errors 4.006e-3 → 7.931e-14 (Solovev, 30 coordinates/32 angles);
-8.875e-3 → 8.210e-13 (shaped, 56/64). Omitting lambda leaves 3.085%/13.295%; AD duality <7e-15. Current-driven shaped seed uses
-frozen iota for this audit, NOT fixed-current variations. Office JAX 0.11.1, 128 angles: 8.354e-13. Actual layout/structured
-chart normal ranks: 36/20; extrema response ratios <9e-15 on both versions. E1 energy identity supported; structured
-reachability fails. Clean shaped chart run: 43.14 s/1117.7 MiB local; 43.55 s/1043.7 MiB office. Repeated local numerical output
-is byte-identical excluding wall time/RSS. Source, JSON and logs are in sibling `vmex-e1-evidence`; reproduction:
-CPU/float64/cache disabled, script `--case shaped-frozen-iota --orders 4 8 12 --angles 64 --output /tmp/e1.json`. Solovev uses
-`--case solovev --angles 32`. Deleted 32 remote and 73 local branches after ancestry or exact merged-PR-head checks; remote SHA
-leases protected concurrent changes. Open dependencies/worktrees retained; 16 remote and 33 local branches remain before
-publishing E1. Deletion SHAs are saved with the raw evidence. Nightly 34132378608 exposed #280's stale example regex after a
-successful certified polish; repair reads all three current metrics and requires finite decreases; real example passed locally
-in 149.72 s. Next: E2 full R/Z reference, then a reachability-preserving chart; no E3 promotion. Finish integration checks and
-a1 routing; P0.4 and fixed-current closure remain open. No release.
+**2026-09-07, #287 / E1 and cleanup.** Branch `research/e1-functional-consistency`, base #286 `6a4d560f`; measured script
+`b17352c1`. Complete prescribed-profile/GAMMA=0 energy work passes off-root on Solovev (30 coordinates, 7.931e-14 discrepancy)
+and shaped tokamak (56, 8.210e-13); omitting lambda leaves 3.085%/13.295%. Office JAX 0.11.1 with 128 angles gives 8.354e-13.
+Structured/layout normal ranks 20/36; Z-extremum response ratios <9e-15. Raw results, commands and deletion SHAs: sibling
+`vmex-e1-evidence`. Clean shaped chart: local 43.14 s/1117.7 MiB, office 43.55 s/1043.7 MiB; repeated numerical output identical
+excluding time/RSS. Deleted 32 remote/73 local merged branches using ancestry or exact merged-PR heads; open
+dependencies/worktrees preserved. Nightly 34132378608 exposed #280's stale example regex after a successful polish; #287 repairs
+all three metric checks (real example passed/149.72 s). Its strict preflight passed 77 guards/19.00 s. E1 identifies a physical
+reachability restriction; it does not promote E3.
+
+**2026-09-07, E2 shaped reference.** `research/e2-full-rz-reference`, base #287 `4ba23d30`; clean measurement `c725c407`.
+CPU/float64/cache off: `python benchmarks/e2_dense_reference.py --order 10 --angles 48 --output /tmp/e2.json` (3 steps). Full
+R/Z/lambda versus structured coordinates, same ns=9, degree=3/two-span seed, frozen iota/pressure; not the fixed-current or
+production-resolution solve. QR/GELSY and SVD/GELSD agree; full J rank 56, FD/JVP error <2e-9, Hessian asymmetry <4e-16.
+Independent force RMS: 2194.742 → 188.549/335.259 N/m³ (full/structured), peak 863.77/905.48; positive sampled Jacobians and
+certificate radial discrepancy <6e-13. Order 6/24-angle RMS: 188.558/336.526. Local JAX 0.9.2: 52.27 s/1105.1 MiB; office
+0.11.1: 115.58 s/2127.8 MiB. Physical corrections agree to 2.3e-11 relative. Reference J/H: 1.25 MiB, separate from process RSS.
+The earlier `7048b71b` metric depended on arbitrary SVD coordinates; physical-coefficient damping removed its platform-dependent
+trajectories. Raw results and both attempts: sibling `vmex-e2-evidence`. The off-root Hessian's small negative curvature (~-276
+versus maximum 3.7e8) does not alone reject Newton. SciPy supplies the independent diagnostic; SOLVAX's production GN remains
+unchanged. Next: affordable finite-beta QA reference and bounded convergence, then chart/solver integration. E2 is not passed
+for QA; E3, a1 routing, P0.4, fixed-current closure and release remain gated. Integration CI is pending.


### PR DESCRIPTION
E1 found that the structured chart removes physical normal-motion directions. This E2 diagnostic tests whether retaining those directions actually improves force balance, using independent dense QR/SVD steps in the full constrained R/Z/lambda space and the existing structured subspace.

Both start from the same small shaped-tokamak seed (ns=9, cubic splines on two spans), freeze iota/pressure and take three bounded damped steps. This is not the original fixed-current closure, a production-resolution solve, or a production solver change. SciPy supplies an independent reference; SOLVAX algorithms remain unchanged.

On clean commit c725c407, with finer solve quadrature:
- Independent force RMS: 2194.742 → 188.549 N/m³ with full R/Z, versus 335.259 with the structured chart. Peak force: 863.77 versus 905.48 N/m³. Both retain positive sampled Jacobians; certificate radial-refinement discrepancies are below 6e-13.
- Coarser quadrature gives 188.558/336.526 N/m³. Local JAX 0.9.2 and office JAX 0.11.1 agree on physical corrections to 2.3e-11 relative after defining damping in physical spline coefficients. The earlier arbitrary-SVD-coordinate metric and its platform-dependent trajectories remain logged as superseded evidence.
- QR/GELSY and SVD/GELSD steps agree; Jacobian/finite-difference error is below 2e-9 and energy-Hessian asymmetry below 4e-16. The reference reports actual scaling, spectra, true linear residuals, geometry trials and independent certificates, with time/matrix budgets enforced.
- Fine-grid J/H storage is 1.25 MiB. Measured full diagnostic: 52.27 s/1105.1 MiB process RSS locally; 115.58 s/2127.8 MiB on office. These are diagnostic costs, not production performance claims.

The authoritative plan stays at 650 lines and now removes two invalid assumptions: unknown count alone does not bound Jacobian memory, and an indefinite off-root Hessian alone does not reject Newton. The next E2 gate is affordable finite-beta 3-D QA and bounded convergence before any production chart/solver promotion. No release.

Validation: strict static/docs preflight passed Ruff, mypy, Sphinx and 77 guards in 23.77 s; independent numerical consistency and geometry gates passed on both JAX versions. Exact commands, SHAs, raw JSON/log locations and failed/superseded interpretations are recorded in plan.md.

Sources: [SciPy least-squares drivers](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.lstsq.html), [trust-region handling of indefinite models](https://docs.scipy.org/doc/scipy/tutorial/optimize.html).

Stacked on #287. Retarget to main before deleting that base branch. Parent integration checks are still running; do not bypass unfinished checks.
