### PR TITLE
Say when the single-stage example misses its own targets

### DIFF
--- a/examples/optimization/single_stage_optimization.py
+++ b/examples/optimization/single_stage_optimization.py
@@ -291,6 +291,25 @@ print(f"Minimum coil-surface distance = {coil_surface_distance:.4f} m "
 print(f"Minimum coil-coil distance = {coil_distance:.4f} m (target >= {COIL_DISTANCE_LIMIT:.4f} m)")
 print(f"Maximum curvature = {maximum_curvature:.4f} 1/m (target <= {CURVATURE_LIMIT:.4f} 1/m)")
 
+# The coil metrics above are each printed against their limit; the plasma
+# targets were not, so a run that drove the coil terms down while leaving the
+# rotational transform near zero read as a success. A boundary with no
+# transform also makes the quasisymmetry residual trivially small, so report
+# both plasma targets explicitly and say plainly whether they were met.
+minimum_iota = float(opt.min_abs_iota(final_equilibrium.state, final_equilibrium.runtime))
+final_aspect = float(opt.aspect_ratio(final_equilibrium.state, final_equilibrium.runtime))
+print(f"Minimum |iota| = {minimum_iota:.4f} (target >= {IOTA_FLOOR:.4f})")
+print(f"Aspect ratio = {final_aspect:.4f} (target {ASPECT_TARGET:.4f})")
+unmet = []
+if minimum_iota < IOTA_FLOOR:
+    unmet.append(f"minimum |iota| {minimum_iota:.4f} below the {IOTA_FLOOR:.4f} floor")
+if normal_field_rms > NORMAL_FIELD_LIMIT:
+    unmet.append(f"B.n/B RMS {100 * normal_field_rms:.3f}% above {100 * NORMAL_FIELD_LIMIT:.1f}%")
+if unmet:
+    print("\nThis run did NOT meet its stated targets: " + "; ".join(unmet) + ".")
+    print("A lower weighted objective with an unmet target is not a design. "
+          "Raise the weight, reseed, or extend the budget before using it.")
+
 # Save results
 input_path = final_input.to_indata("input.single_stage_optimized")
 wout_path = vj.write_wout("wout_single_stage_optimized.nc", final_equilibrium.wout)

--- a/plan.md
+++ b/plan.md
@@ -689,3 +689,24 @@ and E1's Solov'ev work discrepancy comes back 8.014e-14 against the floor's
 or newer, so the floor environment cannot install it; the persistent head
 environment is `~/local/venvs/vmex-head`. Raw JSON and logs, both versions:
 sibling `vmex-e2qa-evidence` (`floor/` and `head/`).
+
+**2026-09-07, single-stage example does not meet its own targets.** Running
+`examples/optimization/single_stage_optimization.py` as shipped (CPU, JAX
+0.9.2, ESSOS at `1b3210c`, 92 L-BFGS-B iterations, 30 min) drives the weighted
+objective from 4.495e+02 to 1.177e+01 and prints a QA residual of 3.44e-02,
+yet the converged equilibrium has minimum `|iota|` 0.0181 against the example's
+own `IOTA_FLOOR` of 0.42, and aspect 5.29 against a target of 4.0. The
+objective history shows why: the coil normal-field term falls from 4.238e+02 to
+4.452e-01 and the aspect term from 1.926e+01 to 8.27e-01, while the iota-floor
+term rises from 5.897 to 8.038 and the QA term rises from 1.220e-03 to
+1.704e-02. A boundary with almost no rotational transform makes the
+quasisymmetry residual trivially small, which is the same degeneracy #266
+recorded for the free-boundary variant; here it appears in the fixed-boundary
+one. The example printed every coil metric beside its limit but printed
+`mean iota` with no target, so the run read as a success. It now reports
+minimum `|iota|` and aspect against their targets and says plainly when a
+target is unmet. The optimizer, objective weights and seed are unchanged: this
+records the behaviour rather than tuning it away. Whether the fix is a higher
+`IOTA_WEIGHT`, a transform-carrying seed or a constrained formulation is open,
+and it belongs with P3's application work, not with P2. Evidence:
+`~/local/vmex-single-stage-evidence`.


### PR DESCRIPTION
Running `examples/optimization/single_stage_optimization.py` as shipped produces a design that does not meet the example's own targets, and prints nothing to say so.

On CPU with JAX 0.9.2 and ESSOS at `1b3210c`, 92 L-BFGS-B iterations in about 30 minutes:

| quantity | start | end | target |
|---|---|---|---|
| weighted objective | 4.495e+02 | 1.177e+01 | lower |
| coil normal-field term | 4.238e+02 | 4.452e-01 | lower |
| aspect term | 1.926e+01 | 8.270e-01 | lower |
| iota-floor term | 5.897 | 8.038 | lower |
| QA term | 1.220e-03 | 1.704e-02 | lower |
| minimum `\|iota\|` | | 0.0181 | >= 0.42 |
| aspect | | 5.29 | 4.0 |

The optimizer drove the two dominant coil and aspect terms down while the iota floor and quasisymmetry both got worse. A boundary with almost no rotational transform makes the quasisymmetry residual trivially small, so a small QA number there means little. This is the same degeneracy [#266](https://github.com/uwplasma/vmex/pull/266) recorded for the free-boundary variant, appearing here in the fixed-boundary one.

The example already printed every coil metric beside its limit, `B.n/B` against its percentage, coil-surface and coil-coil distance against theirs, curvature against its cap. It printed `mean iota` with no target at all, so a reader saw `mean iota = 0.0196` with nothing to compare it against and the run read as a success.

This adds minimum `|iota|` and aspect reported against their targets, and an explicit statement when a target is unmet, in the same style as the coil lines. Nothing else changes: the optimizer, the objective weights and the seed are untouched, so this records the behaviour rather than tuning it away. Whether the remedy is a larger `IOTA_WEIGHT`, a transform-carrying seed or a constrained formulation is open and belongs with the application work, not with the force-balance experiments.

The plan's logbook records the run, the objective history and the reading. Raw log, objective history, final `wout` and the optimization movie are in `~/local/vmex-single-stage-evidence`.

Validation: ruff, prose and media gates, static preflight and the example's contract test pass. The new reporting was exercised against the equilibrium the run actually produced, printing minimum `|iota|` 0.0181 against the 0.42 floor.
