### PR TITLE
Read DESC inputs and equilibria through the VMEX CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,9 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install . pytest pytest-cov pytest-xdist
+      - name: Install optional DESC bridge for interoperability coverage
+        if: matrix.python-version == '3.12'
+        run: python -m pip install '.[desc]'
       - name: Check repository size
         run: |
           size_kb=$(du -sk --exclude=.git . | cut -f1)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Native DESC text decks use their final continuation stage; HDF5/pickle outputs u
 `--outdir DIR` places both files in DIR. Output extensions are stripped from names; native text deck names are preserved.
 DESC's exporter transfers boundary, pressure, current/iota, flux, field periods and asymmetry to a standard fixed-boundary VMEC input.
 Non-polynomial profiles are sampled at 101 radial points, with enclosed current transferred directly. WOUT iota has the opposite sign to DESC's right-handed convention.
-Conversion chooses the smallest rectangular boundary spectrum with a conservative 1% bound on discarded position and angular derivatives relative to their nonconstant RMS Fourier amplitudes.
+Conversion chooses the smallest rectangular boundary spectrum with a conservative 1% position/derivative bound relative to nonconstant RMS Fourier amplitudes, plus one solver harmonic for interior accuracy.
 This bounds boundary truncation, not magnetic-field error. `--desc-tol 0` retains all nonzero boundary modes.
 Generated inputs use 17/33/65 radial surfaces; edit the input for stricter resolution studies.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ for a saved WOUT. [Restart](https://vmex.readthedocs.io/en/latest/howto/restart-
 and [CLI](https://vmex.readthedocs.io/en/latest/reference/cli.html) guides cover
 resolution changes, devices, profiles and output controls.
 
+```console
+pip install 'vmex[desc]'
+vmex equilibrium.h5  # writes input.equilibrium and solves it to write wout_equilibrium.nc
+vmex input.equilibrium  # reproduce the WOUT without DESC
+```
+
+Native DESC text decks use their final continuation stage; HDF5/pickle outputs use the final `Equilibrium` in an `EquilibriaFamily` or a single equilibrium.
+`--outdir DIR` places both files in DIR. Output extensions are stripped from names; native text deck names are preserved.
+DESC's exporter transfers boundary, pressure, current/iota, flux, field periods and asymmetry to a standard fixed-boundary VMEC input.
+Non-polynomial profiles are sampled at 101 radial points, with enclosed current transferred directly. WOUT iota has the opposite sign to DESC's right-handed convention.
+Conversion chooses the smallest rectangular boundary spectrum with a conservative 1% bound on discarded position and angular derivatives relative to their nonconstant RMS Fourier amplitudes.
+This bounds boundary truncation, not magnetic-field error. `--desc-tol 0` retains all nonzero boundary modes.
+Generated inputs use 17/33/65 radial surfaces; edit the input for stricter resolution studies.
+
 ## Differentiate and optimize
 
 Compute a boundary/profile derivative without differentiating through every

--- a/docs/reference/api/basic.rst
+++ b/docs/reference/api/basic.rst
@@ -22,6 +22,9 @@ Inputs
 .. automodule:: vmex.core.input
    :members:
 
+.. automodule:: vmex.core.desc
+   :members:
+
 Run directives (``!@VMEX`` comment lines and the JSON ``_vmex`` section) are
 execution metadata and never become :class:`~vmex.core.input.VmecInput`
 fields; they are parsed and resolved here.  The precedence rule is stated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ Issues = "https://github.com/uwplasma/vmex/issues"
 Changelog = "https://github.com/uwplasma/vmex/releases"
 
 [project.optional-dependencies]
+desc = ["desc-opt>=0.17"]
 optimizers = [
   "jaxopt",
   "optax",

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -23,6 +23,7 @@
     ["tests/test_test_manifest.py", "infrastructure", "unit", "fast", "cpu", "none", "none", ["pr-parity-c2", "full-core-t-z"]],
     ["tests/test_cited_paths.py", "infrastructure", "unit", "fast", "cpu", "none", "none", ["pr-fast", "pr-parity-c2", "full-core-a-c"]],
     ["tests/test_cli.py", "interface", "integration", "medium", "cpu", "none", "analytic", ["pr-parity-c1", "full-core-a-c"]],
+    ["tests/test_desc.py", "interface", "integration", "medium", "cpu", "generated", "analytic", ["pr-fast", "pr-parity-c1", "full-core-d-f0"]],
     ["tests/test_cli_device.py", "interface", "unit", "fast", "cpu-gpu", "none", "none", ["pr-parity-c1", "full-core-a-c"]],
     ["tests/test_cli_freeboundary.py", "interface", "integration", "medium", "cpu-gpu", "generated", "analytic", ["pr-parity-a1", "full-core-a-c"]],
     ["tests/test_cli_summary_wout.py", "interface", "integration", "medium", "cpu", "golden", "golden", ["pr-parity-c1", "full-core-a-c"]],

--- a/tests/test_desc.py
+++ b/tests/test_desc.py
@@ -94,7 +94,7 @@ def test_hdf5_preserves_physical_profiles_and_surface(tmp_path, desc_equilibrium
     (EquilibriaFamily(desc_equilibrium(), eq) if family else eq).save(str(source))
     inp = VmecInput.from_file(write_desc_input(source))
     assert (inp.nfp, inp.lasym, inp.phiedge) == (3, asymmetric, 2.3)
-    assert (inp.mpol, inp.ntor) == (2, 1)
+    assert (inp.mpol, inp.ntor) == (3, 2)
     s = np.linspace(0.01, 1, 41)
     np.testing.assert_allclose(pressure(inp.pmass_type, inp.am, inp.am_aux_s, inp.am_aux_f, s), 1200 - 1000*s)
     if current:
@@ -215,6 +215,6 @@ def test_native_final_continuation_stage(tmp_path, desc_equilibrium):
                       "m: -1 n: 0 R1 = 0 Z1 = -1\nm: 1 n: 1 R1 = 0.1 Z1 = 0\n")
     inp = VmecInput.from_file(write_desc_input(source))
     np.testing.assert_allclose(inp.am[:2], [1200, -1000])
-    assert inp.ntor == 1
+    assert inp.ntor == 2
     assert inp.nfp == 3
-    assert np.max(abs(inp.rbc[[0, 2]])) > 0.01
+    assert np.max(abs(inp.rbc[[1, 3]])) > 0.01

--- a/tests/test_desc.py
+++ b/tests/test_desc.py
@@ -1,0 +1,220 @@
+"""DESC interoperability contracts: analytic geometry/profiles and reproducible solves."""
+
+from dataclasses import replace
+import sys
+
+import numpy as np
+import pytest
+
+from vmex.core import cli
+from vmex.core.desc import _compact_boundary, is_desc_file, write_desc_input
+from vmex.core.errors import VmecInputError
+from vmex.core.input import VmecInput
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("# DESC\nsym = 1\nM = 4", True), ("Psi = 1", True),
+    ("&INDATA\nMPOL=4\n/", False), ('{"mpol": 4}', False),
+    ("# sym = 1\n! M = 4\ninvalid", False),
+])
+def test_detection(tmp_path, text, expected):
+    path = tmp_path / "deck"
+    path.write_text(text)
+    assert is_desc_file(path) is expected
+    assert is_desc_file(tmp_path / "output.HDF5")
+
+
+@pytest.mark.parametrize("tol", [-1, 0.02, float("nan"), float("inf")])
+def test_invalid_tolerance(tmp_path, tol):
+    with pytest.raises(VmecInputError, match="tolerance"):
+        write_desc_input(tmp_path / "eq.h5", tolerance=tol)
+
+
+def test_missing_optional_dependency(tmp_path, monkeypatch):
+    monkeypatch.setitem(sys.modules, "desc.equilibrium", None)
+    with pytest.raises(VmecInputError, match="desc-opt"):
+        write_desc_input(tmp_path / "eq.h5")
+
+
+@pytest.mark.parametrize("asymmetric", [False, True])
+def test_truncation_is_minimal_and_bounds_off_grid_geometry(asymmetric):
+    rng = np.random.default_rng(392)
+    inp = VmecInput(mpol=9, ntor=7, lasym=asymmetric)
+    arrays = {key: np.array(getattr(inp, key)) for key in ("rbc", "zbs", "rbs", "zbc")}
+    arrays["rbc"][7, 0], arrays["rbc"][7, 1], arrays["zbs"][7, 1] = 10, 1, 1
+    for key in ("rbc", "zbs", "rbs", "zbc")[:4 if asymmetric else 2]:
+        arrays[key] += rng.normal(size=inp.rbc.shape) * 1e-7
+    arrays["rbc"][9, 3] = 0.1
+    inp = replace(inp, **arrays)
+    compact = _compact_boundary(inp, 0.01)
+    assert (compact.mpol, compact.ntor) == (4, 2)
+    exact = _compact_boundary(inp, 0)
+    assert (exact.mpol, exact.ntor) == (9, 7)
+    # Independently reconstruct both coordinate families at random angles;
+    # derivatives make this sensitive to lost small, high-frequency modes.
+    u, v = rng.uniform(0, 2 * np.pi, (2, 301))
+    def evaluate(deck, derivative):
+        m = np.arange(deck.mpol)
+        n = np.arange(-deck.ntor, deck.ntor + 1)[:, None]
+        phase = m * u[:, None, None] - n * v[:, None, None]
+        weight = 1 if derivative == 0 else (m if derivative == 1 else -n)
+        c = np.cos(phase + (np.pi / 2 if derivative else 0)) * weight
+        s = np.sin(phase + (np.pi / 2 if derivative else 0)) * weight
+        return np.stack([np.sum(deck.rbc*c + deck.rbs*s, axis=(1, 2)),
+                         np.sum(deck.zbc*c + deck.zbs*s, axis=(1, 2))])
+    for derivative in range(3):
+        assert np.max(abs(evaluate(inp, derivative) - evaluate(compact, derivative))) < 0.01
+
+
+@pytest.fixture
+def desc_equilibrium():
+    pytest.importorskip("desc")
+    import jax
+    from desc.equilibrium import Equilibrium
+    previous = jax.config.jax_disable_jit
+    jax.config.update("jax_disable_jit", False)
+    yield Equilibrium
+    jax.config.update("jax_disable_jit", previous)
+
+
+@pytest.mark.parametrize("family,current,asymmetric", [(False, False, False), (True, True, True)])
+def test_hdf5_preserves_physical_profiles_and_surface(tmp_path, desc_equilibrium, family, current, asymmetric):
+    from desc.equilibrium import EquilibriaFamily
+    from desc.geometry import FourierRZToroidalSurface
+    from vmex.core.profiles import current as evaluate_current, iota, pressure
+    surface = FourierRZToroidalSurface(
+        R_lmn=[10, 1, 0.07], modes_R=[[0, 0], [1, 0], [1, 1]],
+        Z_lmn=[-1, 0.05], modes_Z=[[-1, 0], [1 if asymmetric else -1, 1]],
+        NFP=3, sym=not asymmetric,
+    )
+    eq = desc_equilibrium(L=4, M=4, N=3, surface=surface, Psi=2.3,
+                          pressure=np.array([[0, 1200], [2, -1000]]),
+                          **({"current": np.array([[2, 8e3], [4, 3e3]])} if current else {"iota": np.array([[0, 0.4], [2, 0.1]])}))
+    source = tmp_path / "eq.h5"
+    (EquilibriaFamily(desc_equilibrium(), eq) if family else eq).save(str(source))
+    inp = VmecInput.from_file(write_desc_input(source))
+    assert (inp.nfp, inp.lasym, inp.phiedge) == (3, asymmetric, 2.3)
+    assert (inp.mpol, inp.ntor) == (2, 1)
+    s = np.linspace(0.01, 1, 41)
+    np.testing.assert_allclose(pressure(inp.pmass_type, inp.am, inp.am_aux_s, inp.am_aux_f, s), 1200 - 1000*s)
+    if current:
+        values = evaluate_current(inp.pcurr_type, inp.ac, inp.ac_aux_s, inp.ac_aux_f, s)
+        np.testing.assert_allclose(values, 8e3*s + 3e3*s**2)
+        assert inp.curtor == 11000
+    else:
+        np.testing.assert_allclose(iota(inp.piota_type, inp.ai, inp.ai_aux_s, inp.ai_aux_f, s), 0.4 + 0.1*s)
+    # Direct independent DESC evaluation checks Fourier signs, NFP and LASYM.
+    from desc.grid import Grid
+    rng = np.random.default_rng(742)
+    theta, zeta = rng.uniform(0, 2*np.pi, (2, 83))
+    data = eq.surface.compute(["R", "Z"], grid=Grid(np.column_stack([np.ones(83), theta, zeta]), sort=False))
+    phase = np.arange(inp.mpol)*theta[:, None, None] - np.arange(-inp.ntor, inp.ntor+1)[None, :, None]*inp.nfp*zeta[:, None, None]
+    for key, c, ss in [("R", inp.rbc, inp.rbs), ("Z", inp.zbc, inp.zbs)]:
+        np.testing.assert_allclose(np.sum(c*np.cos(phase) + ss*np.sin(phase), axis=(1, 2)), data[key], atol=1e-8)
+
+
+@pytest.mark.parametrize("saved", [False, True])
+def test_cli_and_reproduction(tmp_path, desc_equilibrium, saved):
+    from vmex.core.wout import read_wout
+    source = tmp_path / "input.native"
+    source.write_text("sym = 1\nNFP = 1\nPsi = 1\nM_pol = 4\nN_tor = 0\n"
+                      "l: 0 p = 0 i = 0.4\nn: 0 R0 = 10 Z0 = 0\n"
+                      "m: 0 n: 0 R1 = 10 Z1 = 0\nm: 1 n: 0 R1 = 1 Z1 = 0\n"
+                      "m: -1 n: 0 R1 = 0 Z1 = -1\n")
+    if saved:
+        eq = desc_equilibrium.from_input_file(str(source))
+        source = tmp_path / "input.native.h5"
+        eq.save(str(source))
+    original = source.read_bytes()
+    outdir = tmp_path / "converted"
+    assert cli.main([str(source), "--outdir", str(outdir)]) == 0
+    deck = outdir / "input.input.native"
+    first = read_wout(outdir / "wout_input.native.nc")
+    np.testing.assert_allclose(first.iotaf, -0.4, atol=1e-12)
+    assert source.read_bytes() == original
+    assert cli.main([str(deck), "--outdir", str(tmp_path / "rerun"), "--quiet"]) == 0
+    second = read_wout(tmp_path / "rerun" / "wout_input.native.nc")
+    for field in ("rmnc", "zmns", "bmnc", "iotaf", "presf"):
+        np.testing.assert_allclose(getattr(first, field), getattr(second, field), atol=1e-12, rtol=1e-12)
+    assert write_desc_input(source).name == "input.input.native"
+
+
+def test_invalid_desc_object(tmp_path, desc_equilibrium):
+    from desc.geometry import FourierRZToroidalSurface
+    path = tmp_path / "bad.h5"
+    FourierRZToroidalSurface().save(str(path))
+    with pytest.raises(VmecInputError, match="expected a DESC"):
+        write_desc_input(path)
+    path.write_bytes(b"not HDF5")
+    with pytest.raises(VmecInputError, match="Cannot convert"):
+        write_desc_input(path)
+
+
+@pytest.mark.parametrize("kind", ["current", "iota"])
+def test_spline_profiles_preserve_values_between_knots(tmp_path, desc_equilibrium, kind):
+    from desc.profiles import SplineProfile
+    from vmex.core.profiles import current, iota, pressure
+    rho = np.linspace(0, 1, 17)
+    prof = SplineProfile(1e4*rho**2 + 2e3*rho**4 if kind == "current" else 0.4+0.1*rho**2,
+                         knots=rho, method="cubic2")
+    p = SplineProfile(1000*(1-rho**2), knots=rho, method="cubic2")
+    eq = desc_equilibrium(L=4, M=4, N=0, pressure=p, **{kind: prof})
+    source = tmp_path / "splines.h5"
+    eq.save(str(source))
+    inp = VmecInput.from_file(write_desc_input(source))
+    s = np.linspace(0, 1, 257)
+    actual = (current(inp.pcurr_type, inp.ac, inp.ac_aux_s, inp.ac_aux_f, s) if kind == "current"
+              else iota(inp.piota_type, inp.ai, inp.ai_aux_s, inp.ai_aux_f, s))
+    expected = prof(np.sqrt(s))
+    if kind == "current":
+        actual = actual * inp.curtor / actual[-1]
+    assert np.max(abs(np.asarray(actual-expected))) < 1e-3*np.max(abs(np.asarray(expected)))
+    np.testing.assert_allclose(pressure(inp.pmass_type, inp.am, inp.am_aux_s, inp.am_aux_f,s),
+                               p(np.sqrt(s)),atol=1,rtol=0)
+
+
+def test_unreadable_input_is_typed(tmp_path):
+    with pytest.raises(VmecInputError, match="Cannot read"):
+        is_desc_file(tmp_path)
+
+
+@pytest.mark.parametrize("extension", ["HDF5", "pkl", "pickle"])
+def test_saved_formats_and_failure_do_not_replace_input(tmp_path, desc_equilibrium, extension):
+    eq = desc_equilibrium(L=2, M=2, N=0)
+    source = tmp_path / f"saved.{extension}"
+    eq.save(str(source), file_format="hdf5" if extension == "HDF5" else "pickle")
+    target = write_desc_input(source)
+    before = target.read_bytes()
+    assert target.name == "input.saved"
+    source.write_bytes(b"corrupted equilibrium")
+    assert cli.main([str(source), "--quiet"]) == 5
+    assert target.read_bytes() == before
+
+
+def test_truncation_retains_small_rapid_variations_and_is_scale_invariant():
+    coeff = np.zeros((1, 21))
+    coeff[0, :2] = [10, 1]
+    coeff[0, 20] = 0.001
+    z = np.zeros_like(coeff)
+    z[0, 1] = 1
+    inp = VmecInput(mpol=21, ntor=0, rbc=coeff, zbs=z)
+    # Position alone permits removal, but its derivative exceeds the bound.
+    assert _compact_boundary(inp, 0.01).mpol == 21
+    for scale in (1e-3, 1e3):
+        scaled = replace(inp, rbc=scale*coeff, zbs=scale*z)
+        assert _compact_boundary(scaled, 0.01).mpol == 21
+
+
+def test_native_final_continuation_stage(tmp_path, desc_equilibrium):
+    source = tmp_path / "continuation.desc"
+    source.write_text("sym = 1\nNFP = 3\nPsi = 2\nM_pol = 2, 4\nN_tor = 1\n"
+                      "pres_ratio = 0, 1\nbdry_ratio = 0, 1\n"
+                      "l: 0 p = 1200 i = 0.4\nl: 2 p = -1000 i = 0.1\n"
+                      "n: 0 R0 = 10 Z0 = 0\n"
+                      "m: 0 n: 0 R1 = 10 Z1 = 0\nm: 1 n: 0 R1 = 1 Z1 = 0\n"
+                      "m: -1 n: 0 R1 = 0 Z1 = -1\nm: 1 n: 1 R1 = 0.1 Z1 = 0\n")
+    inp = VmecInput.from_file(write_desc_input(source))
+    np.testing.assert_allclose(inp.am[:2], [1200, -1000])
+    assert inp.ntor == 1
+    assert inp.nfp == 3
+    assert np.max(abs(inp.rbc[[0, 2]])) > 0.01

--- a/vmex/core/cli.py
+++ b/vmex/core/cli.py
@@ -163,7 +163,7 @@ def build_parser() -> argparse.ArgumentParser:
         nargs="?",
         default=None,
         help=(
-            "VMEC input file (input.* namelist or VMEC++ .json) to solve, or a "
+            "VMEC input file (input.* namelist or VMEC++ .json), DESC text/HDF5/pickle file to solve, or a "
             "wout_*.nc/mout_*.nc/boozmn_*.nc file for --plot/--booz."
         ),
     )
