### PR TITLE
E2 on finite-beta 3-D QA: the chart helps, and is not the obstruction

### DIFF
--- a/benchmarks/e1_functional_consistency.py
+++ b/benchmarks/e1_functional_consistency.py
@@ -152,6 +152,35 @@ def shaped_state():
     return native, layout
 
 
+def qa_state(mpol=3, ntor=2, ns=9, spans=2):
+    """Seed the finite-beta 3-D QA deck, then freeze both flux derivatives.
+
+    The same prescribed-iota audit as :func:`shaped_state` on a genuinely
+    toroidally varying equilibrium. Resolution is a deliberate reduction of
+    the deck's MPOL=NTOR=5: the dense reference is bounded, not production.
+    """
+    from vmex.core import implicit
+    from vmex.core.input import VmecInput
+    from vmex.core.polish import make_high_low_transfer, make_strong_root_layout
+
+    inp = VmecInput.from_file(ROOT / "examples/data/input.nfp2_QA_smooth_beta")
+    inp = replace(
+        inp.change_resolution(mpol=mpol, ntor=ntor, ntheta=2 * mpol + 6,
+                              nzeta=max(4, 2 * ntor + 2)),
+        ns_array=np.asarray([ns]), ftol_array=np.asarray([1e-10]),
+        niter_array=np.asarray([4000]),
+    )
+    config = implicit.make_config(inp, ftol=1e-10, max_iterations=4000)
+    params = implicit.params_from_input(inp)
+    state, mask = implicit.solve_implicit_with_aux(params, config)
+    runtime = implicit.runtime_from_params(params, config)
+    basis = BSplineBasis.clamped(np.linspace(0, 1, spans + 1), degree=3)
+    native = lift_high_order_state(state, runtime, radial_basis=basis)
+    transfer = make_high_low_transfer(native, runtime, project_config=config, project_mask=mask)
+    layout = make_strong_root_layout(mask, native, transfer=transfer)
+    return native, layout
+
+
 def chart_audit(native, layout):
     """Audit the production structured subspace before invertible Ruiz scaling.
 

--- a/benchmarks/e2_dense_reference.py
+++ b/benchmarks/e2_dense_reference.py
@@ -1,8 +1,9 @@
 """E2 fixed-profile dense reference: full R/Z versus the structured subspace.
 
