### PR TITLE
Test whether the radial knots belong in rho, and report that they do not

### DIFF
--- a/benchmarks/knot_grading.py
+++ b/benchmarks/knot_grading.py
@@ -1,0 +1,338 @@
+"""Where the radial spline knots belong: uniform in ``s`` or uniform in ``rho``.
+
+``benchmarks/residual_vs_resolution.py`` measured the continuum residual of one
+converged ``input.DSHAPE`` solve against the number of spline spans, with
+breakpoints uniform in the flux label ``s``.  Refinement helped the edge and hurt
+the axis: near-axis volume L2 rose monotonically from 1.0e3 to 1.3e4 N m^-3
+between four and twelve spans while the edge fell from 1.3e7 to 5.1e2.
+
+The representation is written ``rho^|m| q(s)`` with ``rho = sqrt(s)``
+(``radial_basis.evaluate_regularized_mode``), and ``q`` is a clamped B-spline
+whose *breakpoints are in* ``s`` (``BSplineBasis.clamped``).  Breakpoints uniform
+in ``s`` are therefore sparse in ``rho`` near the axis: the first span of a
+four-span basis covers ``s`` in ``[0, 0.25]``, which is the inner half of the
+minor radius.  Grading them so they are uniform in ``rho`` -- breakpoints
+``linspace(0, 1, spans + 1) ** 2`` in ``s`` -- moves spline freedom inward at an
+identical coefficient count, since a clamped degree-``p`` basis on ``k`` spans has
+``k + p`` coefficients whatever the breakpoint spacing.
+
+This script lifts one converged solve onto both bases at matched coefficient
+counts and certifies each with ``certify_strong_force``, at two quadrature
+settings, reporting the near-axis, bulk, edge and total dimensional L2 and both
+published normalizations, as ``residual_vs_resolution.py`` does.
+
+Read the region splits with the grid in view.  ``certify_strong_force`` places
+Gauss-Legendre nodes per spline span of the state's own basis, so the two
+gradings are certified on different grids: the near-axis region ``rho < 0.2`` is
+a masked sub-interval of one wide span under uniform-``s`` breakpoints and a
+whole span or more under graded ones.  Every row therefore carries its per-region
+node counts, the smallest sampled ``rho``, the certificate's own
+``radial_refinement_difference``, and the change in each region between the two
+quadrature settings.  A region whose value moves under quadrature refinement
+reports the grid, not the representation.
+
+This is a measurement of one representation choice on the decks named in the
+output, not a claim about any other code or resolution.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import replace
+from importlib.metadata import version
+import json
+from pathlib import Path
+import platform
+import resource
+import signal
+import sys
+import time
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import jax
+import numpy as np
+
+import vmex
+from benchmarks._provenance import assert_repo_vmex, git_state
+from vmex.core.radial_basis import BSplineBasis
+from vmex.core.strong_force import certify_strong_force, lift_high_order_state
+
+DECKS = {
+    "dshape": "input.DSHAPE",
+    "tokamak": "input.shaped_tokamak_pressure_polished",
+    "qa": "input.nfp2_QA_smooth_beta",
+}
+
+GRADINGS = ("uniform_s", "rho_graded")
+
+# certify_strong_force splits on rho, not s; keep the same edges here so the
+# reported node counts describe exactly the regions the report sums over.
+NEAR_AXIS_RHO = 0.2
+EDGE_RHO = 0.8
+
+
+def breakpoints(spans: int, grading: str, exponent: float) -> np.ndarray:
+    """Spline breakpoints in ``s`` for one grading.
+
+    ``uniform_s`` is the existing convention.  ``rho_graded`` places the same
+    number of breakpoints uniformly in ``rho = s ** (1 / exponent)``, which for
+    the default ``exponent = 2`` is uniform in the square root of the flux label.
+    Both start at 0 and end at 1, so the fixed boundary and the axis limit are
+    untouched and only the interior spacing differs.
+    """
+    uniform = np.linspace(0.0, 1.0, spans + 1)
+    if grading == "uniform_s":
+        return uniform
+    if grading == "rho_graded":
+        return uniform**exponent
+    raise ValueError(f"unknown grading {grading!r}")
+
+
+def _certificate(state, *, angular_multiplier, radial_increment):
+    """Both published normalizations, the dimensional L2, and where the error sits."""
+    report = certify_strong_force(
+        state, angular_multiplier=angular_multiplier,
+        radial_order_increment=radial_increment)
+    window = report.window_normalizations
+    whole = report.global_normalizations
+    rho = np.asarray(report.radial_nodes, dtype=float)
+    return {
+        "absolute_l2": float(report.absolute_l2),
+        "absolute_linf": float(report.absolute_linf),
+        "near_axis_l2": float(report.near_axis_l2),
+        "bulk_l2": float(report.bulk_l2),
+        "edge_l2": float(report.edge_l2),
+        "minimum_signed_jacobian": float(report.minimum_signed_jacobian),
+        "radial_refinement_difference": float(report.radial_refinement_difference),
+        "boundary_residual": float(report.boundary_residual),
+        "pressure_normalized": {
+            "whole_volume": float(whole.relative_force_error),
+            "window": float(window.relative_force_error),
+        },
+        "magnetic_normalized": {
+            "whole_volume": float(whole.magnetic_relative_force_error),
+            "window": float(window.magnetic_relative_force_error),
+        },
+        "window": {"s_min": float(window.s_min), "s_max": float(window.s_max),
+                   "nodes": int(window.node_count)},
+        # The certificate's radial grid follows the state's own breakpoints, so
+        # the region splits are only comparable across gradings where they are
+        # quadrature converged.  These counts say how thin the estimate is.
+        "grid": {
+            "radial_nodes": int(rho.size),
+            "near_axis_nodes": int(np.count_nonzero(rho < NEAR_AXIS_RHO)),
+            "bulk_nodes": int(np.count_nonzero((rho >= NEAR_AXIS_RHO) & (rho <= EDGE_RHO))),
+            "edge_nodes": int(np.count_nonzero(rho > EDGE_RHO)),
+            "minimum_rho": float(rho.min()),
+            "maximum_rho": float(rho.max()),
+        },
+    }
+
+
+def _solved(deck, ns, mpol, ntor):
+    """One converged VMEC-lane solve at this radial mesh, reused by every basis."""
+    from vmex.core import implicit
+    from vmex.core.input import VmecInput
+
+    inp = VmecInput.from_file(ROOT / "examples/data" / deck)
+    if mpol is not None:
+        inp = inp.change_resolution(mpol=mpol, ntor=ntor, ntheta=2 * mpol + 6,
+                                    nzeta=max(4, 2 * ntor + 2))
+    inp = replace(inp, ns_array=np.asarray([ns]), ftol_array=np.asarray([1.0e-12]),
+                  niter_array=np.asarray([8000]))
+    config = implicit.make_config(inp, ftol=1.0e-12, max_iterations=8000)
+    params = implicit.params_from_input(inp)
+    started = time.perf_counter()
+    state, _mask = implicit.solve_implicit_with_aux(params, config)
+    seconds = time.perf_counter() - started
+    return state, implicit.runtime_from_params(params, config), seconds
+
+
+REGIONS = ("absolute_l2", "near_axis_l2", "bulk_l2", "edge_l2")
+
+
+def _drift(coarse, fine):
+    """Relative change of each region between two quadrature settings."""
+    return {key: abs(fine[key] - coarse[key]) / max(fine[key], 1.0e-300)
+            for key in REGIONS}
+
+
+def _source_support(basis, s_full):
+    """How many VMEC full-mesh samples land in each span, and in the fit at all.
+
+    ``lift_high_order_state`` fits the spline by unregularized least squares on
+    the solve's own ``s`` mesh, dropping ``s = 0`` for every ``m > 0`` mode.  A
+    span holding no interior sample contributes columns the data cannot
+    determine, so the fitted coefficients there are whatever the minimum-norm
+    solution supplies rather than a property of the equilibrium.  This is the
+    variable that separates a representation result from a fitting artefact, so
+    it is recorded beside every certificate.
+    """
+    edges = np.asarray(basis.breakpoints, dtype=float)
+    s_full = np.asarray(s_full, dtype=float)
+    interior = s_full[(s_full > 0.0) & (s_full < 1.0)]
+    per_span = [int(np.count_nonzero((interior >= lo) & (interior < hi)))
+                for lo, hi in zip(edges[:-1], edges[1:], strict=False)]
+    positive = s_full[s_full > 1.0e-10]
+    return {
+        "samples_per_span": per_span,
+        "minimum_samples_per_span": int(min(per_span)),
+        "empty_spans": int(sum(1 for count in per_span if count == 0)),
+        "fit_rows_m_positive": int(positive.size),
+        "fit_columns": int(basis.size),
+    }
+
+
+def grading_scan(deck, ns, span_counts, degree, mpol, ntor, quadratures, exponent):
+    """Certify both gradings at every span count and every quadrature setting."""
+    state, runtime, seconds = _solved(deck, ns, mpol, ntor)
+    s_full = np.asarray(runtime.setup.s_full, dtype=float)
+    rows = []
+    for spans in span_counts:
+        sizes = set()
+        by_grading = {}
+        for grading in GRADINGS:
+            basis = BSplineBasis.clamped(breakpoints(spans, grading, exponent),
+                                         degree=degree)
+            sizes.add(int(basis.size))
+            native = lift_high_order_state(state, runtime, radial_basis=basis)
+            certificates = {}
+            for angular, increment in quadratures:
+                certificates[f"angular{angular}_increment{increment}"] = _certificate(
+                    native, angular_multiplier=angular, radial_increment=increment)
+            coarse, fine = (certificates[f"angular{a}_increment{i}"]
+                            for a, i in (quadratures[0], quadratures[-1]))
+            by_grading[grading] = {
+                "breakpoints_s": [float(v) for v in basis.breakpoints],
+                "coefficients_per_mode": int(basis.size),
+                "coefficients": int(np.asarray(native.R_cos).size),
+                "source_support": _source_support(basis, s_full),
+                "certificates": certificates,
+                "quadrature_drift": _drift(coarse, fine) if len(quadratures) > 1 else None,
+            }
+            print(json.dumps({"spans": spans, "grading": grading,
+                              "absolute_l2": fine["absolute_l2"],
+                              "near_axis_l2": fine["near_axis_l2"]}), flush=True)
+        if len(sizes) != 1:
+            raise RuntimeError(f"coefficient counts not matched at {spans} spans: {sizes}")
+        finest = f"angular{quadratures[-1][0]}_increment{quadratures[-1][1]}"
+        uniform = by_grading["uniform_s"]["certificates"][finest]
+        graded = by_grading["rho_graded"]["certificates"][finest]
+        rows.append({
+            "spans": int(spans),
+            "degree": int(degree),
+            "coefficients_per_mode": sizes.pop(),
+            "gradings": by_grading,
+            # Below one, the graded basis is the smaller residual.
+            "graded_over_uniform": {
+                key: graded[key] / max(uniform[key], 1.0e-300) for key in REGIONS},
+        })
+    return {"ns": int(ns), "solve_seconds": seconds, "rows": rows}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--deck", choices=sorted(DECKS), default="dshape")
+    parser.add_argument("--ns", type=int, default=17,
+                        help="radial mesh of the single converged solve")
+    parser.add_argument("--spans", default="4,6,8,10",
+                        help="spline span counts; both gradings run at each")
+    parser.add_argument("--degree", type=int, default=3)
+    parser.add_argument("--grading-exponent", type=float, default=2.0,
+                        help="graded breakpoints are linspace(0,1,k+1) ** exponent")
+    parser.add_argument("--quadratures", default="2:2,4:8",
+                        help="certificate settings as angular:radial_increment pairs")
+    parser.add_argument("--mpol", type=int)
+    parser.add_argument("--ntor", type=int)
+    parser.add_argument("--budget-seconds", type=int, default=600)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    spans = [int(v) for v in args.spans.split(",") if v]
+    try:
+        quadratures = [tuple(int(part) for part in pair.split(":"))
+                       for pair in args.quadratures.split(",") if pair]
+    except ValueError:
+        parser.error("quadratures must be angular:radial_increment pairs")
+    if not jax.config.x64_enabled:
+        parser.error("require float64")
+    if not 5 <= args.ns <= 201:
+        parser.error("ns must be 5..201")
+    if not spans or any(v < 1 or v > 12 for v in spans):
+        parser.error("span counts must be 1..12")
+    if len(set(spans)) != len(spans):
+        parser.error("span counts must be distinct")
+    if args.degree not in (3, 5, 7):
+        parser.error("degree must be 3, 5 or 7")
+    if not 1.0 <= args.grading_exponent <= 4.0:
+        parser.error("grading-exponent must be 1.0..4.0")
+    if not quadratures or any(len(pair) != 2 for pair in quadratures):
+        parser.error("quadratures must be angular:radial_increment pairs")
+    if any(not 1 <= a <= 8 or not 0 <= i <= 12 for a, i in quadratures):
+        parser.error("angular multipliers must be 1..8 and radial increments 0..12")
+    if not 60 <= args.budget_seconds <= 1800:
+        parser.error("budget-seconds must be 60..1800")
+    if (args.mpol is None) != (args.ntor is None):
+        parser.error("set both --mpol and --ntor, or neither")
+
+    def expired(*_):
+        raise TimeoutError(f"knot grading scan {args.budget_seconds} s budget")
+
+    signal.signal(signal.SIGALRM, expired)
+    signal.alarm(args.budget_seconds)
+
+    provenance = git_state(ROOT)
+    provenance.update(
+        vmex_module=assert_repo_vmex(vmex.__file__, ROOT),
+        python=platform.python_version(), platform=platform.system(),
+        versions={name: version(name) for name in ("jax", "jaxlib", "numpy", "scipy", "solvax")},
+        device=str(jax.devices()[0]), precision="float64")
+    started = time.perf_counter()
+    output = {
+        "_provenance": provenance,
+        "deck": DECKS[args.deck],
+        "settings": {k: v for k, v in vars(args).items() if k != "output"},
+        "definitions": {
+            "uniform_s": "breakpoints linspace(0, 1, spans + 1) in s, the existing convention",
+            "rho_graded": "breakpoints linspace(0, 1, spans + 1) ** exponent in s, "
+                          "so they are uniform in rho = sqrt(s) at exponent 2",
+            "matched": "a clamped degree-p basis on k spans has k + p coefficients per "
+                       "mode whatever the spacing, so the two arms are compared at "
+                       "identical coefficient counts",
+            "absolute_l2": "volume-weighted RMS of |J x B - grad p|, N m^-3",
+            "pressure_normalized": "<|F|>/<|grad p|>, Panici et al. 2023",
+            "magnetic_normalized": "<|F|>/<|grad(B^2/2 mu0)|>, Thun et al. 2026",
+            "graded_over_uniform": "ratio at the finest quadrature; below 1 the graded "
+                                   "basis is the smaller residual",
+            "quadrature_drift": "relative change of each region between the coarsest and "
+                                "finest quadrature setting; a large value means that "
+                                "region reports the grid rather than the representation",
+            "grid": "the certificate samples per span of the state's own basis, so the "
+                    "two gradings are certified on different node sets; the counts say "
+                    "how many nodes each region estimate rests on",
+            "source_support": "VMEC full-mesh samples available to the least-squares "
+                              "lift in each span; an empty span means the fit there is "
+                              "determined by the minimum-norm solution, not by the data",
+        },
+    }
+    try:
+        output["scan"] = grading_scan(
+            DECKS[args.deck], args.ns, spans, args.degree, args.mpol, args.ntor,
+            quadratures, args.grading_exponent)
+        output["status"] = ("measured at these resolutions on this deck; no trend is "
+                            "extrapolated beyond them and no cross-code claim is made")
+    except Exception as error:
+        output["status"] = f"{type(error).__name__}: {error}"
+        raise
+    finally:
+        signal.alarm(0)
+        output["seconds"] = time.perf_counter() - started
+        output["peak_rss_MiB"] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / (
+            1024**2 if platform.system() == "Darwin" else 1024)
+        args.output.write_text(json.dumps(output, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/residual_vs_resolution.py
+++ b/benchmarks/residual_vs_resolution.py
@@ -1,0 +1,232 @@
+"""Continuum force residual against resolution, in the norms other codes publish.
+
+A small ``FSQR`` says the discrete solve converged; it does not bound the
+continuum residual ``J x B - grad p``. This measures that residual on the
+independent certificate as resolution rises, along the two axes VMEX can
+refine separately:
+
+* the VMEC lane's radial mesh, ``ns``, at fixed Fourier resolution;
+* the continuous representation's spline count, at a fixed converged solve.
+
+Both are reported in the two published normalizations so the numbers are
+comparable outside this repository: ``<|F|>/<|grad p|>`` of Panici, Conlin,
+Dudt, Unalmis and Kolemen, *J. Plasma Phys.* **89** (2023) 955890303, and
+``<|F|>/<|grad(B^2/2 mu0)|>`` of Thun, Merlo, Conlin, Panici and Boeckenhoff,
+*Nucl. Fusion* **66** (2026), which stays finite in vacuum. The dimensional
+volume L2 is carried beside them because no normalization can hide it, and the
+near-axis, bulk and edge splits are carried because VMEC's error concentrates
+at the axis.
+
+This is a measurement, not a claim about another code: DESC and VMEC++ points
+belong on the same axes only when produced under the same contract, which is
+recorded per run rather than assumed.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import replace
+from importlib.metadata import version
+import json
+from pathlib import Path
+import platform
+import resource
+import signal
+import sys
+import time
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import jax
+import numpy as np
+
+import vmex
+from benchmarks._provenance import assert_repo_vmex, git_state
+from vmex.core.radial_basis import BSplineBasis
+from vmex.core.strong_force import certify_strong_force, lift_high_order_state
+
+DECKS = {
+    "dshape": "input.DSHAPE",
+    "tokamak": "input.shaped_tokamak_pressure_polished",
+    "qa": "input.nfp2_QA_smooth_beta",
+}
+
+
+def _certificate(state, *, angular_multiplier, radial_increment):
+    """Both published normalizations, the dimensional L2, and where the error sits."""
+    report = certify_strong_force(
+        state, angular_multiplier=angular_multiplier,
+        radial_order_increment=radial_increment)
+    window = report.window_normalizations
+    whole = report.global_normalizations
+    return {
+        "absolute_l2": float(report.absolute_l2),
+        "absolute_linf": float(report.absolute_linf),
+        "near_axis_l2": float(report.near_axis_l2),
+        "bulk_l2": float(report.bulk_l2),
+        "edge_l2": float(report.edge_l2),
+        "minimum_signed_jacobian": float(report.minimum_signed_jacobian),
+        "radial_refinement_difference": float(report.radial_refinement_difference),
+        "pressure_normalized": {
+            "whole_volume": float(whole.relative_force_error),
+            "window": float(window.relative_force_error),
+        },
+        "magnetic_normalized": {
+            "whole_volume": float(whole.magnetic_relative_force_error),
+            "window": float(window.magnetic_relative_force_error),
+        },
+        "window": {"s_min": float(window.s_min), "s_max": float(window.s_max),
+                   "nodes": int(window.node_count)},
+    }
+
+
+def _solved(deck, ns, mpol, ntor):
+    """One converged VMEC-lane solve at this radial mesh."""
+    from vmex.core import implicit
+    from vmex.core.input import VmecInput
+
+    inp = VmecInput.from_file(ROOT / "examples/data" / deck)
+    if mpol is not None:
+        inp = inp.change_resolution(mpol=mpol, ntor=ntor, ntheta=2 * mpol + 6,
+                                    nzeta=max(4, 2 * ntor + 2))
+    inp = replace(inp, ns_array=np.asarray([ns]), ftol_array=np.asarray([1.0e-12]),
+                  niter_array=np.asarray([8000]))
+    config = implicit.make_config(inp, ftol=1.0e-12, max_iterations=8000)
+    params = implicit.params_from_input(inp)
+    started = time.perf_counter()
+    state, mask = implicit.solve_implicit_with_aux(params, config)
+    seconds = time.perf_counter() - started
+    return state, mask, implicit.runtime_from_params(params, config), seconds
+
+
+def radial_scan(deck, mesh, span_counts, degree, mpol, ntor, angular, radial_increment):
+    """Certificate against the VMEC lane's radial mesh.
+
+    A lift held fixed while ``ns`` rises measures the basis, not the solve: a
+    finer solution carries radial structure a coarse spline basis cannot
+    represent, and the certificate then reports that projection error. Every
+    mesh point is therefore certified at two lift resolutions, and the pair is
+    reported so a reader can see whether the number is lift-limited.
+    """
+    rows = []
+    for ns in mesh:
+        state, _, runtime, seconds = _solved(deck, ns, mpol, ntor)
+        lifts = {}
+        for spans in span_counts:
+            basis = BSplineBasis.clamped(np.linspace(0, 1, spans + 1), degree=degree)
+            native = lift_high_order_state(state, runtime, radial_basis=basis)
+            lifts[str(spans)] = _certificate(
+                native, angular_multiplier=angular, radial_increment=radial_increment)
+        coarse, fine = (lifts[str(v)] for v in (min(span_counts), max(span_counts)))
+        drift = abs(fine["absolute_l2"] - coarse["absolute_l2"]) / max(
+            fine["absolute_l2"], 1.0e-300)
+        row = {"ns": int(ns), "solve_seconds": seconds, "lift_degree": degree,
+               "lifts": lifts, "finest_spans": max(span_counts),
+               "lift_convergence_difference": drift,
+               "lift_limited": bool(drift > 0.1),
+               "absolute_l2": fine["absolute_l2"]}
+        rows.append(row)
+        print(json.dumps({"axis": "ns", "ns": row["ns"],
+                          "absolute_l2": row["absolute_l2"],
+                          "lift_limited": row["lift_limited"]}), flush=True)
+    return rows
+
+
+def spline_scan(deck, ns, span_counts, degree, mpol, ntor, angular, radial_increment):
+    """Certificate against the continuous representation, at one converged solve."""
+    state, _, runtime, seconds = _solved(deck, ns, mpol, ntor)
+    rows = []
+    for spans in span_counts:
+        basis = BSplineBasis.clamped(np.linspace(0, 1, spans + 1), degree=degree)
+        native = lift_high_order_state(state, runtime, radial_basis=basis)
+        row = {"ns": int(ns), "solve_seconds": seconds, "lift_spans": int(spans),
+               "lift_degree": degree,
+               "coefficients": int(np.asarray(native.R_cos).size)}
+        row.update(_certificate(native, angular_multiplier=angular,
+                                radial_increment=radial_increment))
+        rows.append(row)
+        print(json.dumps({"axis": "spans", **{k: row[k] for k in ("lift_spans", "absolute_l2")}}),
+              flush=True)
+    return rows
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--deck", choices=sorted(DECKS), default="dshape")
+    parser.add_argument("--mesh", default="9,17,25,33",
+                        help="ns values for the radial scan")
+    parser.add_argument("--spans", default="2,3,4,6",
+                        help="spline span counts for the representation scan")
+    parser.add_argument("--lift-spans", type=int, default=4,
+                        help="spans held fixed while ns varies")
+    parser.add_argument("--degree", type=int, default=3)
+    parser.add_argument("--mpol", type=int)
+    parser.add_argument("--ntor", type=int)
+    parser.add_argument("--angular", type=int, default=2)
+    parser.add_argument("--radial-increment", type=int, default=2)
+    parser.add_argument("--budget-seconds", type=int, default=3600)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    mesh = [int(v) for v in args.mesh.split(",") if v]
+    spans = [int(v) for v in args.spans.split(",") if v]
+    if not jax.config.x64_enabled:
+        parser.error("require float64")
+    if not mesh or any(n < 5 or n > 201 for n in mesh):
+        parser.error("mesh values must be 5..201")
+    if not spans or any(v < 1 or v > 12 for v in spans):
+        parser.error("span counts must be 1..12")
+    if args.degree not in (3, 5, 7):
+        parser.error("degree must be 3, 5 or 7")
+    if not 60 <= args.budget_seconds <= 21600:
+        parser.error("budget-seconds must be 60..21600")
+    if (args.mpol is None) != (args.ntor is None):
+        parser.error("set both --mpol and --ntor, or neither")
+
+    def expired(*_):
+        raise TimeoutError(f"residual scan {args.budget_seconds} s budget")
+
+    signal.signal(signal.SIGALRM, expired)
+    signal.alarm(args.budget_seconds)
+
+    provenance = git_state(ROOT)
+    provenance.update(
+        vmex_module=assert_repo_vmex(vmex.__file__, ROOT),
+        python=platform.python_version(), platform=platform.system(),
+        versions={name: version(name) for name in ("jax", "jaxlib", "numpy", "scipy", "solvax")},
+        device=str(jax.devices()[0]), precision="float64")
+    started = time.perf_counter()
+    output = {
+        "_provenance": provenance,
+        "deck": DECKS[args.deck],
+        "settings": {k: v for k, v in vars(args).items() if k != "output"},
+        "normalizations": {
+            "pressure_normalized": "<|F|>/<|grad p|>, Panici et al. 2023",
+            "magnetic_normalized": "<|F|>/<|grad(B^2/2 mu0)|>, Thun et al. 2026",
+            "absolute_l2": "volume-weighted RMS of |J x B - grad p|, N m^-3",
+            "lift_limited": "the two lift resolutions disagree by more than 10%, so "
+                            "the number reports the basis rather than the solve",
+        },
+    }
+    try:
+        output["radial_scan"] = radial_scan(
+            DECKS[args.deck], mesh, sorted({args.lift_spans, max(spans)}),
+            args.degree, args.mpol, args.ntor, args.angular, args.radial_increment)
+        output["spline_scan"] = spline_scan(
+            DECKS[args.deck], max(mesh), spans, args.degree, args.mpol, args.ntor,
+            args.angular, args.radial_increment)
+        output["status"] = ("measured at these resolutions; no cross-code claim is "
+                            "made and no trend is extrapolated beyond them")
+    except Exception as error:
+        output["status"] = f"{type(error).__name__}: {error}"
+        raise
+    finally:
+        output["seconds"] = time.perf_counter() - started
+        output["peak_rss_MiB"] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / (
+            1024**2 if platform.system() == "Darwin" else 1024)
+        args.output.write_text(json.dumps(output, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this measures

`benchmarks/residual_vs_resolution.py` (#293) found that refining the radial
spline basis of one converged `input.DSHAPE` solve with breakpoints uniform in
`s` improves the edge and degrades the axis. The hypothesis under test was that
uniform-in-`s` knots starve the axis of spline freedom — the first span of a
four-span basis covers `s` in `[0, 0.25]`, the inner half of the minor radius —
and that grading them uniformly in `rho = sqrt(s)`, i.e. breakpoints
`linspace(0, 1, k+1) ** 2` in `s`, would lower the near-axis residual at an equal
coefficient count.

**The hypothesis does not hold. It is refuted in the opposite direction:**
moving spline freedom toward the axis makes the near-axis residual *worse*,
monotonically in the strength of the grading, on both decks tested, while it
improves the edge. `benchmarks/knot_grading.py` is the bounded diagnostic that
shows it.

Convention confirmed by reading, not assumed: `evaluate_regularized_mode`
evaluates `rho^|m| q(s)` with `q` a clamped B-spline whose breakpoints are in
`s` (`radial_basis.py:395-432`, `BSplineBasis.clamped`). A clamped degree-`p`
basis on `k` spans has `k + p` coefficients per mode whatever the spacing, so
the two arms are compared at identical coefficient counts; the script asserts
this rather than trusting it.

## Result: `input.DSHAPE`, ns=17, degree 3, fine quadrature (angular 4, radial increment 8)

Dimensional volume L2 of `J x B - grad p`, N m^-3. `min J` is the smallest
signed Jacobian on the certificate grid; `empty` is the number of spline spans
containing no VMEC full-mesh sample.

| spans | coeff/mode | grading | near-axis | bulk | edge | total | min J | empty |
|---|---|---|---|---|---|---|---|---|
| 4 | 7 | uniform_s | **1003** | 4345 | 1.347e+07 | 7.870e+06 | 0.738 | 0 |
| 4 | 7 | rho_graded | 1.111e+11 | 2.710e+04 | 2.508e+06 | 2.213e+10 | 0.0118 | 1 |
| 6 | 9 | uniform_s | **1300** | 1166 | 1.832e+04 | 1.051e+04 | 2.874 | 0 |
| 6 | 9 | rho_graded | 1.003e+11 | 715.7 | 4544 | 2.158e+10 | 0.0124 | 1 |
| 8 | 11 | uniform_s | **1916** | 527.1 | 2514 | 1551 | 2.895 | 0 |
| 8 | 11 | rho_graded | 1.512e+18 | 4.524e+10 | 2917 | 6.276e+17 | **-67.51** | 2 |
| 10 | 13 | uniform_s | **3904** | 838.3 | 510.0 | 1084 | 2.892 | 0 |
| 10 | 13 | rho_graded | 1.026e+18 | 4242 | 769.8 | 4.484e+17 | **-85.99** | 2 |

The `uniform_s` column reproduces #293's published readings exactly — near-axis
1003 / 1300 / 1916 / 3904, edge 1.347e+07 / 1.832e+04 / 2514 / 510, total
7.87e+06 / 1.051e+04 / 1551 / 1084 — so the two scripts agree on the arm they
share and the graded arm is the only new variable.

At 8 and 10 spans the graded lift is not merely inaccurate: its signed Jacobian
changes sign, so the lifted geometry is not nested and no force number from it
means anything beyond "this representation failed".

## Result: `input.shaped_tokamak_pressure_polished`, ns=17 — not deck-specific

| spans | grading | near-axis | bulk | edge | total | min J | empty |
|---|---|---|---|---|---|---|---|
| 4 | uniform_s | **703.0** | 531.8 | 2452 | 1569 | 5.839 | 0 |
| 4 | rho_graded | 1.292e+12 | 3.054e+05 | 1907 | 2.402e+11 | 0.0127 | 1 |
| 6 | uniform_s | **634.3** | 302.7 | 656.6 | 477.6 | 5.839 | 0 |
| 6 | rho_graded | 1.194e+12 | 335.0 | 429.9 | 2.396e+11 | 0.0129 | 1 |
| 8 | uniform_s | **615.8** | 217.8 | 415.7 | 328.3 | 5.839 | 0 |
| 8 | rho_graded | 7.185e+17 | 2.240e+09 | 413.1 | 3.047e+17 | **-85.96** | 2 |
| 10 | uniform_s | **1072** | 342.2 | 411.2 | 417.5 | 5.839 | 0 |
| 10 | rho_graded | 4.984e+17 | 1364 | 412.5 | 2.227e+17 | **-110.0** | 2 |

Published normalizations track the same story. On the tokamak at 6 spans the
pressure-normalized window value `<|F|>/<|grad p|>` is 2.586e-03 uniform against
2.120e-03 graded, and the whole-volume value 3.064e-03 against 2571 — the window
excludes `s < 0.1`, which is exactly where the graded fit fails, so any figure
quoted on the window alone would have hidden this.

## Why: the graded basis outruns its own source data

`lift_high_order_state` fits each mode by unregularized least squares
(`strong_force.py:1037-1071`, `np.linalg.lstsq`, `rcond=1e-12`) on the solve's
own `s` mesh. A `k`-span rho-graded basis has first span `[0, 1/k^2]` in `s`,
while the VMEC full mesh has spacing `1/(ns-1)`, so it needs `ns - 1 > k^2` to
place even one interior sample there, against `ns - 1 > k` for uniform spacing.
Grading costs a *quadratic* increase in the required radial mesh. At ns=17 that
threshold is already crossed at `k = 4`: the inner span holds no data, its
coefficients come from the minimum-norm solution rather than from the
equilibrium, and the second derivatives that `curl B` needs are then arbitrary.
This is the same failure mode `lift_high_order_state`'s own default guards
against with "roughly two mesh samples per free span"; the graded basis
concentrates spans exactly where the source is thinnest. The script records
`samples_per_span` for every run so this is visible rather than inferred.

## The hypothesis fails even where the fit is fully supported

Starvation is not the whole answer. Two configurations keep every span fed and
the result does not change sign.

**Milder grading, exponent 1.5 (`--grading-exponent 1.5`), DSHAPE ns=17, no
empty spans in either arm:**

| spans | grading | near-axis | bulk | edge | total | min J | refinement diff |
|---|---|---|---|---|---|---|---|
| 4 | uniform_s | **1003** | 4345 | 1.347e+07 | 7.870e+06 | 0.738 | 2.45e-01 |
| 4 | rho_graded | 1952 | 1188 | 1.798e+04 | 1.029e+04 | 2.852 | 9.13e-08 |
| 6 | uniform_s | **1300** | 1166 | 1.832e+04 | 1.051e+04 | 2.874 | 4.44e-11 |
| 6 | rho_graded | 8.376e+05 | 5.088e+04 | 1547 | 1.889e+05 | 2.304 | 2.44e-02 |

Both arms are nested and, at 4 spans, the graded one is the better-conditioned
measurement (refinement difference 9.13e-08 against 2.45e-01). It cuts the total
by 765x and the edge by 749x — and still raises the near-axis residual by 1.95x.
At 6 spans it raises the axis by 644x. So the axis penalty is not a fitting
artefact: it survives into the regime where the fit is supported, quadrature
converged and nested.

**Higher source mesh, DSHAPE ns=65, no empty spans in either arm** (`min
samples/span` 15 and 3 at 4 spans, 10 and 1 at 6 spans). Both arms are
lift-limited here — a 4-to-6-span basis cannot represent an ns=65 solve, and
both go non-nested — so only the near-axis column, which stays quadrature
converged (drift 0.19 / 0.05 / 0.01 / 0.08), is readable:

| spans | uniform near-axis | graded near-axis |
|---|---|---|
| 4 | **412.8** | 1082 |
| 6 | **559.9** | 2798 |

Same direction: 2.6x and 5.0x worse.

Across grading strength at DSHAPE ns=17, 4 spans, the near-axis residual is
monotone in how far the knots move inward — exponent 1.0: **1003**; exponent
1.5: 1952; exponent 2.0: 1.111e+11. The axis residual §3.2 records is not a
shortage of radial freedom near the axis. Adding freedom there fits the weak
source data — the uniform-in-`s` half mesh with the axis row copied from the
first surface (`geometry.py:22`) — more faithfully, noise included. That is
consistent with §3.2's existing conclusion that a rho-uniform mesh for the
finite-difference lane is not the fix, and it now covers the representation as
well as the mesh.

## Quadrature convergence: the result is not the grid

`certify_strong_force` places Gauss-Legendre nodes per span of the state's own
basis, so the two gradings are certified on different node sets. Every row
therefore carries per-region node counts and the change in each region between
the coarse (angular 2, radial increment 2) and fine (angular 4, radial
increment 8) settings.

- Every `uniform_s` row at 6 spans and above is converged: certificate
  `radial_refinement_difference` 4.44e-11 (DSHAPE 6), 5.68e-11 (8), 2.40e-09
  (10), 1.35e-13 / 1.06e-11 / 3.48e-12 (tokamak 6/8/10), and coarse-to-fine
  drift at or below 0.02 in the near-axis and edge regions. The near-axis
  readings that carry the conclusion are the converged ones.
- The `uniform_s` 4-span row is *not* converged (refinement difference 2.45e-01,
  total and edge drift 0.86). Its 7.87e+06 total and 1.347e+07 edge are
  grid-limited, and should be read that way in #293 as well; its near-axis 1003
  moves only 10%.
- Every catastrophic `rho_graded` row is also quadrature-limited (refinement
  difference 0.75-0.87, drift 0.99). Their exact magnitudes are not certified —
  but the sign of the result is not in question at 8 to 15 orders of magnitude,
  and the negative Jacobians are a grid-independent statement.
- The exponent-1.5 rows, which carry the supported-fit conclusion, are the
  converged ones: 9.13e-08 and 2.44e-02, near-axis drift 0.007 and 0.025.

The graded arm samples the axis region *better*, not worse (7 to 24 near-axis
nodes against 3 to 5, smallest sampled `rho` 0.0096 against 0.030), so the
comparison is not one where the winner simply looked at fewer bad points.

## Verdict

The hypothesis is refuted. Grading the radial knots in `rho` does not reduce the
near-axis residual at matched coefficient count; it increases it, on both decks,
at every span count and at every grading strength tested, and past a
mesh-dependent threshold it destroys nestedness outright. Uniform-in-`s`
breakpoints should stay. Two things follow for P2 that are worth more than a
knot placement:

1. The near-axis residual rising under uniform refinement (1003 → 3904) and
   under grading is one phenomenon: the lift's least-squares fit has more
   freedom near the axis than the VMEC source constrains. The lever is the
   source data and the fit — a regularized or constrained inner fit, or a
   source that is not the copied axis row — not the knot vector.
2. `lift_high_order_state` accepts any `radial_basis` and will silently return a
   min-norm fit with unfed spans and a sign-changing Jacobian. A caller-supplied
   basis is a documented seam (`strong_force.py:1112`); it has no guard. Adding
   the `samples_per_span` check to the lift itself would turn a silent 1e+18
   into an error. Not done here — this branch only measures.

No tuning was done to reach a favourable answer. Every configuration run is
listed below; there are no unreported ones.

## Exact commands

Environment: macOS arm64, CPU, float64, Python 3.11.14, JAX/jaxlib 0.9.2,
numpy 2.3.5, scipy 1.16.3, SOLVAX 0.20. Measurement commit `f6700c5a`,
`measurement_dirty` false in every artifact.

```
python -m ruff check benchmarks
python tools/preflight.py --static

E=~/local/wt-knots-evidence

# headline, both decks, four span counts, two quadrature settings
python benchmarks/knot_grading.py --deck dshape --ns 17 --spans 4,6,8,10 \
    --quadratures 2:2,4:8 --budget-seconds 900 --output $E/dshape_ns17.json
python benchmarks/knot_grading.py --deck tokamak --ns 17 --spans 4,6,8,10 \
    --quadratures 2:2,4:8 --budget-seconds 900 --output $E/tokamak_ns17.json

# supported-fit checks
python benchmarks/knot_grading.py --deck dshape --ns 17 --spans 4,6 \
    --grading-exponent 1.5 --quadratures 2:2,4:8 --budget-seconds 900 \
    --output $E/dshape_ns17_exponent1p5.json
python benchmarks/knot_grading.py --deck dshape --ns 65 --spans 4,6 \
    --quadratures 2:2,4:8 --budget-seconds 900 --output $E/dshape_ns65.json

# regenerability
python benchmarks/knot_grading.py --deck dshape --ns 17 --spans 4,6,8,10 \
    --quadratures 2:2,4:8 --budget-seconds 900 --output $E/dshape_ns17_repeat.json
```

That is the complete list of measurement runs on this branch, plus one earlier
single-span smoke run (`--spans 4 --quadratures 2:2`) whose readings the
headline run reproduces and supersedes.

Cost, one job at a time: DSHAPE ns=17 170.9 s / 7076.1 MiB peak RSS; tokamak
ns=17 156.9 s / 6022.6 MiB; exponent 1.5 89.2 s / 4068.6 MiB; ns=65 88.8 s /
4046.2 MiB. Peak RSS at 10 spans and angular 4 / increment 8 is about twice the
3.5 GiB this workload usually costs; the budget flag bounds wall clock, not
memory.

## Verification

- `python -m ruff check benchmarks` — all checks passed.
- `python tools/preflight.py --static` — PASS, 75 guard tests passed, 3 skipped,
  18.19 s; docs prose and media gates clean.
- Regenerable: `dshape_ns17.json` and `dshape_ns17_repeat.json` are identical on
  every field except `seconds`, `peak_rss_MiB` and `scan.solve_seconds`.

Raw JSON: sibling `~/local/wt-knots-evidence`, not committed.

## Note on `benchmarks/residual_vs_resolution.py`

Carried here verbatim from the open #293 so this branch can reproduce that PR's
readings; the blob is byte-identical, so it merges cleanly and drops out of the
diff once #293 lands. It is not modified here and is not for review on this PR.
No file owned by another workstream is touched: `plan.md`, `CHANGELOG.md`,
`vmex/core/polish_driver.py`, `vmex/core/polish.py` and `vmec_jax/` are
unchanged, and the finding is recorded here rather than in the logbook.
