### PR TITLE
Certify and accelerate winding root sensitivities

### DIFF
--- a/examples/optimization/QA_optimization.py
+++ b/examples/optimization/QA_optimization.py
@@ -55,7 +55,6 @@ def iota_floor(equilibrium_state, solver_context):
 import jax
 jax.config.update("jax_enable_compilation_cache", False)
 
-from simsopt.geo import SurfaceRZFourier
 from vmex.core.statephysics import _aspect_scalars
 from vmex.core.solver import _geometry
 from jaxopt import LBFGS as minimize
@@ -69,69 +68,56 @@ SPECTRAL_WEIGHT = 0.02
 WINDING_NTHETA = 24
 WINDING_NPHI = 24
 
-def r_surface(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs = None, n_min = None, m_min = 0):
-    num_m_modes = len(rsurfacecc)
-    num_n_modes = len(rsurfacecc[0])
+def _surface_series(cosine, sine, nfp, tor_angle, pol_angle, n_min, m_min,
+                    derivative=None):
+    """Contract Fourier modes without expanding one graph per coefficient."""
+    cosine = None if cosine is None else jnp.asarray(cosine)
+    sine = None if sine is None else jnp.asarray(sine)
+    if cosine is not None and sine is not None and cosine.shape != sine.shape:
+        raise ValueError("Cosine and sine coefficients must have matching shapes.")
+    coefficients = cosine if cosine is not None else sine
+    tor_angle, pol_angle = jnp.broadcast_arrays(tor_angle, pol_angle)
+    trailing = (1,) * tor_angle.ndim
+    m = (jnp.arange(coefficients.shape[0]) + m_min).reshape((-1, 1) + trailing)
     if n_min is None:
-        n_min = -(num_n_modes - 1)/2
-    r = 0
-    for m in range(num_m_modes):
-        for n in range(num_n_modes):
-            r += rsurfacecc[m][n]*jnp.cos((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    if rsurfacecs is not None:
-        assert len(rsurfacecc) == len(rsurfacecs), 'If rsurfacecs is specified, it must be the same length as rsurfacecc.'
-        for m in range(num_m_modes):
-            for n in range(num_n_modes):
-                r += rsurfacecs[m][n]*jnp.sin((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    return r
+        n_min = -(coefficients.shape[1] - 1) / 2
+    n = ((jnp.arange(coefficients.shape[1]) + n_min) * nfp).reshape((1, -1) + trailing)
+    angle = m * pol_angle - n * tor_angle
+    c, s = jnp.cos(angle), jnp.sin(angle)
+    if derivative is not None:
+        frequency = m if derivative == "theta" else -n
+        c, s = -frequency * s, frequency * c
+    result = 0.0
+    if cosine is not None:
+        result = result + jnp.sum(cosine.reshape(cosine.shape + trailing) * c, axis=(0, 1))
+    if sine is not None:
+        result = result + jnp.sum(sine.reshape(sine.shape + trailing) * s, axis=(0, 1))
+    return result
 
-def z_surface(zsurfacecs, nfp, tor_angle, pol_angle, zsurfacecc = None, n_min = None, m_min=0):
-    num_m_modes = len(zsurfacecs)
-    num_n_modes = len(zsurfacecs[0])
-    if n_min is None:
-        n_min = -(num_n_modes - 1)/2
-    z = 0
-    for m in range(num_m_modes):
-        for n in range(num_n_modes):
-            z += zsurfacecs[m][n]*jnp.sin((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    if zsurfacecc is not None:
-        assert len(zsurfacecs) == len(zsurfacecc), 'If zsurfacecc is specified, it must be the same length as zsurfacecs'
-        for m in range(num_m_modes):
-            for n in range(num_n_modes):
-                z += zsurfacecc[m][n]*jnp.cos((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    return z
 
-def r_surface_prime_phi(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs = None, n_min = None, m_min = 0):
-    num_m_modes = len(rsurfacecc)
-    num_n_modes = len(rsurfacecc[0])
-    if n_min is None:
-        n_min = -(num_n_modes - 1)/2
-    r_phi = 0
-    for m in range(num_m_modes):
-        for n in range(num_n_modes):
-            r_phi += rsurfacecc[m][n]*(n+n_min)*nfp*jnp.sin((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    if rsurfacecs is not None:
-        assert len(rsurfacecc) == len(rsurfacecs), 'If rsurfacecs is specified, it must be the same length as rsurfacecc.'
-        for m in range(num_m_modes):
-            for n in range(num_n_modes):
-                r_phi += -rsurfacecs[m][n]*(n+n_min)*nfp*jnp.cos((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    return r_phi
+def r_surface(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs=None,
+              n_min=None, m_min=0):
+    return _surface_series(rsurfacecc, rsurfacecs, nfp, tor_angle, pol_angle,
+                           n_min, m_min)
 
-def z_surface_prime_phi(zsurfacecs, nfp, tor_angle, pol_angle, zsurfacecc = None, n_min = None, m_min=0):
-    num_m_modes = len(zsurfacecs)
-    num_n_modes = len(zsurfacecs[0])
-    if n_min is None:
-        n_min = -(num_n_modes - 1)/2
-    z_phi = 0
-    for m in range(num_m_modes):
-        for n in range(num_n_modes):
-            z_phi += -zsurfacecs[m][n]*(n+n_min)*nfp*jnp.cos((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    if zsurfacecc is not None:
-        assert len(zsurfacecs) == len(zsurfacecc), 'If zsurfacecc is specified, it must be the same length as zsurfacecs'
-        for m in range(num_m_modes):
-            for n in range(num_n_modes):
-                z_phi += zsurfacecc[m][n]*(n+n_min)*nfp*jnp.sin((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    return z_phi
+
+def z_surface(zsurfacecs, nfp, tor_angle, pol_angle, zsurfacecc=None,
+              n_min=None, m_min=0):
+    return _surface_series(zsurfacecc, zsurfacecs, nfp, tor_angle, pol_angle,
+                           n_min, m_min)
+
+
+def r_surface_prime_phi(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs=None,
+                        n_min=None, m_min=0):
+    return _surface_series(rsurfacecc, rsurfacecs, nfp, tor_angle, pol_angle,
+                           n_min, m_min, "phi")
+
+
+def z_surface_prime_phi(zsurfacecs, nfp, tor_angle, pol_angle, zsurfacecc=None,
+                        n_min=None, m_min=0):
+    return _surface_series(zsurfacecc, zsurfacecs, nfp, tor_angle, pol_angle,
+                           n_min, m_min, "phi")
+
 
 def surface_del_phi(rsurfacecc, zsurfacecs, nfp, tor_angle, pol_angle, rsurfacecs = None, zsurfacecc = None, n_min = None, m_min = 0):
     r = r_surface(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs=rsurfacecs, n_min=n_min, m_min=m_min)
@@ -141,37 +127,17 @@ def surface_del_phi(rsurfacecc, zsurfacecs, nfp, tor_angle, pol_angle, rsurfacec
     sinterm = jnp.sin(tor_angle)
     return [r_phi*costerm - r*sinterm, r_phi*sinterm + r*costerm, z_phi]
 
-def r_surface_prime_theta(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs = None, n_min = None, m_min = 0):
-    num_m_modes = len(rsurfacecc)
-    num_n_modes = len(rsurfacecc[0])
-    if n_min is None:
-        n_min = -(num_n_modes - 1)/2
-    r_theta = 0
-    for m in range(num_m_modes):
-        for n in range(num_n_modes):
-            r_theta += -rsurfacecc[m][n]*(m+m_min)*jnp.sin((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    if rsurfacecs is not None:
-        assert len(rsurfacecc) == len(rsurfacecs), 'If rsurfacecs is specified, it must be the same length as rsurfacecc.'
-        for m in range(num_m_modes):
-            for n in range(num_n_modes):
-                r_theta += rsurfacecs[m][n]*(m+m_min)*jnp.cos((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    return r_theta
+def r_surface_prime_theta(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs=None,
+                          n_min=None, m_min=0):
+    return _surface_series(rsurfacecc, rsurfacecs, nfp, tor_angle, pol_angle,
+                           n_min, m_min, "theta")
 
-def z_surface_prime_theta(zsurfacecs, nfp, tor_angle, pol_angle, zsurfacecc = None, n_min = None, m_min=0):
-    num_m_modes = len(zsurfacecs)
-    num_n_modes = len(zsurfacecs[0])
-    if n_min is None:
-        n_min = -(num_n_modes - 1)/2
-    z_theta = 0
-    for m in range(num_m_modes):
-        for n in range(num_n_modes):
-            z_theta += zsurfacecs[m][n]*(m+m_min)*jnp.cos((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    if zsurfacecc is not None:
-        assert len(zsurfacecs) == len(zsurfacecc), 'If zsurfacecc is specified, it must be the same length as zsurfacecs'
-        for m in range(num_m_modes):
-            for n in range(num_n_modes):
-                z_theta += -zsurfacecc[m][n]*(m+m_min)*jnp.sin((m_min+m)*pol_angle - (n+n_min)*nfp*tor_angle)
-    return z_theta
+
+def z_surface_prime_theta(zsurfacecs, nfp, tor_angle, pol_angle, zsurfacecc=None,
+                          n_min=None, m_min=0):
+    return _surface_series(zsurfacecc, zsurfacecs, nfp, tor_angle, pol_angle,
+                           n_min, m_min, "theta")
+
 
 def surface_del_theta(rsurfacecc, zsurfacecs, nfp, tor_angle, pol_angle, rsurfacecs = None, zsurfacecc = None, n_min = None, m_min = 0):
     r_theta = r_surface_prime_theta(rsurfacecc, nfp, tor_angle, pol_angle, rsurfacecs=rsurfacecs, n_min=n_min, m_min=m_min)
@@ -496,14 +462,6 @@ def calc_objectives(dofs, plasma_points, plasma_normals, weights, winding_R_cos)
 
 
 
-def mode_weights(surface):
-    weights = []
-    for name in surface.dof_names:
-        mode = int(name.split("(")[1].split(",")[0])
-        weights.append(mode ** 2)
-    return jnp.asarray(weights)
-
-
 def mode_weights_from_coefficients(rc):
     mpol = rc.shape[0] - 1
     ntor = _ntor_from_coefficients(rc)
@@ -516,8 +474,6 @@ def mode_weights_from_coefficients(rc):
         mode_matrix.reshape(-1)[ntor + 1:]))
 
 
-surface = SurfaceRZFourier(nfp=2, mpol=inp.mpol, ntor=inp.ntor)
-weights = mode_weights(surface)
 
 
 

--- a/examples/optimization/QA_optimization.py
+++ b/examples/optimization/QA_optimization.py
@@ -78,10 +78,13 @@ def _surface_series(cosine, sine, nfp, tor_angle, pol_angle, n_min, m_min,
     coefficients = cosine if cosine is not None else sine
     tor_angle, pol_angle = jnp.broadcast_arrays(tor_angle, pol_angle)
     trailing = (1,) * tor_angle.ndim
-    m = (jnp.arange(coefficients.shape[0]) + m_min).reshape((-1, 1) + trailing)
+    angle_dtype = jnp.result_type(tor_angle, pol_angle, 1.0)
+    m = (jnp.arange(coefficients.shape[0], dtype=angle_dtype) + m_min).reshape(
+        (-1, 1) + trailing)
     if n_min is None:
         n_min = -(coefficients.shape[1] - 1) / 2
-    n = ((jnp.arange(coefficients.shape[1]) + n_min) * nfp).reshape((1, -1) + trailing)
+    n = ((jnp.arange(coefficients.shape[1], dtype=angle_dtype) + n_min) * nfp).reshape(
+        (1, -1) + trailing)
     angle = m * pol_angle - n * tor_angle
     c, s = jnp.cos(angle), jnp.sin(angle)
     if derivative is not None:

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -102,6 +102,7 @@
     ["tests/test_validation_guards.py", "diagnostics", "unit", "fast", "cpu", "none", "none", ["pr-parity-c2", "full-core-t-z"]],
     ["tests/test_vmec2000_feature_stress.py", "equilibrium", "oracle", "medium", "cpu", "generated", "vmec2000", ["pr-parity-c2", "full-core-t-z"]],
     ["tests/test_vmec2000_live.py", "equilibrium", "oracle", "campaign", "cpu", "external", "vmec2000", ["pr-external", "full-core-t-z"]],
+    ["tests/test_winding_geometry.py", "interface", "ad", "fast", "cpu-gpu", "none", "analytic", ["pr-parity-c1", "full-core-t-z"]],
     ["tests/test_wout_golden.py", "equilibrium", "oracle", "slow", "cpu", "golden", "vmec2000", ["pr-parity-b", "full-core-t-z"]]
   ],
   "excluded": {

--- a/tests/test_winding_geometry.py
+++ b/tests/test_winding_geometry.py
@@ -1,0 +1,115 @@
+"""Analytic geometry and AD checks for the winding-surface example helpers."""
+import ast
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+@pytest.fixture(scope="module")
+def geometry():
+    # Load only pure helpers: importing the example starts a full optimization.
+    path = Path(__file__).parents[1] / "examples/optimization/QA_optimization.py"
+    names = {
+        "_surface_series", "r_surface", "z_surface", "r_surface_prime_phi",
+        "z_surface_prime_phi", "r_surface_prime_theta", "z_surface_prime_theta",
+        "surface_del_phi", "surface_del_theta", "surface_normal", "surface_unitnormal",
+        "surface_coefficients_from_dofs", "points_normals_normal_lengths", "enclosed_volume",
+    }
+    tree = ast.parse(path.read_text(), filename=str(path))
+    tree.body = [node for node in tree.body if isinstance(node, ast.FunctionDef)
+                 and node.name in names]
+    namespace = {"jax": jax, "jnp": jnp}
+    exec(compile(tree, str(path), "exec"), namespace)
+    previous = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", True)
+    try:
+        with jax.disable_jit(False):
+            yield namespace
+    finally:
+        jax.config.update("jax_enable_x64", previous)
+
+
+@pytest.mark.parametrize("nfp", [1, 2, 5])
+@pytest.mark.parametrize("optional", [False, True])
+@pytest.mark.parametrize("n_min,m_min", [(None, 0), (-1, 2)])
+def test_fourier_values_and_derivatives(geometry, nfp, optional, n_min, m_min):
+    rng = np.random.default_rng(17)
+    primary, extra = [rng.normal(size=(3, 5)) for _ in range(2)]
+    phi, theta = .37, 1.13
+    m = np.arange(3)[:, None] + m_min
+    n = np.arange(5)[None, :] + (-2 if n_min is None else n_min)
+    angle = m * theta - n * nfp * phi
+    for family in ("r", "z"):
+        c, s = ((primary, extra) if family == "r" else (extra, primary))
+        if not optional:
+            if family == "r":
+                s = np.zeros_like(s)
+            else:
+                c = np.zeros_like(c)
+        expected = np.sum(c * np.cos(angle) + s * np.sin(angle))
+        args = (jnp.asarray(primary), nfp, phi, theta,
+                jnp.asarray(extra) if optional else None, n_min, m_min)
+        value = geometry[f"{family}_surface"](*args)
+        np.testing.assert_allclose(value, expected, rtol=2e-13, atol=2e-13)
+        for coordinate, frequency in (("phi", -n * nfp), ("theta", m)):
+            expected_d = np.sum(frequency * (-c * np.sin(angle) + s * np.cos(angle)))
+            actual = geometry[f"{family}_surface_prime_{coordinate}"](*args)
+            np.testing.assert_allclose(actual, expected_d, rtol=2e-13, atol=2e-13)
+            argnum = 2 if coordinate == "phi" else 3
+            derivative = jax.grad(geometry[f"{family}_surface"], argnums=argnum)(*args)
+            np.testing.assert_allclose(derivative, actual, rtol=2e-13, atol=2e-13)
+
+
+def test_broadcast_and_coefficient_ad(geometry):
+    coefficients = jnp.arange(15., dtype=jnp.float64).reshape(3, 5) / 15
+    phi, theta = jnp.array([.1, .4])[:, None], jnp.array([.2, .7, 1.2])[None, :]
+    function = geometry["r_surface"]
+    expected = np.array([[function(coefficients, 3, p, t) for t in theta[0]]
+                         for p in phi[:, 0]])
+    np.testing.assert_allclose(function(coefficients, 3, phi, theta), expected, atol=1e-14)
+    def loss(c):
+        return jnp.sum(function(c, 3, phi, theta) ** 2)
+    direction = jnp.cos(coefficients)
+    value, tangent = jax.jit(lambda c, d: jax.jvp(loss, (c,), (d,)))(coefficients, direction)
+    reverse = jnp.vdot(jax.jit(jax.grad(loss))(coefficients), direction)
+    epsilon = 1e-5
+    finite_difference = (loss(coefficients + epsilon * direction)
+                         - loss(coefficients - epsilon * direction)) / (2 * epsilon)
+    assert np.isfinite(value)
+    np.testing.assert_allclose(tangent, reverse, rtol=2e-13, atol=2e-13)
+    np.testing.assert_allclose(tangent, finite_difference, rtol=1e-9)
+
+
+def test_circular_torus_geometry_and_volume(geometry):
+    radius, minor = 3., .7
+    # mpol=1, ntor=0: R00, R10, Z10.
+    dofs = jnp.array([radius, minor, minor])
+    points, normals, jacobian, raw = geometry["points_normals_normal_lengths"](
+        dofs, 1, 0, 3, 12, 16)
+    phi = np.linspace(0, 2 * np.pi, 12, endpoint=False)[:, None]
+    theta = np.linspace(0, 2 * np.pi, 16, endpoint=False)[None, :]
+    expected = np.stack(np.broadcast_arrays(np.cos(phi) * np.cos(theta),
+                        np.sin(phi) * np.cos(theta), np.sin(theta)), axis=-1)
+    np.testing.assert_allclose(normals, expected, atol=3e-15)
+    np.testing.assert_allclose(jacobian, np.broadcast_to(
+        minor * (radius + minor * np.cos(theta)), (12, 16)), atol=3e-15)
+    volume = geometry["enclosed_volume"](points, raw, 12, 16)
+    np.testing.assert_allclose(volume, 2 * np.pi**2 * radius * minor**2, rtol=2e-15)
+
+    def volume_of(coefficients):
+        position, _, _, normal = geometry["points_normals_normal_lengths"](
+            coefficients, 1, 0, 3, 12, 16)
+        return geometry["enclosed_volume"](position, normal, 12, 16)
+
+    derivative = jax.jit(jax.grad(volume_of))(dofs)
+    np.testing.assert_allclose(derivative, 2 * np.pi**2 * np.array(
+        [minor**2, radius * minor, radius * minor]), rtol=2e-15)
+
+
+def test_array_like_coefficients_and_mismatched_parity(geometry):
+    assert geometry["r_surface"]([[3.]], 2, .1, .2) == 3.
+    with pytest.raises(ValueError, match="matching shapes"):
+        geometry["r_surface"](jnp.ones((2, 3)), 2, .1, .2, jnp.ones((1, 3)))

--- a/tests/test_winding_geometry.py
+++ b/tests/test_winding_geometry.py
@@ -17,11 +17,18 @@ def geometry():
         "z_surface_prime_phi", "r_surface_prime_theta", "z_surface_prime_theta",
         "surface_del_phi", "surface_del_theta", "surface_normal", "surface_unitnormal",
         "surface_coefficients_from_dofs", "points_normals_normal_lengths", "enclosed_volume",
+        "_ntor_from_coefficients", "reduced_memory_induction_matrix", "spectral_width",
+        "smooth_minimum_distance", "calc_objectives", "_winding_objective_value",
     }
     tree = ast.parse(path.read_text(), filename=str(path))
     tree.body = [node for node in tree.body if isinstance(node, ast.FunctionDef)
                  and node.name in names]
-    namespace = {"jax": jax, "jnp": jnp}
+    namespace = {
+        "jax": jax, "jnp": jnp, "MU0": 4 * np.pi * 1e-7, "nfp": 2,
+        "WINDING_NPHI": 12, "WINDING_NTHETA": 12, "MINIMUM_DISTANCE": .05,
+        "DISTANCE_WALL_SCALE": .01, "DISTANCE_WALL_WEIGHT": 10.,
+        "PCA_WEIGHT": 1., "VOLUME_WEIGHT": .02, "SPECTRAL_WEIGHT": .02,
+    }
     exec(compile(tree, str(path), "exec"), namespace)
     previous = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", True)
@@ -113,3 +120,38 @@ def test_array_like_coefficients_and_mismatched_parity(geometry):
     assert geometry["r_surface"]([[3.]], 2, .1, .2) == 3.
     with pytest.raises(ValueError, match="matching shapes"):
         geometry["r_surface"](jnp.ones((2, 3)), 2, .1, .2, jnp.ones((1, 3)))
+
+
+def test_winding_objective_hvp_matches_gradient_difference(geometry):
+    # Break repeated singular values without altering the entropy definition.
+    rc, zs = np.zeros((3, 5)), np.zeros((3, 5))
+    rc[0, 2], rc[1, 2], zs[1, 2] = 3., .7, .7
+    dofs = np.r_[rc.ravel()[2:], zs.ravel()[3:]]
+    dofs = jnp.asarray(dofs + .003 * np.random.default_rng(12).normal(size=dofs.shape))
+    plasma = (.75 * dofs).at[0].set(dofs[0])
+    points, normals, _, _ = geometry["points_normals_normal_lengths"](
+        plasma, 2, 2, 2, 12, 12)
+    points, normals = points.reshape(-1, 3), normals.reshape(-1, 3)
+    weights = jnp.ones_like(dofs)
+    scales = geometry["calc_objectives"](dofs, points, normals, weights, rc)
+
+    def objective(value):
+        return geometry["_winding_objective_value"](value, points, normals, weights, rc, scales)
+
+    direction = jnp.sin(dofs + .1)
+    gradient = jax.jit(jax.grad(objective))
+    hvp = jax.jit(lambda value: jax.jvp(
+        jax.grad(objective), (value,), (direction,))[1])(dofs)
+    assert np.all(np.isfinite(hvp))
+    for epsilon in (1e-5, 1e-6):
+        finite_difference = (gradient(dofs + epsilon * direction)
+                             - gradient(dofs - epsilon * direction)) / (2 * epsilon)
+        np.testing.assert_allclose(hvp, finite_difference, rtol=2e-5, atol=2e-7)
+
+
+def test_float32_geometry_keeps_angular_precision(geometry):
+    rc = jnp.array([[3.], [.7]], dtype=jnp.float32)
+    phi, theta = jnp.asarray(.1, dtype=jnp.float32), jnp.asarray(.3, dtype=jnp.float32)
+    value = geometry["r_surface"](rc, 2, phi, theta)
+    assert value.dtype == jnp.float32
+    np.testing.assert_allclose(value, 3 + .7 * np.cos(.3), rtol=2e-7)


### PR DESCRIPTION
The winding example's implicit response spent about 15 seconds per warmed GPU evaluation and differed from independently converged inner-solve finite differences by about 0.2%. The default normal-equation CG solve was the accuracy bottleneck: its stopping criterion did not certify the original Hessian equation.

This PR targets `ds/working_winding` and builds on #301. Until that dependency is incorporated, GitHub also shows its geometry commits; the response change is isolated in commit `8225d40fb2156774e0f659264c23dc752a053d1b`. Both PRs remain draft. No merge or release is requested by this action.

### Change

- Inject existing SOLVAX GCROT into `root_jvp`, solving the original Hessian system without squaring its condition number. Cache the linearized operator so Krylov iterations reuse its differentiation intermediates.
- Preserve forward, reverse, and higher derivatives through `jax.lax.custom_linear_solve`, including its transpose solve. A failed original-system residual certificate returns nonfinite sensitivities. The custom root response also rejects inner gradient norm above the existing 1e-6 tolerance.
- Keep the entropy/geometry objective, initial guess, inner 100-iteration budget and tolerance unchanged. No regularization, singular-value truncation, stopped physics gradient, or new generic solver implementation is introduced.
- Install the existing optional `optimizers` extra in the c1 parity job that exercises the response tests. The preceding #301 commit installs it only in the misc job that runs the QA example; no example smoke is skipped.

[JAXopt documents the root invariant and its default normal-CG injection](https://jaxopt.github.io/stable/_autosummary/jaxopt.implicit_diff.root_jvp.html). [JAX documents the implicit linear-solve and transpose contract](https://docs.jax.dev/en/latest/_autosummary/jax.lax.custom_linear_solve.html). Generic iteration and original-residual diagnostics remain in [SOLVAX's existing Krylov implementation](https://github.com/uwplasma/SOLVAX/blob/9b37d6998240ac839e9dc5da35f3cbba8a560980/src/solvax/krylov.py).

### Numerical certificate

The public initial QA boundary, including the example's rotating ellipse, uses 99 winding coefficients and a 24×24 grid. The unchanged inner solve reached gradient norm 8.46e-7 in 56 iterations, with no failed line search. All six perturbed-boundary solves used for central differences also reached the original 1e-6 tolerance.

The 99×99 Hessian was assembled only as a diagnostic with sequential HVPs. Its relative asymmetry was 6.13e-15 and condition number 100.06. It was positive definite at this point, but the production solver does not assume positive definiteness. The stationary induction matrix was full rank, with no nearly repeated singular values.

| Certificate | Default normal CG | Direct-H GCROT |
|---|---:|---:|
| Original Hessian-equation relative residual | 5.90e-5 | 5.33e-9 |
| Relative solution error against dense diagnostic | 1.95e-3 | 8.65e-8 |
| Central FD error, step 1e-3 | 1.96e-3 | 5.38e-5 |
| Central FD error, step 3e-4 | 1.93e-3 | 3.61e-5 |
| Central FD error, step 1e-4 | 2.03e-3 | 1.04e-4 |

GCROT converged in 40 iterations, and independently multiplying the dense diagnostic by its response reproduced the reported original-system residual. The remaining smallest-step FD error is consistent with the unchanged finite inner tolerance; this is not an exact-root claim.

### Performance and memory

Float64 JAX 0.9.2, JAXopt 0.8.5, SOLVAX 0.20.0, RTX A4000. Both arms use the same saved stationary state and dynamic JIT arguments, including the derivative of the complete boundary/offset/scales construction. Eleven synchronized warm samples per arm:

| Root response | Default normal CG | Certified GCROT |
|---|---:|---:|
| Warm median | 14.965 s | 1.067 s |
| Compilation | 9.888 s | 9.184 s |
| Lowered graph | 699 KB | 485 KB |
| Device temporary allocation | 139 MB | 222 MB |

This is a 14.0× improvement for the measured root-response component with a stricter accuracy certificate. Cached intermediates increase temporary memory by about 83 MB; not every metric improves. The paired process reached 1.84 GiB RSS. Its 300-second profiling cap stopped a subsequent optional full-inner phase after both paired measurements were saved; that timeout is not a solver failure. A separate bounded process completed the actual inner solve plus custom JVP in 89.35 seconds including compilation, with 1.82 GiB peak RSS for the full diagnostic process. The final inner gradient was 8.48e-7, its solution differed by 1.93e-10 from the saved original inner result, and its response agreed with the certified checkpoint to 3.76e-9 relative.

The actual four-evaluation CPU QA smoke completed in 482 seconds, including compilation, equilibria and all figures, with 6.32 GiB peak RSS. Cost decreased from 22.929 to 2.2854 and the expected input, wout and summary image were produced. This validates the example/optional-dependency contract; it is not a fully converged stellarator optimization or a claim that the entire workflow is now fast.

### Validation and reproduction

- 22 tests pass on CPU and GPU. They cover analytic Fourier/torus physics, coefficient AD, full entropy HVP finite differences, indefinite and nonsymmetric direct solves, transpose AD, a parameter-dependent Hessian's root curvature, zero RHS, exhausted linear budget and an unstationary inner solve.
- All 9 changed executable source lines are covered. Ruff and diff checks pass. Independent source review found no blocking issues. Current-head CI remains required.

Install `.[optimizers]`, then run:

```sh
JAX_ENABLE_X64=1 JAX_PLATFORMS=cpu python -m pytest -q tests/test_winding_geometry.py
JAX_ENABLE_X64=1 JAX_PLATFORMS=cuda,cpu XLA_PYTHON_CLIENT_PREALLOCATE=false \
python -m pytest -q tests/test_winding_geometry.py
VMEX_EXAMPLES_CI=1 MPLBACKEND=Agg python examples/optimization/QA_optimization.py
```

To reproduce the root certificate, use `examples/data/input.minimal_seed_nfp2`, set `RBC(-1,1)=-0.05` and `ZBS(-1,1)=0.05` as the example does, and use the first-stage VMEC resolution mpol=5, ntor=5. Construct the 24×24 offset and scales with the existing helpers; the averaged cross-section minor radius is sqrt(0.007501). Differentiate with respect to the ellipse amplitude, including the offset/scales, and compare the saved stationary response with fresh inner solves at amplitude 0.05±{1e-3,3e-4,1e-4}. Keep the existing inner tolerance and iteration budget. Measure lowering, compilation, synchronized execution and memory separately.

### Remaining scope

This preserves the branch's unweighted full-torus entropy proxy. [ESSOS #66](https://github.com/uwplasma/ESSOS/pull/66) addresses distinct physical current-potential, quadrature and finite-coil objectives; this PR does not establish physical coil improvement. Repeated-positive-singular-value curvature failures observed in near-symmetric CPU fixtures remain an inherited limitation, and residual convergence alone does not prove Hessian uniqueness or good conditioning. Larger-mode and batched outer Jacobians still need memory/runtime profiling, and the forward inner optimizer remains substantial work. No new objective or broad experimental lane is introduced.