-Uses the actual constrained layout from E1. Both runs start from the same
-shaped-tokamak seed with frozen flux and pressure profiles (GAMMA=0). This
-is a bounded diagnostic, not a production solver or a fixed-current solve.
+Uses the actual constrained layout from E1. Runs start from the shaped-tokamak
+seed or, with ``--case qa --planes N``, the finite-beta 3-D QA deck sampled on
+N field-period planes; both freeze the flux and pressure profiles (GAMMA=0).
+This is a bounded diagnostic, not a production solver or a fixed-current solve.
 Augmented least squares uses SciPy's independent GELSD/GELSY implementations:
 https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.lstsq.html
 """
@@ -29,7 +30,7 @@ from scipy.linalg import lstsq
 
 import vmex
 from benchmarks._provenance import assert_repo_vmex, git_state
-from benchmarks.e1_functional_consistency import shaped_state
+from benchmarks.e1_functional_consistency import qa_state, shaped_state
 from vmex.core.polish import _flatten_high, _physical_equation_basis, apply_high_order_correction
 from vmex.core.profiles import MU0
 from vmex.core.radial_basis import _span_quadrature
@@ -50,11 +51,16 @@ def spectrum(matrix):
             "singular_values": singular.tolist()}
 
 
-def experiment(native, layout, steps, order, angles, damping):
+def experiment(native, layout, steps, order, angles, damping, planes=1):
     rho, weights = _span_quadrature(np.sqrt(native.radial_basis.breakpoints), order)
-    points = jnp.asarray([(r, theta, 0.0) for r in rho
-                          for theta in np.arange(angles) * 2 * np.pi / angles])
-    weights = jnp.asarray(np.repeat(weights, angles) * (2 * np.pi)**2 / angles)
+    # `planes` samples the field-period toroidal angle. One plane reproduces
+    # the axisymmetric grid exactly, including its quadrature weights.
+    zetas = np.arange(planes) * 2 * np.pi / planes
+    points = jnp.asarray([(r, theta, zeta) for r in rho
+                          for theta in np.arange(angles) * 2 * np.pi / angles
+                          for zeta in zetas])
+    weights = jnp.asarray(np.repeat(weights, angles * planes)
+                          * (2 * np.pi)**2 / (angles * planes))
     zero = jnp.zeros(layout.size)
     coefficient_map = np.asarray(jax.jacfwd(lambda vector: _flatten_high(layout.unpack(vector)))(zero))
 
@@ -171,26 +177,57 @@ def main():
     parser.add_argument("--order", type=int, default=6)
     parser.add_argument("--angles", type=int, default=24)
     parser.add_argument("--damping", type=float, default=1e-3)
+    parser.add_argument("--case", choices=("shaped", "qa"), default="shaped")
+    parser.add_argument("--planes", type=int, default=1)
+    # Seed resolution is the representation under test: E2 requires at least
+    # three radial refinements and two angular resolutions before a verdict.
+    parser.add_argument("--seed-ns", type=int, default=9)
+    parser.add_argument("--seed-spans", type=int, default=2)
+    parser.add_argument("--seed-mpol", type=int, default=3)
+    parser.add_argument("--seed-ntor", type=int, default=2)
+    parser.add_argument("--budget-seconds", type=int, default=600)
     args = parser.parse_args()
     if not jax.config.x64_enabled or not 1 <= args.steps <= 5 or not 4 <= args.order <= 12 or not 16 <= args.angles <= 64:
         parser.error("require float64, steps 1..5, order 4..12, angles 16..64")
+    if not 1 <= args.planes <= 16:
+        parser.error("planes must be 1..16")
+    if args.case == "shaped" and args.planes != 1:
+        parser.error("the shaped tokamak is axisymmetric: use --planes 1")
+    if args.case == "qa" and args.planes == 1:
+        parser.error("the QA case is 3-D: use --planes > 1")
+    if not 60 <= args.budget_seconds <= 3600:
+        parser.error("budget-seconds must be 60..3600")
+    if not 5 <= args.seed_ns <= 51 or not 1 <= args.seed_spans <= 8:
+        parser.error("seed-ns must be 5..51 and seed-spans 1..8")
+    if not 2 <= args.seed_mpol <= 8 or not 0 <= args.seed_ntor <= 8:
+        parser.error("seed-mpol must be 2..8 and seed-ntor 0..8")
+    if args.case == "shaped" and (args.seed_ns, args.seed_spans, args.seed_mpol, args.seed_ntor) != (9, 2, 3, 2):
+        parser.error("seed resolution flags apply to --case qa; the shaped seed is fixed")
     if not np.isfinite(args.damping) or args.damping <= 0:
         parser.error("damping must be finite and positive")
     def expired(*_):
-        raise TimeoutError("E2 600 s diagnostic budget")
+        raise TimeoutError(f"E2 {args.budget_seconds} s diagnostic budget")
     signal.signal(signal.SIGALRM, expired)
-    signal.alarm(600)
+    signal.alarm(args.budget_seconds)
     provenance = git_state(ROOT)
     provenance.update(vmex_module=assert_repo_vmex(vmex.__file__, ROOT),
                       python=platform.python_version(), platform=platform.system(),
                       versions={name: version(name) for name in ("jax", "jaxlib", "scipy", "numpy", "solvax")},
                       device=str(jax.devices()[0]), precision="float64")
     started = time.perf_counter()
-    output = {"_provenance": provenance, "case": "shaped tokamak, frozen iota/pressure, GAMMA=0",
+    seed = {"shaped": ("shaped tokamak, frozen iota/pressure, GAMMA=0",
+                       shaped_state),
+            "qa": (f"nfp2 QA smooth beta at mpol={args.seed_mpol} ntor={args.seed_ntor} "
+                   f"ns={args.seed_ns} spans={args.seed_spans}, frozen iota/pressure, GAMMA=0",
+                   lambda: qa_state(mpol=args.seed_mpol, ntor=args.seed_ntor,
+                                    ns=args.seed_ns, spans=args.seed_spans))}[args.case]
+    output = {"_provenance": provenance, "case": seed[0],
               "settings": {k: v for k, v in vars(args).items() if k != "output"}}
     try:
-        output["result"] = experiment(*shaped_state(), args.steps, args.order, args.angles, args.damping)
-        output["status"] = "completed diagnostic; QA and nonlinear convergence not established"
+        output["result"] = experiment(*seed[1](), args.steps, args.order, args.angles,
+                                      args.damping, args.planes)
+        output["status"] = ("completed bounded diagnostic at this resolution; "
+                            "nonlinear convergence and production promotion not established")
         if not output["result"]["verification_passed"]:
             raise RuntimeError("E2 reference consistency or geometry check failed")
     except Exception as error:

--- a/plan.md
+++ b/plan.md
@@ -190,7 +190,9 @@ attempts are saved as such.
   Jacobian memory. Measure assembly/factorization costs rather than extrapolating. Pass: the independent
   certificate improves by an order of magnitude on the QA target. Fail: the
   obstruction is representation, reachability or closure; no Krylov work
-  follows.
+  follows. **Result 2026-09-07: the shaped tokamak passes, QA does not.**
+  Converge the toroidal sampling before reading any QA number: six planes
+  under-resolves this nfp=2 deck and inverts the chart comparison.
 - **E3, variational Newton (one to two weeks, only if E1 passes).** Newton on
   `∂W/∂c = 0` with matrix-free Hessian products, MINRES or CG inner solves at
   Eisenstat–Walker forcing, the banded per-(m, n) preconditioner assembled
@@ -205,7 +207,9 @@ attempts are saved as such.
 
 **Decision tree.** If even the trusted dense step cannot improve the
 independent force, investigate representation, closure or admissibility and
-stop tuning Krylov iterations. If the dense step works but no iterative solve
+stop tuning Krylov iterations. **This branch is now taken for 3-D**: E2's QA
+run reaches 2.31x against a 10x gate, so representation, closure and
+admissibility come before any 3-D solver or chart replacement work. If the dense step works but no iterative solve
 does, the 3-D solver is dense LM with an explicit memory-bounded resolution
 cap. If E3 passes, it is the scalable mode and E2 the reference. If both work
 but cost is excessive, profile the demonstrated bottleneck. If the bounded QA
@@ -649,3 +653,33 @@ trajectories. Raw results and both attempts: sibling `vmex-e2-evidence`. The off
 versus maximum 3.7e8) does not alone reject Newton. SciPy supplies the independent diagnostic; SOLVAX's production GN remains
 unchanged. Next: affordable finite-beta QA reference and bounded convergence, then chart/solver integration. E2 is not passed
 for QA; E3, a1 routing, P0.4, fixed-current closure and release remain gated. Integration CI is pending.
+
+**2026-09-07, E2 on finite-beta 3-D QA.** Branch `research/e2-qa-reference`,
+base #288; clean measurement commit `e9412c93` (`measurement_dirty` false).
+`benchmarks/e2_dense_reference.py` gains a `qa_state` seed from
+`input.nfp2_QA_smooth_beta` and field-period sampling; one plane reproduces the
+axisymmetric grid and weights exactly, and the shaped case re-ran bit-identical
+(`188.549`/`335.256`, FD `1.575e-9`), so #288's numbers stand. Seed resolution
+is a flag because the representation is what E2 varies. CPU/JAX 0.9.2/float64,
+`--seed-ns 13 --order 8 --angles 32 --steps 5`; every run passed the script's
+own FD, Hessian-symmetry, QR/SVD and geometry gates.
+Toroidal convergence at 2 spans, full R/Z certificate gain: 1.373x (6 planes),
+2.291x (8), 2.302x (10), 2.306x (12), 2.306x (16). **Six planes under-resolves
+this nfp=2 deck**; readings below use 12. Radial refinement at 12 planes:
+2 spans (152 coordinates, initial 167752 N/m^3) 2.306x full versus 1.918x
+structured; 3 spans (187, 135583) 1.820x versus 1.588x; 4 spans (222, 128655)
+1.694x versus 1.515x. Structured columns are 112/137/162, so the chart drops
+26-28% of the constrained space, matching E1's rank finding in 3-D.
+Readings: retaining independent R/Z helps at every refinement, by 12-20%, so
+E1's reachability result holds in 3-D; refining radially lowers the initial
+force error but also lowers what a bounded step recovers; the minimum signed
+Jacobian stays 0.0094 at every seed, against 5.84 on the tokamak. **E2 is not
+passed on QA**: the best gain anywhere is 2.306x against the order-of-magnitude
+gate, so no chart replacement, E3 promotion or Krylov work is justified by this
+evidence. Next: representation, closure and admissibility, starting with the
+0.0094 seed geometry, not a solver. An earlier 6-plane sweep suggested the
+chart advantage vanished under radial refinement; that was an under-resolved
+artifact and is superseded by the 12-plane numbers above. Process RSS reached
+13.0 GiB at 4 spans / 8 planes while reference matrices stayed under 18 MiB, so
+the 2 GiB matrix budget does not bound the job. Raw JSON and logs: sibling
+`vmex-e2qa-evidence`.

--- a/plan.md
+++ b/plan.md
@@ -681,5 +681,11 @@ evidence. Next: representation, closure and admissibility, starting with the
 chart advantage vanished under radial refinement; that was an under-resolved
 artifact and is superseded by the 12-plane numbers above. Process RSS reached
 13.0 GiB at 4 spans / 8 planes while reference matrices stayed under 18 MiB, so
-the 2 GiB matrix budget does not bound the job. Raw JSON and logs: sibling
-`vmex-e2qa-evidence`.
+the 2 GiB matrix budget does not bound the job. The verdict is version
+independent: Python 3.12 with JAX/jaxlib 0.11.1, numpy 2.5.3 and scipy 1.18.1
+reproduces both 12-plane readings exactly (2.306x/1.918x and 1.694x/1.515x),
+and E1's Solov'ev work discrepancy comes back 8.014e-14 against the floor's
+7.931e-14, which is round-off at that magnitude. JAX 0.11 requires Python 3.12
+or newer, so the floor environment cannot install it; the persistent head
+environment is `~/local/venvs/vmex-head`. Raw JSON and logs, both versions:
+sibling `vmex-e2qa-evidence` (`floor/` and `head/`).


### PR DESCRIPTION
E2's dense reference could not decide the plan's QA gate: the shaped tokamak is axisymmetric, so the diagnostic sampled a single toroidal plane. This extends it to the finite-beta 3-D deck the plan names and records the verdict, which is negative and redirects P2.

**What changed.** A `qa_state` seed from `input.nfp2_QA_smooth_beta` with the same prescribed-iota, GAMMA=0 freeze as the shaped seed; field-period sampling on N planes, where one plane reproduces the axisymmetric grid and its quadrature weights exactly; seed resolution exposed as flags, because the representation is what E2 has to vary and the gate asks for at least three radial refinements and two angular resolutions. The wall-clock budget is now a flag, and the status string no longer claims more than a bounded result at the resolution actually run. The shaped case was re-run and is bit-identical (`188.549`/`335.256`, FD `1.575e-9`), so #288's published numbers stand.

**Converge the toroidal sampling before reading any QA number.** Full R/Z certificate gain at 2 spans: 1.373x (6 planes), 2.291x (8), 2.302x (10), 2.306x (12), 2.306x (16). Six planes under-resolves this nfp=2 deck and inverts the chart comparison; an earlier 6-plane sweep is recorded as superseded rather than dropped.

**Radial refinement at 12 planes**, full R/Z versus the production structured chart:

| seed | coordinates | structured | initial N/m^3 | full R/Z | structured | advantage |
|---|---|---|---|---|---|---|
| 2 spans | 152 | 112 | 167752 | 2.306x | 1.918x | 1.20 |
| 3 spans | 187 | 137 | 135583 | 1.820x | 1.588x | 1.15 |
| 4 spans | 222 | 162 | 128655 | 1.694x | 1.515x | 1.12 |

**Readings.** Retaining independent R/Z helps at every refinement, by 12 to 20 percent, so E1's reachability result holds in 3-D and the chart drops 26 to 28 percent of the constrained space here as it does axisymmetrically. Refining radially lowers the initial force error but also lowers what a bounded step recovers. The minimum signed Jacobian stays 0.0094 at every seed against 5.84 on the tokamak.

**E2 is not passed on QA.** The best gain anywhere is 2.306x against the order-of-magnitude gate, so no chart replacement, E3 promotion or Krylov work is justified by this evidence. The plan's decision tree now takes its representation, closure and admissibility branch, starting from that 0.0094 seed geometry rather than from a solver.

Validation: every run passed the script's own FD, Hessian-symmetry, QR/SVD-agreement and geometry gates. Clean measurement commit with `measurement_dirty` false. The verdict is version independent: a Python 3.12 / JAX 0.11.1 environment reproduces both 12-plane readings exactly, and E1's Solov'ev work discrepancy returns 8.014e-14 against the floor's 7.931e-14. JAX 0.11 requires Python 3.12 or newer, so the floor environment cannot install it at all. Ruff, prose gate and static preflight pass. Raw JSON and logs for both versions are in the sibling `vmex-e2qa-evidence` directory. Process RSS reached 13.0 GiB at 4 spans while reference matrices stayed under 18 MiB, so the 2 GiB matrix budget does not bound the job; that is recorded too. No production solver or SOLVAX algorithm changed, and no release is proposed.