@@ -174,6 +174,8 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="SCALE",
         help="with --scale: optional multiplicative B_scale R_scale factors",
     )
+    p.add_argument("--desc-tol", type=float, default=0.01,
+                   help="DESC boundary truncation bound (0..0.01; 0 retains all nonzero modes).")
     p.add_argument(
         "--scale",
         action="store_true",
@@ -1249,6 +1251,12 @@ def _dispatch(args, parser: argparse.ArgumentParser, *, emit) -> int:
             _run_trace(input_path, args, plot_outdir, emit=emit, quiet=quiet)
         return 0
 
+    from .desc import is_desc_file, write_desc_input
+
+    if is_desc_file(input_path):
+        input_path = write_desc_input(input_path, outdir, tolerance=args.desc_tol)
+        if not quiet:
+            emit(f" Wrote DESC-derived VMEC input: {input_path}")
     return _solve_input_file(args, input_path, outdir, emit=emit)
 
 

--- a/vmex/core/desc.py
+++ b/vmex/core/desc.py
@@ -1,0 +1,98 @@
+"""Optional DESC input bridge; WOUT is produced by the ordinary VMEX solve."""
+
+from dataclasses import replace
+from pathlib import Path
+import re
+from tempfile import TemporaryDirectory
+
+import numpy as np
+
+from .errors import VmecInputError
+from .input import VmecInput
+
+_FORMATS = {".h5": "hdf5", ".hdf5": "hdf5", ".pkl": "pickle", ".pickle": "pickle"}
+
+
+def is_desc_file(path: Path) -> bool:
+    """Recognize DESC outputs or native text decks without importing DESC."""
+    if path.suffix.lower() in _FORMATS:
+        return True
+    try:
+        with path.open("rb") as stream:
+            text = stream.read(65536).decode("utf-8", errors="replace")
+    except OSError as err:
+        raise VmecInputError(f"Cannot read input file: {path}", hint=str(err)) from err
+    text = re.sub(r"[!#].*", "", text)
+    return not re.search(r"&indata|^\s*\{", text, re.I) and bool(
+        re.search(r"^\s*(?:sym|M_pol|L_rad|N_tor|Psi)\s*=", text, re.M | re.I)
+    )
+
+
+def _compact_boundary(inp, tolerance):
+    # Triangle inequality bounds the displacement everywhere, relative to the
+    # RMS nonconstant R/Z geometry (not the much larger major radius). Apply
+    # the same bound to both angular derivatives to retain small sharp modes.
+    coefficients = np.stack([getattr(inp, key) for key in ("rbc", "zbs", "rbs", "zbc")])
+    m = np.arange(inp.mpol)[None, :]
+    n = np.arange(-inp.ntor, inp.ntor + 1)[:, None]
+    amplitude = np.sum(np.abs(coefficients), axis=0)
+    weights = np.stack(np.broadcast_arrays(np.ones_like(amplitude), m, abs(n)))
+    scales = np.sqrt(np.sum((coefficients[None] * weights[:, None]) ** 2, axis=(1, 2, 3)) / 2)
+    scales[0] = np.sqrt(np.sum(coefficients[:, (n != 0) | (m != 0)] ** 2) / 2)
+    candidates = []
+    for mp in range(2, inp.mpol + 1):
+        for nt in range(inp.ntor + 1):
+            omitted = (m >= mp) | (abs(n) > nt)
+            tail = np.sum(weights * amplitude * omitted, axis=(1, 2))
+            if np.all(tail <= tolerance * scales):
+                candidates.append((mp * (2 * nt + 1), mp, nt))
+    _, mp, nt = min(candidates)
+    cut = slice(inp.ntor - nt, inp.ntor + nt + 1)
+    return replace(inp, mpol=mp, ntor=nt, **{
+        key: getattr(inp, key)[cut, :mp] for key in ("rbc", "zbs", "rbs", "zbc")
+    })
+
+
+def write_desc_input(source: Path, outdir: Path | None = None, *, tolerance: float = 0.01) -> Path:
+    """Convert the final DESC equilibrium/deck stage to a compact VMEC input.
+
+    ``tolerance`` bounds discarded boundary position and angular derivatives;
+    it is not a bound on the solved magnetic field. Zero retains all nonzero
+    boundary modes. DESC is imported only for this optional conversion.
+    """
+    if not np.isfinite(tolerance) or not 0 <= tolerance <= 0.01:
+        raise VmecInputError("DESC boundary tolerance must lie between 0 and 0.01")
+    try:
+        from desc.equilibrium import EquilibriaFamily, Equilibrium
+        from desc.io import load
+        from desc.profiles import PowerSeriesProfile
+        from desc.vmec import VMECIO
+    except ImportError as err:
+        raise VmecInputError("DESC conversion requires desc-opt", hint="Install with pip install 'vmex[desc]'") from err
+    try:
+        file_format = _FORMATS.get(source.suffix.lower())
+        eq = (load(str(source), file_format=file_format) if file_format
+              else Equilibrium.from_input_file(str(source)))
+        if isinstance(eq, EquilibriaFamily):
+            eq = eq[-1]
+        if not isinstance(eq, Equilibrium):
+            raise ValueError("expected a DESC Equilibrium or nonempty EquilibriaFamily")
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "input.desc"
+            VMECIO.write_vmec_input(eq, str(path), NS_ARRAY=[17, 33, 65],
+                                    NITER_ARRAY=[2000, 4000, 8000], FTOL_ARRAY=[1e-8, 1e-10, 1e-12])
+            inp = _compact_boundary(VmecInput.from_file(path), tolerance)
+        # Splines in rho are not splines in s=rho**2. Sample the actual
+        # profiles, especially enclosed current: DESC's derivative exporter
+        # sets dI/ds=0 on axis, which distorts otherwise regular currents.
+        rho = np.linspace(0, 1, 101)
+        for profile, prefix, kind in ((eq.pressure, "am", "pmass"), (eq.iota, "ai", "piota"),
+                                      (eq.current, "ac", "pcurr")):
+            if profile is not None and not (isinstance(profile, PowerSeriesProfile) and profile.sym):
+                inp = replace(inp, **{f"{kind}_type": "cubic_spline_I" if kind == "pcurr" else "cubic_spline",
+                                      f"{prefix}_aux_s": rho**2, f"{prefix}_aux_f": np.asarray(profile(rho))})
+        name = source.stem if file_format else source.name
+        target = (outdir or source.parent) / f"input.{name}"
+        return inp.to_indata(target)
+    except Exception as err:
+        raise VmecInputError(f"Cannot convert DESC file: {err}", hint=str(source)) from err

--- a/vmex/core/desc.py
+++ b/vmex/core/desc.py
@@ -82,6 +82,14 @@ def write_desc_input(source: Path, outdir: Path | None = None, *, tolerance: flo
             VMECIO.write_vmec_input(eq, str(path), NS_ARRAY=[17, 33, 65],
                                     NITER_ARRAY=[2000, 4000, 8000], FTOL_ARRAY=[1e-8, 1e-10, 1e-12])
             inp = _compact_boundary(VmecInput.from_file(path), tolerance)
+        # Boundary resolution alone under-resolves the interior after VMEC's
+        # poloidal reparameterization. Keep one extra solver harmonic; these
+        # zero boundary coefficients add no surface-shape detail.
+        extra_n = int(inp.ntor > 0)
+        inp = replace(inp, mpol=inp.mpol + 1, ntor=inp.ntor + extra_n, **{
+            key: np.pad(getattr(inp, key), ((extra_n, extra_n), (0, 1)))
+            for key in ("rbc", "zbs", "rbs", "zbc")
+        })
         # Splines in rho are not splines in s=rho**2. Sample the actual
         # profiles, especially enclosed current: DESC's derivative exporter
         # sets dI/ds=0 on axis, which distorts otherwise regular currents.


### PR DESCRIPTION
## Behavior

`vmex equilibrium.h5` writes `input.equilibrium`, solves it, and writes `wout_equilibrium.nc`. A normal VMEX installation is sufficient: DESC is **not** a runtime dependency or an installation extra. Rerunning the generated input reproduces the WOUT without a hidden restart state.

Accepts native DESC text decks and saved HDF5/pickle equilibria or families, using the final continuation stage or family member. Conversion uses the fixed outer boundary; it does not run DESC's nonlinear solver. Goals are reproducible inputs, percentage-level physical accuracy with few Fourier modes, fast conversion, a small implementation, and at least 95% coverage.

## Implementation

- `vmex/core/desc.py` reads persisted numerical data directly. HDF5 uses `h5py`; pickle uses inert DESC records and an allowlist of NumPy reconstruction functions. Unsupported globals are rejected. No DESC imports or exporter calls remain.
- Product-to-sum identities transfer all four boundary Fourier families without fitting or a dense transform. The initial axis comes from the volume's Zernike coefficients at rho=0.
- Even power series map directly from rho to s=rho². Other supported radial profiles are sampled at 101 rho points. Enclosed current is transferred directly, including its zero-axis condition. Supported profiles include power series, splines, Hermite splines, two-power, modified-tanh and arithmetic compositions; kinetic pressure uses electron/ion profiles. Unknown profiles, anisotropy and non-outer boundaries fail explicitly.
- Native decks preserve continuation scaling, vacuum settings and DESC's right-handed coordinate convention. WOUT iota has the opposite sign to DESC.
- `vmex/core/cli.py` detects DESC files before the ordinary solve and adds `--desc-tol`. README/API documentation and the test manifest register the capability. CI installs DESC only to generate independent interoperability fixtures.

The default 0.01 tolerance selects the smallest rectangular boundary spectrum whose omitted position and angular derivatives obey triangle-inequality bounds relative to nonconstant RMS Fourier geometry. `--desc-tol 0` retains every nonzero boundary mode. One additional zero-boundary solver harmonic in each nontrivial angular direction resolves interior reparameterization. This bounds boundary truncation, **not magnetic-field error**. The solver ladder is NS=17/33/65, NITER=2000/4000/8000, FTOL=1e-8/1e-10/1e-12.

## Sources

DESC source inspected at `ad105c5e525fbf26824d6cf9dde48775db0f8a2c`:

- [HDF5 persistence](https://github.com/PlasmaControl/DESC/blob/ad105c5e525fbf26824d6cf9dde48775db0f8a2c/desc/io/hdf5_io.py) and [serialized object state](https://github.com/PlasmaControl/DESC/blob/ad105c5e525fbf26824d6cf9dde48775db0f8a2c/desc/io/optimizable_io.py).
- [Native input and continuation](https://github.com/PlasmaControl/DESC/blob/ad105c5e525fbf26824d6cf9dde48775db0f8a2c/desc/input_reader.py) and [coordinate handedness](https://github.com/PlasmaControl/DESC/blob/ad105c5e525fbf26824d6cf9dde48775db0f8a2c/desc/compat.py).
- [Profiles](https://github.com/PlasmaControl/DESC/blob/ad105c5e525fbf26824d6cf9dde48775db0f8a2c/desc/profiles.py), [kinetic pressure](https://github.com/PlasmaControl/DESC/blob/ad105c5e525fbf26824d6cf9dde48775db0f8a2c/desc/compute/_profiles.py), and [VMEC conventions/exporter](https://github.com/PlasmaControl/DESC/blob/ad105c5e525fbf26824d6cf9dde48775db0f8a2c/desc/vmec.py).

Tests evaluate DESC profiles independently between nonuniform knots; this also verifies that `cubic2` uses not-a-knot endpoints. Saved files from DESC 0.14.2 were exercised in the supplied cases. DESC-generated fixtures avoid committing binary test data.

## Physical validation

Four supplied HDF5 files contain three distinct equilibria. All retain the previously selected mode counts. The direct reader preserves full coefficient precision; differences from the earlier exporter-based inputs are only text-export rounding.

Fresh CPU runs used a clean normal installation, verified that DESC was absent, solved all three cases, and reran each generated input. Python 3.11, JAX 0.10.2, float64, Apple M3 Max:

| Case | MPOL/NTOR | Conversion + solve | Maximum WOUT coefficient change from validated reference |
|---|---:|---:|---:|
| A | 12/11 | 67.5 s | 2.48e-9 |
| B | 11/10 | 29.6 s | 5.25e-9 |
| C | 11/9 | 33.7 s | 3.98e-9 |

Coefficient changes cover `rmnc`, `zmns`, `bmnc`, `iotaf`, and `presf`, normalized by each reference array's peak. Input reruns agree elementwise at `rtol=atol=1e-12`. Times include compilation and are not controlled performance benchmarks.

The earlier reference validation compared Cartesian B at 256 random physical points per case, seed 97315, normalized flux in [0.05,0.95], a full poloidal turn and one toroidal field period. VMEX independently inverted the DESC positions; extra angular guesses resolved difficult inversions. All samples were finite. B errors use the local DESC magnitude; iota compares 20 surfaces in [0.05,1] with the orientation sign corrected.

| Case | B-vector RMS error | B-vector max error | Iota max error |
|---|---:|---:|---:|
| A | 0.118% | 0.699% | 0.271% |
| B | 0.154% | 0.474% | 0.218% |
| C | 0.148% | 0.414% | 0.592% |

Volume, major/minor radius and volume-averaged beta agreed within 3.5e-6 relative error. These samples do not establish a uniform axis/boundary error bound. For case A, boundary-only 11/10 gave 1.81% peak B error; NS=129 gave 1.83%; adding an interior harmonic gave 0.70%. An untrimmed 16/17 cold solve failed the Jacobian check, although a restarted solve reached 0.25%. This supports the compact reproducible default; stricter studies should vary resolution and verify convergence.

Earlier CPU/GPU reference comparisons covered all three cases: Python 3.11/3.12, JAX 0.9.2, float64, NVIDIA RTX A4000. Peak-normalized coefficient differences were below 1.77e-9; all arrays passed `rtol=1e-6, atol=1e-8`. GPU times were 374/183/200 s, slower than CPU in these runs.

A fresh direct-reader GPU run of case C also succeeded with DESC uninstalled: 170.1 s on the RTX A4000, JAX 0.9.2. Against the fresh JAX 0.10.2 CPU result, the largest peak-normalized coefficient difference was 8.67e-10; pressure was identical and all arrays passed the parity tolerances above.

## Tests and handoff

- **57 tests passed** on the final reader; **100% executable-line coverage (245/245)** in `vmex/core/desc.py`.
- **95.415653%** combined configured coverage: fresh reader tests plus matching unchanged-source CI and full physics certificates. Old coverage for the replaced reader was removed before combining.
- Ruff, mypy, package build, documentation prose checks, Sphinx and test-manifest validation passed.
- [Current CI](https://github.com/uwplasma/vmex/actions/runs/34729319561) is queued; this is not a claim that the new commit has passed CI. [Previous complete CI](https://github.com/uwplasma/vmex/actions/runs/34699929988) passed before the runtime dependency removal.

The current suite covers generated HDF5/pickle families, native continuation and handedness, independent asymmetric Fourier/axis evaluation, analytic geometry/derivative bounds, 13 profile variants, kinetic pressure, invalid inputs and restricted pickle loading. Fresh-interpreter tests block all DESC imports for every format. CLI tests solve both text and saved inputs and reproduce their WOUTs.

```sh
python -m pip install -e '.[dev]'
# Test fixture generation only:
python -m pip install 'desc-opt>=0.17'
JAX_ENABLE_X64=1 pytest -q tests/test_desc.py --cov=vmex --cov-report=xml
diff-cover coverage.xml --compare-branch=origin/main --fail-under=95

# Normal installation, without DESC:
vmex equilibrium.h5 --device cpu
vmex input.equilibrium --device cpu
```

For GPU parity, solve the same equilibrium with `--device gpu` in a separate normal VMEX installation with compatible CUDA-enabled JAX, and compare the five WOUT arrays above against the CPU output.

Full physics certificates contributing to repository-wide coverage:

```sh
RUN_FULL=1 VMEX_COMPILATION_CACHE=disabled JAX_ENABLE_X64=1 \
OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 pytest -q \
  tests/test_freeboundary_implicit.py::test_free_boundary_current_gradient_matches_resolve_finite_difference \
  tests/mirror/test_free_boundary.py::test_unbounded_exterior_free_boundary_beta_scan_converges \
  tests/test_freeboundary_implicit.py::test_boundary_schur_adjoint_reproduces_the_coupled_gcrot_gradient \
  --cov=vmex --cov-report=xml
```

Combine matching-source CI and full-certificate coverage, replacing old coverage for changed modules. Existing optional virtual-casing/turbulence exclusions remain unchanged. Prior CI alone covered 94.046%; prior CI plus these certificates covered 95.381365%. The unchanged-base QI numerical pin remains environment-sensitive in the DESC-compatible environment (0.134997 versus 0.136266); its tolerance was not loosened.

Two supplied private Python scripts were separately reformatted with AST equality checks. Machine-specific notes and artifacts remain private. No merge is requested or performed.

Current implementation commit: `c97369ae`. No local or remote validation jobs remain; current CI is pending.
