### PR TITLE
Let the logbook ride along without forcing every CI lane

### DIFF
--- a/tests/test_test_manifest.py
+++ b/tests/test_test_manifest.py
@@ -51,6 +51,21 @@ def test_ci_scope_narrows_lanes_only_for_attributable_changes() -> None:
     # Data files under a narrowable prefix need no numerical lane.
     assert ci_scope.needed_lanes(["docs/_static/figures/figures.json"]) == set()
 
+    # Root prose is narrowable wherever it lives, because the logbook rides
+    # along with almost every change and cannot alter what the package
+    # computes. It still runs the lanes owning the guards that read it.
+    plan_lanes = ci_scope.needed_lanes(["plan.md"])
+    assert plan_lanes is not None and "pr-parity-c2" in plan_lanes
+    assert ci_scope.needed_lanes(["README.md"]) is not None
+    mixed = ci_scope.needed_lanes(
+        ["examples/optimization/single_stage_optimization.py", "plan.md"]
+    )
+    assert mixed is not None and mixed >= plan_lanes, (
+        "a change carrying the logbook must still run the logbook's guards"
+    )
+    # Prose alongside package code keeps the full matrix.
+    assert ci_scope.needed_lanes(["vmex/core/solver.py", "plan.md"]) is None
+
 
 def test_ci_scope_skips_only_documentation_and_rendered_media() -> None:
     assert ci_scope.classify(

--- a/tools/ci_scope.py
+++ b/tools/ci_scope.py
@@ -64,6 +64,19 @@ NARROWABLE_PREFIXES = ("tests/", "benchmarks/", "examples/", "docs/")
 _IMPORTS = re.compile(r"^\s*(?:from|import)\s+(benchmarks|examples)\b", re.MULTILINE)
 
 
+def _is_narrowable(path: str) -> bool:
+    """Whether ``path`` can be attributed to particular lanes.
+
+    Documentation is narrowable wherever it sits, including the root files the
+    logbook and README live in: prose cannot change what the package computes,
+    only what the documentation guards read. Everything else must sit under a
+    tree the package does not import.
+    """
+    return path.startswith(NARROWABLE_PREFIXES) or any(
+        path.lower().endswith(suffix) for suffix in DOCUMENTATION_SUFFIXES
+    )
+
+
 def _owning_lanes(modules: Iterable[str], manifest: dict) -> set[str]:
     """PR lanes that own any of ``modules``, by the manifest's own ownership."""
     wanted = set(modules)
@@ -82,11 +95,12 @@ def _tests_referencing(paths: Iterable[str], root: Path) -> set[str]:
     for helpers, and a literal path for scripts they execute. Missing either
     would silently drop a lane, so both are matched.
     """
-    targets = [path for path in paths if path.endswith(".py")]
+    targets = list(paths)
     if not targets:
         return set()
-    packages = {path.split("/", 1)[0] for path in targets}
-    stems = {Path(path).stem for path in targets}
+    packages = {path.split("/", 1)[0] for path in targets if path.endswith(".py")}
+    stems = {Path(path).name for path in targets}
+    stems |= {Path(path).stem for path in targets if path.endswith(".py")}
     found = set()
     for path in sorted((root / "tests").rglob("test_*.py")):
         text = path.read_text(encoding="utf-8", errors="ignore")
@@ -105,7 +119,7 @@ def needed_lanes(paths: Iterable[str], *, manifest=None, root=None) -> set[str] 
     """
     root = Path(root) if root is not None else ROOT
     changed = tuple(path.strip("/") for path in paths if path.strip("/"))
-    if not changed or not all(path.startswith(NARROWABLE_PREFIXES) for path in changed):
+    if not changed or not all(_is_narrowable(path) for path in changed):
         return None
     if manifest is None:
         manifest = json.loads((root / "tests" / "manifest.json").read_text(encoding="utf-8"))
@@ -113,7 +127,9 @@ def needed_lanes(paths: Iterable[str], *, manifest=None, root=None) -> set[str] 
     modules = {path for path in changed if path.startswith("tests/") and path.endswith(".py")}
     scripts = [path for path in changed
                if path.startswith(("benchmarks/", "examples/")) and path.endswith(".py")]
-    modules |= _tests_referencing(scripts, root)
+    documents = [path for path in changed
+                 if any(path.lower().endswith(suffix) for suffix in DOCUMENTATION_SUFFIXES)]
+    modules |= _tests_referencing(scripts + documents, root)
     unattributed = [path for path in changed
                     if path.endswith(".py") and path not in modules
                     and path not in scripts]


### PR DESCRIPTION
The lane narrowing merged in #290 only applied to paths under `tests/`, `benchmarks/`, `examples/` and `docs/`, so any root file fell back to the full matrix. The logbook is a root file that almost every change carries: #291 ran all sixteen lanes to add one print statement and a plan entry.

Documentation is now narrowable wherever it sits. Prose cannot change what the package computes, only what the documentation guards read, and those guards are owned by lanes like any other test. `plan.md`, `README.md` and `CHANGELOG.md` are read by tests in `pr-fast`, `pr-parity-c1` and `pr-parity-c2`, so a change carrying them still runs exactly those. Attribution now matches full file names as well as module stems, so a figure or a data file finds its guards too.

Measured on the same changes:

| change | lanes before | lanes now |
|---|---|---|
| `plan.md` alone | 16 | 0, the documentation-only path already skipped the test jobs |
| example plus `plan.md` (#291) | 16 | 2 |
| benchmark plus `plan.md` | 16 | 3 |
| `README.md` plus the figure manifest | 16 | 2 |
| package code, tooling, workflow | 16 | 16 |
| package code plus `plan.md` | 16 | 16 |

The conservative direction is unchanged: anything the manifest cannot attribute, and any change that also touches package code, tooling, workflows or packaging, keeps every lane. A miss costs runner time and never coverage.

Validation: ruff, prose and media gates, static preflight, and 27 tests across the manifest and cited-path guards, including new assertions that root prose is narrowable, that a change carrying the logbook still runs the logbook's guards, and that prose alongside package code keeps the full matrix.