### PR TITLE
Reduce winding geometry compilation before nested derivatives

### DIFF
--- a/examples/optimization/QA_optimization.py
+++ b/examples/optimization/QA_optimization.py
@@ -55,7 +55,6 @@ def iota_floor(equilibrium_state, solver_context):
 import jax
 jax.config.update("jax_enable_compilation_cache", False)
 
-from simsopt.geo import SurfaceRZFourier
 from vmex.core.statephysics import _aspect_scalars
 from vmex.core.solver import _geometry
 from jaxopt import LBFGS as minimize
@@ -69,69 +68,56 @@ SPECTRAL_WEIGHT = 0.02
 WINDING_NTHETA = 24
 WINDING_NPHI = 24
 
-def r_surface(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs = None, n_min = None, m_min = 0):
-    num_m_modes = len(rsurfacecc)
-    num_n_modes = len(rsurfacecc[0])
+def _surface_series(cosine, sine, nfp, tor_angle, pol_angle, n_min, m_min,
+                    derivative=None):
+    """Contract Fourier modes without expanding one graph per coefficient."""
+    cosine = None if cosine is None else jnp.asarray(cosine)
+    sine = None if sine is None else jnp.asarray(sine)
+    if cosine is not None and sine is not None and cosine.shape != sine.shape:
+        raise ValueError("Cosine and sine coefficients must have matching shapes.")
+    coefficients = cosine if cosine is not None else sine
+    tor_angle, pol_angle = jnp.broadcast_arrays(tor_angle, pol_angle)
+    trailing = (1,) * tor_angle.ndim
+    m = (jnp.arange(coefficients.shape[0]) + m_min).reshape((-1, 1) + trailing)
     if n_min is None:
-        n_min = -(num_n_modes - 1)/2
-    r = 0
-    for m in range(num_m_modes):
-        for n in range(num_n_modes):
-            r += rsurfacecc[m][n]*jnp.cos((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    if rsurfacecs is not None:
-        assert len(rsurfacecc) == len(rsurfacecs), 'If rsurfacecs is specified, it must be the same length as rsurfacecc.'
-        for m in range(num_m_modes):
-            for n in range(num_n_modes):
-                r += rsurfacecs[m][n]*jnp.sin((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    return r
+        n_min = -(coefficients.shape[1] - 1) / 2
+    n = ((jnp.arange(coefficients.shape[1]) + n_min) * nfp).reshape((1, -1) + trailing)
+    angle = m * pol_angle - n * tor_angle
+    c, s = jnp.cos(angle), jnp.sin(angle)
+    if derivative is not None:
+        frequency = m if derivative == "theta" else -n
+        c, s = -frequency * s, frequency * c
+    result = 0.0
+    if cosine is not None:
+        result = result + jnp.sum(cosine.reshape(cosine.shape + trailing) * c, axis=(0, 1))
+    if sine is not None:
+        result = result + jnp.sum(sine.reshape(sine.shape + trailing) * s, axis=(0, 1))
+    return result
 
-def z_surface(zsurfacecs, nfp, tor_angle, pol_angle, zsurfacecc = None, n_min = None, m_min=0):
-    num_m_modes = len(zsurfacecs)
-    num_n_modes = len(zsurfacecs[0])
-    if n_min is None:
-        n_min = -(num_n_modes - 1)/2
-    z = 0
-    for m in range(num_m_modes):
-        for n in range(num_n_modes):
-            z += zsurfacecs[m][n]*jnp.sin((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    if zsurfacecc is not None:
-        assert len(zsurfacecs) == len(zsurfacecc), 'If zsurfacecc is specified, it must be the same length as zsurfacecs'
-        for m in range(num_m_modes):
-            for n in range(num_n_modes):
-                z += zsurfacecc[m][n]*jnp.cos((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    return z
 
-def r_surface_prime_phi(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs = None, n_min = None, m_min = 0):
-    num_m_modes = len(rsurfacecc)
-    num_n_modes = len(rsurfacecc[0])
-    if n_min is None:
-        n_min = -(num_n_modes - 1)/2
-    r_phi = 0
-    for m in range(num_m_modes):
-        for n in range(num_n_modes):
-            r_phi += rsurfacecc[m][n]*(n+n_min)*nfp*jnp.sin((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    if rsurfacecs is not None:
-        assert len(rsurfacecc) == len(rsurfacecs), 'If rsurfacecs is specified, it must be the same length as rsurfacecc.'
-        for m in range(num_m_modes):
-            for n in range(num_n_modes):
-                r_phi += -rsurfacecs[m][n]*(n+n_min)*nfp*jnp.cos((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    return r_phi
+def r_surface(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs=None,
+              n_min=None, m_min=0):
+    return _surface_series(rsurfacecc, rsurfacecs, nfp, tor_angle, pol_angle,
+                           n_min, m_min)
 
-def z_surface_prime_phi(zsurfacecs, nfp, tor_angle, pol_angle, zsurfacecc = None, n_min = None, m_min=0):
-    num_m_modes = len(zsurfacecs)
-    num_n_modes = len(zsurfacecs[0])
-    if n_min is None:
-        n_min = -(num_n_modes - 1)/2
-    z_phi = 0
-    for m in range(num_m_modes):
-        for n in range(num_n_modes):
-            z_phi += -zsurfacecs[m][n]*(n+n_min)*nfp*jnp.cos((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    if zsurfacecc is not None:
-        assert len(zsurfacecs) == len(zsurfacecc), 'If zsurfacecc is specified, it must be the same length as zsurfacecs'
-        for m in range(num_m_modes):
-            for n in range(num_n_modes):
-                z_phi += zsurfacecc[m][n]*(n+n_min)*nfp*jnp.sin((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    return z_phi
+
+def z_surface(zsurfacecs, nfp, tor_angle, pol_angle, zsurfacecc=None,
+              n_min=None, m_min=0):
+    return _surface_series(zsurfacecc, zsurfacecs, nfp, tor_angle, pol_angle,
+                           n_min, m_min)
+
+
+def r_surface_prime_phi(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs=None,
+                        n_min=None, m_min=0):
+    return _surface_series(rsurfacecc, rsurfacecs, nfp, tor_angle, pol_angle,
+                           n_min, m_min, "phi")
+
+
+def z_surface_prime_phi(zsurfacecs, nfp, tor_angle, pol_angle, zsurfacecc=None,
+                        n_min=None, m_min=0):
+    return _surface_series(zsurfacecc, zsurfacecs, nfp, tor_angle, pol_angle,
+                           n_min, m_min, "phi")
+
 
 def surface_del_phi(rsurfacecc, zsurfacecs, nfp, tor_angle, pol_angle, rsurfacecs = None, zsurfacecc = None, n_min = None, m_min = 0):
     r = r_surface(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs=rsurfacecs, n_min=n_min, m_min=m_min)
@@ -141,37 +127,17 @@ def surface_del_phi(rsurfacecc, zsurfacecs, nfp, tor_angle, pol_angle, rsurfacec
     sinterm = jnp.sin(tor_angle)
     return [r_phi*costerm - r*sinterm, r_phi*sinterm + r*costerm, z_phi]
 
-def r_surface_prime_theta(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs = None, n_min = None, m_min = 0):
-    num_m_modes = len(rsurfacecc)
-    num_n_modes = len(rsurfacecc[0])
-    if n_min is None:
-        n_min = -(num_n_modes - 1)/2
-    r_theta = 0
-    for m in range(num_m_modes):
-        for n in range(num_n_modes):
-            r_theta += -rsurfacecc[m][n]*(m+m_min)*jnp.sin((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    if rsurfacecs is not None:
-        assert len(rsurfacecc) == len(rsurfacecs), 'If rsurfacecs is specified, it must be the same length as rsurfacecc.'
-        for m in range(num_m_modes):
-            for n in range(num_n_modes):
-                r_theta += rsurfacecs[m][n]*(m+m_min)*jnp.cos((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    return r_theta
+def r_surface_prime_theta(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs=None,
+                          n_min=None, m_min=0):
+    return _surface_series(rsurfacecc, rsurfacecs, nfp, tor_angle, pol_angle,
+                           n_min, m_min, "theta")
 
-def z_surface_prime_theta(zsurfacecs, nfp, tor_angle, pol_angle, zsurfacecc = None, n_min = None, m_min=0):
-    num_m_modes = len(zsurfacecs)
-    num_n_modes = len(zsurfacecs[0])
-    if n_min is None:
-        n_min = -(num_n_modes - 1)/2
-    z_theta = 0
-    for m in range(num_m_modes):
-        for n in range(num_n_modes):
-            z_theta += zsurfacecs[m][n]*(m+m_min)*jnp.cos((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    if zsurfacecc is not None:
-        assert len(zsurfacecs) == len(zsurfacecc), 'If zsurfacecc is specified, it must be the same length as zsurfacecs'
-        for m in range(num_m_modes):
-            for n in range(num_n_modes):
-                z_theta += -zsurfacecc[m][n]*(m+m_min)*jnp.sin((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    return z_theta
+
+def z_surface_prime_theta(zsurfacecs, nfp, tor_angle, pol_angle, zsurfacecc=None,
+                          n_min=None, m_min=0):
+    return _surface_series(zsurfacecc, zsurfacecs, nfp, tor_angle, pol_angle,
+                           n_min, m_min, "theta")
+
 
 def surface_del_theta(rsurfacecc, zsurfacecs, nfp, tor_angle, pol_angle, rsurfacecs = None, zsurfacecc = None, n_min = None, m_min = 0):
     r_theta = r_surface_prime_theta(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs=rsurfacecs, n_min=n_min, m_min=m_min)
@@ -496,14 +462,6 @@ def calc_objectives(dofs, plasma_points, plasma_normals, weights, winding_R_cos)
 
 
 
-def mode_weights(surface):
-    weights = []
-    for name in surface.dof_names:
-        mode = int(name.split("(")[1].split(",")[0])
-        weights.append(mode ** 2)
-    return jnp.asarray(weights)
-
-
 def mode_weights_from_coefficients(rc):
     mpol = rc.shape[0] - 1
     ntor = _ntor_from_coefficients(rc)
@@ -516,8 +474,6 @@ def mode_weights_from_coefficients(rc):
         mode_matrix.reshape(-1)[ntor + 1:]))
 
 
-surface = SurfaceRZFourier(nfp=2, mpol=inp.mpol, ntor=inp.ntor)
-weights = mode_weights(surface)
 
 
 

--- a/examples/optimization/QA_optimization.py
+++ b/examples/optimization/QA_optimization.py
@@ -78,10 +78,13 @@ def _surface_series(cosine, sine, nfp, tor_angle, pol_angle, n_min, m_min,
     coefficients = cosine if cosine is not None else sine
     tor_angle, pol_angle = jnp.broadcast_arrays(tor_angle, pol_angle)
     trailing = (1,) * tor_angle.ndim
-    m = (jnp.arange(coefficients.shape[0]) + m_min).reshape((-1, 1) + trailing)
+    angle_dtype = jnp.result_type(tor_angle, pol_angle, 1.0)
+    m = (jnp.arange(coefficients.shape[0], dtype=angle_dtype) + m_min).reshape(
+        (-1, 1) + trailing)
     if n_min is None:
         n_min = -(coefficients.shape[1] - 1) / 2
-    n = ((jnp.arange(coefficients.shape[1]) + n_min) * nfp).reshape((1, -1) + trailing)
+    n = ((jnp.arange(coefficients.shape[1], dtype=angle_dtype) + n_min) * nfp).reshape(
+        (1, -1) + trailing)
     angle = m * pol_angle - n * tor_angle
     c, s = jnp.cos(angle), jnp.sin(angle)
     if derivative is not None:

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -102,6 +102,7 @@
     ["tests/test_validation_guards.py", "diagnostics", "unit", "fast", "cpu", "none", "none", ["pr-parity-c2", "full-core-t-z"]],
     ["tests/test_vmec2000_feature_stress.py", "equilibrium", "oracle", "medium", "cpu", "generated", "vmec2000", ["pr-parity-c2", "full-core-t-z"]],
     ["tests/test_vmec2000_live.py", "equilibrium", "oracle", "campaign", "cpu", "external", "vmec2000", ["pr-external", "full-core-t-z"]],
+    ["tests/test_winding_geometry.py", "interface", "ad", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-t-z"]],
     ["tests/test_wout_golden.py", "equilibrium", "oracle", "slow", "cpu", "golden", "vmec2000", ["pr-parity-b", "full-core-t-z"]]
   ],
   "excluded": {

--- a/tests/test_winding_geometry.py
+++ b/tests/test_winding_geometry.py
@@ -1,0 +1,115 @@
+"""Analytic geometry and AD checks for the winding-surface example helpers."""
+import ast
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+@pytest.fixture(scope="module")
+def geometry():
+    # Load only pure helpers: importing the example starts a full optimization.
+    path = Path(__file__).parents[1] / "examples/optimization/QA_optimization.py"
+    names = {
+        "_surface_series", "r_surface", "z_surface", "r_surface_prime_phi",
+        "z_surface_prime_phi", "r_surface_prime_theta", "z_surface_prime_theta",
+        "surface_del_phi", "surface_del_theta", "surface_normal", "surface_unitnormal",
+        "surface_coefficients_from_dofs", "points_normals_normal_lengths", "enclosed_volume",
+    }
+    tree = ast.parse(path.read_text(), filename=str(path))
+    tree.body = [node for node in tree.body if isinstance(node, ast.FunctionDef)
+                 and node.name in names]
+    namespace = {"jax": jax, "jnp": jnp}
+    exec(compile(tree, str(path), "exec"), namespace)
+    previous = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        with jax.disable_jit(False):
+            yield namespace
+    finally:
+        jax.config.update("jax_enable_x64", previous)
+
+
+@pytest.mark.parametrize("nfp", [1, 2, 5])
+@pytest.mark.parametrize("optional", [False, True])
+@pytest.mark.parametrize("n_min,m_min", [(None, 0), (-1, 2)])
+def test_fourier_values_and_derivatives(geometry, nfp, optional, n_min, m_min):
+    rng = np.random.default_rng(17)
+    primary, extra = [rng.normal(size=(3, 5)) for _ in range(2)]
+    phi, theta = .37, 1.13
+    m = np.arange(3)[:, None] + m_min
+    n = np.arange(5)[None, :] + (-2 if n_min is None else n_min)
+    angle = m * theta - n * nfp * phi
+    for family in ("r", "z"):
+        c, s = ((primary, extra) if family == "r" else (extra, primary))
+        if not optional:
+            if family == "r":
+                s = np.zeros_like(s)
+            else:
+                c = np.zeros_like(c)
+        expected = np.sum(c * np.cos(angle) + s * np.sin(angle))
+        args = (jnp.asarray(primary), nfp, phi, theta,
+                jnp.asarray(extra) if optional else None, n_min, m_min)
+        value = geometry[f"{family}_surface"](*args)
+        np.testing.assert_allclose(value, expected, rtol=2e-13, atol=2e-13)
+        for coordinate, frequency in (("phi", -n * nfp), ("theta", m)):
+            expected_d = np.sum(frequency * (-c * np.sin(angle) + s * np.cos(angle)))
+            actual = geometry[f"{family}_surface_prime_{coordinate}"](*args)
+            np.testing.assert_allclose(actual, expected_d, rtol=2e-13, atol=2e-13)
+            argnum = 2 if coordinate == "phi" else 3
+            derivative = jax.grad(geometry[f"{family}_surface"], argnums=argnum)(*args)
+            np.testing.assert_allclose(derivative, actual, rtol=2e-13, atol=2e-13)
+
+
+def test_broadcast_and_coefficient_ad(geometry):
+    coefficients = jnp.arange(15., dtype=jnp.float64).reshape(3, 5) / 15
+    phi, theta = jnp.array([.1, .4])[:, None], jnp.array([.2, .7, 1.2])[None, :]
+    function = geometry["r_surface"]
+    expected = np.array([[function(coefficients, 3, p, t) for t in theta[0]]
+                         for p in phi[:, 0]])
+    np.testing.assert_allclose(function(coefficients, 3, phi, theta), expected, atol=1e-14)
+    def loss(c):
+        return jnp.sum(function(c, 3, phi, theta) ** 2)
+    direction = jnp.cos(coefficients)
+    value, tangent = jax.jit(lambda c, d: jax.jvp(loss, (c,), (d,)))(coefficients, direction)
+    reverse = jnp.vdot(jax.jit(jax.grad(loss))(coefficients), direction)
+    epsilon = 1e-5
+    finite_difference = (loss(coefficients + epsilon * direction)
+                         - loss(coefficients - epsilon * direction)) / (2 * epsilon)
+    assert np.isfinite(value)
+    np.testing.assert_allclose(tangent, reverse, rtol=2e-13, atol=2e-13)
+    np.testing.assert_allclose(tangent, finite_difference, rtol=1e-9)
+
+
+def test_circular_torus_geometry_and_volume(geometry):
+    radius, minor = 3., .7
+    # mpol=1, ntor=0: R00, R10, Z10.
+    dofs = jnp.array([radius, minor, minor])
+    points, normals, jacobian, raw = geometry["points_normals_normal_lengths"](
+        dofs, 1, 0, 3, 12, 16)
+    phi = np.linspace(0, 2 * np.pi, 12, endpoint=False)[:, None]
+    theta = np.linspace(0, 2 * np.pi, 16, endpoint=False)[None, :]
+    expected = np.stack(np.broadcast_arrays(np.cos(phi) * np.cos(theta),
+                        np.sin(phi) * np.cos(theta), np.sin(theta)), axis=-1)
+    np.testing.assert_allclose(normals, expected, atol=3e-15)
+    np.testing.assert_allclose(jacobian, np.broadcast_to(
+        minor * (radius + minor * np.cos(theta)), (12, 16)), atol=3e-15)
+    volume = geometry["enclosed_volume"](points, raw, 12, 16)
+    np.testing.assert_allclose(volume, 2 * np.pi**2 * radius * minor**2, rtol=2e-15)
+
+    def volume_of(coefficients):
+        position, _, _, normal = geometry["points_normals_normal_lengths"](
+            coefficients, 1, 0, 3, 12, 16)
+        return geometry["enclosed_volume"](position, normal, 12, 16)
+
+    derivative = jax.jit(jax.grad(volume_of))(dofs)
+    np.testing.assert_allclose(derivative, 2 * np.pi**2 * np.array(
+        [minor**2, radius * minor, radius * minor]), rtol=2e-15)
+
+
+def test_array_like_coefficients_and_mismatched_parity(geometry):
+    assert geometry["r_surface"]([[3.]], 2, .1, .2) == 3.
+    with pytest.raises(ValueError, match="matching shapes"):
+        geometry["r_surface"](jnp.ones((2, 3)), 2, .1, .2, jnp.ones((1, 3)))

--- a/tests/test_winding_geometry.py
+++ b/tests/test_winding_geometry.py
@@ -17,11 +17,18 @@ def geometry():
         "z_surface_prime_phi", "r_surface_prime_theta", "z_surface_prime_theta",
         "surface_del_phi", "surface_del_theta", "surface_normal", "surface_unitnormal",
         "surface_coefficients_from_dofs", "points_normals_normal_lengths", "enclosed_volume",
+        "_ntor_from_coefficients", "reduced_memory_induction_matrix", "spectral_width",
+        "smooth_minimum_distance", "calc_objectives", "_winding_objective_value",
     }
     tree = ast.parse(path.read_text(), filename=str(path))
     tree.body = [node for node in tree.body if isinstance(node, ast.FunctionDef)
                  and node.name in names]
-    namespace = {"jax": jax, "jnp": jnp}
+    namespace = {
+        "jax": jax, "jnp": jnp, "MU0": 4 * np.pi * 1e-7, "nfp": 2,
+        "WINDING_NPHI": 12, "WINDING_NTHETA": 12, "MINIMUM_DISTANCE": .05,
+        "DISTANCE_WALL_SCALE": .01, "DISTANCE_WALL_WEIGHT": 10.,
+        "PCA_WEIGHT": 1., "VOLUME_WEIGHT": .02, "SPECTRAL_WEIGHT": .02,
+    }
     exec(compile(tree, str(path), "exec"), namespace)
     previous = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", True)
@@ -113,3 +120,38 @@ def test_array_like_coefficients_and_mismatched_parity(geometry):
     assert geometry["r_surface"]([[3.]], 2, .1, .2) == 3.
     with pytest.raises(ValueError, match="matching shapes"):
         geometry["r_surface"](jnp.ones((2, 3)), 2, .1, .2, jnp.ones((1, 3)))
+
+
+def test_winding_objective_hvp_matches_gradient_difference(geometry):
+    # Break repeated singular values without altering the entropy definition.
+    rc, zs = np.zeros((3, 5)), np.zeros((3, 5))
+    rc[0, 2], rc[1, 2], zs[1, 2] = 3., .7, .7
+    dofs = np.r_[rc.ravel()[2:], zs.ravel()[3:]]
+    dofs = jnp.asarray(dofs + .003 * np.random.default_rng(12).normal(size=dofs.shape))
+    plasma = (.75 * dofs).at[0].set(dofs[0])
+    points, normals, _, _ = geometry["points_normals_normal_lengths"](
+        plasma, 2, 2, 2, 12, 12)
+    points, normals = points.reshape(-1, 3), normals.reshape(-1, 3)
+    weights = jnp.ones_like(dofs)
+    scales = geometry["calc_objectives"](dofs, points, normals, weights, rc)
+
+    def objective(value):
+        return geometry["_winding_objective_value"](value, points, normals, weights, rc, scales)
+
+    direction = jnp.sin(dofs + .1)
+    gradient = jax.jit(jax.grad(objective))
+    hvp = jax.jit(lambda value: jax.jvp(
+        jax.grad(objective), (value,), (direction,))[1])(dofs)
+    assert np.all(np.isfinite(hvp))
+    for epsilon in (1e-5, 1e-6):
+        finite_difference = (gradient(dofs + epsilon * direction)
+                             - gradient(dofs - epsilon * direction)) / (2 * epsilon)
+        np.testing.assert_allclose(hvp, finite_difference, rtol=2e-5, atol=2e-7)
+
+
+def test_float32_geometry_keeps_angular_precision(geometry):
+    rc = jnp.array([[3.], [.7]], dtype=jnp.float32)
+    phi, theta = jnp.asarray(.1, dtype=jnp.float32), jnp.asarray(.3, dtype=jnp.float32)
+    value = geometry["r_surface"](rc, 2, phi, theta)
+    assert value.dtype == jnp.float32
+    np.testing.assert_allclose(value, 3 + .7 * np.cos(.3), rtol=2e-7)


### PR DESCRIPTION
The nested winding-surface objective expands every Fourier mode into separate Python operations before differentiating its geometry, SVD, and inner optimality condition. Contracting those same modes as arrays reduces the traced geometry graph while preserving the existing Fourier signs, normal orientation, angular derivatives, and objective.

This PR targets **`ds/working_winding` at `913377b6c8587ee02d9a34155c5b456a4e289181`**, independently of the main-branch performance work. It replaces six repeated Fourier loops with one shared contraction and removes an unused Simsopt surface/weight initialization. Production example source decreases by 41 lines. No equilibrium solver, inner iteration budget, acceptance tolerance, induction weighting, or entropy definition changes.

### Validation

- 17 analytic/numerical tests pass on CPU and CUDA, including both Fourier parities, nfp 1/2/5, custom mode origins, broadcast angles, angle derivatives, coefficient JVP/VJP and finite differences, torus normals/Jacobians/volume and its analytic coefficient gradient, and malformed parity shapes.
- **100% coverage of changed executable source: 35/35 lines and 8/8 branches.** This is patch coverage, not a claim of full-example or repository coverage.
- Tests are registered in the existing test manifest. Ruff on the new tests and `git diff --check` pass.
- Full manifest collection in the isolated environment reports the pre-existing optional ESSOS tracing module as skipped; its required selector therefore cannot collect there. The new module itself collects and passes. CI remains a separate gate.

### Paired profiling

Fresh-process, float64 JAX 0.9.2 measurements of the **complete winding objective value, gradient, and Hessian-vector product**, with `mpol=ntor=5`, nfp 2 and a 24×24 grid. Eleven synchronized warm evaluations per arm. These are component measurements, not a full outer equilibrium optimization.

| Measurement | Original | Fourier contraction |
|---|---:|---:|
| Xeon W2295 compilation | 57.06 s | 0.550 s |
| Xeon W2295 warm median | 274.78 ms | 133.88 ms |
| Xeon W2295 peak process RSS | 8.62 GiB | 1.08 GiB |
| RTX A4000 compilation | 15.06 s | 2.71 s |
| RTX A4000 warm median | 625.56 ms | 583.11 ms |
| RTX A4000 peak process RSS | 1.45 GiB | 1.10 GiB |
| Lowered objective/gradient/HVP graph | 3.02 MB | 0.274 MB |

The CPU table uses a deterministic generic perturbation (see recipe below), with finite value, gradient and HVP on both implementations. CPU value agrees exactly; gradient/HVP relative differences are below 3e-14. GPU value agrees exactly; gradient/HVP relative differences are below 1.2e-13. At the unperturbed nearly symmetric point, CPU HVPs are nonfinite in **both** implementations. The sampled induction matrix is full rank (576), with positive singular values 2.32e-5–5.16e-5 and five nearly repeated pairs; this particular failure is not a zero-singular-value/current-potential nullspace. No regularization was added to hide it. The generic perturbation separates the repeated values and has a finite HVP, additionally checked against gradient finite differences in the automated tests. CPU and GPU fixture choices differ, so this table does not compare hardware performance. Device temporary allocation for the full objective is essentially unchanged: 63.40→63.37 MB on GPU and 111.66→111.69 MB on CPU. The geometry-only contraction increases its temporary arrays, but they do not increase the full objective's peak allocation materially. The full SVD remains the dominant warm GPU cost.

Reproduction geometry uses R00=3, R10=Z10=0.7, R(1,+1)=0.03, Z(1,-1)=0.02, all other modes zero. The plasma scales all non-major-radius coefficients by 0.75. Set spectral weights to one, keep the initial objective scales fixed, and use `sin(dofs+0.1)` as the HVP direction. For the generic CPU fixture, add `0.003 * np.random.default_rng(12).normal(size=dofs.shape)` to the winding coefficients before constructing the plasma. Time `jax.jit` of the existing objective's value/gradient and `jax.jvp(jax.grad(...))`, with synchronization. Record lowering, compilation, `memory_analysis()`, and warm times separately. Run the test suite with:

```sh
JAX_ENABLE_X64=1 JAX_PLATFORMS=cpu python -m pytest -q tests/test_winding_geometry.py
# On a CUDA runner:
JAX_ENABLE_X64=1 JAX_PLATFORMS=cuda,cpu XLA_PYTHON_CLIENT_PREALLOCATE=false \
python -m pytest -q tests/test_winding_geometry.py
```

Independent source review found no blocking changes in Fourier signs, broadcasting, dtype preservation, or objective semantics. Current head is `38d60046fd94af3c2e981106f1e338c3eb773c3e`; final candidate source SHA-256 is `502cca1845b2879a7b7c78125da6fa1ec85b213f54bdbddf126a541d207dc3ec`. Final CPU/GPU tests pass 17 cases. The preceding CI run exposed an inherited feature-branch integration gap: the QA smoke invokes the winding example but the parity job omitted its already-declared optional `optimizers` extra. Commit 38d60046 installs that extra only in the misc example job; renewed CI will validate the unchanged geometry/response branch. No QA smoke is skipped. This PR remains draft and auto-merge is disabled.

### Physics scope and remaining gates

[ESSOS #66](https://github.com/uwplasma/ESSOS/pull/66) distinguishes quadrature-weighted induction, symmetric-sector entropy, current-normalized solves, and independently validated finite-coil objectives. This branch still uses its existing unweighted full-torus entropy proxy. This PR preserves that proxy and does not establish physical coil improvement or replace it with another objective.

A separate audit reconstructed the initial public QA boundary (including its rotating-ellipse perturbation), first-stage 99 winding coefficients and original 24×24 offset/scales/weights. The unchanged inner solve reached its 1e-6 gradient tolerance in 56 iterations (gradient norm 8.46e-7), with no failed line search and 149 value/gradient calls. Its original implicit JVP was finite, but the original Hessian equation residual was 5.90e-5 relative: a normal-equation CG stopping rule does not certify the original equation at the same tolerance. This stationary matrix was full rank, with no nearly repeated singular values. This is one initial-boundary check, not a completed outer optimization. The nested optimizer still needs explicit achieved optimality and original-equation residual certificates, plus finite-difference checks at perturbed boundaries, before its implicit response can be treated as an accurate derivative of a converged inner solve. That concern, full outer-optimization profiling, and the ESSOS physical-objective corrections remain open. No speedup is obtained by stopping gradients or weakening physics/linear-solve acceptance. No release is proposed.
